### PR TITLE
Updating Microsoft.Windows.SDK.NET.Ref versions

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -127,9 +127,9 @@
     <MicrosoftNETTestSdkVersion>16.8.0-release-20200902-05</MicrosoftNETTestSdkVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftWindowsSDKNETRef10_0_17763PackageVersion>10.0.17763.2-preview</MicrosoftWindowsSDKNETRef10_0_17763PackageVersion>
-    <MicrosoftWindowsSDKNETRef10_0_18362PackageVersion>10.0.18362.3-preview</MicrosoftWindowsSDKNETRef10_0_18362PackageVersion>
-    <MicrosoftWindowsSDKNETRef10_0_19041PackageVersion>10.0.19041.2-preview</MicrosoftWindowsSDKNETRef10_0_19041PackageVersion>
+    <MicrosoftWindowsSDKNETRef10_0_17763PackageVersion>10.0.17763.3-preview</MicrosoftWindowsSDKNETRef10_0_17763PackageVersion>
+    <MicrosoftWindowsSDKNETRef10_0_18362PackageVersion>10.0.18362.4-preview</MicrosoftWindowsSDKNETRef10_0_18362PackageVersion>
+    <MicrosoftWindowsSDKNETRef10_0_19041PackageVersion>10.0.19041.3-preview</MicrosoftWindowsSDKNETRef10_0_19041PackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- pinned dependency. This package is not being produced outside of the 2.0 branch of corefx and should not change. -->


### PR DESCRIPTION
Microsoft.Windows.SDK.NET.Ref package had to be rebuilt, updating to new version.