### PR TITLE
Add arm64 as a possible WinForms arch

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -108,6 +108,9 @@
       <WindowsDesktop30RuntimePackRids Include="win-x64;win-x86" />
       <WindowsDesktop31RuntimePackRids Include="@(WindowsDesktop30RuntimePackRids)" />
       <WindowsDesktopRuntimePackRids Include="@(WindowsDesktop31RuntimePackRids)" />
+      <!-- TODO: remove this once WPF is available on ARM64 and replace usage
+            of this group for WindowsDesktopRuntimePackRids. -->
+      <WindowsDesktopRuntimePackWinformsRids Include="@(WindowsDesktopRuntimePackRids);win-arm64" />
     </ItemGroup>
 
     <!--
@@ -256,7 +259,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                               TargetingPackName="Microsoft.WindowsDesktop.App.Ref"
                               TargetingPackVersion="$(MicrosoftWindowsDesktopAppRefPackageVersion)"
                               RuntimePackNamePatterns="Microsoft.WindowsDesktop.App.Runtime.**RID**"
-                              RuntimePackRuntimeIdentifiers="@(WindowsDesktopRuntimePackRids, '%3B')"
+                              RuntimePackRuntimeIdentifiers="@(WindowsDesktopRuntimePackWinformsRids, '%3B')"
                               IsWindowsOnly="true"
                               Profile="WindowsForms"
                               />

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -283,7 +283,7 @@
 
     <PropertyGroup>
       <IncludeWpfAndWinForms Condition=" '$(IncludeWpfAndWinForms)' == '' AND '$(Architecture)' == 'arm'">false</IncludeWpfAndWinForms>
-      <IncludeWpfAndWinForms Condition=" '$(IncludeWpfAndWinForms)' == '' AND '$(OS)' == 'Windows_NT' AND '$(Architecture)' != 'arm64' ">true</IncludeWpfAndWinForms>
+      <IncludeWpfAndWinForms Condition=" '$(IncludeWpfAndWinForms)' == '' AND '$(OS)' == 'Windows_NT'">true</IncludeWpfAndWinForms>
       <IncludeWpfAndWinForms Condition=" '$(IncludeWpfAndWinForms)' == '' ">false</IncludeWpfAndWinForms>
     </PropertyGroup>
 

--- a/test/EndToEnd/ProjectBuildTests.cs
+++ b/test/EndToEnd/ProjectBuildTests.cs
@@ -83,7 +83,7 @@ namespace EndToEnd.Tests
                 .Should().Pass().And.HaveStdOutContaining("Hello World!");
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void ItCanPublishArm64Winforms()
         {
             DirectoryInfo directory = TestAssets.CreateTestDirectory();
@@ -109,7 +109,7 @@ namespace EndToEnd.Tests
             selfContainedPublishDir.Should().HaveFilesMatching($"{directory.Name}.dll", SearchOption.TopDirectoryOnly);
         }
         
-        [Fact]
+        [WindowsOnlyFact]
         public void ItCantPublishArm64Wpf()
         {
             DirectoryInfo directory = TestAssets.CreateTestDirectory();

--- a/test/EndToEnd/ProjectBuildTests.cs
+++ b/test/EndToEnd/ProjectBuildTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Xml.Linq;
 using Microsoft.DotNet.TestFramework;
@@ -80,6 +81,51 @@ namespace EndToEnd.Tests
                 .WithWorkingDirectory(projectDirectory)
                 .ExecuteWithCapturedOutput()
                 .Should().Pass().And.HaveStdOutContaining("Hello World!");
+        }
+
+        [Fact]
+        public void ItCanPublishArm64Winforms()
+        {
+            DirectoryInfo directory = TestAssets.CreateTestDirectory();
+            string projectDirectory = directory.FullName;
+
+            string newArgs = "winforms --no-restore";
+            new NewCommandShim()
+                .WithWorkingDirectory(projectDirectory)
+                .Execute(newArgs)
+                .Should().Pass();
+
+            string publishArgs="-r win-arm64";
+            new PublishCommand()
+                .WithWorkingDirectory(projectDirectory)
+                .Execute(publishArgs)
+                .Should().Pass();
+            
+            var selfContainedPublishDir = new DirectoryInfo(projectDirectory)
+                .Sub("bin").Sub("Debug").GetDirectories().FirstOrDefault()
+                .Sub("win-arm64").Sub("publish");
+
+            selfContainedPublishDir.Should().HaveFilesMatching("System.Windows.Forms.dll", SearchOption.TopDirectoryOnly);
+            selfContainedPublishDir.Should().HaveFilesMatching($"{directory.Name}.dll", SearchOption.TopDirectoryOnly);
+        }
+        
+        [Fact]
+        public void ItCantPublishArm64Wpf()
+        {
+            DirectoryInfo directory = TestAssets.CreateTestDirectory();
+            string projectDirectory = directory.FullName;
+
+            string newArgs = "wpf --no-restore";
+            new NewCommandShim()
+                .WithWorkingDirectory(projectDirectory)
+                .Execute(newArgs)
+                .Should().Pass();
+
+            string publishArgs="-r win-arm64";
+            new PublishCommand()
+                .WithWorkingDirectory(projectDirectory)
+                .Execute(publishArgs)
+                .Should().Fail();
         }
 
         [Theory]


### PR DESCRIPTION
Makes it possible to build/publish ARM64 WinForms apps.

- If an app tries anything requiring `UseWPF` it will fail as a build time scenario as there's no available runtime pack.
- Anything using `UsingWindowsForms` will correctly compile and run natively as long as all the references are in the assemblies produced by winforms.

cc: @merriemcgaw, @tommcdon 