### PR TITLE
Use Microsoft.NETCore.App.Internal package version

### DIFF
--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "dotnet": "5.0.100-preview.6.20310.4",
     "runtimes": {
       "dotnet": [
-        "$(MicrosoftNETCoreAppRuntimePackageVersion)"
+        "$(MicrosoftNETCoreAppInternalPackageVersion)"
       ]
     }
   },


### PR DESCRIPTION
This version does not get stabilized and so this will work for repeatable stable builds.