### PR TITLE
Try newer docker image for Rhel.6

### DIFF
--- a/eng/docker/rhel.6/Dockerfile
+++ b/eng/docker/rhel.6/Dockerfile
@@ -4,7 +4,7 @@
 #
 
 # Dockerfile that creates a container suitable to build dotnet-cli
-FROM microsoft/dotnet-buildtools-prereqs:centos-6-376e1a3-20174311014331
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:centos-6-203142e-20200131220151
 
 # yum doesn't work with the special curl version we have in the base docker image,
 # so we remove /usr/local/lib from the library path for this command


### PR DESCRIPTION
Attempting to get past the disk space issue that's been hitting the rhel.6 builds in this repo. Test build here: https://dev.azure.com/dnceng/internal/_build/results?buildId=603864