### PR TITLE
Disable SDL and other validation

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -260,14 +260,13 @@ stages:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng\common\templates\post-build\post-build.yml
     parameters:
-      # Symbol validation isn't being very reliable lately. This should be enabled back
-      # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871
       enableSymbolValidation: false
-      # This repo doesn't produce any signed packages.
       enableSigningValidation: false
+      enableNugetValidation: false
+      enableSourceLinkValidation: false
       publishInstallersAndChecksums: true
       SDLValidationParameters:
-        enable: true
+        enable: false
         params: ' -SourceToolsList @("policheck","credscan")
         -TsaInstanceURL $(_TsaInstanceURL)
         -TsaProjectName $(_TsaProjectName)


### PR DESCRIPTION
After onboarding to post-build/nightly SDL validation, all this validation is run once a day and so can be removed from the build, saving significant time.
