### PR TITLE
Update to Windows SDK projection for RC2

### DIFF
--- a/eng/ManualVersions.props
+++ b/eng/ManualVersions.props
@@ -9,8 +9,8 @@
      Basically: In this file, choose the highest version when resolving merge conflicts.
  -->
   <PropertyGroup>
-    <MicrosoftWindowsSDKNETRef10_0_17763PackageVersion>10.0.17763.4-preview</MicrosoftWindowsSDKNETRef10_0_17763PackageVersion>
-    <MicrosoftWindowsSDKNETRef10_0_18362PackageVersion>10.0.18362.5-preview</MicrosoftWindowsSDKNETRef10_0_18362PackageVersion>
-    <MicrosoftWindowsSDKNETRef10_0_19041PackageVersion>10.0.19041.4-preview</MicrosoftWindowsSDKNETRef10_0_19041PackageVersion>
+    <MicrosoftWindowsSDKNETRef10_0_17763PackageVersion>10.0.17763.6-preview</MicrosoftWindowsSDKNETRef10_0_17763PackageVersion>
+    <MicrosoftWindowsSDKNETRef10_0_18362PackageVersion>10.0.18362.6-preview</MicrosoftWindowsSDKNETRef10_0_18362PackageVersion>
+    <MicrosoftWindowsSDKNETRef10_0_19041PackageVersion>10.0.19041.6-preview</MicrosoftWindowsSDKNETRef10_0_19041PackageVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Updating the Windows SDK projection to the one we intended to release for RC2 and also aligning version numbers to be the same.