### PR TITLE
Update to the latest 3.1 AspNetCore template package

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -100,7 +100,7 @@
     <MicrosoftDotNetCommonItemTemplates31PackageVersion>3.1.2</MicrosoftDotNetCommonItemTemplates31PackageVersion>
     <MicrosoftDotNetCommonProjectTemplates31PackageVersion>$(MicrosoftDotNetCommonItemTemplates31PackageVersion)</MicrosoftDotNetCommonProjectTemplates31PackageVersion>
     <MicrosoftDotNetTestProjectTemplates31PackageVersion>$(MicrosoftDotNetTestProjectTemplates50PackageVersion)</MicrosoftDotNetTestProjectTemplates31PackageVersion>
-    <AspNetCorePackageVersionFor31Templates>3.1.2</AspNetCorePackageVersionFor31Templates>
+    <AspNetCorePackageVersionFor31Templates>3.1.7</AspNetCorePackageVersionFor31Templates>
     <!-- 3.0 Template versions -->
     <MicrosoftDotnetWinFormsProjectTemplates30PackageVersion>4.8.0-rc2.19462.10</MicrosoftDotnetWinFormsProjectTemplates30PackageVersion>
     <MicrosoftDotNetWpfProjectTemplates30PackageVersion>3.0.0</MicrosoftDotNetWpfProjectTemplates30PackageVersion>


### PR DESCRIPTION
The 3.1 AspNetCore templates in the 5.0 SDK need to be manually updated. This change updates the templates to v3.1.7.