### PR TITLE
Stamp runtimeconfigs with M.AspNetCore.App versions

### DIFF
--- a/src/core-sdk-tasks/ReplaceFileContents.cs
+++ b/src/core-sdk-tasks/ReplaceFileContents.cs
@@ -12,18 +12,18 @@ namespace Microsoft.DotNet.Cli.Build
 {
     /// <summary>
     /// Reads contents of an input file, and searches for each replacement passed in.
-    /// 
+    ///
     /// When ReplacementItems is matched, it will replace the Include/ItemSpec with the corresponding
     /// ReplacementString metadata value. This can be useful if the ReplacementString is a value that
     /// cannot be represented by ITaskItem.ItemSpec (like string.Empty).
-    /// 
-    /// When a ReplacementPattern is matched it will replace it with the string of the corresponding (by index) 
+    ///
+    /// When a ReplacementPattern is matched it will replace it with the string of the corresponding (by index)
     /// item in ReplacementStrings.
-    /// 
-    /// For example, if 2 ReplacementPatterns are passed in, 2 ReplacementStrings must also passed in and the first 
+    ///
+    /// For example, if 2 ReplacementPatterns are passed in, 2 ReplacementStrings must also passed in and the first
     /// pattern will be replaced with the first string, and the second pattern replaced with the second string.
-    /// 
-    /// ReplacementPattern could easily be a regex, but it isn't needed for current use cases, so leaving this 
+    ///
+    /// ReplacementPattern could easily be a regex, but it isn't needed for current use cases, so leaving this
     /// as just a string that will be replaced.
     /// </summary>
     public class ReplaceFileContents : Task
@@ -39,6 +39,11 @@ namespace Microsoft.DotNet.Cli.Build
         public ITaskItem[] ReplacementPatterns { get; set; }
 
         public ITaskItem[] ReplacementStrings { get; set; }
+
+        /// <summary>
+        /// Gets or sets a string that a file must contain for the replacement to be performed.
+        /// </summary>
+        public string FileMustContainText { get; set; }
 
         public override bool Execute()
         {
@@ -81,6 +86,12 @@ namespace Microsoft.DotNet.Cli.Build
         public void ReplaceContents(string inputFile, string destinationFile)
         {
             string inputFileText = File.ReadAllText(inputFile);
+            if (!string.IsNullOrEmpty(FileMustContainText) && !inputFileText.Contains(FileMustContainText))
+            {
+                Log.LogMessage(MessageImportance.Low, $"Skipping replacement on `{inputFile}` because it does not contain the text '{FileMustContainText}'.");
+                return;
+            }
+
             string outputFileText = ReplacePatterns(inputFileText);
 
             WriteOutputFile(destinationFile, outputFileText);

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -403,15 +403,27 @@
     <PropertyGroup>
       <ReplacementPattern>"version": ".*"</ReplacementPattern>
       <ReplacementString>"version": "$(MicrosoftNETCoreAppRuntimePackageVersion)"</ReplacementString>
+      <AspNetCoreRuntimeReplacementString>"version": "$(MicrosoftAspNetCoreAppRuntimePackageVersion)"</AspNetCoreRuntimeReplacementString>
     </PropertyGroup>
     <ItemGroup>
       <ToolRuntimeConfigPath Include="$(RedistLayoutPath)sdk/$(Version)/**/*.runtimeconfig.json" />
     </ItemGroup>
+
+    <!-- Update runtimeconfig files that target Microsoft.NETCore.App -->
     <ReplaceFileContents
       InputFiles="@(ToolRuntimeConfigPath)"
       DestinationFiles="@(ToolRuntimeConfigPath)"
       ReplacementPatterns="$(ReplacementPattern)"
-      ReplacementStrings="$(ReplacementString)" />
+      ReplacementStrings="$(ReplacementString)"
+      FileMustContainText="Microsoft.NETCore.App" />
+
+    <!-- Update runtimeconfig files that target Microsoft.AspNetCore.App -->
+    <ReplaceFileContents
+      InputFiles="@(ToolRuntimeConfigPath)"
+      DestinationFiles="@(ToolRuntimeConfigPath)"
+      ReplacementPatterns="$(ReplacementPattern)"
+      ReplacementStrings="$(AspNetCoreRuntimeReplacementString)"
+      FileMustContainText="Microsoft.AspNetCore.App" />
   </Target>
 
   <Target Name="GenerateVersionFile"


### PR DESCRIPTION
The installer currently updates all runtimeconfig files with the M.NETCore.App version
regardless of the runtime they are targeting. This causes issues with dotnet-watch
which is targeting the AspNetCore shared runtime as of 5.0-preview8. This change
updates the targets \ task to be more discerning.

