### PR TITLE
Fix license URL for PT-BR (#8374)

### DIFF
--- a/src/redist/targets/packaging/windows/clisdk/LCID/1046/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1046/bundle.wxl
@@ -71,7 +71,7 @@ Recursos
   <String Id="CoreDocumentationLink">&lt;A HREF="https://aka.ms/dotnet-docs"&gt;Documentação do .NET&lt;/A&gt;</String>
   <String Id="SDKDocumentation">&lt;A HREF="https://aka.ms/dotnet-cli-docs"&gt;Documentação do SDK&lt;/A&gt;</String>
   <String Id="PrivacyStatementLink">&lt;A HREF="https://aka.ms/dev-privacy"&gt;Política de Privacidade&lt;/A&gt;</String>
-  <String Id="DotNetEulaLink">&lt; A HREF = "https://aka.ms/dotnet-License-Windows" &gt; Informações de licenciamento para .NET&lt;/A&gt;</String>
+  <String Id="DotNetEulaLink">&lt;A HREF="https://aka.ms/dotnet-License-Windows"&gt;Informações de licenciamento para .NET&lt;/A&gt;</String>
   <String Id="InstallationNoteTitle">Nota de instalação</String>
   <String Id="InstallationNote">Um comando será executado durante o processo de instalação que melhorará a velocidade de restauração do projeto e habilitará o acesso offline. Isso levará até um minuto para ser concluído.
   </String>


### PR DESCRIPTION
Markup for the URL pointing to the EULA in the installer UI contains extra space, causing it to be rendered as text in the installer.
