### PR TITLE
Fixes for stable builds

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,6 +14,10 @@
     <PreReleaseVersionIteration>2</PreReleaseVersionIteration>
     <MajorMinorVersion>$(VersionMajor).$(VersionMinor)</MajorMinorVersion>
     <CliProductBandVersion>$(MajorMinorVersion).$(VersionSDKMinor)</CliProductBandVersion>
+    
+    <!-- Enable to remove prerelease label. -->
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
+    <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/arcade -->

--- a/src/redist/targets/Versions.targets
+++ b/src/redist/targets/Versions.targets
@@ -1,7 +1,8 @@
 <Project>
   <Target Name="GenerateFullNuGetVersion">
     <PropertyGroup>
-      <FullNugetVersion>$(VersionPrefix)-$(PreReleaseVersionLabel).$(PreReleaseVersionIteration)</FullNugetVersion>
+      <FullNugetVersion>$(VersionPrefix)-$(PreReleaseVersionLabel)</FullNugetVersion>
+      <FullNugetVersion Condition="'$(PreReleaseVersionIteration)' != ''">$(FullNugetVersion).$(PreReleaseVersionIteration)</FullNugetVersion>
       <FullNugetVersion Condition=" '$(VersionSuffixDateStamp)' != '' And '$(VersionSuffixBuildOfTheDay)' != '' ">$(FullNugetVersion).$(VersionSuffixDateStamp).$(VersionSuffixBuildOfTheDay)</FullNugetVersion>
     </PropertyGroup>
   </Target>


### PR DESCRIPTION
- Enable the switch for stable builds
- Fixup the calculation of FullNugetVersion to not include the iteration if it is empty
