### PR TITLE
Change to correct channel

### DIFF
--- a/src/CopyToLatest/targets/BranchInfo.props
+++ b/src/CopyToLatest/targets/BranchInfo.props
@@ -1,5 +1,5 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Channel>release/3.1.3xx</Channel>
+    <Channel>release/3.1.4xx</Channel>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/11631

3.1.4xx builds were being published to channel release/3.1.3xx.
This fixes so that they will be published to release/3.1.4xx.