### PR TITLE
Ensure rzc.dll and PresentationBuildTasks.dll are signed

### DIFF
--- a/src/redist/targets/Signing.targets
+++ b/src/redist/targets/Signing.targets
@@ -108,6 +108,8 @@
                             $(SdkOutputDirectory)**/datacollector.exe;
                             $(SdkOutputDirectory)**/MSBuild.dll;
                             $(SdkOutputDirectory)**/MSBuild.resources.dll;
+                            $(SdkOutputDirectory)**/PresentationBuildTasks.dll;
+                            $(SdkOutputDirectory)**/rzc.dll;
                             $(SdkOutputDirectory)**/testhost.dll;
                             $(SdkOutputDirectory)**/testhost.exe;
                             $(SdkOutputDirectory)**/testhost.x86.exe;


### PR DESCRIPTION
SDK DLLs are crossgen'd during the installer build and then resigned. Two files are currently not being picked up by the existing globs: rzc.dll (this is part of the Razor SDK) and PresentationBuildTasks.dll (windows desktop).

The unsigned files are blocking the insertion into VS.
