### PR TITLE
A couple small source-build fixes

### DIFF
--- a/src/redist/targets/BundledTemplates.targets
+++ b/src/redist/targets/BundledTemplates.targets
@@ -119,8 +119,8 @@
   <Target Name="LayoutTemplatesForSDK"
           DependsOnTargets="SetupBundledComponents;CalculateTemplatesVersions">
     <ItemGroup Condition="!$(ProductMonikerRid.StartsWith('win'))">
-      <BundledTemplate Remove="Microsoft.Dotnet.Wpf.ProjectTemplates" />
-      <BundledTemplate Remove="Microsoft.Dotnet.WinForms.ProjectTemplates" />
+      <Bundled30Templates Remove="Microsoft.Dotnet.Wpf.ProjectTemplates" />
+      <Bundled30Templates Remove="Microsoft.Dotnet.WinForms.ProjectTemplates" />
     </ItemGroup>
     <Copy SourceFiles="%(Bundled30Templates.RestoredNupkgPath)"
           DestinationFolder="$(RedistLayoutPath)templates/$(BundledTemplates30InstallPath)"/>

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Microsoft.DotNet.Tools.Tests.Utilities.csproj
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Microsoft.DotNet.Tools.Tests.Utilities.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Exclude another test project from source-build.
- Fix the name of an item group - this was changed from `BundledTemplate` to `Bundled30Templates` in https://github.com/dotnet/core-sdk/commit/49ad1e8dd53623ba33a143663a8781cca1b57f2d but these two lines [appear to have been missed](https://github.com/dotnet/core-sdk/commit/49ad1e8dd53623ba33a143663a8781cca1b57f2d#diff-bd6461bef35a41835253b2408e86032cR91).