### PR TITLE
[Release/5.0.1xx-preview4]fixing the ci build for preview4

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -78,7 +78,12 @@ stages:
     parameters:
       agentOs: Linux
       pool:
-        name: Hosted Ubuntu 1604
+        ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          name: NetCorePublic-Pool
+          queue: BuildPool.Ubuntu.1604.Amd64.Open
+        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          name: NetCoreInternal-Pool
+          queue: BuildPool.Ubuntu.1604.Amd64
       timeoutInMinutes: 180
       strategy:
         matrix:


### PR DESCRIPTION
porting this https://github.com/dotnet/installer/commit/d8fdbc223144e814508e057e696e709b0fc573cc


A couple of ci legs are failing in review 4 branch. The above linked commit fixed the "run out of space" for master