### PR TITLE
Update dependencies from https://github.com/dotnet/sdk build 20200903…

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -79,13 +79,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>da62f3656cac0ac4bfb6b012bc072b3499f78e6c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="5.0.100-rc.1.20453.7">
+    <Dependency Name="Microsoft.NET.Sdk" Version="5.0.100-rc.1.20453.14">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>1c6403afced118a403dfd03f997d8704820c5a94</Sha>
+      <Sha>808c567d7bd443f93553c9a09cfc0f509185c16f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="5.0.100-rc.1.20453.7">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="5.0.100-rc.1.20453.14">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>1c6403afced118a403dfd03f997d8704820c5a94</Sha>
+      <Sha>808c567d7bd443f93553c9a09cfc0f509185c16f</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20451.14" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -53,8 +53,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>5.0.100-rc.1.20453.7</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>5.0.100-rc.1.20453.7</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>5.0.100-rc.1.20453.14</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>5.0.100-rc.1.20453.14</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
   </PropertyGroup>


### PR DESCRIPTION
….14 (#8399)

[release/5.0.1xx] Update dependencies from dotnet/sdk
- Updates:
  - Microsoft.NET.Sdk: from 5.0.100-rc.1.20453.7 to 5.0.100-rc.1.20453.14
  - Microsoft.DotNet.MSBuildSdkResolver: from 5.0.100-rc.1.20453.7 to 5.0.100-rc.1.20453.14

- Please add description for changes you are making.
- If there is an issue related to this PR, please add the reference.
