### PR TITLE
Adding dotnet3.1/dotnet-eng packages sources

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -22,6 +22,7 @@
     <add key="dotnet3.1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1/nuget/v3/index.json" />
     <add key="dotnet3.1-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1-transport/nuget/v3/index.json" />
     <add key="darc-pub-dotnet-templating-247f60e9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-templating-247f60e9/nuget/v3/index.json" />
+    <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />


### PR DESCRIPTION
In order to remove dependencies on sleet from release branches,
it is neccessary to preemptively add these sources so that mehanisms
will be able to restore these packages.

Sleet must be removed because of it's strong dependency on spcific
nuget.packaging versions, which are not stable between 3.0 and 3.1
causing method load exceptions.
