### PR TITLE
Ensure rzc.dll and PresentationBuildTasks.dll are signed

### DIFF
--- a/src/redist/targets/Signing.targets
+++ b/src/redist/targets/Signing.targets
@@ -108,6 +108,8 @@
                             $(SdkOutputDirectory)**/datacollector.exe;
                             $(SdkOutputDirectory)**/MSBuild.dll;
                             $(SdkOutputDirectory)**/MSBuild.resources.dll;
+                            $(SdkOutputDirectory)**/PresentationBuildTasks.dll;
+                            $(SdkOutputDirectory)**/rzc.dll;
                             $(SdkOutputDirectory)**/testhost.dll;
                             $(SdkOutputDirectory)**/testhost.exe;
                             $(SdkOutputDirectory)**/testhost.x86.exe;


### PR DESCRIPTION
After running crossgen, SDK binaries need to be signed. The current globbing patterns excluded rzc.dll and PresentationBuildTasks.dll
