### PR TITLE
[release/3.1.3xx] Set up TLS 1.2 before calling dotnet-install for tests

### DIFF
--- a/src/core-sdk-tasks/DownloadFile.cs
+++ b/src/core-sdk-tasks/DownloadFile.cs
@@ -97,7 +97,7 @@ namespace Microsoft.DotNet.Cli.Build
                     {
                         var httpResponse = await httpClient.GetAsync(source);
 
-                        Log.LogMessage(MessageImportance.High, $"{source} -> {httpResponse.StatusCode}");
+                        Log.LogMessage(MessageImportance.Normal, $"{source} -> {httpResponse.StatusCode}");
 
                         // The Azure Storage REST API returns '400 - Bad Request' in some cases
                         // where the resource is not found on the storage.
@@ -116,7 +116,7 @@ namespace Microsoft.DotNet.Cli.Build
                             await httpResponse.Content.CopyToAsync(outStream);
                         }
 
-                        Log.LogMessage(MessageImportance.High, $"returning true {source} -> {httpResponse.StatusCode}");
+                        Log.LogMessage(MessageImportance.Normal, $"returning true {source} -> {httpResponse.StatusCode}");
                         return true;
                     }
                     catch (Exception e)

--- a/test/SdkTests/SdkTests.csproj
+++ b/test/SdkTests/SdkTests.csproj
@@ -113,16 +113,20 @@
       <RuntimeTargetDirectory>$(DotnetToTestPath)shared\Microsoft.NETCore.App\$(RuntimeVersionToInstall)</RuntimeTargetDirectory>
     </PropertyGroup>
     <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
-      <InstallRuntimeCommand>powershell -NoLogo -NoProfile -ExecutionPolicy ByPass</InstallRuntimeCommand>
-      <InstallRuntimeCommand>$(InstallRuntimeCommand) "$(_DotNetRoot)dotnet-install.ps1"</InstallRuntimeCommand>
+      <!-- Set TLS1.2 explicitly before running this. If TLS1.2 isnt' enbabled by default this command may fail in some
+           scenarios.  Waiting on a fix to dotnet-install.ps1 to fix this in the right place. -->
+      <InstallRuntimeCommand>powershell -NoLogo -NoProfile -ExecutionPolicy ByPass -Command "&amp; {</InstallRuntimeCommand>
+      <InstallRuntimeCommand>$(InstallRuntimeCommand) [Net.ServicePointManager]::SecurityProtocol = 'Tls12, Tls13';</InstallRuntimeCommand>
+      <InstallRuntimeCommand>$(InstallRuntimeCommand) &amp; '$(DotNetRoot)dotnet-install.ps1'</InstallRuntimeCommand>
       <InstallRuntimeCommand>$(InstallRuntimeCommand) -Version $(RuntimeVersionToInstall)</InstallRuntimeCommand>
       <InstallRuntimeCommand>$(InstallRuntimeCommand) -InstallDir $(DotnetToTestPath)</InstallRuntimeCommand>
-      <InstallRuntimeCommand>$(InstallRuntimeCommand) -Runtime "dotnet"</InstallRuntimeCommand>
-      <InstallRuntimeCommand Condition="'$(Architecture)' != ''">$(InstallRuntimeCommand) -Architecture "$(Architecture)"</InstallRuntimeCommand>
+      <InstallRuntimeCommand>$(InstallRuntimeCommand) -Runtime 'dotnet'</InstallRuntimeCommand>
+      <InstallRuntimeCommand Condition="'$(Architecture)' != ''">$(InstallRuntimeCommand) -Architecture '$(Architecture)'</InstallRuntimeCommand>
+      <InstallRuntimeCommand>$(InstallRuntimeCommand) }"</InstallRuntimeCommand>
     </PropertyGroup>
     <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
       <InstallRuntimeCommand>/bin/bash</InstallRuntimeCommand>
-      <InstallRuntimeCommand>$(InstallRuntimeCommand) "$(_DotNetRoot)dotnet-install.sh"</InstallRuntimeCommand>
+      <InstallRuntimeCommand>$(InstallRuntimeCommand) "$(DotNetRoot)dotnet-install.sh"</InstallRuntimeCommand>
       <InstallRuntimeCommand>$(InstallRuntimeCommand) --version $(RuntimeVersionToInstall)</InstallRuntimeCommand>
       <InstallRuntimeCommand>$(InstallRuntimeCommand) --install-dir "$(DotnetToTestPath)"</InstallRuntimeCommand>
       <InstallRuntimeCommand>$(InstallRuntimeCommand) --runtime "dotnet"</InstallRuntimeCommand>


### PR DESCRIPTION
Porting @mmitche's change #7068 to 3.1.3xx
