### PR TITLE
Don't include ios, tvos, android, and browser RIDs for AppHosts

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -73,8 +73,10 @@
 
       <NetCore31RuntimePackRids Include="@(NetCore30RuntimePackRids)"/>
 
+      <NetCore5AppHostRids Include="@(NetCore31RuntimePackRids)"/>
+      
       <NetCore5RuntimePackRids Include="
-          @(NetCore31RuntimePackRids);
+          @(NetCore5AppHostRids);
           ios-arm64;
           ios-arm;
           ios-x64;
@@ -88,7 +90,8 @@
           browser-wasm;
           " />
 
-      <NetCoreRuntimePackRids Include="@(NetCore5RuntimePackRids)"/>
+      <NetCoreAppHostRids Include="@(NetCore5AppHostRids)" />
+      <NetCoreRuntimePackRids Include="@(NetCore5RuntimePackRids)" />
 
       <AspNetCore30RuntimePackRids Include="
         win-x64;
@@ -215,7 +218,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                       TargetFramework="netcoreapp5.0"
                       AppHostPackNamePattern="Microsoft.NETCore.App.Host.**RID**"
                       AppHostPackVersion="$(_NETCoreAppPackageVersion)"
-                      AppHostRuntimeIdentifiers="@(NetCoreRuntimePackRids, '%3B')"
+                      AppHostRuntimeIdentifiers="@(NetCoreAppHostRids, '%3B')"
                       />
 
     <KnownCrossgen2Pack Include="Microsoft.NETCore.App.Crossgen2"


### PR DESCRIPTION
Changes in dotnet/sdk#11183 and dotnet/sdk#11623 disable downloading app hosts for ios, tvos, android, and browser RIDs when a single RuntimeIdentifier is specified.  However, if these RIDs are specified in `RuntimeIdentifiers`, the `ResolveAppHost` task will add corresponding AppHost packages to download, which will fail because they don't exist.

This change removes these RuntimeIdentifiers from the list of RIDs supported in the `KnownAppHost` pack item.  This should mean that ResolveAppHost will no longer try to download those nonexistent runtime packs.

@akoeplinger @swaroop-sridhar @jonathanpeppers