### PR TITLE
Update microsoft.windows.sdk.net.ref

### DIFF
--- a/eng/ManualVersions.props
+++ b/eng/ManualVersions.props
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-<!-- The following property needs to choice the highest when there is merge conflict.
-      Unlike Versions.props the following property is maintained manually. So there won't be
-      a bot Checking into multiple branches. Instead of keeping what's in branch,
-      whenever there is a merge conflict. Pick the highest.
+<!-- The following properties (unlike those in version.props) are maintained manually.  So
+     when there is a merge conflict, the highest version should generally be chosen, rather
+     than keeping what's in the branch, which is the usual strategy with version.props merge
+     conflicts.
+       
+     Basically: In this file, choose the highest version when resolving merge conflicts.
  -->
   <PropertyGroup>
     <MicrosoftWindowsSDKNETRef10_0_17763PackageVersion>10.0.17763.3-preview</MicrosoftWindowsSDKNETRef10_0_17763PackageVersion>

--- a/eng/ManualVersions.props
+++ b/eng/ManualVersions.props
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+<!-- The following property needs to choice the highest when there is merge conflict.
+      Unlike Versions.props the following property is maintained manually. So there won't be
+      a bot Checking into multiple branches. Instead of keeping what's in branch,
+      whenever there is a merge conflict. Pick the highest.
+ -->
+  <PropertyGroup>
+    <MicrosoftWindowsSDKNETRef10_0_17763PackageVersion>10.0.17763.3-preview</MicrosoftWindowsSDKNETRef10_0_17763PackageVersion>
+    <MicrosoftWindowsSDKNETRef10_0_18362PackageVersion>10.0.18362.4-preview</MicrosoftWindowsSDKNETRef10_0_18362PackageVersion>
+    <MicrosoftWindowsSDKNETRef10_0_19041PackageVersion>10.0.19041.3-preview</MicrosoftWindowsSDKNETRef10_0_19041PackageVersion>
+  </PropertyGroup>
+</Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -130,12 +130,8 @@
     <MicrosoftNETTestSdkVersion>16.8.0-release-20200902-05</MicrosoftNETTestSdkVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftWindowsSDKNETRef10_0_17763PackageVersion>10.0.17763.3-preview</MicrosoftWindowsSDKNETRef10_0_17763PackageVersion>
-    <MicrosoftWindowsSDKNETRef10_0_18362PackageVersion>10.0.18362.4-preview</MicrosoftWindowsSDKNETRef10_0_18362PackageVersion>
-    <MicrosoftWindowsSDKNETRef10_0_19041PackageVersion>10.0.19041.3-preview</MicrosoftWindowsSDKNETRef10_0_19041PackageVersion>
-  </PropertyGroup>
-  <PropertyGroup>
     <!-- pinned dependency. This package is not being produced outside of the 2.0 branch of corefx and should not change. -->
     <CLI_NETStandardLibraryNETFrameworkVersion>2.0.1-servicing-26011-01</CLI_NETStandardLibraryNETFrameworkVersion>
   </PropertyGroup>
+  <Import Project="$(RepositoryEngineeringDir)ManualVersions.props" />
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -130,9 +130,9 @@
     <MicrosoftNETTestSdkVersion>16.8.0-release-20200902-05</MicrosoftNETTestSdkVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftWindowsSDKNETRef10_0_17763PackageVersion>10.0.17763.1-preview</MicrosoftWindowsSDKNETRef10_0_17763PackageVersion>
-    <MicrosoftWindowsSDKNETRef10_0_18362PackageVersion>10.0.18362.2-preview</MicrosoftWindowsSDKNETRef10_0_18362PackageVersion>
-    <MicrosoftWindowsSDKNETRef10_0_19041PackageVersion>10.0.19041.1-preview</MicrosoftWindowsSDKNETRef10_0_19041PackageVersion>
+    <MicrosoftWindowsSDKNETRef10_0_17763PackageVersion>10.0.17763.3-preview</MicrosoftWindowsSDKNETRef10_0_17763PackageVersion>
+    <MicrosoftWindowsSDKNETRef10_0_18362PackageVersion>10.0.18362.4-preview</MicrosoftWindowsSDKNETRef10_0_18362PackageVersion>
+    <MicrosoftWindowsSDKNETRef10_0_19041PackageVersion>10.0.19041.3-preview</MicrosoftWindowsSDKNETRef10_0_19041PackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- pinned dependency. This package is not being produced outside of the 2.0 branch of corefx and should not change. -->


### PR DESCRIPTION
Per the comment in ManualVersions.props. We did not merge the change back to RC2 since we usually don't merge Version.props. So I created a separate file that need merge.