### PR TITLE
update dotnet-new-nunit version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- NUnit3.DotNetNew.Template versions do not 'flow in' -->
-    <NUnit3DotNetNewTemplatePackageVersion>1.8.0</NUnit3DotNetNewTemplatePackageVersion>
+    <NUnit3DotNetNewTemplatePackageVersion>1.8.1</NUnit3DotNetNewTemplatePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->


### PR DESCRIPTION
- replace `netcoreapp5.0` to `net5.0` in templates for preview2 and higher to work (https://github.com/nunit/dotnet-new-nunit/issues/38)

Links: 
- https://github.com/nunit/dotnet-new-nunit/releases/tag/v1.8.1
- https://www.nuget.org/packages/NUnit3.DotNetNew.Template/1.8.1

@dotnet/dotnet-cli