### PR TITLE
Revert prior Microsoft.DotNet.Sdk.Internal fixes and fix in a different way.

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -50,11 +50,9 @@
       <AssetManifestFileName Condition="'$(AGENT_JOBNAME)' != ''">$(AssetManifestFileName)-$(AGENT_JOBNAME)</AssetManifestFileName>
       <AssetManifestFileName Condition="'$(AGENT_JOBNAME)' == '' and '$(Architecture)' != ''">$(AssetManifestFileName)-$(Architecture)</AssetManifestFileName>
       <ChecksumsAssetManifestFileName>$(AssetManifestFileName)-checksums</ChecksumsAssetManifestFileName>
-      <PackagesManifestFileName>$(AssetManifestFileName)-packages</PackagesManifestFileName>
       <!-- Property AssetManifestFilePath will be reassigned by the Arcade SDK, so use a different name (DotNetAssetManifestFilePath) -->
       <DotNetAssetManifestFilePath>$(ArtifactsLogDir)AssetManifest\$(AssetManifestFileName).xml</DotNetAssetManifestFilePath>
       <ChecksumsAssetManifestFilePath>$(ArtifactsLogDir)AssetManifest\$(ChecksumsAssetManifestFileName).xml</ChecksumsAssetManifestFilePath>
-      <PackagesManifestFilePath>$(ArtifactsLogDir)AssetManifest\$(PackagesManifestFileName).xml</PackagesManifestFilePath>
 
       <DotnetTempWorkingDirectory>$(ArtifactsDir)..\DotnetAssetsTmpDir\$([System.Guid]::NewGuid())</DotnetTempWorkingDirectory>
       <ChecksumTempWorkingDirectory>$(ArtifactsDir)..\ChecksumAssetsTmpDir\$([System.Guid]::NewGuid())</ChecksumTempWorkingDirectory>
@@ -76,7 +74,6 @@
         Condition=" '$(PublishBinariesAndBadge)' == 'true' and '$(OS)' == 'Windows_NT' and '$(Architecture)' == 'x64'" />
     <SdkAssetsToPublish Include="$(ArtifactsShippingPackagesDir)productCommit-*.txt" Condition=" '$(PublishBinariesAndBadge)' == 'true' " />
     <SdkNonShippingAssetsToPublish Include="$(ArtifactsNonShippingPackagesDir)*.nupkg" />
-    <SdkNonShippingAssetsToPublish Remove="$(ArtifactsNonShippingPackagesDir)Microsoft.Dotnet.Sdk.Internal.*.nupkg" />
     <SdkNonShippingAssetsToPublish Include="$(ArtifactsNonShippingPackagesDir)*.swr" />
     <SdkNonShippingAssetsToPublish Include="$(ArtifactsNonShippingPackagesDir)*.msi" />
     <SdkNonShippingAssetsToPublish Condition="'$(PublishBinariesAndBadge)' != 'false'" Include="$(ArtifactsNonShippingPackagesDir)*.tar.gz" />
@@ -87,7 +84,6 @@
     <CheckSumsToPublish Remove="$(ArtifactsShippingPackagesDir)productVersion.txt.sha" Condition=" '$(OS)' != 'Windows_NT' or '$(Architecture)' != 'x64'" />
     <CheckSumsToPublish Remove="$(ArtifactsShippingPackagesDir)*.zip.sha" Condition=" '$(PublishBinariesAndBadge)' == 'false' "/>
     <CheckSumsToPublish Remove="$(ArtifactsShippingPackagesDir)*.tar.gz.sha" Condition=" '$(PublishBinariesAndBadge)' == 'false' "/>
-    <SdkNonShippingPackagesToPublish Include="$(ArtifactsNonShippingPackagesDir)Microsoft.Dotnet.Sdk.Internal.*.nupkg" />
   </ItemGroup>
 
   <Target Name="PublishSdkAssetsAndChecksums"
@@ -134,10 +130,6 @@
         <RelativeBlobPath>$(BlobStoragePartialRelativePath)/$(FullNugetVersion)/$([System.String]::Copy('%(Filename)%(Extension)'))</RelativeBlobPath>
         <ManifestArtifactData>NonShipping=true</ManifestArtifactData>
       </SdkAssetsToPushToBlobFeed>
-      
-      <SdkPackagesToPush Include="@(SdkNonShippingPackagesToPublish)">
-        <ManifestArtifactData>NonShipping=true</ManifestArtifactData>
-      </SdkPackagesToPush>
 
       <ChecksumsToPushToBlobFeed Include="@(CheckSumsToPublish)">
         <RelativeBlobPath>$(BlobStoragePartialRelativePath)/$(FullNugetVersion)/$([System.String]::Copy('%(Filename)%(Extension)'))</RelativeBlobPath>
@@ -173,16 +165,5 @@
       ManifestCommit="$(BUILD_SOURCEVERSION)"
       AssetManifestPath="$(ChecksumsAssetManifestFilePath)"
       PublishFlatContainer="true" />
-    
-    <!-- Push the sdk internal sentinel package -->
-    <PushToAzureDevOpsArtifacts
-      ItemsToPush="@(SdkPackagesToPush)"
-      ManifestBuildData="@(ManifestBuildData)"
-      ManifestRepoUri="$(BUILD_REPOSITORY_URI)"
-      ManifestBranch="$(BUILD_SOURCEBRANCH)"
-      ManifestBuildId="$(BUILD_BUILDNUMBER)"
-      ManifestCommit="$(BUILD_SOURCEVERSION)"
-      AssetManifestPath="$(PackagesManifestFilePath)"
-      PublishFlatContainer="false" />
   </Target>
 </Project>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -43,15 +43,18 @@
 
   <PropertyGroup>
       <!-- Because we may be building in a container, we should use an asset manifest file path
-             that exists in the container. Disambiguate the manifests via available properties.
-             AGENT_OS and AGENT_JOBNAME are present on Azure DevOps agents -->
-      <AssetManifestFileName Condition="'$(AGENT_OS)' != ''">$(AGENT_OS)</AssetManifestFileName>
-      <AssetManifestFileName Condition="'$(AGENT_OS)' == ''">$(OS)</AssetManifestFileName>
-      <AssetManifestFileName Condition="'$(AGENT_JOBNAME)' != ''">$(AssetManifestFileName)-$(AGENT_JOBNAME)</AssetManifestFileName>
-      <AssetManifestFileName Condition="'$(AGENT_JOBNAME)' == '' and '$(Architecture)' != ''">$(AssetManifestFileName)-$(Architecture)</AssetManifestFileName>
-      <ChecksumsAssetManifestFileName>$(AssetManifestFileName)-checksums</ChecksumsAssetManifestFileName>
-      <!-- Property AssetManifestFilePath will be reassigned by the Arcade SDK, so use a different name (DotNetAssetManifestFilePath) -->
-      <DotNetAssetManifestFilePath>$(ArtifactsLogDir)AssetManifest\$(AssetManifestFileName).xml</DotNetAssetManifestFilePath>
+           that exists in the container. Disambiguate the manifests via available properties.
+           AGENT_OS and AGENT_JOBNAME are present on Azure DevOps agents. AssetManifestOS will also
+           be used by arcade to generate the name of the manifest file name for the built in publishing. -->
+      <AssetManifestOS Condition="'$(AGENT_OS)' != ''">$(AGENT_OS)</AssetManifestOS>
+      <AssetManifestOS Condition="'$(AGENT_OS)' == ''">$(OS)</AssetManifestOS>
+      <AssetManifestOS Condition="'$(AGENT_JOBNAME)' != ''">$(AssetManifestOS)-$(AGENT_JOBNAME)</AssetManifestOS>
+      <BaseAssetManifestFileName>$(AssetManifestOS)</BaseAssetManifestFileName>
+      <BaseAssetManifestFileName Condition="'$(AGENT_JOBNAME)' == '' and '$(Architecture)' != ''">$(AssetManifestOS)-$(Architecture)</BaseAssetManifestFileName>
+      <InstallersAssetManifestFileName>$(BaseAssetManifestFileName)-installers</InstallersAssetManifestFileName>
+      <ChecksumsAssetManifestFileName>$(BaseAssetManifestFileName)-checksums</ChecksumsAssetManifestFileName>
+      <!-- Property AssetManifestFilePath would be reassigned by the Arcade SDK, so use a different name (InstallersAssetManifestFilePath) -->
+      <InstallersAssetManifestFilePath>$(ArtifactsLogDir)AssetManifest\$(InstallersAssetManifestFileName).xml</InstallersAssetManifestFilePath>
       <ChecksumsAssetManifestFilePath>$(ArtifactsLogDir)AssetManifest\$(ChecksumsAssetManifestFileName).xml</ChecksumsAssetManifestFilePath>
 
       <DotnetTempWorkingDirectory>$(ArtifactsDir)..\DotnetAssetsTmpDir\$([System.Guid]::NewGuid())</DotnetTempWorkingDirectory>
@@ -153,7 +156,7 @@
       ManifestBranch="$(BUILD_SOURCEBRANCH)"
       ManifestBuildId="$(BUILD_BUILDNUMBER)"
       ManifestCommit="$(BUILD_SOURCEVERSION)"
-      AssetManifestPath="$(DotNetAssetManifestFilePath)"
+      AssetManifestPath="$(InstallersAssetManifestFilePath)"
       PublishFlatContainer="true" />
 
     <PushToAzureDevOpsArtifacts

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -87,7 +87,7 @@
     <CheckSumsToPublish Remove="$(ArtifactsShippingPackagesDir)productVersion.txt.sha" Condition=" '$(OS)' != 'Windows_NT' or '$(Architecture)' != 'x64'" />
     <CheckSumsToPublish Remove="$(ArtifactsShippingPackagesDir)*.zip.sha" Condition=" '$(PublishBinariesAndBadge)' == 'false' "/>
     <CheckSumsToPublish Remove="$(ArtifactsShippingPackagesDir)*.tar.gz.sha" Condition=" '$(PublishBinariesAndBadge)' == 'false' "/>
-    <SdkNonShippingPackagesToPublish Include="$(ArtifactsNonShippingPackagesDir)Microsoft.Dotnet.Sdk.Internal.*.nupkg" Condition="'$(OS)' == 'Windows_NT' and '$(Architecture)' == 'x64'" />
+    <SdkNonShippingPackagesToPublish Include="$(ArtifactsNonShippingPackagesDir)Microsoft.Dotnet.Sdk.Internal.*.nupkg" />
   </ItemGroup>
 
   <Target Name="PublishSdkAssetsAndChecksums"
@@ -183,7 +183,6 @@
       ManifestBuildId="$(BUILD_BUILDNUMBER)"
       ManifestCommit="$(BUILD_SOURCEVERSION)"
       AssetManifestPath="$(PackagesManifestFilePath)"
-      PublishFlatContainer="false"
-      Condition="'@(SdkPackagesToPush)' != ''" />
+      PublishFlatContainer="false" />
   </Target>
 </Project>


### PR DESCRIPTION
Revert the previous two fixes for this package. They were correct only if installer didn't also use the arcade publishing infra for some packages. Instead:

Set the asset manifest OS and change the name of the installers manifests.
Currently arcade defaults to using OS-Platform as the asset manifest file name.
Installer does a ton of building in docker containers, which ends up generating
many overlapping names. This means that asset manifest kept getting overwritten
and some packages were getting missed for publishing each time (x64 or x86 vs.redist packages).
This didn't really matter because the build contains an explicit publish step to the VS feeds.

To fix, change the name of the blob asset manifest name to include a "-installers" suffix.
Then alter the property names around a bit so that AssetManifestOS is set
prior to publish.proj's publish target being run.