### PR TITLE
Use PublishTestResults@2 task in AzDO build

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -144,7 +144,7 @@ phases:
           publishFeedCredentials: 'DevDiv - VS package feed'
         condition: and(succeeded(), eq(variables['_PushToVSFeed'], 'true'), eq(variables['_DotNetPublishToBlobFeed'], 'true'), or(eq(variables['_BuildArchitecture'], 'x64'), eq(variables['_BuildArchitecture'], 'x86')))
 
-    - task: PublishTestResults@1	
+    - task: PublishTestResults@2	
       displayName: Publish Test Results	
       inputs:
         testRunner: XUnit	


### PR DESCRIPTION
The build produces warnings about using the old task:

```
##[warning]Task 'PublishTestResults' (1.0.45) is using deprecated task execution handler. The task should use the supported task-lib: https://aka.ms/tasklib
```

Just something I noticed while looking at a PR.