### PR TITLE
Remove fake dependency edge for WCF

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -96,12 +96,6 @@
       <Uri>https://github.com/dotnet/wpf</Uri>
       <Sha>973ffc6e2edf170124176e7ebf0a850bdc1b359f</Sha>
     </Dependency>
-    <!-- This is so that WCF packages are included in the final drop for official releases. -->
-    <!-- Replace with better solution, see https://github.com/dotnet/arcade/issues/4162 -->
-    <Dependency Name="System.ServiceModel.Primitives" Version="5.0.0-preview1.20104.1">
-      <Uri>https://github.com/dotnet/wcf</Uri>
-      <Sha>d08484b1422ee45195adff528d6c65c7c788d7fa</Sha>
-    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.20407.3">


### PR DESCRIPTION
Like extensions or additional SDKs, when we want to ship wcf, we just add
another BAR build id to the list of IDs to send to the staging pipeline
