### PR TITLE
Add 3.1 Blazor WASM templates

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -119,7 +119,7 @@
     <MicrosoftDotNetCommonItemTemplates21PackageVersion>1.0.2-beta3</MicrosoftDotNetCommonItemTemplates21PackageVersion>
     <MicrosoftDotNetCommonProjectTemplates21PackageVersion>$(MicrosoftDotNetCommonItemTemplates21PackageVersion)</MicrosoftDotNetCommonProjectTemplates21PackageVersion>
     <MicrosoftDotNetTestProjectTemplates21PackageVersion>1.0.2-beta4.20420.1</MicrosoftDotNetTestProjectTemplates21PackageVersion>
-    <AspNetCorePackageVersionFor21Templates>2.1.14</AspNetCorePackageVersionFor21Templates>
+    <AspNetCorePackageVersionFor21Templates>2.1.22</AspNetCorePackageVersionFor21Templates>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -105,6 +105,7 @@
     <MicrosoftDotNetCommonProjectTemplates31PackageVersion>$(MicrosoftDotNetCommonItemTemplates31PackageVersion)</MicrosoftDotNetCommonProjectTemplates31PackageVersion>
     <MicrosoftDotNetTestProjectTemplates31PackageVersion>$(MicrosoftDotNetTestProjectTemplates50PackageVersion)</MicrosoftDotNetTestProjectTemplates31PackageVersion>
     <AspNetCorePackageVersionFor31Templates>3.1.7</AspNetCorePackageVersionFor31Templates>
+    <MicrosoftAspNetCoreComponentsWebAssemblyTemplatesPackageVersion>3.2.1</MicrosoftAspNetCoreComponentsWebAssemblyTemplatesPackageVersion>
     <!-- 3.0 Template versions -->
     <MicrosoftDotnetWinFormsProjectTemplates30PackageVersion>4.8.0-rc2.19462.10</MicrosoftDotnetWinFormsProjectTemplates30PackageVersion>
     <MicrosoftDotNetWpfProjectTemplates30PackageVersion>3.0.0</MicrosoftDotNetWpfProjectTemplates30PackageVersion>

--- a/src/redist/targets/BundledTemplates.targets
+++ b/src/redist/targets/BundledTemplates.targets
@@ -70,6 +70,7 @@
     <Bundled31Templates Include="Microsoft.DotNet.Web.ItemTemplates" PackageVersion="$(AspNetCorePackageVersionFor31Templates)" />
     <Bundled31Templates Include="Microsoft.DotNet.Web.ProjectTemplates.3.1" PackageVersion="$(AspNetCorePackageVersionFor31Templates)" />
     <Bundled31Templates Include="Microsoft.DotNet.Web.Spa.ProjectTemplates.3.1" PackageVersion="$(AspNetCorePackageVersionFor31Templates)" />
+    <Bundled31Templates Include="Microsoft.AspNetCore.Components.WebAssembly.Templates" PackageVersion="$(MicrosoftAspNetCoreComponentsWebAssemblyTemplatesPackageVersion)" />
     <Bundled31Templates Include="NUnit3.DotNetNew.Template" PackageVersion="$(NUnit3Templates31PackageVersion)" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Blazor WebAssembly 3.2 templates are missing in the 5.0 installer. This change reintroduces them

### Description

Adds Blazor WebAssembly 3.2 templates to the 5.0 installer. 

### Customer impact

In the absence of this, customers are unable to install Blazor templates in VS if all they have is a 5.0 SDK installed.

### Regression

Yes. We shipped these templates with the 3.1 SDK but did not correctly port it to 5.0

### Risk

Low. The generated MSI was manually tested.