### PR TITLE
update nunit templates version for netcore5.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- NUnit3.DotNetNew.Template versions do not 'flow in' -->
-    <NUnit3DotNetNewTemplatePackageVersion>1.7.1</NUnit3DotNetNewTemplatePackageVersion>
+    <NUnit3DotNetNewTemplatePackageVersion>1.8.0</NUnit3DotNetNewTemplatePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
@@ -96,7 +96,7 @@
     <!-- 3.1 Template versions -->
     <MicrosoftDotnetWinFormsProjectTemplates31PackageVersion>4.8.1-servicing.19605.5</MicrosoftDotnetWinFormsProjectTemplates31PackageVersion>
     <MicrosoftDotNetWpfProjectTemplates31PackageVersion>3.1.2-servicing.20066.4</MicrosoftDotNetWpfProjectTemplates31PackageVersion>
-    <NUnit3Templates31PackageVersion>1.7.1</NUnit3Templates31PackageVersion>
+    <NUnit3Templates31PackageVersion>1.7.2</NUnit3Templates31PackageVersion>
     <MicrosoftDotNetCommonItemTemplates31PackageVersion>3.1.2</MicrosoftDotNetCommonItemTemplates31PackageVersion>
     <MicrosoftDotNetCommonProjectTemplates31PackageVersion>$(MicrosoftDotNetCommonItemTemplates31PackageVersion)</MicrosoftDotNetCommonProjectTemplates31PackageVersion>
     <MicrosoftDotNetTestProjectTemplates31PackageVersion>$(MicrosoftDotNetTestProjectTemplates50PackageVersion)</MicrosoftDotNetTestProjectTemplates31PackageVersion>


### PR DESCRIPTION
- added support for `netcoreapp5.0` targeting for nunit templates, set it as default template's framework

newest v1.8.0 links:
- https://github.com/nunit/dotnet-new-nunit/releases/tag/v1.8.0
- https://www.nuget.org/packages/NUnit3.DotNetNew.Template/1.8.0