### PR TITLE
[release/5.0.1xx-preview4] Update dotnet-new-nunit version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- NUnit3.DotNetNew.Template versions do not 'flow in' -->
-    <NUnit3DotNetNewTemplatePackageVersion>1.8.0</NUnit3DotNetNewTemplatePackageVersion>
+    <NUnit3DotNetNewTemplatePackageVersion>1.8.1</NUnit3DotNetNewTemplatePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->


### PR DESCRIPTION
Porting #7169 to preview4.

Replace `netcoreapp5.0` to `net5.0` for preview2 and higher to work (https://github.com/nunit/dotnet-new-nunit/issues/38)
