### PR TITLE
Ensure 3rd party assemblies are signed

### DIFF
--- a/src/redist/targets/Signing.targets
+++ b/src/redist/targets/Signing.targets
@@ -86,7 +86,11 @@
 
     <ItemGroup>
       <!-- External files -->
-      <LayoutFilesToSign Include="$(SdkOutputDirectory)**/Newtonsoft.Json.dll">
+      <LayoutFilesToSign Include="$(SdkOutputDirectory)**/Newtonsoft.Json.dll;
+                            $(SdkOutputDirectory)**/MessagePack.Annotations.dll;
+                            $(SdkOutputDirectory)**/MessagePack.dll;
+                            $(SdkOutputDirectory)**/Nerdbank.Streams.dll;
+                            $(SdkOutputDirectory)**/StreamJsonRpc.dll">
         <CertificateName>$(ExternalCertificateId)</CertificateName>
       </LayoutFilesToSign>
       <!-- Built binaries -->


### PR DESCRIPTION
3rd party files that redistributed should be signed with the Microsoft 3rd party SHA2 authenticode certificate
