### PR TITLE
Try using hosted pools for Linux

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -83,7 +83,12 @@ stages:
     parameters:
       agentOs: Linux
       pool:
-        name: Hosted Ubuntu 1604
+        ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          name: NetCorePublic-Pool
+          queue: BuildPool.Ubuntu.1604.Amd64.Open
+        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          name: NetCoreInternal-Pool
+          queue: BuildPool.Ubuntu.1604.Amd64
       timeoutInMinutes: 180
       strategy:
         matrix:


### PR DESCRIPTION
Companion to https://github.com/dotnet/installer/pull/7187. Trying out using Helix pools for the Linux runs here, to see if that gets us past the 10 GB limit that's causing rhel.6 to run out of disk space.

Internal build: https://dev.azure.com/dnceng/internal/_build/results?buildId=603935

CC @mmitche @wli3 @sfoslund @dsplaisted 