### PR TITLE
[release/5.0.1xx-rc2] Remove double publish in stable builds

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -99,30 +99,6 @@
           PropertyName="FullNugetVersion"/>
     </ReadLinesFromFile>
 
-    <!-- If the sdk version is stabilized, then we should double publish the binaries to suffixed file names.
-         To do this, create new copies of the blobs, replacing the SdkVersion string in the file name with the
-         FullNugetVersion, except if the FullNuGetVersion is already in the file name (which would end up
-         publishing the same exact file name twice). -->
-    <ItemGroup Condition="'$(DotNetFinalVersionKind)'== 'release'">
-        <SdkAssetsToCopyWithSuffix Include="@(SdkAssetsToPublish)" Condition="'$([System.String]::Copy(`%(Filename)`).Contains(`$(Version)`))' == 'true'">
-          <SuffixedPath>$(ArtifactsShippingPackagesDir)/$([System.String]::Copy('%(Filename)%(Extension)').Replace('$(Version)' ,'$(FullNuGetVersion)'))</SuffixedPath>
-        </SdkAssetsToCopyWithSuffix>
-        <CheckSumsToCopyWithSuffix Include="@(CheckSumsToPublish)" Condition="'$([System.String]::Copy(`%(Filename)`).Contains(`$(Version)`))' == 'true'">
-          <SuffixedPath>$(ArtifactsShippingPackagesDir)/$([System.String]::Copy('%(Filename)%(Extension)').Replace('$(Version)' ,'$(FullNuGetVersion)'))</SuffixedPath>
-        </CheckSumsToCopyWithSuffix>
-    </ItemGroup>
-
-    <Copy
-      SourceFiles="@(SdkAssetsToCopyWithSuffix -> '%(Identity)')"
-      DestinationFiles="@(SdkAssetsToCopyWithSuffix -> '%(SuffixedPath)')">
-      <Output TaskParameter="CopiedFiles" ItemName="SdkAssetsToPublishWithSuffix" />
-    </Copy>
-    <Copy
-      SourceFiles="@(CheckSumsToCopyWithSuffix -> '%(Identity)')"
-      DestinationFiles="@(CheckSumsToCopyWithSuffix -> '%(SuffixedPath)')">
-      <Output TaskParameter="CopiedFiles" ItemName="CheckSumsToPublishWithSuffix" />
-    </Copy>
-
     <ItemGroup>
       <!-- Always publish blobs to a suffixed directory. -->
       <SdkAssetsToPushToBlobFeed Include="@(SdkAssetsToPublish)">
@@ -137,20 +113,10 @@
       <ChecksumsToPushToBlobFeed Include="@(CheckSumsToPublish)">
         <RelativeBlobPath>$(BlobStoragePartialRelativePath)/$(FullNugetVersion)/$([System.String]::Copy('%(Filename)%(Extension)'))</RelativeBlobPath>
       </ChecksumsToPushToBlobFeed>
-
-      <SdkAssetsWithSuffixToPushToBlobFeed Include="@(SdkAssetsToPublishWithSuffix)">
-        <RelativeBlobPath>$(BlobStoragePartialRelativePath)/$(FullNugetVersion)/$([System.String]::Copy('%(Filename)%(Extension)'))</RelativeBlobPath>
-        <ManifestArtifactData>NonShipping=true</ManifestArtifactData>
-      </SdkAssetsWithSuffixToPushToBlobFeed>
-
-      <ChecksumsWithSuffixToPushToBlobFeed Include="@(CheckSumsToPublishWithSuffix)" Condition="'$(DotNetFinalVersionKind)'== 'release'">
-        <RelativeBlobPath>$(BlobStoragePartialRelativePath)/$(FullNugetVersion)/$([System.String]::Copy('%(Filename)%(Extension)'))</RelativeBlobPath>
-        <ManifestArtifactData>NonShipping=true</ManifestArtifactData>
-      </ChecksumsWithSuffixToPushToBlobFeed>
     </ItemGroup>
 
     <PushToAzureDevOpsArtifacts
-      ItemsToPush="@(SdkAssetsToPushToBlobFeed);@(SdkAssetsWithSuffixToPushToBlobFeed)"
+      ItemsToPush="@(SdkAssetsToPushToBlobFeed)"
       ManifestBuildData="@(ManifestBuildData)"
       ManifestRepoUri="$(BUILD_REPOSITORY_URI)"
       ManifestBranch="$(BUILD_SOURCEBRANCH)"
@@ -160,7 +126,7 @@
       PublishFlatContainer="true" />
 
     <PushToAzureDevOpsArtifacts
-      ItemsToPush="@(ChecksumsToPushToBlobFeed);@(ChecksumsWithSuffixToPushToBlobFeed)"
+      ItemsToPush="@(ChecksumsToPushToBlobFeed)"
       ManifestBuildData="@(ManifestBuildData)"
       ManifestRepoUri="$(BUILD_REPOSITORY_URI)"
       ManifestBranch="$(BUILD_SOURCEBRANCH)"


### PR DESCRIPTION
https://github.com/dotnet/arcade/pull/6051 fixed the issue where the install
scripts require matching names of files to directories. Remove the double
publish change introduced in 3.0