### PR TITLE
Update test-templates

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -67,13 +67,13 @@
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>fae3dd12aeba7c9995f69bfaa1c9b74d82307ef1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="1.0.2-beta4.20303.2">
+    <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="1.0.2-beta4.20407.5">
       <Uri>https://github.com/dotnet/test-templates</Uri>
-      <Sha>6865397797d0e0c36d8db45a4ea5f916ce616b9c</Sha>
+      <Sha>345cad2a4a3f7dffd53104cb1aa3d582faafb85d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.5.0" Version="1.0.2-beta4.20303.2">
+    <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.5.0" Version="1.0.2-beta4.20407.5">
       <Uri>https://github.com/dotnet/test-templates</Uri>
-      <Sha>6865397797d0e0c36d8db45a4ea5f916ce616b9c</Sha>
+      <Sha>345cad2a4a3f7dffd53104cb1aa3d582faafb85d</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="5.0.0-preview.8.20322.2" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/templating</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -29,7 +29,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/test-templates -->
-    <MicrosoftDotNetTestProjectTemplates50PackageVersion>1.0.2-beta4.20303.2</MicrosoftDotNetTestProjectTemplates50PackageVersion>
+    <MicrosoftDotNetTestProjectTemplates50PackageVersion>1.0.2-beta4.20407.5</MicrosoftDotNetTestProjectTemplates50PackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- NUnit3.DotNetNew.Template versions do not 'flow in' -->
@@ -113,7 +113,7 @@
     <NUnit3Templates21PackageVersion>1.5.3</NUnit3Templates21PackageVersion>
     <MicrosoftDotNetCommonItemTemplates21PackageVersion>1.0.2-beta3</MicrosoftDotNetCommonItemTemplates21PackageVersion>
     <MicrosoftDotNetCommonProjectTemplates21PackageVersion>$(MicrosoftDotNetCommonItemTemplates21PackageVersion)</MicrosoftDotNetCommonProjectTemplates21PackageVersion>
-    <MicrosoftDotNetTestProjectTemplates21PackageVersion>1.0.2-beta4.20303.2</MicrosoftDotNetTestProjectTemplates21PackageVersion>
+    <MicrosoftDotNetTestProjectTemplates21PackageVersion>1.0.2-beta4.20407.5</MicrosoftDotNetTestProjectTemplates21PackageVersion>
     <AspNetCorePackageVersionFor21Templates>2.1.14</AspNetCorePackageVersionFor21Templates>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->


### PR DESCRIPTION
Port changes from #8122 to preview8 branch, to get templates for xUnit updated to version that is compatible with net5.0.

Microsoft.DotNet.Test.ProjectTemplates.2.1 , Microsoft.DotNet.Test.ProjectTemplates.5.0
 From Version 1.0.2-beta4.20303.2 -> To Version 1.0.2-beta4.20407.5