### PR TITLE
Preview2 builds are being uploaded to wrong channel

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -230,7 +230,7 @@ stages:
     dependsOn:
       # This will run only after all the publishing stages have run.
       # These stages are introduced in the eng/common/templates/post-build/channels YAML templates
-      - NetCore_Dev5_Publish
+      - Net5_Preview2_Publish
     jobs:
     - job: Copy_SDK_To_Latest
       pool:


### PR DESCRIPTION
Preview2 builds are being uploaded to net5/dev channel.
This change fixes this by executing the correct build stage.