### PR TITLE
Created a productVersion.txt to be published

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -43,7 +43,7 @@
     <SdkAssetsToPublish Include="$(ArtifactsShippingPackagesDir)*.cab" />
     <SdkAssetsToPublish Include="$(ArtifactsShippingPackagesDir)*.svg" Condition=" '$(PublishBinariesAndBadge)' == 'true' " />
     <SdkAssetsToPublish Include="$(ArtifactsShippingPackagesDir)productVersion.txt" Condition=" '$(PublishBinariesAndBadge)' == 'true' " />
-    <SdkAssetsToPublish Include="$(ArtifactsShippingPackagesDir)productCommit.txt" Condition=" '$(PublishBinariesAndBadge)' == 'true' " />
+    <SdkAssetsToPublish Include="$(ArtifactsShippingPackagesDir)productCommit-*.txt" Condition=" '$(PublishBinariesAndBadge)' == 'true' " />
     <SdkNonShippingAssetsToPublish Include="$(ArtifactsNonShippingPackagesDir)*.nupkg" />
     <SdkNonShippingAssetsToPublish Include="$(ArtifactsNonShippingPackagesDir)*.swr" />
     <CheckSumsToPublish Include="$(ArtifactsShippingPackagesDir)*.sha" />

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -42,6 +42,7 @@
     <SdkAssetsToPublish Include="$(ArtifactsShippingPackagesDir)*.nupkg" />
     <SdkAssetsToPublish Include="$(ArtifactsShippingPackagesDir)*.cab" />
     <SdkAssetsToPublish Include="$(ArtifactsShippingPackagesDir)*.svg" Condition=" '$(PublishBinariesAndBadge)' == 'true' " />
+    <SdkAssetsToPublish Include="$(ArtifactsShippingPackagesDir)productVersion.version" Condition=" '$(PublishBinariesAndBadge)' == 'true' " />
     <SdkNonShippingAssetsToPublish Include="$(ArtifactsNonShippingPackagesDir)*.nupkg" />
     <SdkNonShippingAssetsToPublish Include="$(ArtifactsNonShippingPackagesDir)*.swr" />
     <CheckSumsToPublish Include="$(ArtifactsShippingPackagesDir)*.sha" />
@@ -58,6 +59,12 @@
           TaskParameter="Lines"
           PropertyName="FullNugetVersion"/>
     </ReadLinesFromFile>
+
+  <WriteLinesToFile
+            File="$(ArtifactsShippingPackagesDir)productVersion.version"
+            Lines="$(Version)"
+            Overwrite="true"
+            Encoding="ASCII"/>
 
     <!-- If the sdk version is stabilized, then we should double publish the binaries to suffixed file names.
          To do this, create new copies of the blobs, replacing the SdkVersion string in the file name with the

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -42,7 +42,8 @@
     <SdkAssetsToPublish Include="$(ArtifactsShippingPackagesDir)*.nupkg" />
     <SdkAssetsToPublish Include="$(ArtifactsShippingPackagesDir)*.cab" />
     <SdkAssetsToPublish Include="$(ArtifactsShippingPackagesDir)*.svg" Condition=" '$(PublishBinariesAndBadge)' == 'true' " />
-    <SdkAssetsToPublish Include="$(ArtifactsShippingPackagesDir)productVersion.version" Condition=" '$(PublishBinariesAndBadge)' == 'true' " />
+    <SdkAssetsToPublish Include="$(ArtifactsShippingPackagesDir)productVersion.txt" Condition=" '$(PublishBinariesAndBadge)' == 'true' " />
+    <SdkAssetsToPublish Include="$(ArtifactsShippingPackagesDir)productCommit.txt" Condition=" '$(PublishBinariesAndBadge)' == 'true' " />
     <SdkNonShippingAssetsToPublish Include="$(ArtifactsNonShippingPackagesDir)*.nupkg" />
     <SdkNonShippingAssetsToPublish Include="$(ArtifactsNonShippingPackagesDir)*.swr" />
     <CheckSumsToPublish Include="$(ArtifactsShippingPackagesDir)*.sha" />
@@ -59,12 +60,6 @@
           TaskParameter="Lines"
           PropertyName="FullNugetVersion"/>
     </ReadLinesFromFile>
-
-  <WriteLinesToFile
-            File="$(ArtifactsShippingPackagesDir)productVersion.version"
-            Lines="$(Version)"
-            Overwrite="true"
-            Encoding="ASCII"/>
 
     <!-- If the sdk version is stabilized, then we should double publish the binaries to suffixed file names.
          To do this, create new copies of the blobs, replacing the SdkVersion string in the file name with the

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -12,6 +12,9 @@
     <Task>
       <Using Namespace="System.IO" />
       <Code Type="Fragment" Language="cs">
+        var dir = Path.GetDirectoryName(Path);
+        if(!string.IsNullOrEmpty(dir))
+          Directory.CreateDirectory(dir);
         File.WriteAllText(Path, Content);
       </Code>
     </Task>

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -10,12 +10,11 @@
       <Content Required="true" />
     </ParameterGroup>
     <Task>
-      <Using Namespace="System.IO" />
       <Code Type="Fragment" Language="cs">
-        var dir = Path.GetDirectoryName(Path);
+        var dir = System.IO.Path.GetDirectoryName(Path);
         if(!string.IsNullOrEmpty(dir))
-          Directory.CreateDirectory(dir);
-        File.WriteAllText(Path, Content);
+          System.IO.Directory.CreateDirectory(dir);
+        System.IO.File.WriteAllText(Path, Content);
       </Code>
     </Task>
   </UsingTask>

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -1,34 +1,19 @@
 <Project>
 
-  <!-- Used for creating productVersion and productCommit text files. -->
-  <UsingTask
-    TaskName="WriteTextToFile"
-    TaskFactory="RoslynCodeTaskFactory"
-    AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll" >
-    <ParameterGroup>
-      <Path Required="true" />
-      <Content Required="true" />
-    </ParameterGroup>
-    <Task>
-      <Code Type="Fragment" Language="cs">
-        var dir = System.IO.Path.GetDirectoryName(Path);
-        if(!string.IsNullOrEmpty(dir))
-          System.IO.Directory.CreateDirectory(dir);
-        System.IO.File.WriteAllText(Path, Content);
-      </Code>
-    </Task>
-  </UsingTask>
-
   <Target Name="GenerateBundledVersions"
           DependsOnTargets="GenerateBundledVersionsProps;GenerateBundledCliToolsProps" >
-          
-    <WriteTextToFile
-      Path="$(ArtifactsShippingPackagesDir)productVersion.txt"
-      Content="$(PackageVersion)" />
 
-    <WriteTextToFile
-      Path="$(ArtifactsShippingPackagesDir)productCommit-$(Rid).txt"
-      Content="$(BUILD_SOURCEVERSION)%0A$(PackageVersion)" />
+    <WriteLinesToFile
+      File="$(ArtifactsShippingPackagesDir)productVersion.txt"
+      Lines="$(PackageVersion)"
+      Overwrite="true"
+      Encoding="ASCII"/>
+
+    <WriteLinesToFile
+      File="$(ArtifactsShippingPackagesDir)productCommit-$(Rid).txt"
+      Lines="$(BUILD_SOURCEVERSION)%0A$(PackageVersion)"
+      Overwrite="true"
+      Encoding="ASCII"/>
 
   </Target>
 

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -28,7 +28,7 @@
 
     <WriteTextToFile
       Path="$(ArtifactsShippingPackagesDir)productCommit.txt"
-      Content="$(PackageVersion)%0A$(BUILD_SOURCEVERSION)" />
+      Content="$(BUILD_SOURCEVERSION)%0A$(PackageVersion)" />
 
   </Target>
 

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -1,19 +1,32 @@
 <Project>
 
+  <!-- Used for creating productVersion and productCommit text files. -->
+  <UsingTask
+    TaskName="WriteTextToFile"
+    TaskFactory="RoslynCodeTaskFactory"
+    AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll" >
+    <ParameterGroup>
+      <Path Required="true" />
+      <Content Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System.IO" />
+      <Code Type="Fragment" Language="cs">
+        File.WriteAllText(Path, Content);
+      </Code>
+    </Task>
+  </UsingTask>
+
   <Target Name="GenerateBundledVersions"
           DependsOnTargets="GenerateBundledVersionsProps;GenerateBundledCliToolsProps" >
           
-    <WriteLinesToFile
-      File="$(ArtifactsShippingPackagesDir)productVersion.txt"
-      Lines="$(PackageVersion)"
-      Overwrite="true"
-      Encoding="ASCII"/>
+    <WriteTextToFile
+      Path="$(ArtifactsShippingPackagesDir)productVersion.txt"
+      Content="$(PackageVersion)" />
 
     <WriteLinesToFile
-      File="$(ArtifactsShippingPackagesDir)productCommit.txt"
-      Lines="$(PackageVersion)%0x0A$(BUILD_SOURCEVERSION)"
-      Overwrite="true"
-      Encoding="ASCII"/>
+      Path="$(ArtifactsShippingPackagesDir)productCommit.txt"
+      Content="$(PackageVersion)%0A$(BUILD_SOURCEVERSION)" />
 
   </Target>
 

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -1,7 +1,21 @@
 <Project>
 
   <Target Name="GenerateBundledVersions"
-          DependsOnTargets="GenerateBundledVersionsProps;GenerateBundledCliToolsProps" />
+          DependsOnTargets="GenerateBundledVersionsProps;GenerateBundledCliToolsProps" >
+          
+    <WriteLinesToFile
+      File="$(ArtifactsShippingPackagesDir)productVersion.txt"
+      Lines="$(PackageVersion)"
+      Overwrite="true"
+      Encoding="ASCII"/>
+
+    <WriteLinesToFile
+      File="$(ArtifactsShippingPackagesDir)productCommit.txt"
+      Lines="$(PackageVersion)%0x0A$(BUILD_SOURCEVERSION)"
+      Overwrite="true"
+      Encoding="ASCII"/>
+
+  </Target>
 
   <Target Name="GenerateBundledVersionsProps" DependsOnTargets="SetupBundledComponents">
     <PropertyGroup>

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -27,7 +27,7 @@
       Content="$(PackageVersion)" />
 
     <WriteTextToFile
-      Path="$(ArtifactsShippingPackagesDir)productCommit.txt"
+      Path="$(ArtifactsShippingPackagesDir)productCommit-$(Rid).txt"
       Content="$(BUILD_SOURCEVERSION)%0A$(PackageVersion)" />
 
   </Target>

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -26,7 +26,7 @@
       Path="$(ArtifactsShippingPackagesDir)productVersion.txt"
       Content="$(PackageVersion)" />
 
-    <WriteLinesToFile
+    <WriteTextToFile
       Path="$(ArtifactsShippingPackagesDir)productCommit.txt"
       Content="$(PackageVersion)%0A$(BUILD_SOURCEVERSION)" />
 


### PR DESCRIPTION
Addressing the issue https://github.com/dotnet/core-sdk/issues/5554.

Build process now creates a productVersion.version file and includes it in the list of assets that will be published.
