### PR TITLE
Add light command packages gathering

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -102,5 +102,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>83fda4b3f6d93e713749fd1b27c4a6d40b118b13</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="5.0.0-beta.20417.6">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>83fda4b3f6d93e713749fd1b27c4a6d40b118b13</Sha>
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,6 +16,10 @@
     <CliProductBandVersion>$(MajorMinorVersion).$(VersionSDKMinor)</CliProductBandVersion>
   </PropertyGroup>
   <PropertyGroup>
+    <!-- Dependency from https://github.com/dotnet/arcade -->
+    <MicrosoftDotNetBuildTasksInstallersPackageVersion>5.0.0-beta.20417.6</MicrosoftDotNetBuildTasksInstallersPackageVersion>
+  </PropertyGroup>
+  <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/winforms -->
     <MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>5.0.0-rc.1.20370.3</MicrosoftDotnetWinFormsProjectTemplatesPackageVersion>
   </PropertyGroup>

--- a/src/redist/targets/GenerateMSIs.targets
+++ b/src/redist/targets/GenerateMSIs.targets
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Installers" Version="$(MicrosoftDotNetBuildTasksInstallersPackageVersion)" />
+  </ItemGroup>
+  
+  <PropertyGroup>
+    <MicrosoftDotNetBuildTasksInstallersTaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(NuGetPackageRoot)microsoft.dotnet.build.tasks.installers\$(MicrosoftDotNetBuildTasksInstallersPackageVersion)\tools\netcoreapp2.0\Microsoft.DotNet.Build.Tasks.Installers.dll</MicrosoftDotNetBuildTasksInstallersTaskAssembly>
+    <MicrosoftDotNetBuildTasksInstallersTaskAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(NuGetPackageRoot)microsoft.dotnet.build.tasks.installers\$(MicrosoftDotNetBuildTasksInstallersPackageVersion)\tools\net472\Microsoft.DotNet.Build.Tasks.Installers.dll</MicrosoftDotNetBuildTasksInstallersTaskAssembly>
+  </PropertyGroup>
+
+  <UsingTask TaskName="CreateLightCommandPackageDrop" AssemblyFile="$(MicrosoftDotNetBuildTasksInstallersTaskAssembly)" />
+  
   <Target Name="SetupWixProperties" DependsOnTargets="GetCurrentRuntimeInformation">
     <!-- AcquireWix Properties -->
     <PropertyGroup>
@@ -34,6 +45,11 @@
       <SdkMSBuildExtensionsNuspecFile>$(MSBuildThisFileDirectory)packaging/windows/clisdk/VS.Redist.Common.Net.Core.SDK.MSBuildExtensions.nuspec</SdkMSBuildExtensionsNuspecFile>
       <SdkMSBuildExtensionsNupkgFile>$(ArtifactsNonShippingPackagesDir)VS.Redist.Common.Net.Core.SDK.MSBuildExtensions.$(FullNugetVersion).nupkg</SdkMSBuildExtensionsNupkgFile>
       <SdkMSBuildExtensionsSwrFile>$(ArtifactsNonShippingPackagesDir)VS.Redist.Common.Net.Core.SDK.MSBuildExtensions.swr</SdkMSBuildExtensionsSwrFile>
+
+      <!-- Temp directory for light command layouts -->
+      <LightCommandObjDir>$(ArtifactsObjDir)/LightCommandPackages</LightCommandObjDir>
+      <!-- Directory for the zipped up light command package -->
+      <LightCommandPackagesDir>$(ArtifactsNonShippingPackagesDir)</LightCommandPackagesDir>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -173,6 +189,27 @@
                       '$(Architecture)' ^
                       '$(SdkStableFileIdForApphostTransform)' ^
                       -InformationAction Continue" />
+    <ItemGroup>
+        <SdkMsiWixSrcFiles Include="$(WixRoot)\dotnet.wixobj" />
+        <SdkMsiWixSrcFiles Include="$(WixRoot)\provider.wixobj" />
+        <SdkMsiWixSrcFiles Include="$(WixRoot)\registrykeys.wixobj" />
+        <SdkMsiWixSrcFiles Include="$(WixRoot)\install-files.wixobj" />
+    </ItemGroup>
+    <CreateLightCommandPackageDrop
+      LightCommandWorkingDir="$(LightCommandObjDir)"
+      NoLogo="true"
+      Cultures="en-us"
+      Out="$(SdkMSIInstallerFile)"
+      WixExtensions="WixUIExtension;WixDependencyExtension;WixUtilExtension"
+      WixSrcFiles="@(SdkMsiWixSrcFiles)">
+      <Output TaskParameter="LightCommandPackageNameOutput" PropertyName="_LightCommandPackageNameOutput" />
+    </CreateLightCommandPackageDrop>
+    <MakeDir Directories="$(LightCommandPackagesDir)" />
+
+    <ZipDirectory
+      DestinationFile="$(LightCommandPackagesDir)/LightCommandPackage-$(_LightCommandPackageNameOutput).zip"
+      SourceDirectory="$(LightCommandObjDir)/$(_LightCommandPackageNameOutput)"
+      Overwrite="true" />
   </Target>
 
   <Target Name="GenerateSdkPlaceholderMsi"
@@ -192,27 +229,67 @@
                       '$(SdkPlaceholderDependencyKeyName)' ^
                       '$(Architecture)' ^
                       -InformationAction Continue" />
+    <ItemGroup>
+        <SdkPlaceholdMsiWixSrcFiles Include="$(WixRoot)\provider.wixobj" />
+        <SdkPlaceholdMsiWixSrcFiles Include="$(WixRoot)\sdkplaceholder.wixobj" />
+    </ItemGroup>
+    <CreateLightCommandPackageDrop
+      LightCommandWorkingDir="$(LightCommandObjDir)"
+      NoLogo="true"
+      Cultures="en-us"
+      Out="$(SdkPlaceholderMSIInstallerFile)"
+      WixExtensions="WixUIExtension;WixDependencyExtension;WixUtilExtension"
+      WixSrcFiles="@(SdkPlaceholdMsiWixSrcFiles)"
+      AdditionalBasePaths="$(MSBuildThisFileDirectory)packaging/windows/clisdk">
+      <Output TaskParameter="LightCommandPackageNameOutput" PropertyName="_LightCommandPackageNameOutput" />
+    </CreateLightCommandPackageDrop>
+    <MakeDir Directories="$(LightCommandPackagesDir)" />
+
+    <ZipDirectory
+      DestinationFile="$(LightCommandPackagesDir)/LightCommandPackage-$(_LightCommandPackageNameOutput).zip"
+      SourceDirectory="$(LightCommandObjDir)/$(_LightCommandPackageNameOutput)"
+      Overwrite="true" />
   </Target>
 
   <Target Name="GenerateTemplatesMsis"
           DependsOnTargets="GenerateLayout;AcquireWix;MsiTargetsSetupInputOutputs;SetSdkBrandingInfo;SetupTemplatesMsis"
           Condition="$(ProductMonikerRid.StartsWith('win')) And !$(Architecture.StartsWith('arm'))"
-          Inputs="@(TemplatesMsiComponent->'%(LayoutPath)');
-                    $(TemplatesGenerateMsiPowershellScript)"
-          Outputs="@(TemplatesMsiComponent->'%(MSIInstallerFile)')">
+          Inputs="@(TemplatesMsiComponent);$(TemplatesGenerateMsiPowershellScript)"
+          Outputs="%(TemplatesMsiComponent.MSIInstallerFile)">
 
     <Exec Command="powershell -NoProfile -NoLogo $(TemplatesGenerateMsiPowershellScript) ^
                       '%(TemplatesMsiComponent.LayoutPath)' ^
-                      '@(TemplatesMsiComponent->'%(MSIInstallerFile)')' ^
+                      '%(TemplatesMsiComponent.MSIInstallerFile)' ^
                       '$(WixRoot)' ^
-                      '@(TemplatesMsiComponent->'%(BrandName)')' ^
-                      '@(TemplatesMsiComponent->'%(MsiVersion)')' ^
-                      '@(TemplatesMsiComponent->'%(MsiVersion)')' ^
+                      '%(TemplatesMsiComponent.BrandName)' ^
+                      '%(TemplatesMsiComponent.MsiVersion)' ^
+                      '%(TemplatesMsiComponent.MsiVersion)' ^
                       '$(FullNugetVersion)' ^
-                      '@(TemplatesMsiComponent->'%(UpgradeCode)')' ^
-                      '@(TemplatesMsiComponent->'%(DependencyKeyName)')' ^
+                      '%(TemplatesMsiComponent.UpgradeCode)' ^
+                      '%(TemplatesMsiComponent.DependencyKeyName)' ^
                       '$(Architecture)' ^
                       -InformationAction Continue" />
+    <ItemGroup>
+        <TemplatesMsiWixSrcFiles Include="$(WixRoot)\provider.wixobj" />
+        <TemplatesMsiWixSrcFiles Include="$(WixRoot)\templates.wixobj" />
+        <TemplatesMsiWixSrcFiles Include="$(WixRoot)\template-install-files.wixobj" />
+    </ItemGroup>
+
+    <CreateLightCommandPackageDrop
+      LightCommandWorkingDir="$(LightCommandObjDir)"
+      NoLogo="true"
+      Cultures="en-us"
+      Out="%(TemplatesMsiComponent.MSIInstallerFile)"
+      WixExtensions="WixUIExtension;WixDependencyExtension;WixUtilExtension"
+      WixSrcFiles="@(TemplatesMsiWixSrcFiles)">
+      <Output TaskParameter="LightCommandPackageNameOutput" PropertyName="_LightCommandPackageNameOutput" />
+    </CreateLightCommandPackageDrop>
+    <MakeDir Directories="$(LightCommandPackagesDir)" />
+
+    <ZipDirectory
+      DestinationFile="$(LightCommandPackagesDir)/LightCommandPackage-$(_LightCommandPackageNameOutput).zip"
+      SourceDirectory="$(LightCommandObjDir)/$(_LightCommandPackageNameOutput)"
+      Overwrite="true" />
   </Target>
 
   <Target Name="SetupTemplatesMsis">
@@ -296,6 +373,26 @@
                       '$(MicrosoftAspNetCoreAppRuntimePackageVersion)' ^
                       '$(CliProductBandVersion)' ^
                       -InformationAction Continue " />
+    <ItemGroup>
+        <BundleMsiWixSrcFiles Include="$(WixRoot)\bundle.wixobj" />
+        <BundleMsiWixSrcFiles Include="$(DownloadsFolder)$(DownloadedAspNetCoreSharedFxWixLibFileName)" />
+    </ItemGroup>
+    <CreateLightCommandPackageDrop
+      LightCommandWorkingDir="$(LightCommandObjDir)"
+      NoLogo="true"
+      Cultures="en-us"
+      Out="$(CombinedFrameworkSdkHostMSIInstallerFile)"
+      WixExtensions="WixBalExtension;WixUtilExtension;WixTagExtension"
+      WixSrcFiles="@(BundleMsiWixSrcFiles)"
+      AdditionalBasePaths="$(MSBuildThisFileDirectory)packaging/windows/clisdk">
+      <Output TaskParameter="LightCommandPackageNameOutput" PropertyName="_LightCommandPackageNameOutput" />
+    </CreateLightCommandPackageDrop>
+    <MakeDir Directories="$(LightCommandPackagesDir)" />
+
+    <ZipDirectory
+      DestinationFile="$(LightCommandPackagesDir)/LightCommandPackage-$(_LightCommandPackageNameOutput).zip"
+      SourceDirectory="$(LightCommandObjDir)/$(_LightCommandPackageNameOutput)"
+      Overwrite="true" />
   </Target>
 
   <Target Name="GenerateToolsetNupkg"


### PR DESCRIPTION
Call tasks to gather light command packages after the build of each
installer. The way this is implemented is not ideal. Because powershell
scripts are used to invoke the WiX toolset, the light command package
info must be kept in sync. That said, the command lines and input files
do not change very often.

It's also on the table for .NET 6 to change around and unify the WiX
calls between the repos.

This also changes around the batching for the template MSIs to be compatible
with the call to the light command task

- Please add description for changes you are making.
- If there is an issue related to this PR, please add the reference.
