### PR TITLE
Update README.md to include link to https://github.com/dotnet/install-scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,6 +540,11 @@ Reference notes:
 
 [sdk-shas-2.2.1XX]: https://github.com/dotnet/versions/tree/master/build-info/dotnet/product/cli/release/2.2#built-repositories
 
+Looking for dotnet-install sources?
+-----------------------------------
+
+Sources for dotnet-install.sh and dotnet-install.ps1 are in the [install-scripts repo](https://github.com/dotnet/install-scripts).
+
 Questions & Comments
 --------------------
 


### PR DESCRIPTION
It would be reasonable to expect that the dotnet/install repo contain the dotnet-install.sh, but it does not.