### PR TITLE
[release/5.0.1xx-rc2] Use aspnetcore version suffix for template install directory

### DIFF
--- a/src/core-sdk-tasks/CalculateTemplateVersions.cs
+++ b/src/core-sdk-tasks/CalculateTemplateVersions.cs
@@ -12,9 +12,6 @@ namespace Microsoft.DotNet.Cli.Build
         [Required]
         public string AspNetCorePackageVersionTemplate { get; set; }
 
-        [Required]
-        public string VersionSuffix { get; set; }
-
         [Output]
         public string BundledTemplateInstallPath { get; set; }
 
@@ -28,7 +25,7 @@ namespace Microsoft.DotNet.Cli.Build
 
         public override bool Execute()
         {
-            var result = Calculate(AspNetCorePackageVersionTemplate, VersionSuffix);
+            var result = Calculate(AspNetCorePackageVersionTemplate);
             BundledTemplateInstallPath = result.BundledTemplateInstallPath;
             BundledTemplateMajorMinorVersion = result.BundledTemplateMajorMinorVersion;
             BundledTemplateMajorMinorPatchVersion = result.BundledTemplateMajorMinorPatchVersion;
@@ -40,16 +37,14 @@ namespace Microsoft.DotNet.Cli.Build
             (string BundledTemplateInstallPath,
             string BundledTemplateMajorMinorVersion,
 			string BundledTemplateMajorMinorPatchVersion) 
-            Calculate(
-                string aspNetCorePackageVersionTemplate,
-                string versionSuffix)
+            Calculate(string aspNetCorePackageVersionTemplate)
         {
             var aspNetCoreTemplate = NuGetVersion.Parse(aspNetCorePackageVersionTemplate);
 
             NuGetVersion baseMajorMinorPatch = GetBaseMajorMinorPatch(aspNetCoreTemplate);
 
             string bundledTemplateInstallPath = aspNetCoreTemplate.IsPrerelease
-                ? $"{baseMajorMinorPatch.Major}.{baseMajorMinorPatch.Minor}.{baseMajorMinorPatch.Patch}-{versionSuffix}"
+                ? $"{baseMajorMinorPatch.Major}.{baseMajorMinorPatch.Minor}.{baseMajorMinorPatch.Patch}-{aspNetCoreTemplate.Release}"
                 : $"{baseMajorMinorPatch.Major}.{baseMajorMinorPatch.Minor}.{baseMajorMinorPatch.Patch}";
 
             return (

--- a/src/redist/targets/BundledTemplates.targets
+++ b/src/redist/targets/BundledTemplates.targets
@@ -1,29 +1,25 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Target Name="CalculateTemplatesVersions" DependsOnTargets="SetupWixProperties">
 
-    <CalculateTemplateVersions AspNetCorePackageVersionTemplate="$(AspNetCorePackageVersionFor50Templates)"
-                               VersionSuffix="$(VersionSuffix)">
+    <CalculateTemplateVersions AspNetCorePackageVersionTemplate="$(AspNetCorePackageVersionFor50Templates)">
       <Output TaskParameter="BundledTemplateInstallPath" PropertyName="BundledTemplates50InstallPath" />
       <Output TaskParameter="BundledTemplateMajorMinorVersion" PropertyName="BundledTemplates50MajorMinorVersion" />
       <Output TaskParameter="BundledTemplateMajorMinorPatchVersion" PropertyName="BundledTemplates50MajorMinorPatchVersion" />
     </CalculateTemplateVersions>
 
-    <CalculateTemplateVersions AspNetCorePackageVersionTemplate="$(AspNetCorePackageVersionFor31Templates)"
-                               VersionSuffix="$(VersionSuffix)">
+    <CalculateTemplateVersions AspNetCorePackageVersionTemplate="$(AspNetCorePackageVersionFor31Templates)">
       <Output TaskParameter="BundledTemplateInstallPath" PropertyName="BundledTemplates31InstallPath" />
       <Output TaskParameter="BundledTemplateMajorMinorVersion" PropertyName="BundledTemplates31MajorMinorVersion" />
       <Output TaskParameter="BundledTemplateMajorMinorPatchVersion" PropertyName="BundledTemplates31MajorMinorPatchVersion" />
     </CalculateTemplateVersions>
 
-    <CalculateTemplateVersions AspNetCorePackageVersionTemplate="$(AspNetCorePackageVersionFor30Templates)"
-                               VersionSuffix="$(VersionSuffix)">
+    <CalculateTemplateVersions AspNetCorePackageVersionTemplate="$(AspNetCorePackageVersionFor30Templates)">
       <Output TaskParameter="BundledTemplateInstallPath" PropertyName="BundledTemplates30InstallPath" />
       <Output TaskParameter="BundledTemplateMajorMinorVersion" PropertyName="BundledTemplates30MajorMinorVersion" />
       <Output TaskParameter="BundledTemplateMajorMinorPatchVersion" PropertyName="BundledTemplates30MajorMinorPatchVersion" />
     </CalculateTemplateVersions>
 
-    <CalculateTemplateVersions AspNetCorePackageVersionTemplate="$(AspNetCorePackageVersionFor21Templates)"
-                               VersionSuffix="$(VersionSuffix)">
+    <CalculateTemplateVersions AspNetCorePackageVersionTemplate="$(AspNetCorePackageVersionFor21Templates)">
       <Output TaskParameter="BundledTemplateInstallPath" PropertyName="BundledTemplates21InstallPath" />
       <Output TaskParameter="BundledTemplateMajorMinorVersion" PropertyName="BundledTemplates21MajorMinorVersion" />
       <Output TaskParameter="BundledTemplateMajorMinorPatchVersion" PropertyName="BundledTemplates21MajorMinorPatchVersion" />

--- a/test/core-sdk-tasks.Tests/CalculateTemplateVerionsTests.cs
+++ b/test/core-sdk-tasks.Tests/CalculateTemplateVerionsTests.cs
@@ -9,7 +9,7 @@ namespace EndToEnd
         [Fact]
         public void WhenAspNetCoreTemplateMajorVersionLowerthan3ItCanCalculateTemplateVersionsInStableBuilds()
         {
-            var result = CalculateTemplateVersions.Calculate("3.1.0", "dev");
+            var result = CalculateTemplateVersions.Calculate("3.1.0");
 
             result.Should()
                 .Be(("3.1.1", "3.1", "3.1.1"),
@@ -20,16 +20,16 @@ namespace EndToEnd
         [Fact]
         public void WhenAspNetCoreTemplateMajorVersionLowerthan3ItCanCalculateTemplateVersionsInNonStableBuilds()
         {
-            var result = CalculateTemplateVersions.Calculate("3.0.0-alpha.1.20071.6", "dev");
+            var result = CalculateTemplateVersions.Calculate("3.0.0-alpha.1.20071.6");
 
             result.Should()
-                .Be(("3.0.1-dev", "3.0", "3.0.1"));
+                .Be(("3.0.1-alpha.1.20071.6", "3.0", "3.0.1"));
         }
 
         [Fact]
         public void WhenAspNetCoreTemplateMajorVersionHigherthan3ItCanCalculateTemplateVersionsInStableBuilds()
         {
-            var result = CalculateTemplateVersions.Calculate("5.1.0", "dev");
+            var result = CalculateTemplateVersions.Calculate("5.1.0");
 
             result.Should()
                 .Be(("5.1.0", "5.1", "5.1.0"),
@@ -40,10 +40,10 @@ namespace EndToEnd
         [Fact]
         public void WhenAspNetCoreTemplateMajorVersionHigherthan3ItCanCalculateTemplateVersionsInNonStableBuilds()
         {
-            var result = CalculateTemplateVersions.Calculate("5.0.0-alpha.1.20071.6", "dev");
+            var result = CalculateTemplateVersions.Calculate("5.0.0-alpha.1.20071.6");
 
             result.Should()
-                .Be(("5.0.0-dev", "5.0", "5.0.0"));
+                .Be(("5.0.0-alpha.1.20071.6", "5.0", "5.0.0"));
         }
     }
 }


### PR DESCRIPTION
This change is required for RTM stable builds. When stable versions are generated the CalculateTemplateVersions task will fail.

For .NET 3.x, installer is partially on arcade. It uses its own versioning model, but the arcade generated versions are actually set (specifically VersionSuffix). So even when stable builds are generated, VersionSuffix is available. It is unused when the aspnetcore template versions are stable.

For .NET 5, installer is now fully on arcade versioning, which means VersionSuffix is not set when stable versions are generated.

Instead of using installer's version suffix if aspnetcore's template versions are unstable, use the version suffix of the aspnetcore template versions. This subtley affects the installer directory of the templates:

- If the aspnetcore version is: `5.0.0-rc.1.1234.5`
- And the installer version is: `5.0.100-rc.1.9999.9`

Then:

- Template install dir before this change: .dotnet\templates\5.0.0-rc.1.9999.9
- Template install dir after this change: .dotnet\templates\5.0.0-rc.1.1234.5

Of note: The overall template layout doesn't make a ton of sense. The aspnetcore template version is used for the install directory, but many different templates are put in this directory, including some that have completely different versions.

- Please add description for changes you are making.
- If there is an issue related to this PR, please add the reference.
