### PR TITLE
[release/5.0.1xx-preview3] Set TLS1.2 before running dotnet-install in tests

### DIFF
--- a/test/SdkTests/SdkTests.csproj
+++ b/test/SdkTests/SdkTests.csproj
@@ -120,12 +120,16 @@
       <RuntimeTargetDirectory>$(DotnetToTestPath)shared\Microsoft.NETCore.App\$(RuntimeVersionToInstall)</RuntimeTargetDirectory>
     </PropertyGroup>
     <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
-      <InstallRuntimeCommand>powershell -NoLogo -NoProfile -ExecutionPolicy ByPass</InstallRuntimeCommand>
-      <InstallRuntimeCommand>$(InstallRuntimeCommand) "$(_DotNetRoot)dotnet-install.ps1"</InstallRuntimeCommand>
+      <!-- Set TLS1.2 explicitly before running this. If TLS1.2 isnt' enbabled by default this command may fail in some
+           scenarios.  Waiting on a fix to dotnet-install.ps1 to fix this in the right place. -->
+      <InstallRuntimeCommand>powershell -NoLogo -NoProfile -ExecutionPolicy ByPass -Command { </InstallRuntimeCommand>
+      <InstallRuntimeCommand>[Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12;</InstallRuntimeCommand>
+      <InstallRuntimeCommand>$(InstallRuntimeCommand) &amp; &quot;$(_DotNetRoot)dotnet-install.ps1&quot;</InstallRuntimeCommand>
       <InstallRuntimeCommand>$(InstallRuntimeCommand) -Version $(RuntimeVersionToInstall)</InstallRuntimeCommand>
       <InstallRuntimeCommand>$(InstallRuntimeCommand) -InstallDir $(DotnetToTestPath)</InstallRuntimeCommand>
-      <InstallRuntimeCommand>$(InstallRuntimeCommand) -Runtime "dotnet"</InstallRuntimeCommand>
-      <InstallRuntimeCommand Condition="'$(Architecture)' != ''">$(InstallRuntimeCommand) -Architecture "$(Architecture)"</InstallRuntimeCommand>
+      <InstallRuntimeCommand>$(InstallRuntimeCommand) -Runtime &quot;dotnet&quot;</InstallRuntimeCommand>
+      <InstallRuntimeCommand Condition="'$(Architecture)' != ''">$(InstallRuntimeCommand) -Architecture &quot;$(Architecture)&quot;</InstallRuntimeCommand>
+      <InstallRuntimeCommand>$(InstallRuntimeCommand) }</InstallRuntimeCommand>
     </PropertyGroup>
     <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
       <InstallRuntimeCommand>/bin/bash</InstallRuntimeCommand>

--- a/test/SdkTests/SdkTests.csproj
+++ b/test/SdkTests/SdkTests.csproj
@@ -124,11 +124,11 @@
            scenarios.  Waiting on a fix to dotnet-install.ps1 to fix this in the right place. -->
       <InstallRuntimeCommand>powershell -NoLogo -NoProfile -ExecutionPolicy ByPass -Command { </InstallRuntimeCommand>
       <InstallRuntimeCommand>[Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12;</InstallRuntimeCommand>
-      <InstallRuntimeCommand>$(InstallRuntimeCommand) &amp; &quot;$(_DotNetRoot)dotnet-install.ps1&quot;</InstallRuntimeCommand>
+      <InstallRuntimeCommand>$(InstallRuntimeCommand) &amp; "$(_DotNetRoot)dotnet-install.ps1"</InstallRuntimeCommand>
       <InstallRuntimeCommand>$(InstallRuntimeCommand) -Version $(RuntimeVersionToInstall)</InstallRuntimeCommand>
       <InstallRuntimeCommand>$(InstallRuntimeCommand) -InstallDir $(DotnetToTestPath)</InstallRuntimeCommand>
-      <InstallRuntimeCommand>$(InstallRuntimeCommand) -Runtime &quot;dotnet&quot;</InstallRuntimeCommand>
-      <InstallRuntimeCommand Condition="'$(Architecture)' != ''">$(InstallRuntimeCommand) -Architecture &quot;$(Architecture)&quot;</InstallRuntimeCommand>
+      <InstallRuntimeCommand>$(InstallRuntimeCommand) -Runtime "dotnet"</InstallRuntimeCommand>
+      <InstallRuntimeCommand Condition="'$(Architecture)' != ''">$(InstallRuntimeCommand) -Architecture "$(Architecture)"</InstallRuntimeCommand>
       <InstallRuntimeCommand>$(InstallRuntimeCommand) }</InstallRuntimeCommand>
     </PropertyGroup>
     <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">

--- a/test/SdkTests/SdkTests.csproj
+++ b/test/SdkTests/SdkTests.csproj
@@ -124,7 +124,7 @@
            scenarios.  Waiting on a fix to dotnet-install.ps1 to fix this in the right place. -->
       <InstallRuntimeCommand>powershell -NoLogo -NoProfile -ExecutionPolicy ByPass -Command { </InstallRuntimeCommand>
       <InstallRuntimeCommand>[Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12;</InstallRuntimeCommand>
-      <InstallRuntimeCommand>$(InstallRuntimeCommand) &amp; "$(_DotNetRoot)dotnet-install.ps1"</InstallRuntimeCommand>
+      <InstallRuntimeCommand>$(InstallRuntimeCommand) "$(_DotNetRoot)dotnet-install.ps1"</InstallRuntimeCommand>
       <InstallRuntimeCommand>$(InstallRuntimeCommand) -Version $(RuntimeVersionToInstall)</InstallRuntimeCommand>
       <InstallRuntimeCommand>$(InstallRuntimeCommand) -InstallDir $(DotnetToTestPath)</InstallRuntimeCommand>
       <InstallRuntimeCommand>$(InstallRuntimeCommand) -Runtime "dotnet"</InstallRuntimeCommand>


### PR DESCRIPTION
The new powershell process overrides the setting that build.ps1 sets up.

- If this PR should not run tests please add text "skip[REMOVE_THIS]ci[REMOVE_THIS]please" (remove the marked text, no quotes).
- Please add description for changes you are making.
- If there is an issue related to this PR, please add the reference.
