### PR TITLE
Remove unneeded parameters from build

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -47,32 +47,35 @@ stages:
               _BuildConfig: Debug
               _BuildArchitecture: x86
               _DOTNET_CLI_UI_LANGUAGE: ''
+              _AdditionalBuildParameters: ''
             Build_ES_Debug_x64:
               _BuildConfig: Debug
               _BuildArchitecture: x64
               _DOTNET_CLI_UI_LANGUAGE: es
+              _AdditionalBuildParameters: ''
           # Internal-only builds
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
             Build_Release_x86:
               _BuildConfig: Release
               _BuildArchitecture: x86
               _DOTNET_CLI_UI_LANGUAGE: ''
+              _AdditionalBuildParameters: ''
           # Always run builds
           Build_Release_x64:
             _BuildConfig: Release
             _BuildArchitecture: x64
             _DOTNET_CLI_UI_LANGUAGE: ''
-            _AdditionalBuildParameters: '/p:PublishInternalAsset=true
-              /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
-              /p:DotNetPublishBlobFeedUrl=$(_ArcadePublishBlobFeedUrl)'
+            _AdditionalBuildParameters: '/p:PublishInternalAsset=true'
           Build_Release_arm:
             _BuildConfig: Release
             _BuildArchitecture: arm
             _DOTNET_CLI_UI_LANGUAGE: ''
+            _AdditionalBuildParameters: ''
           Build_Release_arm64:
             _BuildConfig: Release
             _BuildArchitecture: arm64
             _DOTNET_CLI_UI_LANGUAGE: ''
+            _AdditionalBuildParameters: ''
 
   - template: /eng/build.yml
     parameters:

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -56,13 +56,7 @@ phases:
         - _PushToVSFeed: true
         - _SignType: real
         - _BuildArgs: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-                  /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
-                  /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
-                  /p:DotNetPublishBlobFeedUrl=$(PB_PublishBlobFeedUrl)
                   /p:DotnetPublishSdkAssetsBlobFeedUrl=$(_PublishBlobFeedUrl)
-                  /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
-                  /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
-                  /p:PB_PublishType=blob
                   /p:DotnetPublishChecksumsBlobFeedUrl=$(_PublishChecksumsBlobFeedUrl)
                   /p:DotNetSignType=real
                   /p:TeamName=$(_TeamName)


### PR DESCRIPTION
Removes a bunch of old unused parameters and adds _AdditionalParameters to the whole matrix so AzDO doesn't throw out noisy warnings
