### PR TITLE
Finalize ARM64 support (Installers, publishing-rid, revert winforms support)

### DIFF
--- a/src/redist/targets/BundledTemplates.targets
+++ b/src/redist/targets/BundledTemplates.targets
@@ -184,7 +184,7 @@
 
   <Target Name="LayoutTemplatesFor50MSI"
           DependsOnTargets="SetupBundledComponents;CalculateTemplatesVersions"
-          Condition="$(ProductMonikerRid.StartsWith('win')) And !$(Architecture.StartsWith('arm'))">
+          Condition="$(ProductMonikerRid.StartsWith('win')) And '$(Architecture)' != 'arm'">
     <Copy SourceFiles="%(Bundled50Templates.RestoredNupkgPath)"
           DestinationFolder="$(Templates50LayoutPath)templates/$(BundledTemplates50InstallPath)"/>
   </Target>

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -108,7 +108,8 @@
       <Crossgen2SupportedRids Include="linux-musl-x64;linux-x64;win-x64" />
 
       <AspNetCore31RuntimePackRids Include="@(AspNetCore30RuntimePackRids)" />
-      <AspNetCoreRuntimePackRids Include="@(AspNetCore31RuntimePackRids)" />
+      <AspNetCore50RuntimePackRids Include="@(AspNetCore31RuntimePackRids);win-arm64" />
+      <AspNetCoreRuntimePackRids Include="@(AspNetCore50RuntimePackRids)" />
 
       <WindowsDesktop30RuntimePackRids Include="win-x64;win-x86" />
       <WindowsDesktop31RuntimePackRids Include="@(WindowsDesktop30RuntimePackRids)" />
@@ -274,7 +275,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                               TargetingPackName="Microsoft.AspNetCore.App.Ref"
                               TargetingPackVersion="$(MicrosoftAspNetCoreAppRefPackageVersion)"
                               RuntimePackNamePatterns="Microsoft.AspNetCore.App.Runtime.**RID**"
-                              RuntimePackRuntimeIdentifiers="@(AspNetCoreRuntimePackRids, '%3B')"
+                              RuntimePackRuntimeIdentifiers="@(AspNetCore50RuntimePackRids, '%3B')"
                               />
 
     <KnownFrameworkReference Include="Microsoft.Windows.SDK.NET.Ref"

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -113,9 +113,6 @@
       <WindowsDesktop30RuntimePackRids Include="win-x64;win-x86" />
       <WindowsDesktop31RuntimePackRids Include="@(WindowsDesktop30RuntimePackRids)" />
       <WindowsDesktopRuntimePackRids Include="@(WindowsDesktop31RuntimePackRids)" />
-      <!-- TODO: remove this once WPF is available on ARM64 and replace usage
-            of this group for WindowsDesktopRuntimePackRids. -->
-      <WindowsDesktopRuntimePackWinformsRids Include="@(WindowsDesktopRuntimePackRids);win-arm64" />
     </ItemGroup>
 
     <!--
@@ -264,7 +261,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                               TargetingPackName="Microsoft.WindowsDesktop.App.Ref"
                               TargetingPackVersion="$(MicrosoftWindowsDesktopAppRefPackageVersion)"
                               RuntimePackNamePatterns="Microsoft.WindowsDesktop.App.Runtime.**RID**"
-                              RuntimePackRuntimeIdentifiers="@(WindowsDesktopRuntimePackWinformsRids, '%3B')"
+                              RuntimePackRuntimeIdentifiers="@(WindowsDesktopRuntimePackRids, '%3B')"
                               IsWindowsOnly="true"
                               Profile="WindowsForms"
                               />

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -167,29 +167,30 @@
       </BundledInstallerComponent>
 
       <BundledInstallerComponent Include="DownloadedSharedFrameworkInstallerFile"
-                                 Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And !$(Architecture.StartsWith('arm'))">
+                                 Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64')">
         <BaseUrl>$(CoreSetupRootUrl)$(CoreSetupBlobVersion)</BaseUrl>
         <DownloadFileName>$(DownloadedSharedFrameworkInstallerFileName)</DownloadFileName>
       </BundledInstallerComponent>
 
       <BundledInstallerComponent Include="DownloadedSharedHostInstallerFile"
-                                 Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And !$(Architecture.StartsWith('arm'))">
+                                 Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64')">
         <BaseUrl>$(CoreSetupRootUrl)$(CoreSetupBlobVersion)</BaseUrl>
         <DownloadFileName>$(DownloadedSharedHostInstallerFileName)</DownloadFileName>
       </BundledInstallerComponent>
 
       <BundledInstallerComponent Include="DownloadedHostFxrInstallerFile"
-                                 Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And !$(Architecture.StartsWith('arm'))">
+                                 Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64')">
         <BaseUrl>$(CoreSetupRootUrl)$(CoreSetupBlobVersion)</BaseUrl>
         <DownloadFileName>$(DownloadedHostFxrInstallerFileName)</DownloadFileName>
       </BundledInstallerComponent>
 
       <BundledInstallerComponent Include="DownloadedNetCoreAppTargetingPackInstallerFile"
-                                 Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And !$(Architecture.StartsWith('arm'))">
+                                 Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64')">
         <BaseUrl>$(CoreSetupRootUrl)$(NETCoreAppTargetingPackBlobVersion)</BaseUrl>
         <DownloadFileName>$(DownloadedNetCoreAppTargetingPackInstallerFileName)</DownloadFileName>
       </BundledInstallerComponent>
 
+      <!-- TODO: Should we somehow obtain a .NET Standard ARM64 package? -->
       <BundledInstallerComponent Include="DownloadedNetStandardTargetingPackInstallerFile"
                            Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And !$(Architecture.StartsWith('arm'))">
         <BaseUrl>$(CoreSetupRootUrl)$(NETCoreAppTargetingPackBlobVersion)</BaseUrl>
@@ -198,7 +199,7 @@
       </BundledInstallerComponent>
 
       <BundledInstallerComponent Include="DownloadedNetCoreAppHostPackInstallerFile"
-                     Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And !$(Architecture.StartsWith('arm'))">
+                     Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64')">
         <BaseUrl>$(CoreSetupRootUrl)$(CoreSetupBlobVersion)</BaseUrl>
         <DownloadFileName>$(DownloadedNetCoreAppHostPackInstallerFileName)</DownloadFileName>
       </BundledInstallerComponent>
@@ -251,19 +252,19 @@
       </BundledLayoutComponent>
 
       <BundledInstallerComponent Include="DownloadedAspNetTargetingPackInstallerFile"
-                                 Condition="'$(InstallerExtension)' != '.pkg' And '$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And !$(Architecture.StartsWith('arm'))">
+                                 Condition="'$(InstallerExtension)' != '.pkg' And '$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64')">
         <BaseUrl>$(AspNetCoreSharedFxRootUrl)$(AspNetCoreTargetingPackBlobVersion)</BaseUrl>
         <DownloadFileName>$(DownloadedAspNetTargetingPackInstallerFileName)</DownloadFileName>
       </BundledInstallerComponent>
 
       <BundledInstallerComponent Include="DownloadedAspNetCoreSharedFxInstallerFile"
-                                 Condition="'$(InstallerExtension)' != '.pkg' And '$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And !$(Architecture.StartsWith('arm'))">
+                                 Condition="'$(InstallerExtension)' != '.pkg' And '$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64')">
         <BaseUrl>$(AspNetCoreSharedFxRootUrl)$(AspNetCoreBlobVersion)</BaseUrl>
         <DownloadFileName>$(DownloadedAspNetCoreSharedFxInstallerFileName)</DownloadFileName>
       </BundledInstallerComponent>
 
       <BundledInstallerComponent Include="DownloadedAspNetCoreSharedFxWixLibFile"
-                                 Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' == '.msi' And !$(Architecture.StartsWith('arm'))">
+                                 Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' == '.msi' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64')">
         <BaseUrl>$(AspNetCoreSharedFxRootUrl)$(AspNetCoreBlobVersion)</BaseUrl>
         <DownloadFileName>$(DownloadedAspNetCoreSharedFxWixLibFileName)</DownloadFileName>
       </BundledInstallerComponent>
@@ -275,7 +276,7 @@
       </BundledInstallerComponent>
 
       <BundledInstallerComponent Include="AspNetCoreSharedFxBaseRuntimeVersionFile"
-                                 Condition="!$(Architecture.StartsWith('arm'))">
+                                 Condition="!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64'">
         <BaseUrl>$(AspNetCoreSharedFxRootUrl)$(AspNetCoreBlobVersion)</BaseUrl>
         <DownloadFileName>$(AspNetCoreSharedFxBaseRuntimeVersionFileName)</DownloadFileName>
       </BundledInstallerComponent>

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -283,7 +283,7 @@
 
     <PropertyGroup>
       <IncludeWpfAndWinForms Condition=" '$(IncludeWpfAndWinForms)' == '' AND '$(Architecture)' == 'arm'">false</IncludeWpfAndWinForms>
-      <IncludeWpfAndWinForms Condition=" '$(IncludeWpfAndWinForms)' == '' AND '$(OS)' == 'Windows_NT'">true</IncludeWpfAndWinForms>
+      <IncludeWpfAndWinForms Condition=" '$(IncludeWpfAndWinForms)' == '' AND '$(OS)' == 'Windows_NT' AND '$(Architecture)' != 'arm64' ">true</IncludeWpfAndWinForms>
       <IncludeWpfAndWinForms Condition=" '$(IncludeWpfAndWinForms)' == '' ">false</IncludeWpfAndWinForms>
     </PropertyGroup>
 

--- a/src/redist/targets/GenerateMSIs.targets
+++ b/src/redist/targets/GenerateMSIs.targets
@@ -14,7 +14,7 @@
   <Target Name="SetupWixProperties" DependsOnTargets="GetCurrentRuntimeInformation">
     <!-- AcquireWix Properties -->
     <PropertyGroup>
-      <WixVersion>3.10.4</WixVersion>
+      <WixVersion>3.14.0.4118</WixVersion>
       <WixDownloadUrl>https://dotnetcli.azureedge.net/build/wix/wix.$(WixVersion).zip</WixDownloadUrl>
       <WixRoot>$(ArtifactsDir)Tools/WixTools/$(WixVersion)</WixRoot>
       <WixDestinationPath>$(WixRoot)/WixTools.$(WixVersion).zip</WixDestinationPath>
@@ -253,7 +253,7 @@
 
   <Target Name="GenerateTemplatesMsis"
           DependsOnTargets="GenerateLayout;AcquireWix;MsiTargetsSetupInputOutputs;SetSdkBrandingInfo;SetupTemplatesMsis"
-          Condition="$(ProductMonikerRid.StartsWith('win')) And !$(Architecture.StartsWith('arm'))"
+          Condition="$(ProductMonikerRid.StartsWith('win')) And '$(Architecture)' != 'arm'"
           Inputs="@(TemplatesMsiComponent);$(TemplatesGenerateMsiPowershellScript)"
           Outputs="%(TemplatesMsiComponent.MSIInstallerFile)">
 
@@ -306,6 +306,9 @@
         <UpgradeCode>$(Templates50InstallerUpgradeCode)</UpgradeCode>
         <DependencyKeyName>NetCore_Templates_5.0</DependencyKeyName>
       </TemplatesMsiComponent>
+    </ItemGroup>
+
+    <ItemGroup Condition="!$(Architecture.StartsWith('arm'))">
       <TemplatesMsiComponent Include="NetCore31TemplatesMsi">
         <LayoutPath>$(Templates31LayoutPath.TrimEnd('\'))</LayoutPath>
         <MSIInstallerFile>$(Templates31MSIInstallerFile)</MSIInstallerFile>
@@ -549,7 +552,7 @@
                             GenerateVSToolsNupkg;
                             GenerateVSToolsResolverNupkg;
                             GenerateSdkMSBuildExtensionsNupkg"
-        Condition=" '$(OS)' == 'Windows_NT' and !$(Architecture.StartsWith('arm')) " />
+        Condition=" '$(OS)' == 'Windows_NT' and '$(Architecture)' != 'arm' " />
 
 
 </Project>

--- a/src/redist/targets/Signing.targets
+++ b/src/redist/targets/Signing.targets
@@ -183,10 +183,15 @@
 
     <ItemGroup>
       <TemplatesMsiFilesToSign Include="$(Templates50MSIInstallerFile)" />
+    </ItemGroup>
+
+    <ItemGroup Condition="!$(Architecture.StartsWith('arm'))">
       <TemplatesMsiFilesToSign Include="$(Templates31MSIInstallerFile)" />
       <TemplatesMsiFilesToSign Include="$(Templates30MSIInstallerFile)" />
       <TemplatesMsiFilesToSign Include="$(Templates21MSIInstallerFile)" />
-
+    </ItemGroup>
+    
+    <ItemGroup>
       <TemplatesMsiFileSignInfo Include="@(TemplatesMsiFilesToSign->'%(Filename)%(Extension)')">
         <CertificateName>$(InternalCertificateId)</CertificateName>
       </TemplatesMsiFileSignInfo>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1028/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1028/bundle.wxl
@@ -63,6 +63,21 @@
     • 如需 SDK 文件，請前往 https://aka.ms/dotnet-sdk-docs
     • 如需版本資訊，請前往 https://aka.ms/dotnet5-release-notes
     • 如需教學課程，請前往 https://aka.ms/dotnet-tutorials</String>
+<String Id="FirstTimeWelcomeMessageArm64">安裝成功。
+
+下列項目已安裝在: '[DOTNETHOME]'
+    • .NET SDK [DOTNETSDKVERSION]
+    • .NET Runtime [DOTNETRUNTIMEVERSION]
+    • ASP.NET Core Runtime [ASPNETCOREVERSION]
+
+此產品會收集使用方式資料
+    • 如需詳細資訊並退出，請前往 https://aka.ms/dotnet-cli-telemetry
+
+資源
+    • 如需 .NET 文件，請前往 https://aka.ms/dotnet-docs
+    • 如需 SDK 文件，請前往 https://aka.ms/dotnet-sdk-docs
+    • 如需版本資訊，請前往 https://aka.ms/dotnet5-release-notes
+    • 如需教學課程，請前往 https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">.NET SDK</String>
   <String Id="WelcomeDescription">
     .NET SDK 可用於建置、執行及測試 .NET 應用程式。您可以選擇多種語言、編輯器以及開發人員工具，並可利用程式庫的大型生態系統，來建置 Web、行動裝置、桌面、遊戲及 IoT 的應用程式。希望您會喜歡!</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1029/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1029/bundle.wxl
@@ -63,6 +63,21 @@ Zdroje informací
     • Dokumentace k sadě SDK: https://aka.ms/dotnet-sdk-docs
     • Zpráva k vydání verze: https://aka.ms/dotnet5-release-notes
     • Kurzy: https://aka.ms/dotnet-tutorials</String>
+  <String Id="FirstTimeWelcomeMessageArm64">Instalace proběhla úspěšně.
+
+Do [DOTNETHOME] byly nainstalovány tyto součásti:
+    • Sada .NET SDK [DOTNETSDKVERSION]
+    • Modul runtime .NET [DOTNETRUNTIMEVERSION]
+    • Modul runtime ASP.NET Core [ASPNETCOREVERSION]
+
+Tento produkt shromažďuje data o využití.
+    • Další informace a vyjádření výslovného nesouhlasu: https://aka.ms/dotnet-cli-telemetry
+
+Zdroje informací
+    • Dokumentace k .NET : https://aka.ms/dotnet-docs
+    • Dokumentace k sadě SDK: https://aka.ms/dotnet-sdk-docs
+    • Zpráva k vydání verze: https://aka.ms/dotnet5-release-notes
+    • Kurzy: https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">Sada .NET SDK</String>
   <String Id="WelcomeDescription">
     Sada .NET SDK se používá k vytváření, spouštění a testování aplikací .NET. Můžete si vybrat z několika jazyků, editorů a vývojářských nástrojů. K dispozici jsou výhody rozsáhlého ekosystému knihoven, se kterými můžete vytvářet aplikace pro web, mobilní zařízení, desktop, herní zařízení a IoT. Doufáme, že se vám bude líbit!</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1031/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1031/bundle.wxl
@@ -63,6 +63,21 @@ Ressourcen
     • SDK-Dokumentation: https://aka.ms/dotnet-sdk-docs
     • Versionshinweise: https://aka.ms/dotnet5-release-notes
     • Tutorials: https://aka.ms/dotnet-tutorials</String>
+<String Id="FirstTimeWelcomeMessageArm64">Die Installation war erfolgreich.
+
+Folgende Komponenten wurden unter [DOTNETHOME] installiert:
+    • .NET SDK [DOTNETSDKVERSION]
+    • .NET-Runtime [DOTNETRUNTIMEVERSION]
+    • ASP.NET Core-Runtime [ASPNETCOREVERSION]
+
+Dieses Produkt erfasst Nutzungsdaten.
+    • Weitere Informationen und Deaktivieren der Erfassung: https://aka.ms/dotnet-cli-telemetry
+
+Ressourcen
+    • .NET-Dokumentation: https://aka.ms/dotnet-docs
+    • SDK-Dokumentation: https://aka.ms/dotnet-sdk-docs
+    • Versionshinweise: https://aka.ms/dotnet5-release-notes
+    • Tutorials: https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">.NET SDK</String>
   <String Id="WelcomeDescription">
     Das .NET SDK wird zum Erstellen, Ausführen und Testen von .NET-Anwendungen verwendet. Sie können aus mehreren Sprachen, Editoren und Entwicklertools auswählen und ein großes Bibliotheksnetzwerk nutzen, um Apps für das Web, mobile Geräte, Desktops, Gaming und IoT zu entwickeln. Wir wünschen Ihnen viel Spaß damit!</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1033/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1033/bundle.wxl
@@ -63,6 +63,21 @@ Resources
     • SDK Documentation https://aka.ms/dotnet-sdk-docs
     • Release Notes https://aka.ms/dotnet5-release-notes
     • Tutorials https://aka.ms/dotnet-tutorials</String>
+<String Id="FirstTimeWelcomeMessageArm64">The installation was successful.
+
+The following were installed at: '[DOTNETHOME]'
+    • .NET SDK [DOTNETSDKVERSION]
+    • .NET Runtime [DOTNETRUNTIMEVERSION]
+    • ASP.NET Core Runtime [ASPNETCOREVERSION]
+
+This product collects usage data
+    • More information and opt-out https://aka.ms/dotnet-cli-telemetry
+
+Resources
+    • .NET Documentation https://aka.ms/dotnet-docs
+    • SDK Documentation https://aka.ms/dotnet-sdk-docs
+    • Release Notes https://aka.ms/dotnet5-release-notes
+    • Tutorials https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">.NET SDK</String>
   <String Id="WelcomeDescription">
     The .NET SDK is used to build, run and test .NET applications. You can choose from multiple languages, editors, and developer tools, and take advantage of a large ecosystem of libraries to build apps for web, mobile, desktop, gaming and IoT. We hope you enjoy it!</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1036/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1036/bundle.wxl
@@ -63,6 +63,21 @@ Ressources
     • Documentation de kit SDK sur https://aka.ms/dotnet-sdk-docs
     • Notes de publication sur https://aka.ms/dotnet5-release-notes
     • Tutoriels sur https://aka.ms/dotnet-tutorials</String>
+  <String Id="FirstTimeWelcomeMessageArm64">L'installation a réussi.
+
+Les éléments suivants ont été installés sur : '[DOTNETHOME]'
+    • Kit SDK .NET [DOTNETSDKVERSION]
+    • Runtime .NET [DOTNETRUNTIMEVERSION]
+    • Runtime ASP.NET Core [ASPNETCOREVERSION]
+
+Ce produit collecte des données d'utilisation
+    • Plus informations et refus d'adhésion sur https://aka.ms/dotnet-cli-telemetry
+
+Ressources
+    • Documentation .NET sur https://aka.ms/dotnet-docs
+    • Documentation de kit SDK sur https://aka.ms/dotnet-sdk-docs
+    • Notes de publication sur https://aka.ms/dotnet5-release-notes
+    • Tutoriels sur https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">SDK .NET</String>
   <String Id="WelcomeDescription">
     Le kit SDK .NET permet de générer, d'exécuter et de tester des applications .NET. Vous pouvez choisir parmi plusieurs langages, éditeurs et outils de développement. De plus, vous pouvez bénéficier d'un vaste écosystème de bibliothèques afin de générer des applications pour le web, les appareils mobiles, les ordinateurs de bureau, les jeux et l'IoT. Nous espérons que vous l'apprécierez !</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1040/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1040/bundle.wxl
@@ -63,6 +63,21 @@ Risorse
     • Documentazione dell'SDK https://aka.ms/dotnet-sdk-docs
     • Note sulla versione https://aka.ms/dotnet5-release-notes
     • Esercitazioni https://aka.ms/dotnet-tutorials</String>
+  <String Id="FirstTimeWelcomeMessageArm64">L'installazione è riuscita.
+
+I componenti seguenti sono stati installati in '[DOTNETHOME]'
+    • .NET SDK [DOTNETSDKVERSION]
+    • Runtime di .NET [DOTNETRUNTIMEVERSION]
+    • Runtime di ASP.NET Core [ASPNETCOREVERSION]
+
+Questo prodotto consente di raccogliere i dati sull'utilizzo
+    • Altre informazioni e annullamento sottoscrizione https://aka.ms/dotnet-cli-telemetry
+
+Risorse
+    • Documentazione di .NET https://aka.ms/dotnet-docs
+    • Documentazione dell'SDK https://aka.ms/dotnet-sdk-docs
+    • Note sulla versione https://aka.ms/dotnet5-release-notes
+    • Esercitazioni https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">.NET SDK</String>
   <String Id="WelcomeDescription">
     .NET SDK consente di creare, eseguire e testare applicazioni NET. È possibile scegliere tra più linguaggi, editor e strumenti di sviluppo e sfruttare un vasto ecosistema di librerie per creare app per Web, dispositivi mobili, desktop, giochi e IoT.</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1041/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1041/bundle.wxl
@@ -63,6 +63,21 @@
     • SDK ドキュメント https://aka.ms/dotnet-sdk-docs
     • リリース ノート https://aka.ms/dotnet5-release-notes
     • チュートリアル https://aka.ms/dotnet-tutorials</String>
+  <String Id="FirstTimeWelcomeMessageArm64">インストールが成功しました。
+
+'[DOTNETHOME]' に以下がインストールされました
+    • .NET SDK [DOTNETSDKVERSION]
+    • .NET Runtime [DOTNETRUNTIMEVERSION]
+    • ASP.NET Core Runtime [ASPNETCOREVERSION]
+
+この製品は使用状況データを収集します
+    • 詳細およびオプトアウト https://aka.ms/dotnet-cli-telemetry
+
+リソース
+    • .NET ドキュメント https://aka.ms/dotnet-docs
+    • SDK ドキュメント https://aka.ms/dotnet-sdk-docs
+    • リリース ノート https://aka.ms/dotnet5-release-notes
+    • チュートリアル https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">.NET SDK</String>
   <String Id="WelcomeDescription">
     .Net SDK は、.NET アプリケーションをビルド、実行、テストするために使用されます。複数の言語、エディター、開発者ツールから選択し、ライブラリの大規模なエコシステムを利用して、Web、モバイル、デスクトップ、ゲーム、IoT 用のアプリを作成できます。ぜひご利用ください。</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1042/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1042/bundle.wxl
@@ -63,6 +63,21 @@
     • SDK 설명서 https://aka.ms/dotnet-sdk-docs
     • 릴리스 정보 https://aka.ms/dotnet5-release-notes
     • 자습서 https://aka.ms/dotnet-tutorials</String>
+  <String Id="FirstTimeWelcomeMessageArm64">설치가 완료되었습니다.
+
+다음이 '[DOTNETHOME]'에 설치되었습니다.
+    • .NET SDK [DOTNETSDKVERSION]
+    • .NET 런타임 [DOTNETRUNTIMEVERSION]
+    • ASP.NET Core 런타임 [ASPNETCOREVERSION]
+
+이 제품은 사용량 현황 데이터를 수집합니다.
+    • 추가 정보 및 옵트아웃 https://aka.ms/dotnet-cli-telemetry
+
+리소스
+    • .NET 설명서 https://aka.ms/dotnet-docs
+    • SDK 설명서 https://aka.ms/dotnet-sdk-docs
+    • 릴리스 정보 https://aka.ms/dotnet5-release-notes
+    • 자습서 https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">.NET SDK</String>
   <String Id="WelcomeDescription">
     .NET SDK는 .NET 애플리케이션을 빌드, 실행 및 테스트하는 데 사용됩니다. 여러 언어, 편집기 및 개발자 도구 중에서 선택하고 대규모 라이브러리 에코시스템을 활용하여 웹, 모바일, 데스크톱, 게임 및 IoT용 앱을 빌드할 수 있습니다. .NET SDK를 유용하게 사용하시길 바랍니다.</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1045/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1045/bundle.wxl
@@ -63,6 +63,21 @@ Zasoby
     • Dokumentacja zestawu SDK: https://aka.ms/dotnet-sdk-docs
     • Informacje o wersji: https://aka.ms/dotnet5-release-notes
     • Samouczki: https://aka.ms/dotnet-tutorials</String>
+  <String Id="FirstTimeWelcomeMessageArm64">Instalacja zakończyła się pomyślnie.
+
+Następujące elementy zostały zainstalowane w: „[DOTNETHOME]”
+    • Zestaw .NET SDK [DOTNETSDKVERSION]
+    • Środowisko uruchomieniowe platformy .NET [DOTNETRUNTIMEVERSION]
+    • Środowisko uruchomieniowe platformy ASP.NET Core [ASPNETCOREVERSION]
+
+Ten produkt gromadzi dane dotyczące użycia
+    • Więcej informacji i rezygnacja: https://aka.ms/dotnet-cli-telemetry
+
+Zasoby
+    • Dokumentacja platformy .NET: https://aka.ms/dotnet-docs
+    • Dokumentacja zestawu SDK: https://aka.ms/dotnet-sdk-docs
+    • Informacje o wersji: https://aka.ms/dotnet5-release-notes
+    • Samouczki: https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">.NET SDK</String>
   <String Id="WelcomeDescription">
     Zestaw SDK platformy .NET służy do tworzenia, uruchamiania i testowania aplikacji platformy .NET. Możesz wybierać spośród wielu języków, edytorów i narzędzi deweloperskich oraz korzystać z dużego ekosystemu bibliotek do tworzenia aplikacji dla sieci Web, urządzeń przenośnych, komputerów, środowisk gier i technologii IoT. Mamy nadzieję, że Ci się podoba!</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1046/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1046/bundle.wxl
@@ -63,6 +63,21 @@ Recursos
     • Documentação do SDK: https://aka.ms/dotnet-sdk-docs
     • Notas sobre a Versão: https://aka.ms/netcore3releasenotes
     • Tutoriais: https://aka.ms/dotnet-tutorials</String>
+  <String Id="FirstTimeWelcomeMessageArm64">A instalação foi bem-sucedida.
+
+O seguinte foi instalado em: '[DOTNETHOME]'
+    • SDK do .NET [DOTNETSDKVERSION]
+    • Runtime do .NET [DOTNETRUNTIMEVERSION]
+    • Runtime do ASP.NET Core [ASPNETCOREVERSION]
+
+Este produto coleta dados de uso
+    • Para obter mais informações ou recusá-lo, acesse https://aka.ms/dotnet-cli-telemetry
+
+Recursos
+    • Documentação do .NET: https://aka.ms/dotnet-docs
+    • Documentação do SDK: https://aka.ms/dotnet-sdk-docs
+    • Notas sobre a Versão: https://aka.ms/netcore3releasenotes
+    • Tutoriais: https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">SDK do .NET</String>
   <String Id="WelcomeDescription">
     O SDK do .NET é usado para compilar, executar e testar aplicativos .NET. Você pode escolher entre vários idiomas, editores e ferramentas de desenvolvedor e aproveitar um grande ecossistema de bibliotecas para criar aplicativos para Web, móveis, área de trabalho, jogos e IoT. Esperamos que você goste!</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1049/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1049/bundle.wxl
@@ -63,6 +63,21 @@
     • Документация по SDK: https://aka.ms/dotnet-sdk-docs
     • Заметки о выпуске: https://aka.ms/dotnet5-release-notes
     • Учебники: https://aka.ms/dotnet-tutorials</String>
+  <String Id="FirstTimeWelcomeMessageArm64">Установка выполнена.
+
+В "[DOTNETHOME]" установлены следующие компоненты:
+    • Пакет SDK для .NET [DOTNETSDKVERSION]
+    • Среда выполнения .NET [DOTNETRUNTIMEVERSION]
+    • Среда выполнения ASP.NET Core [ASPNETCOREVERSION]
+
+Этот продукт собирает данные об использовании.
+    • Чтобы получить дополнительные сведения или отказаться от использования продукта, перейдите на страницу https://aka.ms/dotnet-cli-telemetry
+
+Ресурсы
+    • Документация по .NET: https://aka.ms/dotnet-docs
+    • Документация по SDK: https://aka.ms/dotnet-sdk-docs
+    • Заметки о выпуске: https://aka.ms/dotnet5-release-notes
+    • Учебники: https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">Пакет SDK для .NET</String>
   <String Id="WelcomeDescription">
     Пакет SDK для .NET используется для сборки, запуска и тестирования приложений .NET. Вы можете выбрать один из нескольких языков, использовать различные редакторы и инструменты для разработчиков, а также воспользоваться преимуществами большой экосистемы библиотек для создания веб-приложений, мобильных и классических приложений, игр и приложений Интернета вещей. Надеемся, вам понравится!</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1055/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1055/bundle.wxl
@@ -63,6 +63,21 @@ Kaynaklar
     • SDK Belgeleri https://aka.ms/dotnet-sdk-docs
     • Sürüm Notları https://aka.ms/dotnet5-release-notes
     • Öğreticiler https://aka.ms/dotnet-tutorials</String>
+  <String Id="FirstTimeWelcomeMessageArm64">Yükleme başarılı oldu.
+
+Aşağıdakiler şu konumda yüklü: '[DOTNETHOME]'
+    • .NET SDK [DOTNETSDKVERSION]
+    • .NET Çalışma Zamanı [DOTNETRUNTIMEVERSION]
+    • ASP.NET Core Çalışma Zamanı [ASPNETCOREVERSION]
+
+Bu ürün, kullanım verilerini toplar
+    • Daha fazla bilgi ve katılmamayı seçmek için bkz. https://aka.ms/dotnet-cli-telemetry
+
+Kaynaklar
+    • .NET Belgeleri https://aka.ms/dotnet-docs
+    • SDK Belgeleri https://aka.ms/dotnet-sdk-docs
+    • Sürüm Notları https://aka.ms/dotnet5-release-notes
+    • Öğreticiler https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">.NET SDK'sı</String>
   <String Id="WelcomeDescription">
     .NET SDK, .NET uygulamalarını derlemek, çalıştırmak ve test etmek için kullanılır. Birden çok dil, düzenleyici ve geliştirici aracı arasından seçim yapabilirsiniz ve web, mobil, masaüstü, oyun ve IoT uygulamaları oluşturmak için büyük bir kitaplık ekosisteminden yararlanabilirsiniz. Beğeneceğinizi umuyoruz!</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/2052/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/2052/bundle.wxl
@@ -63,6 +63,21 @@
     • SDK 文档: https://aka.ms/dotnet-sdk-docs
     • 发行说明: https://aka.ms/dotnet5-release-notes
     • 教程: https://aka.ms/dotnet-tutorials</String>
+<String Id="FirstTimeWelcomeMessageArm64">已成功安装。
+
+下列项安装于: "[DOTNETHOME]"
+    • .NET SDK [DOTNETSDKVERSION]
+    • .NET 运行时 [DOTNETRUNTIMEVERSION]
+    • ASP.NET Core 运行时 [ASPNETCOREVERSION]
+
+此产品会收集用法数据
+    • 详细信息和选择退出选项: https://aka.ms/dotnet-cli-telemetry
+
+资源
+    • .NET 文档: https://aka.ms/dotnet-docs
+    • SDK 文档: https://aka.ms/dotnet-sdk-docs
+    • 发行说明: https://aka.ms/dotnet5-release-notes
+    • 教程: https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">.NET SDK</String>
   <String Id="WelcomeDescription">
     .NET SDK 用于生成、运行和测试 .NET 应用程序。有多种语言、编辑器和开发人员工具可供选择，你也可使用由库构成的大型生态系统来构建面向 Web、移动设备、桌面、游戏和 IoT 的应用。希望你喜欢它!</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/3082/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/3082/bundle.wxl
@@ -63,6 +63,21 @@ Recursos
     • Documentación del SDK https://aka.ms/dotnet-sdk-docs
     • Notas de la versión https://aka.ms/dotnet5-release-notes
     • Tutoriales https://aka.ms/dotnet-tutorials</String>
+  <String Id="FirstTimeWelcomeMessageArm64">La instalación se realizó correctamente.
+
+Se instaló lo siguiente en: "[DOTNETHOME]"
+    • SDK de .NET [DOTNETSDKVERSION]
+    • .NET Runtime [DOTNETRUNTIMEVERSION]
+    • ASP.NET Core Runtime [ASPNETCOREVERSION]
+
+Este producto recopila datos de uso
+    • Para obtener más información y declinar la participación, visite https://aka.ms/dotnet-cli-telemetry
+
+Recursos
+    • Documentación de .NET https://aka.ms/dotnet-docs
+    • Documentación del SDK https://aka.ms/dotnet-sdk-docs
+    • Notas de la versión https://aka.ms/dotnet5-release-notes
+    • Tutoriales https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">SDK de .NET</String>
   <String Id="WelcomeDescription">
     El SDK de .NET se usa para compilar, ejecutar y probar las aplicaciones .NET. Puede elegir entre varios lenguajes, editores y herramientas de desarrollo y aprovechar las ventajas de un amplio ecosistema de bibliotecas para compilar aplicaciones web, móviles, de escritorio, juegos e IoT. Esperamos que lo disfrute.</String>

--- a/src/redist/targets/packaging/windows/clisdk/bundle.wxs
+++ b/src/redist/targets/packaging/windows/clisdk/bundle.wxs
@@ -195,7 +195,15 @@
 
   <Fragment>
     <PayloadGroup Id="DotnetCoreBAPayloads">
+      <!-- This theme is dupped with a slight change: It uses a modified version of FirstTimeWelcomeMessageArm64
+      for SuccessInstallHeader to account for ARM64's lack of support for WPF/WinForms. Once they converge, remove
+      this and remove FirstTimeWelcomeMessageArm64 from the wxl files. -->
+      <?if $(var.Platform)=arm64?>
+      <Payload Name="thm.xml" Compressed="yes" SourceFile="bundleArm64.thm" />
+      <?else?>
       <Payload Name="thm.xml" Compressed="yes" SourceFile="bundle.thm" />
+      <?endif?>
+
       <!-- Default/Neutral localized content is US English -->
       <Payload Name="thm.wxl" Compressed="yes" SourceFile="LCID\1033\bundle.wxl" />
       <Payload Name="bg.png" Compressed="yes" SourceFile="..\..\osx\clisdk\resources\dotnetbackground.png" />

--- a/src/redist/targets/packaging/windows/clisdk/bundle.wxs
+++ b/src/redist/targets/packaging/windows/clisdk/bundle.wxs
@@ -14,6 +14,10 @@
         WixBundleInstalled OR ((NOT (DOTNETHOME_X64 ~= DOTNETHOME_X86)) OR DOTNETHOMESIMILARITYCHECKOVERRIDE)
     </bal:Condition>
 
+    <bal:Condition Message="The installation path for ARM64 SDK installations: &quot;[DOTNETHOME_ARM64]&quot; cannot be the same as for x86 SDK installations: &quot;[DOTNETHOME_X86]&quot;">
+        WixBundleInstalled OR ((NOT (DOTNETHOME_ARM64 ~= DOTNETHOME_X86)) OR DOTNETHOMESIMILARITYCHECKOVERRIDE)
+    </bal:Condition>
+
     <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.Foundation">
       <bal:WixStandardBootstrapperApplication
         LicenseFile="dummyeula.rtf"
@@ -25,13 +29,13 @@
 
     <swid:Tag Regid="microsoft.com" InstallPath="[DOTNETHOME]" />
 
-      <util:RegistrySearch Id="CheckDotnetInstallLocation_x86"
+    <util:RegistrySearch Id="CheckDotnetInstallLocation_x86"
               Variable="DotnetInstallLocationExists_x86"
               Result="exists"
               Root="HKLM"
               Key="SOFTWARE\dotnet\Setup\InstalledVersions\x86"
               Value="InstallLocation" />
-      <util:RegistrySearch Id="DotnetInstallLocation_x86"
+    <util:RegistrySearch Id="DotnetInstallLocation_x86"
               After="CheckDotnetInstallLocation_x86"
               Condition="DotnetInstallLocationExists_x86"
               Variable="DOTNETHOME_X86"
@@ -40,18 +44,19 @@
               Key="SOFTWARE\dotnet\Setup\InstalledVersions\x86"
               Value="InstallLocation" />
 
-      <util:FileSearch Id="DotnetExeSearch_x86"
+    <util:FileSearch Id="DotnetExeSearch_x86"
               After="DotnetInstallLocation_x86"
               Variable="DotnetExeExists_x86"
               Condition="NOT DotnetInstallLocationExists_x86"
               Result="exists"
               Path="[ProgramFilesFolder]dotnet\dotnet.exe"/>
-      <util:DirectorySearch Id="DotnetExeLocation_x86"
+    <util:DirectorySearch Id="DotnetExeLocation_x86"
               After="DotnetExeSearch_x86"
               Condition="DotnetExeExists_x86"
               Variable="DOTNETHOME_X86"
               Path="[ProgramFilesFolder]dotnet"/>
-      
+
+    <?if $(var.Platform)=x64?>
     <util:RegistrySearch Id="CheckDotnetInstallLocation_x64"
               Variable="DotnetInstallLocationExists_x64"
               Result="exists"
@@ -79,6 +84,35 @@
               Variable="DOTNETHOME_X64"
               Path="[ProgramFiles64Folder]dotnet"/>
 
+    <?elseif $(var.Platform)=arm64?>
+    <util:RegistrySearch Id="CheckDotnetInstallLocation_arm64"
+              Variable="DotnetInstallLocationExists_arm64"
+              Result="exists"
+              Root="HKLM"
+              Key="SOFTWARE\dotnet\Setup\InstalledVersions\arm64"
+              Value="InstallLocation" />
+    <util:RegistrySearch Id="DotnetInstallLocation_arm64"
+              After="CheckDotnetInstallLocation_arm64"
+              Condition="DotnetInstallLocationExists_arm64"
+              Variable="DOTNETHOME_ARM64"
+              Result="value"
+              Root="HKLM"
+              Key="SOFTWARE\dotnet\Setup\InstalledVersions\arm64"
+              Value="InstallLocation" />
+
+    <util:FileSearch Id="DotnetExeSearch_arm64"
+              After="DotnetInstallLocation_arm64"
+              Variable="DotnetExeExists_arm64"
+              Condition="NOT DotnetInstallLocationExists_arm64"
+              Result="exists"
+              Path="[ProgramFiles64Folder]dotnet\dotnet.exe"/>
+    <util:DirectorySearch Id="DotnetExeLocation_arm64"
+              After="DotnetExeSearch_arm64"
+              Condition="DotnetExeExists_arm64"
+              Variable="DOTNETHOME_ARM64"
+              Path="[ProgramFiles64Folder]dotnet"/>
+    <?endif?>
+
     <!-- 
         When installing the SDK bundle to a custom location using the commandline parameters, it is intended, not mandatory, that 
         both "DOTNETHOME_X86" and "DOTNETHOME_X64" should be used on the commandline and should take this convention:
@@ -89,6 +123,7 @@
     -->
     <Variable Name="DOTNETHOME_X86" Type="string" Value="[ProgramFilesFolder]dotnet" bal:Overridable="yes" />
     <Variable Name="DOTNETHOME_X64" Type="string" Value="[ProgramFiles64Folder]dotnet" bal:Overridable="yes" />
+    <Variable Name="DOTNETHOME_ARM64" Type="string" Value="[ProgramFiles64Folder]dotnet" bal:Overridable="yes" />
     <Variable Name="DOTNETHOME" Type="string" Value="[DOTNETHOME_$(var.PlatformToken)]" bal:Overridable="no" />
     <Variable Name="BUNDLEMONIKER" Type="string" Value="$(var.ProductMoniker)" bal:Overridable="no" />
     <Variable Name="DOTNETSDKVERSION" Type="string" Value="$(var.NugetVersion)" bal:Overridable="no" />
@@ -107,15 +142,13 @@
       <MsiPackage SourceFile="$(var.SharedHostMsiSourcePath)">
         <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
       </MsiPackage>
-      <MsiPackage SourceFile="$(var.WinFormsAndWpfMsiSourcePath)">
-        <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
-      </MsiPackage>
       <MsiPackage SourceFile="$(var.NetCoreAppTargetingPackMsiSourcePath)">
         <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
       </MsiPackage>
       <MsiPackage SourceFile="$(var.NetCoreAppHostPackMsiSourcePath)">
         <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
       </MsiPackage>
+      <?if $(var.Platform)=x86 or $(var.Platform)=x64?>
       <MsiPackage SourceFile="$(var.AlternateNetCoreAppHostPackMsiSourcePath)">
         <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
       </MsiPackage>
@@ -128,10 +161,14 @@
       <MsiPackage SourceFile="$(var.NetStandardTargetingPackMsiSourcePath)">
         <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
       </MsiPackage>
-      <MsiPackage SourceFile="$(var.AspNetTargetingPackMsiSourcePath)">
-        <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
+      <MsiPackage SourceFile="$(var.WinFormsAndWpfMsiSourcePath)">
+          <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
       </MsiPackage>
       <MsiPackage SourceFile="$(var.WindowsDesktopTargetingPackMsiSourcePath)">
+        <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
+      </MsiPackage>
+      <?endif?>
+      <MsiPackage SourceFile="$(var.AspNetTargetingPackMsiSourcePath)">
         <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
       </MsiPackage>
       <MsiPackage SourceFile="$(var.TemplatesMsiSourcePath)">
@@ -142,6 +179,7 @@
         <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
         <MsiProperty Name="DOTNETHOME_X86" Value="[DOTNETHOME_X86]" />
         <MsiProperty Name="DOTNETHOME_X64" Value="[DOTNETHOME_X64]" />
+        <MsiProperty Name="DOTNETHOME_ARM64" Value="[DOTNETHOME_ARM64]" />
         <MsiProperty Name="EXEFULLPATH" Value="[WixBundleOriginalSource]" />
         <MsiProperty Name="ALLOWMSIINSTALL" Value="True" />
       </MsiPackage>
@@ -149,6 +187,8 @@
         <PackageGroupRef Id="PG_AspNetCoreSharedFramework_x86"/>
       <?elseif $(var.Platform)=x64?>
         <PackageGroupRef Id="PG_AspNetCoreSharedFramework_x64"/>
+      <?elseif $(var.Platform)=arm64?>
+        <PackageGroupRef Id="PG_AspNetCoreSharedFramework_arm64"/>
       <?endif?>
     </Chain>
   </Bundle>

--- a/src/redist/targets/packaging/windows/clisdk/bundleArm64.thm
+++ b/src/redist/targets/packaging/windows/clisdk/bundleArm64.thm
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Theme xmlns="http://wixtoolset.org/schemas/thmutil/2010">
+  <Window Width="660" Height="488" HexStyle="100a0000" FontId="0">#(loc.Caption)</Window>
+    <Font Id="0" Height="-12" Weight="500" Foreground="000000" Background="FFFFFF">Segoe UI</Font>
+    <Font Id="1" Height="-24" Weight="900" Foreground="FFFFFF" Background="D42B51">Segoe UI</Font>
+    <Font Id="2" Height="-22" Weight="500" Foreground="666666">Segoe UI</Font>
+    <Font Id="3" Height="-12" Weight="500" Foreground="000000" Background="FFFFFF">Segoe UI</Font>
+    <Font Id="4" Height="-12" Weight="500" Foreground="ff0000" Background="FFFFFF" Underline="yes">Segoe UI</Font>
+    <Font Id="5" Height="-14" Weight="500" Foreground="444444">Segoe UI</Font>
+
+    <Text Name="Title" X="11" Y="11" Width="-11" Height="64" FontId="1" Visible="yes" Center="yes" DisablePrefix="yes">#(loc.Title)</Text>
+
+    <Page Name="Help">
+        <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
+        <Text X="0" Y="0" Width="660" Height="75" FontId="1" />
+
+        <Text Name="HelpHeader" X="151" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.HelpHeader)</Text>
+        <Text Name="HelpText" X="160" Y="115" Width="-11" Height="-35" FontId="3" DisablePrefix="yes">#(loc.HelpText)</Text>
+        <Button Name="HelpCancelButton" X="-32" Y="-11" Width="99" Height="23" TabStop="yes" FontId="0">#(loc.HelpCloseButton)</Button>
+    </Page>
+    <Page Name="Install">
+        <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
+        <Text X="0" Y="0" Width="660" Height="75" FontId="1" />
+
+        <Text Name="WelcomeText" X="155" Y="80" Width="-11" Height="-70" FontId="2" HexStyle="0x800000" DisablePrefix="yes" />
+        <Text Name="WelcomeHeaderMessage" X="160" Y="80" Width="300" Height="30" FontId="2">#(loc.WelcomeHeaderMessage)</Text>
+        <Text Name="WelcomeDescription" X="160" Y="125" Width="460" Height="65" FontId="3">#(loc.WelcomeDescription)</Text>
+        <Hypertext Name="VisualStudioWarning" X="160" Y="209" Width="460" Height="30" TabStop="yes" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.VisualStudioWarning)</Hypertext>
+        <Text Name="LicenseAssent" X="160" Y="264" Width="460" Height="30" FontId="3">#(loc.LicenseAssent)</Text>
+        <Hypertext Name="PrivacyStatementLink" X="185" Y="301" Width="400" Height="22" FontId="3" TabStop="yes" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.PrivacyStatementLink)</Hypertext>
+        <Hypertext Name="DotNetEulaLink" X="185" Y="323" Width="400" Height="22" FontId="3" TabStop="yes" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.DotNetEulaLink)</Hypertext>
+        <Button Name="InstallButton" X="-133" Y="-11" Width="99" Height="23" TabStop="yes" FontId="0">#(loc.InstallInstallButton)</Button>
+        <Button Name="WelcomeCancelButton" X="-32" Y="-11" Width="99" Height="23" TabStop="yes" FontId="0">#(loc.InstallCloseButton)</Button>
+    </Page>
+    <Page Name="FilesInUse">
+        <Text X="0" Y="0" Width="660" Height="75" FontId="1" />
+
+        <Text Name="FilesInUseHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.FilesInUseHeader)</Text>
+        <Text Name="FilesInUseLabel" X="11" Y="121" Width="-11" Height="34" FontId="3" DisablePrefix="yes">#(loc.FilesInUseLabel)</Text>
+        <Text Name="FilesInUseText" X="11" Y="150" Width="-11" Height="-86" FontId="3" DisablePrefix="yes" HexStyle="0x0000000C"></Text>
+
+        <Button Name="FilesInUseCloseRadioButton" X="300" Y="-65" Width="-11" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes" HexStyle="0x000009">#(loc.FilesInUseCloseRadioButton)</Button>
+        <Button Name="FilesInUseDontCloseRadioButton" X="300" Y="-45" Width="-11" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes" HexStyle="0x000009">#(loc.FilesInUseDontCloseRadioButton)</Button>
+
+        <Button Name="FilesInUseOkButton" X="-133" Y="-11" Width="99" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.FilesInUseOkButton)</Button>
+        <Button Name="FilesInUseCancelButton" X="-32" Y="-11" Width="99" Height="23" TabStop="yes" FontId="0">#(loc.FilesInUseCancelButton)</Button>
+        <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
+    </Page>
+    <Page Name="Progress">
+        <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
+        <Text X="0" Y="0" Width="660" Height="75" FontId="1" />
+
+        <Text Name="ProgressHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.ProgressHeader)</Text>
+        <Text Name="ProgressLabel" X="11" Y="121" Width="70" Height="17" FontId="3" DisablePrefix="yes">#(loc.ProgressLabel)</Text>
+        <Text Name="OverallProgressPackageText" X="85" Y="121" Width="-11" Height="17" FontId="3" DisablePrefix="yes">#(loc.OverallProgressPackageText)</Text>
+        <Progressbar Name="OverallCalculatedProgressbar" X="11" Y="143" Width="-11" Height="15" />
+        <Button Name="ProgressCancelButton" X="-32" Y="-11" Width="99" Height="23" TabStop="yes" FontId="0">#(loc.ProgressCancelButton)</Button>
+    </Page>
+    <Page Name="Modify">
+        <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
+        <Text X="0" Y="0" Width="660" Height="75" FontId="1" />
+
+        <Text Name="ModifyHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.ModifyHeader)</Text>
+        <Button Name="RepairButton" X="-234" Y="-11" Width="99" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.ModifyRepairButton)</Button>
+        <Button Name="UninstallButton" X="-133" Y="-11" Width="99" Height="23" TabStop="yes" FontId="0">#(loc.ModifyUninstallButton)</Button>
+        <Button Name="ModifyCancelButton" X="-32" Y="-11" Width="99" Height="23" TabStop="yes" FontId="0">#(loc.ModifyCloseButton)</Button>
+    </Page>
+    <Page Name="Success">
+        <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
+        <Text X="0" Y="0" Width="660" Height="75" FontId="1" />
+
+        <Text Name="SuccessHeader" X="11" Y="80"  Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessHeader)</Text>
+        <Richedit Name="SuccessInstallHeader" X="160" Y="81" Width="-12" Height="-71" FontId="5" HideWhenDisabled="yes">#(loc.FirstTimeWelcomeMessageArm64)</Richedit>
+        <Text Name="SuccessRepairHeader" X="160" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessRepairHeader)</Text>
+        <Text Name="SuccessUninstallHeader" X="160" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessUninstallHeader)</Text>
+        <Button Name="LaunchButton" X="-133" Y="-11" Width="99" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.SuccessLaunchButton)</Button>
+        <Text Name="SuccessRestartText" X="-11" Y="-40" Width="400" Height="23" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessRestartText)</Text>
+        <Button Name="SuccessRestartButton" X="-133" Y="-11" Width="99" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.SuccessRestartButton)</Button>
+        <Button Name="SuccessCancelButton" X="-32" Y="-11" Width="99" Height="23" TabStop="yes" FontId="0">#(loc.SuccessCloseButton)</Button>
+    </Page>
+    <Page Name="Failure">
+        <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
+        <Text X="0" Y="0" Width="660" Height="75" FontId="1" />
+
+        <Text Name="FailureHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureHeader)</Text>
+        <Text Name="FailureInstallHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureInstallHeader)</Text>
+        <Text Name="FailureUninstallHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureUninstallHeader)</Text>
+        <Text Name="FailureRepairHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureRepairHeader)</Text>
+        <Hypertext Name="FailureLogFileLink" X="11" Y="121" Width="-11" Height="42" FontId="3" TabStop="yes" HideWhenDisabled="yes">#(loc.FailureHyperlinkLogText)</Hypertext>
+        <Hypertext Name="FailureMessageText" X="22" Y="163" Width="-11" Height="51" FontId="3" TabStop="yes" HideWhenDisabled="yes" />
+        <Text Name="FailureRestartText" X="-11" Y="-40" Width="400" Height="34" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureRestartText)</Text>
+        <Button Name="FailureRestartButton" X="-133" Y="-11" Width="99" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.FailureRestartButton)</Button>
+        <Button Name="FailureCloseButton" X="-32" Y="-11" Width="99" Height="23" TabStop="yes" FontId="0">#(loc.FailureCloseButton)</Button>
+    </Page>
+</Theme>

--- a/src/redist/targets/packaging/windows/clisdk/dotnet.wxs
+++ b/src/redist/targets/packaging/windows/clisdk/dotnet.wxs
@@ -2,7 +2,7 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <?include "Variables.wxi" ?>
   <Product Id="*" Name="$(var.ProductName)" Language="$(var.ProductLanguage)" Version="$(var.ProductVersion)" Manufacturer="$(var.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
-    <Package Compressed="yes" InstallScope="perMachine" InstallerVersion="200" />
+    <Package Compressed="yes" InstallScope="perMachine" InstallerVersion="$(var.InstallerVersion)" />
 
     <Condition Message="$(var.ProductName) must be installed as part of a coordinated SDK installation.">
       Installed OR ALLOWMSIINSTALL

--- a/src/redist/targets/packaging/windows/clisdk/registrykeys.wxs
+++ b/src/redist/targets/packaging/windows/clisdk/registrykeys.wxs
@@ -15,6 +15,12 @@
           <RegistryValue Action="write" Name="WpfWinformsTemplates" Type="integer" Value="1" KeyPath="yes"/>
         </RegistryKey>
       </Component>
+      <Component Id="DotnetInstallLocation_arm64" Directory="TARGETDIR" Win64="no">
+        <Condition>VersionNT64 AND DOTNETHOME_ARM64</Condition>
+        <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\Setup\InstalledVersions\arm64">
+          <RegistryValue Action="write" Name="InstallLocation" Type="string" Value="[DOTNETHOME_ARM64]" KeyPath="yes"/>
+        </RegistryKey>
+      </Component>
       <Component Id="DotnetInstallLocation_x64" Directory="TARGETDIR" Win64="no">
         <Condition>VersionNT64 AND DOTNETHOME_X64</Condition>
         <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\Setup\InstalledVersions\x64">

--- a/src/redist/targets/packaging/windows/clisdk/templates.wxs
+++ b/src/redist/targets/packaging/windows/clisdk/templates.wxs
@@ -2,7 +2,7 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <?include "Variables.wxi" ?>
   <Product Id="*" Name="$(var.ProductName)" Language="$(var.ProductLanguage)" Version="$(var.ProductVersion)" Manufacturer="$(var.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
-    <Package Compressed="yes" InstallScope="perMachine" InstallerVersion="200" />
+    <Package Compressed="yes" InstallScope="perMachine" InstallerVersion="$(var.InstallerVersion)" />
 
     <Condition Message="$(var.ProductName) must be installed as part of a coordinated SDK installation.">
       Installed OR ALLOWMSIINSTALL

--- a/src/redist/targets/packaging/windows/clisdk/variables.wxi
+++ b/src/redist/targets/packaging/windows/clisdk/variables.wxi
@@ -26,8 +26,21 @@
   <?define WixQuietExec="WixQuietExec64"?>
   <?define Program_Files="ProgramFiles64Folder"?>
   <?define Win64AttributeValue=yes?>
+  <?elseif $(var.Platform)=arm64?>
+  <?define PlatformToken="arm64"?>
+  <?define WixQuietExec="WixQuietExec64"?>
+  <?define Program_Files="ProgramFiles64Folder"?>
+  <?define Win64AttributeValue=yes?>
   <?else?>
   <?error Invalid Platform ($(var.Platform))?>
+  <?endif?>
+
+  <!-- See https://docs.microsoft.com/en-us/windows/win32/msi/using-64-bit-windows-installer-packages. -->
+  <!-- For 64-bit packages on the Arm64 platform, the Windows Installer database schema must be 500 or higher. -->
+  <?if $(var.Platform)=arm64?>
+  <?define InstallerVersion="500"?>
+  <?else?>
+  <?define InstallerVersion="200"?>
   <?endif?>
 
   <?define DependencyKey   = "$(var.DependencyKeyName)_$(var.SDKBundleVersion)_$(var.Platform)"?>

--- a/src/redist/targets/packaging/windows/clisdk/variables.wxi
+++ b/src/redist/targets/packaging/windows/clisdk/variables.wxi
@@ -27,7 +27,7 @@
   <?define Program_Files="ProgramFiles64Folder"?>
   <?define Win64AttributeValue=yes?>
   <?elseif $(var.Platform)=arm64?>
-  <?define PlatformToken="arm64"?>
+  <?define PlatformToken="ARM64"?>
   <?define WixQuietExec="WixQuietExec64"?>
   <?define Program_Files="ProgramFiles64Folder"?>
   <?define Win64AttributeValue=yes?>

--- a/test/EndToEnd/ProjectBuildTests.cs
+++ b/test/EndToEnd/ProjectBuildTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Xml.Linq;
 using Microsoft.DotNet.TestFramework;
@@ -81,51 +80,6 @@ namespace EndToEnd.Tests
                 .WithWorkingDirectory(projectDirectory)
                 .ExecuteWithCapturedOutput()
                 .Should().Pass().And.HaveStdOutContaining("Hello World!");
-        }
-
-        [WindowsOnlyFact]
-        public void ItCanPublishArm64Winforms()
-        {
-            DirectoryInfo directory = TestAssets.CreateTestDirectory();
-            string projectDirectory = directory.FullName;
-
-            string newArgs = "winforms --no-restore";
-            new NewCommandShim()
-                .WithWorkingDirectory(projectDirectory)
-                .Execute(newArgs)
-                .Should().Pass();
-
-            string publishArgs="-r win-arm64";
-            new PublishCommand()
-                .WithWorkingDirectory(projectDirectory)
-                .Execute(publishArgs)
-                .Should().Pass();
-            
-            var selfContainedPublishDir = new DirectoryInfo(projectDirectory)
-                .Sub("bin").Sub("Debug").GetDirectories().FirstOrDefault()
-                .Sub("win-arm64").Sub("publish");
-
-            selfContainedPublishDir.Should().HaveFilesMatching("System.Windows.Forms.dll", SearchOption.TopDirectoryOnly);
-            selfContainedPublishDir.Should().HaveFilesMatching($"{directory.Name}.dll", SearchOption.TopDirectoryOnly);
-        }
-        
-        [WindowsOnlyFact]
-        public void ItCantPublishArm64Wpf()
-        {
-            DirectoryInfo directory = TestAssets.CreateTestDirectory();
-            string projectDirectory = directory.FullName;
-
-            string newArgs = "wpf --no-restore";
-            new NewCommandShim()
-                .WithWorkingDirectory(projectDirectory)
-                .Execute(newArgs)
-                .Should().Pass();
-
-            string publishArgs="-r win-arm64";
-            new PublishCommand()
-                .WithWorkingDirectory(projectDirectory)
-                .Execute(publishArgs)
-                .Should().Fail();
         }
 
         [Theory]


### PR DESCRIPTION
@wli3 @marcpopMSFT @sfoslund  this is the PR I folded the other one into. It's still in draft as I'm testing but I wanted some feedback.

- Enable Win-ARM64 as a possible RID for ASP.NET core
- ARM64 bundled installer

I've excluded the following assets from the ARM64 installer. Are these ok?
- There are no alternate architecture hosts MSIs available. I've excluded those.
- There is no ARM64 targeting pack available for .NET standard. I'd have to do this from a servicing branch and it wasn't very straightforward. Would these get downloaded as NuGet packages if not available in-box?
- It was decided to revert WinForms Win-ARM64 support until WPF is ready.