### PR TITLE
Add iOS/tvOS/Android to .NET5 runtime pack IDs

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -78,6 +78,8 @@
           ios-arm64;
           ios-arm;
           ios-x64;
+          tvos-arm64;
+          tvos-x64;
           " />
 
       <NetCoreRuntimePackRids Include="@(NetCore5RuntimePackRids)"/>

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -80,6 +80,10 @@
           ios-x64;
           tvos-arm64;
           tvos-x64;
+          android-arm64;
+          android-arm;
+          android-x64;
+          android-x86;
           " />
 
       <NetCoreRuntimePackRids Include="@(NetCore5RuntimePackRids)"/>

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -72,7 +72,15 @@
           " />
 
       <NetCore31RuntimePackRids Include="@(NetCore30RuntimePackRids)"/>
-      <NetCoreRuntimePackRids Include="@(NetCore31RuntimePackRids)"/>
+
+      <NetCore5RuntimePackRids Include="
+          @(NetCore31RuntimePackRids);
+          ios-arm64;
+          ios-arm;
+          ios-x64;
+          " />
+
+      <NetCoreRuntimePackRids Include="@(NetCore5RuntimePackRids)"/>
 
       <AspNetCore30RuntimePackRids Include="
         win-x64;


### PR DESCRIPTION
This adds the iOS/tvOS/Android runtime pack IDs to GenerateBundledVersions.targets for .NET 5