### PR TITLE
Update dependencies from https://github.com/dotnet/sdk build 20200304.1

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -75,13 +75,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>f15388ee6e45a8923fba0f54f55154aee991fb84</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="5.0.100-preview.2.20152.2">
+    <Dependency Name="Microsoft.NET.Sdk" Version="5.0.100-preview.1.20154.2">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>e596309d1fb1f4944f3f7706f3dc83343ddd14a4</Sha>
+      <Sha>5ae7875811f6559583710ad26e6f7a92f927e09e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="5.0.100-preview.2.20152.2">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="5.0.100-preview.1.20154.2">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>e596309d1fb1f4944f3f7706f3dc83343ddd14a4</Sha>
+      <Sha>5ae7875811f6559583710ad26e6f7a92f927e09e</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-preview.2.20154.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -50,14 +50,14 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/cli -->
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>5.0.100-preview.2.20152.2</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>5.0.100-preview.1.20154.2</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicroBuildCorePackageVersion>0.2.0</MicroBuildCorePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk (to run tests) -->
-    <MicrosoftNETSdkPackageVersion>5.0.100-preview.2.20152.2</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>5.0.100-preview.1.20154.2</MicrosoftNETSdkPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION

Fixes #- Microsoft.DotNet.MSBuildSdkResolver - 5.0.100-preview.1.20154.2
- Microsoft.NET.Sdk - 5.0.100-preview.1.20154.2

- Please add description for changes you are making.
- If there is an issue related to this PR, please add the reference.
