### PR TITLE
Add .NET 6 template packages

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -79,17 +79,17 @@
       <Uri>https://github.com/dotnet/test-templates</Uri>
       <Sha>a2b05d8171915c69ad97ab5d49bbb07d2c780a67</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="6.0.0-alpha.1.20501.1" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="6.0.0-alpha.1.20508.2" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>8764c82892d6f028e45d49514660aa2026bd980e</Sha>
+      <Sha>0589fb051fac78cde679708575087d4ec6e29971</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20508.6">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20508.7">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>4992bc6c079ddabc2035c14cb45b416d50685450</Sha>
+      <Sha>ba1f938272f5bda91f3e5464e4162e27637dc341</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20508.6">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20508.7">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>4992bc6c079ddabc2035c14cb45b416d50685450</Sha>
+      <Sha>ba1f938272f5bda91f3e5464e4162e27637dc341</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -43,33 +43,33 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>f63b0c1a7562b5a70c6f02db8f99e2c9b5b97cac</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20501.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20502.7" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>619a992fc38921ea0fedd8e0fad4c593be30fed8</Sha>
+      <Sha>336e05577cd8bec2000ffcada926189199e4cef0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20501.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20502.7" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>619a992fc38921ea0fedd8e0fad4c593be30fed8</Sha>
+      <Sha>336e05577cd8bec2000ffcada926189199e4cef0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20501.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20502.7" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>619a992fc38921ea0fedd8e0fad4c593be30fed8</Sha>
+      <Sha>336e05577cd8bec2000ffcada926189199e4cef0</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20501.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20502.7" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>619a992fc38921ea0fedd8e0fad4c593be30fed8</Sha>
+      <Sha>336e05577cd8bec2000ffcada926189199e4cef0</Sha>
     </Dependency>
-    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20501.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20502.7" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>619a992fc38921ea0fedd8e0fad4c593be30fed8</Sha>
+      <Sha>336e05577cd8bec2000ffcada926189199e4cef0</Sha>
     </Dependency>
-    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20501.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20502.7" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>619a992fc38921ea0fedd8e0fad4c593be30fed8</Sha>
+      <Sha>336e05577cd8bec2000ffcada926189199e4cef0</Sha>
     </Dependency>
-    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20501.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20502.7" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>619a992fc38921ea0fedd8e0fad4c593be30fed8</Sha>
+      <Sha>336e05577cd8bec2000ffcada926189199e4cef0</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="1.0.2-beta4.20420.1">
       <Uri>https://github.com/dotnet/test-templates</Uri>
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>8764c82892d6f028e45d49514660aa2026bd980e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20502.4">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20502.9">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>cc90fd6430d27e535a6341ee309afa783fb4f62d</Sha>
+      <Sha>61af970c8058d815b0570c5ced5c46f22755f91a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20502.4">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20502.9">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>cc90fd6430d27e535a6341ee309afa783fb4f62d</Sha>
+      <Sha>61af970c8058d815b0570c5ced5c46f22755f91a</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>8764c82892d6f028e45d49514660aa2026bd980e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20508.5">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20508.6">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>75674af716f72847b766fbef40f8b36cb062711c</Sha>
+      <Sha>4992bc6c079ddabc2035c14cb45b416d50685450</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20508.5">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20508.6">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>75674af716f72847b766fbef40f8b36cb062711c</Sha>
+      <Sha>4992bc6c079ddabc2035c14cb45b416d50685450</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">
@@ -100,9 +100,9 @@
       <Uri>https://github.com/dotnet/wpf</Uri>
       <Sha>b91ba697c48bc7825580e3c7fa09c5c3781c3788</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.FSharp.Compiler" Version="11.0.0-beta.20478.4" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.FSharp.Compiler" Version="11.0.0-beta.20507.4" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/fsharp</Uri>
-      <Sha>f394b34045020afb92a4510a98c8c4bde9ac33f4</Sha>
+      <Sha>da6be68280c89131cdba2045525b80890401defd</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Test.Sdk" Version="16.9.0-preview-20201006-01" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/microsoft/vstest</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -43,33 +43,33 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>4af0db78428b39315b4683f749237d9dd7b6020a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="6.0.0-alpha.1.20512.13" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="6.0.0-alpha.1.20513.5" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>593005230fc9900564a74e38112bfb1133932679</Sha>
+      <Sha>95921cf68d99484c3a32e667388abfa46cf87fd0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="6.0.0-alpha.1.20512.13" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="6.0.0-alpha.1.20513.5" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>593005230fc9900564a74e38112bfb1133932679</Sha>
+      <Sha>95921cf68d99484c3a32e667388abfa46cf87fd0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="6.0.0-alpha.1.20512.13" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="6.0.0-alpha.1.20513.5" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>593005230fc9900564a74e38112bfb1133932679</Sha>
+      <Sha>95921cf68d99484c3a32e667388abfa46cf87fd0</Sha>
     </Dependency>
     <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20512.5" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>b866b765b3493c7943829ce830e509d61f958102</Sha>
     </Dependency>
-    <Dependency Name="dotnet-dev-certs" Version="6.0.0-alpha.1.20512.13" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-dev-certs" Version="6.0.0-alpha.1.20513.5" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>593005230fc9900564a74e38112bfb1133932679</Sha>
+      <Sha>95921cf68d99484c3a32e667388abfa46cf87fd0</Sha>
     </Dependency>
-    <Dependency Name="dotnet-user-secrets" Version="6.0.0-alpha.1.20512.13" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-user-secrets" Version="6.0.0-alpha.1.20513.5" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>593005230fc9900564a74e38112bfb1133932679</Sha>
+      <Sha>95921cf68d99484c3a32e667388abfa46cf87fd0</Sha>
     </Dependency>
-    <Dependency Name="dotnet-watch" Version="6.0.0-alpha.1.20512.13" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-watch" Version="6.0.0-alpha.1.20513.5" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>593005230fc9900564a74e38112bfb1133932679</Sha>
+      <Sha>95921cf68d99484c3a32e667388abfa46cf87fd0</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="1.0.2-beta4.20420.1">
       <Uri>https://github.com/dotnet/test-templates</Uri>
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>39fa7665ccf365a2c0804109c6b09650d52ffff0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20513.9">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20513.11">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>f30b07c4032748d9f39ecacc0b5a350320ad6931</Sha>
+      <Sha>b492fb67ebbc325d0c698c2e36f07794ab65312d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20513.9">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20513.11">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>f30b07c4032748d9f39ecacc0b5a350320ad6931</Sha>
+      <Sha>b492fb67ebbc325d0c698c2e36f07794ab65312d</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -43,33 +43,33 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>4fef87c65e7466000884aeb9dee6498b162fe2fa</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20508.29" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20509.5" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>b7b300143518f86d5e4ff6630688c7d578efda07</Sha>
+      <Sha>36f6242e6f84208bc1c9d2c4cac94cbb134196df</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20508.29" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20509.5" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>b7b300143518f86d5e4ff6630688c7d578efda07</Sha>
+      <Sha>36f6242e6f84208bc1c9d2c4cac94cbb134196df</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20508.29" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20509.5" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>b7b300143518f86d5e4ff6630688c7d578efda07</Sha>
+      <Sha>36f6242e6f84208bc1c9d2c4cac94cbb134196df</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20508.29" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20509.5" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>b7b300143518f86d5e4ff6630688c7d578efda07</Sha>
+      <Sha>36f6242e6f84208bc1c9d2c4cac94cbb134196df</Sha>
     </Dependency>
-    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20508.29" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20509.5" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>b7b300143518f86d5e4ff6630688c7d578efda07</Sha>
+      <Sha>36f6242e6f84208bc1c9d2c4cac94cbb134196df</Sha>
     </Dependency>
-    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20508.29" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20509.5" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>b7b300143518f86d5e4ff6630688c7d578efda07</Sha>
+      <Sha>36f6242e6f84208bc1c9d2c4cac94cbb134196df</Sha>
     </Dependency>
-    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20508.29" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20509.5" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>b7b300143518f86d5e4ff6630688c7d578efda07</Sha>
+      <Sha>36f6242e6f84208bc1c9d2c4cac94cbb134196df</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="1.0.2-beta4.20420.1">
       <Uri>https://github.com/dotnet/test-templates</Uri>
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>ddf5f8e5de38c184ea015d9dc817cbfd4f4a3d4f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20509.7">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20509.14">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>e6e486ccf982d865cda602f460b59e1f46278855</Sha>
+      <Sha>987d0bd4bbdd20db1513245994e82c33934b3f1c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20509.7">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20509.14">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>e6e486ccf982d865cda602f460b59e1f46278855</Sha>
+      <Sha>987d0bd4bbdd20db1513245994e82c33934b3f1c</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>39fa7665ccf365a2c0804109c6b09650d52ffff0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20513.3">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20513.6">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>57a05af647673186a892a84e8c2546842bf656bd</Sha>
+      <Sha>78ad03bfaaefc968150d1c4356d691501fdcf232</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20513.3">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20513.6">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>57a05af647673186a892a84e8c2546842bf656bd</Sha>
+      <Sha>78ad03bfaaefc968150d1c4356d691501fdcf232</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">
@@ -108,9 +108,9 @@
       <Uri>https://github.com/microsoft/vstest</Uri>
       <Sha>d834b9b8c4337438622cb7b7d77f1520b479cb88</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.0-alpha.1.20513.2" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.0-alpha.1.20513.3" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/mono/linker</Uri>
-      <Sha>2bcc466760c8c5fd08f79eb35ca1e5beb888ae77</Sha>
+      <Sha>35ca60df42b88fc66f75c15b8b189a213bbfa42c</Sha>
       <RepoName>linker</RepoName>
     </Dependency>
     <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.9.0-1.20513.5" CoherentParentDependency="Microsoft.NET.Sdk">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -43,33 +43,33 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>f63b0c1a7562b5a70c6f02db8f99e2c9b5b97cac</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20479.8" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20480.7" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9f4d4746483fcc2cbfe9c473d0abbc76d2b54a4b</Sha>
+      <Sha>dd7d7772a608c78d44a5cce09627f132f8dad306</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20479.8" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20480.7" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9f4d4746483fcc2cbfe9c473d0abbc76d2b54a4b</Sha>
+      <Sha>dd7d7772a608c78d44a5cce09627f132f8dad306</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20479.8" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20480.7" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9f4d4746483fcc2cbfe9c473d0abbc76d2b54a4b</Sha>
+      <Sha>dd7d7772a608c78d44a5cce09627f132f8dad306</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20479.8" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20480.7" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9f4d4746483fcc2cbfe9c473d0abbc76d2b54a4b</Sha>
+      <Sha>dd7d7772a608c78d44a5cce09627f132f8dad306</Sha>
     </Dependency>
-    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20479.8" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20480.7" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9f4d4746483fcc2cbfe9c473d0abbc76d2b54a4b</Sha>
+      <Sha>dd7d7772a608c78d44a5cce09627f132f8dad306</Sha>
     </Dependency>
-    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20479.8" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20480.7" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9f4d4746483fcc2cbfe9c473d0abbc76d2b54a4b</Sha>
+      <Sha>dd7d7772a608c78d44a5cce09627f132f8dad306</Sha>
     </Dependency>
-    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20479.8" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20480.7" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9f4d4746483fcc2cbfe9c473d0abbc76d2b54a4b</Sha>
+      <Sha>dd7d7772a608c78d44a5cce09627f132f8dad306</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="1.0.2-beta4.20420.1">
       <Uri>https://github.com/dotnet/test-templates</Uri>
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>8764c82892d6f028e45d49514660aa2026bd980e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20501.4">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20501.6">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>66ae83f896a765baaad29a7c7402686c33aed422</Sha>
+      <Sha>ea5601c12d4e9bcc5cba42ab15039918b46d68da</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20501.4">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20501.6">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>66ae83f896a765baaad29a7c7402686c33aed422</Sha>
+      <Sha>ea5601c12d4e9bcc5cba42ab15039918b46d68da</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>39fa7665ccf365a2c0804109c6b09650d52ffff0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20513.8">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20513.9">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>09aa6b162c942e9f40ab6683df6c4567a5a37f39</Sha>
+      <Sha>f30b07c4032748d9f39ecacc0b5a350320ad6931</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20513.8">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20513.9">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>09aa6b162c942e9f40ab6683df6c4567a5a37f39</Sha>
+      <Sha>f30b07c4032748d9f39ecacc0b5a350320ad6931</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">
@@ -113,9 +113,9 @@
       <Sha>35ca60df42b88fc66f75c15b8b189a213bbfa42c</Sha>
       <RepoName>linker</RepoName>
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.9.0-1.20513.5" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.9.0-1.20513.7" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>16db183b2b316d515cb4072cf925cff3a45a8ecb</Sha>
+      <Sha>c69d99cbdc5de6c330bf86a44ca7af1547906bb6</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Build" Version="16.9.0-preview-20513-04" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/msbuild</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -13,25 +13,25 @@
       <Uri>https://github.com/dotnet/windowsdesktop</Uri>
       <Sha>85186023c8de8237268033cadc41d738b7f2005e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-alpha.1.20502.2" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-alpha.1.20503.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>22791d4e8830d4e94930c8fa84555fa6dacf8829</Sha>
+      <Sha>54623ba202cbb62fb3c5c9d9117ab55dcd5469e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Internal" Version="6.0.0-alpha.1.20502.2" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.App.Internal" Version="6.0.0-alpha.1.20503.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>22791d4e8830d4e94930c8fa84555fa6dacf8829</Sha>
+      <Sha>54623ba202cbb62fb3c5c9d9117ab55dcd5469e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-alpha.1.20502.2" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-alpha.1.20503.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>22791d4e8830d4e94930c8fa84555fa6dacf8829</Sha>
+      <Sha>54623ba202cbb62fb3c5c9d9117ab55dcd5469e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Host.win-x64" Version="6.0.0-alpha.1.20502.2" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.App.Host.win-x64" Version="6.0.0-alpha.1.20503.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>22791d4e8830d4e94930c8fa84555fa6dacf8829</Sha>
+      <Sha>54623ba202cbb62fb3c5c9d9117ab55dcd5469e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="6.0.0-alpha.1.20502.2" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="6.0.0-alpha.1.20503.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>22791d4e8830d4e94930c8fa84555fa6dacf8829</Sha>
+      <Sha>54623ba202cbb62fb3c5c9d9117ab55dcd5469e4</Sha>
     </Dependency>
     <!-- Change blob version in GenerateLayout.targets if this is unpinned to service targeting pack -->
     <!-- No new netstandard.library planned for 3.1 timeframe at this time. -->
@@ -39,9 +39,9 @@
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>7d57652f33493fa022125b7f63aad0d70c52d810</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.0-alpha.1.20502.2" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.0-alpha.1.20503.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>22791d4e8830d4e94930c8fa84555fa6dacf8829</Sha>
+      <Sha>54623ba202cbb62fb3c5c9d9117ab55dcd5469e4</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20503.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>8764c82892d6f028e45d49514660aa2026bd980e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20503.4">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20504.1">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>45561dcbcb4939beaee4266f67c0536d9861089a</Sha>
+      <Sha>2cccde7c7e0cb61f257f56b953470877ec6d0829</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20503.4">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20504.1">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>45561dcbcb4939beaee4266f67c0536d9861089a</Sha>
+      <Sha>2cccde7c7e0cb61f257f56b953470877ec6d0829</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>39fa7665ccf365a2c0804109c6b09650d52ffff0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20513.7">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20513.8">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>6e9622afd0695115f46fa09dbdc30bfa2a89d378</Sha>
+      <Sha>09aa6b162c942e9f40ab6683df6c4567a5a37f39</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20513.7">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20513.8">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>6e9622afd0695115f46fa09dbdc30bfa2a89d378</Sha>
+      <Sha>09aa6b162c942e9f40ab6683df6c4567a5a37f39</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">
@@ -117,9 +117,9 @@
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>16db183b2b316d515cb4072cf925cff3a45a8ecb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build" Version="16.9.0-preview-20513-02" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.Build" Version="16.9.0-preview-20513-04" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>5d8ae7e88b7d5371ec375eaa3aab2ad50fcb5869</Sha>
+      <Sha>0d9652e75b74fc8b359c3cd4528b10e932b239c9</Sha>
     </Dependency>
     <Dependency Name="NuGet.Build.Tasks" Version="5.8.0-rc.6860" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/NuGet/NuGet.Client</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -79,17 +79,17 @@
       <Uri>https://github.com/dotnet/test-templates</Uri>
       <Sha>a2b05d8171915c69ad97ab5d49bbb07d2c780a67</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="6.0.0-alpha.1.20480.2" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="6.0.0-alpha.1.20501.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>139e639026f5e1abdd6fd87ed5ba1ba87fd57de1</Sha>
+      <Sha>8764c82892d6f028e45d49514660aa2026bd980e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20480.18">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20501.4">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>89a7175e75cf11c47d6f74278597f69082f72508</Sha>
+      <Sha>66ae83f896a765baaad29a7c7402686c33aed422</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20480.18">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20501.4">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>89a7175e75cf11c47d6f74278597f69082f72508</Sha>
+      <Sha>66ae83f896a765baaad29a7c7402686c33aed422</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -13,25 +13,25 @@
       <Uri>https://github.com/dotnet/windowsdesktop</Uri>
       <Sha>85186023c8de8237268033cadc41d738b7f2005e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-alpha.1.20503.1" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-alpha.1.20505.12" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>54623ba202cbb62fb3c5c9d9117ab55dcd5469e4</Sha>
+      <Sha>214458e2748c7857ab2e2cfdb3a3d32d65e95bfe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Internal" Version="6.0.0-alpha.1.20503.1" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.App.Internal" Version="6.0.0-alpha.1.20505.12" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>54623ba202cbb62fb3c5c9d9117ab55dcd5469e4</Sha>
+      <Sha>214458e2748c7857ab2e2cfdb3a3d32d65e95bfe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-alpha.1.20503.1" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-alpha.1.20505.12" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>54623ba202cbb62fb3c5c9d9117ab55dcd5469e4</Sha>
+      <Sha>214458e2748c7857ab2e2cfdb3a3d32d65e95bfe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Host.win-x64" Version="6.0.0-alpha.1.20503.1" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.App.Host.win-x64" Version="6.0.0-alpha.1.20505.12" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>54623ba202cbb62fb3c5c9d9117ab55dcd5469e4</Sha>
+      <Sha>214458e2748c7857ab2e2cfdb3a3d32d65e95bfe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="6.0.0-alpha.1.20503.1" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="6.0.0-alpha.1.20505.12" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>54623ba202cbb62fb3c5c9d9117ab55dcd5469e4</Sha>
+      <Sha>214458e2748c7857ab2e2cfdb3a3d32d65e95bfe</Sha>
     </Dependency>
     <!-- Change blob version in GenerateLayout.targets if this is unpinned to service targeting pack -->
     <!-- No new netstandard.library planned for 3.1 timeframe at this time. -->
@@ -39,9 +39,9 @@
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>7d57652f33493fa022125b7f63aad0d70c52d810</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.0-alpha.1.20503.1" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.0-alpha.1.20505.12" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>54623ba202cbb62fb3c5c9d9117ab55dcd5469e4</Sha>
+      <Sha>214458e2748c7857ab2e2cfdb3a3d32d65e95bfe</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20505.7" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>8764c82892d6f028e45d49514660aa2026bd980e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20506.2">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20506.3">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>79e3234b73c909d715cca6bc199d5c2b98c3248d</Sha>
+      <Sha>ed0c6da996c5f0c2db7e6c16e2b622523c40bddd</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20506.2">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20506.3">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>79e3234b73c909d715cca6bc199d5c2b98c3248d</Sha>
+      <Sha>ed0c6da996c5f0c2db7e6c16e2b622523c40bddd</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">
@@ -113,9 +113,9 @@
       <Sha>b89cb90abdfdc4e1ccd0822b62d367fa35d30f00</Sha>
       <RepoName>linker</RepoName>
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.8.0-4.20469.1" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.8.0-4.20475.8" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>f1a29d004314b99af8ab07d2334cbd1bf9e716c5</Sha>
+      <Sha>dd7319ea5e31ffe79f558c2c835067f4a9091902</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Build" Version="16.9.0-preview-20502-03" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/msbuild</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -43,33 +43,33 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>214458e2748c7857ab2e2cfdb3a3d32d65e95bfe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20505.9" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20506.10" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>dab6a2f611c329428607c58931343480021948a4</Sha>
+      <Sha>9939b3358c886b725ac122b63bfcbf0d665d1d21</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20505.9" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20506.10" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>dab6a2f611c329428607c58931343480021948a4</Sha>
+      <Sha>9939b3358c886b725ac122b63bfcbf0d665d1d21</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20505.9" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20506.10" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>dab6a2f611c329428607c58931343480021948a4</Sha>
+      <Sha>9939b3358c886b725ac122b63bfcbf0d665d1d21</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20505.9" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20506.10" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>dab6a2f611c329428607c58931343480021948a4</Sha>
+      <Sha>9939b3358c886b725ac122b63bfcbf0d665d1d21</Sha>
     </Dependency>
-    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20505.9" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20506.10" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>dab6a2f611c329428607c58931343480021948a4</Sha>
+      <Sha>9939b3358c886b725ac122b63bfcbf0d665d1d21</Sha>
     </Dependency>
-    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20505.9" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20506.10" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>dab6a2f611c329428607c58931343480021948a4</Sha>
+      <Sha>9939b3358c886b725ac122b63bfcbf0d665d1d21</Sha>
     </Dependency>
-    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20505.9" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20506.10" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>dab6a2f611c329428607c58931343480021948a4</Sha>
+      <Sha>9939b3358c886b725ac122b63bfcbf0d665d1d21</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="1.0.2-beta4.20420.1">
       <Uri>https://github.com/dotnet/test-templates</Uri>
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>8764c82892d6f028e45d49514660aa2026bd980e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20506.12">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20506.14">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>ed818b5677ea2202847096749d190055b677b3c1</Sha>
+      <Sha>0937145e32f24cac01a25d7e199fa62088004e21</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20506.12">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20506.14">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>ed818b5677ea2202847096749d190055b677b3c1</Sha>
+      <Sha>0937145e32f24cac01a25d7e199fa62088004e21</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>8764c82892d6f028e45d49514660aa2026bd980e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20504.1">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20504.2">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>2cccde7c7e0cb61f257f56b953470877ec6d0829</Sha>
+      <Sha>eabe646e825d32c522a59f266f268ea7a477ee2e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20504.1">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20504.2">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>2cccde7c7e0cb61f257f56b953470877ec6d0829</Sha>
+      <Sha>eabe646e825d32c522a59f266f268ea7a477ee2e</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>8764c82892d6f028e45d49514660aa2026bd980e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20501.10">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20502.4">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>9e77ead294b3529cbbe6107cf2e7e285e251d965</Sha>
+      <Sha>cc90fd6430d27e535a6341ee309afa783fb4f62d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20501.10">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20502.4">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>9e77ead294b3529cbbe6107cf2e7e285e251d965</Sha>
+      <Sha>cc90fd6430d27e535a6341ee309afa783fb4f62d</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">
@@ -108,9 +108,9 @@
       <Uri>https://github.com/microsoft/vstest</Uri>
       <Sha>6a774215a898bb38184e1115e2fb4801185fb0db</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.0-alpha.1.20480.9" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.0-alpha.1.20502.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/mono/linker</Uri>
-      <Sha>8da366656b4224a6b7483df2800dad13947cac06</Sha>
+      <Sha>b89cb90abdfdc4e1ccd0822b62d367fa35d30f00</Sha>
       <RepoName>linker</RepoName>
     </Dependency>
     <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.8.0-4.20469.1" CoherentParentDependency="Microsoft.NET.Sdk">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>0589fb051fac78cde679708575087d4ec6e29971</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20508.7">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20508.11">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>ba1f938272f5bda91f3e5464e4162e27637dc341</Sha>
+      <Sha>acc78e6ff441e92a58a23fd2d6e5966ce7b49c30</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20508.7">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20508.11">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>ba1f938272f5bda91f3e5464e4162e27637dc341</Sha>
+      <Sha>acc78e6ff441e92a58a23fd2d6e5966ce7b49c30</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -43,33 +43,33 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>4fef87c65e7466000884aeb9dee6498b162fe2fa</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20508.6" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20508.16" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>628ce6114bd426c80e57f637234fe94cf9b37c7d</Sha>
+      <Sha>a84868a602ac45c85b30d706c3bfcb8900c804a2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20508.6" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20508.16" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>628ce6114bd426c80e57f637234fe94cf9b37c7d</Sha>
+      <Sha>a84868a602ac45c85b30d706c3bfcb8900c804a2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20508.6" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20508.16" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>628ce6114bd426c80e57f637234fe94cf9b37c7d</Sha>
+      <Sha>a84868a602ac45c85b30d706c3bfcb8900c804a2</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20508.6" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20508.16" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>628ce6114bd426c80e57f637234fe94cf9b37c7d</Sha>
+      <Sha>a84868a602ac45c85b30d706c3bfcb8900c804a2</Sha>
     </Dependency>
-    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20508.6" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20508.16" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>628ce6114bd426c80e57f637234fe94cf9b37c7d</Sha>
+      <Sha>a84868a602ac45c85b30d706c3bfcb8900c804a2</Sha>
     </Dependency>
-    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20508.6" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20508.16" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>628ce6114bd426c80e57f637234fe94cf9b37c7d</Sha>
+      <Sha>a84868a602ac45c85b30d706c3bfcb8900c804a2</Sha>
     </Dependency>
-    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20508.6" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20508.16" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>628ce6114bd426c80e57f637234fe94cf9b37c7d</Sha>
+      <Sha>a84868a602ac45c85b30d706c3bfcb8900c804a2</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="1.0.2-beta4.20420.1">
       <Uri>https://github.com/dotnet/test-templates</Uri>
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>0589fb051fac78cde679708575087d4ec6e29971</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20508.15">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20508.18">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>abfc4d94ea4a92db693ae7b01649d4e243d0218e</Sha>
+      <Sha>ebec66211c2d04668c741a6d1b3dcd00369d5043</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20508.15">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20508.18">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>abfc4d94ea4a92db693ae7b01649d4e243d0218e</Sha>
+      <Sha>ebec66211c2d04668c741a6d1b3dcd00369d5043</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -13,25 +13,25 @@
       <Uri>https://github.com/dotnet/windowsdesktop</Uri>
       <Sha>85186023c8de8237268033cadc41d738b7f2005e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-alpha.1.20479.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-alpha.1.20502.2" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f63b0c1a7562b5a70c6f02db8f99e2c9b5b97cac</Sha>
+      <Sha>22791d4e8830d4e94930c8fa84555fa6dacf8829</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Internal" Version="6.0.0-alpha.1.20479.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.App.Internal" Version="6.0.0-alpha.1.20502.2" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f63b0c1a7562b5a70c6f02db8f99e2c9b5b97cac</Sha>
+      <Sha>22791d4e8830d4e94930c8fa84555fa6dacf8829</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-alpha.1.20479.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-alpha.1.20502.2" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f63b0c1a7562b5a70c6f02db8f99e2c9b5b97cac</Sha>
+      <Sha>22791d4e8830d4e94930c8fa84555fa6dacf8829</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Host.win-x64" Version="6.0.0-alpha.1.20479.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.App.Host.win-x64" Version="6.0.0-alpha.1.20502.2" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f63b0c1a7562b5a70c6f02db8f99e2c9b5b97cac</Sha>
+      <Sha>22791d4e8830d4e94930c8fa84555fa6dacf8829</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="6.0.0-alpha.1.20479.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="6.0.0-alpha.1.20502.2" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f63b0c1a7562b5a70c6f02db8f99e2c9b5b97cac</Sha>
+      <Sha>22791d4e8830d4e94930c8fa84555fa6dacf8829</Sha>
     </Dependency>
     <!-- Change blob version in GenerateLayout.targets if this is unpinned to service targeting pack -->
     <!-- No new netstandard.library planned for 3.1 timeframe at this time. -->
@@ -39,9 +39,9 @@
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>7d57652f33493fa022125b7f63aad0d70c52d810</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.0-alpha.1.20479.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.0-alpha.1.20502.2" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f63b0c1a7562b5a70c6f02db8f99e2c9b5b97cac</Sha>
+      <Sha>22791d4e8830d4e94930c8fa84555fa6dacf8829</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20502.12" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>8764c82892d6f028e45d49514660aa2026bd980e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20502.16">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20503.3">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>8888740832d541f91ff67ed9905544a687c18832</Sha>
+      <Sha>d95c3f39ede9dfd9f04edc398820d307f18f62d7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20502.16">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20503.3">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>8888740832d541f91ff67ed9905544a687c18832</Sha>
+      <Sha>d95c3f39ede9dfd9f04edc398820d307f18f62d7</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>8764c82892d6f028e45d49514660aa2026bd980e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20506.3">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20506.8">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>ed0c6da996c5f0c2db7e6c16e2b622523c40bddd</Sha>
+      <Sha>7b27129e2cad2432c0e596096e56d69bdd2ce32b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20506.3">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20506.8">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>ed0c6da996c5f0c2db7e6c16e2b622523c40bddd</Sha>
+      <Sha>7b27129e2cad2432c0e596096e56d69bdd2ce32b</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">
@@ -104,9 +104,9 @@
       <Uri>https://github.com/dotnet/fsharp</Uri>
       <Sha>f394b34045020afb92a4510a98c8c4bde9ac33f4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Test.Sdk" Version="16.9.0-preview-20201005-01" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NET.Test.Sdk" Version="16.9.0-preview-20201006-01" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/microsoft/vstest</Uri>
-      <Sha>a319f62bfd966d584b3a19e20bad55288436cc97</Sha>
+      <Sha>5e59fa403297516710222264b5df53496e379f8f</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.0-alpha.1.20502.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/mono/linker</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -13,25 +13,25 @@
       <Uri>https://github.com/dotnet/windowsdesktop</Uri>
       <Sha>85186023c8de8237268033cadc41d738b7f2005e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-alpha.1.20510.8" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-alpha.1.20513.9" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4af0db78428b39315b4683f749237d9dd7b6020a</Sha>
+      <Sha>eea2256e56f32d70e3fbe72a1473a7ffd2f5c16e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Internal" Version="6.0.0-alpha.1.20510.8" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.App.Internal" Version="6.0.0-alpha.1.20513.9" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4af0db78428b39315b4683f749237d9dd7b6020a</Sha>
+      <Sha>eea2256e56f32d70e3fbe72a1473a7ffd2f5c16e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-alpha.1.20510.8" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-alpha.1.20513.9" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4af0db78428b39315b4683f749237d9dd7b6020a</Sha>
+      <Sha>eea2256e56f32d70e3fbe72a1473a7ffd2f5c16e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Host.win-x64" Version="6.0.0-alpha.1.20510.8" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.App.Host.win-x64" Version="6.0.0-alpha.1.20513.9" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4af0db78428b39315b4683f749237d9dd7b6020a</Sha>
+      <Sha>eea2256e56f32d70e3fbe72a1473a7ffd2f5c16e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="6.0.0-alpha.1.20510.8" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="6.0.0-alpha.1.20513.9" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4af0db78428b39315b4683f749237d9dd7b6020a</Sha>
+      <Sha>eea2256e56f32d70e3fbe72a1473a7ffd2f5c16e</Sha>
     </Dependency>
     <!-- Change blob version in GenerateLayout.targets if this is unpinned to service targeting pack -->
     <!-- No new netstandard.library planned for 3.1 timeframe at this time. -->
@@ -39,9 +39,9 @@
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>7d57652f33493fa022125b7f63aad0d70c52d810</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.0-alpha.1.20510.8" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.0-alpha.1.20513.9" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4af0db78428b39315b4683f749237d9dd7b6020a</Sha>
+      <Sha>eea2256e56f32d70e3fbe72a1473a7ffd2f5c16e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="6.0.0-alpha.1.20513.8" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>b930c7c022425a92b0f153728bfee1df9d354477</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20514.4">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20514.6">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>a1e219f2d2ad43e7cd129e9d405fe728452e3bb0</Sha>
+      <Sha>3aadcbd5a27b46b6372b5594b27e6b5b92fd1111</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20514.4">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20514.6">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>a1e219f2d2ad43e7cd129e9d405fe728452e3bb0</Sha>
+      <Sha>3aadcbd5a27b46b6372b5594b27e6b5b92fd1111</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -43,33 +43,33 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>4fef87c65e7466000884aeb9dee6498b162fe2fa</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20507.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20508.6" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>dbdfca422299d4c613fbbed551f68f63de92975c</Sha>
+      <Sha>628ce6114bd426c80e57f637234fe94cf9b37c7d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20507.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20508.6" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>dbdfca422299d4c613fbbed551f68f63de92975c</Sha>
+      <Sha>628ce6114bd426c80e57f637234fe94cf9b37c7d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20507.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20508.6" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>dbdfca422299d4c613fbbed551f68f63de92975c</Sha>
+      <Sha>628ce6114bd426c80e57f637234fe94cf9b37c7d</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20507.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20508.6" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>dbdfca422299d4c613fbbed551f68f63de92975c</Sha>
+      <Sha>628ce6114bd426c80e57f637234fe94cf9b37c7d</Sha>
     </Dependency>
-    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20507.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20508.6" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>dbdfca422299d4c613fbbed551f68f63de92975c</Sha>
+      <Sha>628ce6114bd426c80e57f637234fe94cf9b37c7d</Sha>
     </Dependency>
-    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20507.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20508.6" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>dbdfca422299d4c613fbbed551f68f63de92975c</Sha>
+      <Sha>628ce6114bd426c80e57f637234fe94cf9b37c7d</Sha>
     </Dependency>
-    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20507.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20508.6" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>dbdfca422299d4c613fbbed551f68f63de92975c</Sha>
+      <Sha>628ce6114bd426c80e57f637234fe94cf9b37c7d</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="1.0.2-beta4.20420.1">
       <Uri>https://github.com/dotnet/test-templates</Uri>
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>0589fb051fac78cde679708575087d4ec6e29971</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20508.13">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20508.15">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>d4eac864ce7b9b4daa85c2b77957880a171033f8</Sha>
+      <Sha>abfc4d94ea4a92db693ae7b01649d4e243d0218e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20508.13">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20508.15">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>d4eac864ce7b9b4daa85c2b77957880a171033f8</Sha>
+      <Sha>abfc4d94ea4a92db693ae7b01649d4e243d0218e</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>8764c82892d6f028e45d49514660aa2026bd980e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20502.9">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20502.11">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>61af970c8058d815b0570c5ced5c46f22755f91a</Sha>
+      <Sha>54dca82b90706e8bad26cb4795228443cb413079</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20502.9">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20502.11">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>61af970c8058d815b0570c5ced5c46f22755f91a</Sha>
+      <Sha>54dca82b90706e8bad26cb4795228443cb413079</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">
@@ -117,9 +117,9 @@
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>f1a29d004314b99af8ab07d2334cbd1bf9e716c5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build" Version="16.8.0-preview-20475-05" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.Build" Version="16.9.0-preview-20502-03" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>aed5e7ed0b7e031d3e486c63b206902bf825b128</Sha>
+      <Sha>ca44138662e3aa90eb9305dd31d906ef02e962cb</Sha>
     </Dependency>
     <Dependency Name="NuGet.Build.Tasks" Version="5.8.0-rc.6860" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/NuGet/NuGet.Client</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>8764c82892d6f028e45d49514660aa2026bd980e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20506.14">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20506.15">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>0937145e32f24cac01a25d7e199fa62088004e21</Sha>
+      <Sha>ded0b206b0589cdb7fec807efa542c3e5f137a32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20506.14">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20506.15">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>0937145e32f24cac01a25d7e199fa62088004e21</Sha>
+      <Sha>ded0b206b0589cdb7fec807efa542c3e5f137a32</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">
@@ -113,9 +113,9 @@
       <Sha>b89cb90abdfdc4e1ccd0822b62d367fa35d30f00</Sha>
       <RepoName>linker</RepoName>
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.9.0-1.20504.1" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.9.0-1.20507.5" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>88287e9625dd15e0bad4f2a9a33fb5af3b3d0315</Sha>
+      <Sha>c4de37f9dd1c635b42b6e7376e0eaf9547f27ad4</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Build" Version="16.9.0-preview-20502-03" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/msbuild</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -13,25 +13,25 @@
       <Uri>https://github.com/dotnet/windowsdesktop</Uri>
       <Sha>85186023c8de8237268033cadc41d738b7f2005e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-alpha.1.20507.4" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-alpha.1.20510.8" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4fef87c65e7466000884aeb9dee6498b162fe2fa</Sha>
+      <Sha>4af0db78428b39315b4683f749237d9dd7b6020a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Internal" Version="6.0.0-alpha.1.20507.4" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.App.Internal" Version="6.0.0-alpha.1.20510.8" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4fef87c65e7466000884aeb9dee6498b162fe2fa</Sha>
+      <Sha>4af0db78428b39315b4683f749237d9dd7b6020a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-alpha.1.20507.4" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-alpha.1.20510.8" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4fef87c65e7466000884aeb9dee6498b162fe2fa</Sha>
+      <Sha>4af0db78428b39315b4683f749237d9dd7b6020a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Host.win-x64" Version="6.0.0-alpha.1.20507.4" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.App.Host.win-x64" Version="6.0.0-alpha.1.20510.8" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4fef87c65e7466000884aeb9dee6498b162fe2fa</Sha>
+      <Sha>4af0db78428b39315b4683f749237d9dd7b6020a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="6.0.0-alpha.1.20507.4" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="6.0.0-alpha.1.20510.8" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4fef87c65e7466000884aeb9dee6498b162fe2fa</Sha>
+      <Sha>4af0db78428b39315b4683f749237d9dd7b6020a</Sha>
     </Dependency>
     <!-- Change blob version in GenerateLayout.targets if this is unpinned to service targeting pack -->
     <!-- No new netstandard.library planned for 3.1 timeframe at this time. -->
@@ -39,37 +39,37 @@
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>7d57652f33493fa022125b7f63aad0d70c52d810</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.0-alpha.1.20507.4" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.0-alpha.1.20510.8" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4fef87c65e7466000884aeb9dee6498b162fe2fa</Sha>
+      <Sha>4af0db78428b39315b4683f749237d9dd7b6020a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20509.5" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20509.13" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>36f6242e6f84208bc1c9d2c4cac94cbb134196df</Sha>
+      <Sha>ab973d23fb5fc3b00d37ba63182b5bb14dc02803</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20509.5" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20509.13" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>36f6242e6f84208bc1c9d2c4cac94cbb134196df</Sha>
+      <Sha>ab973d23fb5fc3b00d37ba63182b5bb14dc02803</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20509.5" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20509.13" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>36f6242e6f84208bc1c9d2c4cac94cbb134196df</Sha>
+      <Sha>ab973d23fb5fc3b00d37ba63182b5bb14dc02803</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20509.5" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20509.13" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>36f6242e6f84208bc1c9d2c4cac94cbb134196df</Sha>
+      <Sha>ab973d23fb5fc3b00d37ba63182b5bb14dc02803</Sha>
     </Dependency>
-    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20509.5" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20509.13" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>36f6242e6f84208bc1c9d2c4cac94cbb134196df</Sha>
+      <Sha>ab973d23fb5fc3b00d37ba63182b5bb14dc02803</Sha>
     </Dependency>
-    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20509.5" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20509.13" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>36f6242e6f84208bc1c9d2c4cac94cbb134196df</Sha>
+      <Sha>ab973d23fb5fc3b00d37ba63182b5bb14dc02803</Sha>
     </Dependency>
-    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20509.5" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20509.13" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>36f6242e6f84208bc1c9d2c4cac94cbb134196df</Sha>
+      <Sha>ab973d23fb5fc3b00d37ba63182b5bb14dc02803</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="1.0.2-beta4.20420.1">
       <Uri>https://github.com/dotnet/test-templates</Uri>
@@ -79,17 +79,17 @@
       <Uri>https://github.com/dotnet/test-templates</Uri>
       <Sha>a2b05d8171915c69ad97ab5d49bbb07d2c780a67</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="6.0.0-alpha.1.20509.2" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="6.0.0-alpha.1.20512.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>ddf5f8e5de38c184ea015d9dc817cbfd4f4a3d4f</Sha>
+      <Sha>39fa7665ccf365a2c0804109c6b09650d52ffff0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20509.14">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20512.3">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>987d0bd4bbdd20db1513245994e82c33934b3f1c</Sha>
+      <Sha>2491722eef22909f6e95a97fe6cdca08faca060a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20509.14">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20512.3">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>987d0bd4bbdd20db1513245994e82c33934b3f1c</Sha>
+      <Sha>2491722eef22909f6e95a97fe6cdca08faca060a</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">
@@ -104,18 +104,18 @@
       <Uri>https://github.com/dotnet/fsharp</Uri>
       <Sha>da6be68280c89131cdba2045525b80890401defd</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Test.Sdk" Version="16.9.0-preview-20201006-01" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NET.Test.Sdk" Version="16.8.0-release-20201009-01" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/microsoft/vstest</Uri>
-      <Sha>5e59fa403297516710222264b5df53496e379f8f</Sha>
+      <Sha>0b1e2e51743cc083d99b88673fe518672e2af9f0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.0-alpha.1.20502.1" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.0-alpha.1.20512.2" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/mono/linker</Uri>
-      <Sha>b89cb90abdfdc4e1ccd0822b62d367fa35d30f00</Sha>
+      <Sha>24c3616ee88623bea1e068605eba15009a8a3043</Sha>
       <RepoName>linker</RepoName>
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.9.0-1.20507.19" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.9.0-1.20512.2" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>38ec7d8512b5fa10aa9d567d7d13a6bfd8caf3e4</Sha>
+      <Sha>53f4d5b526c845d39387f8d2782e6c2bb7301ac9</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Build" Version="16.9.0-preview-20507-01" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/msbuild</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -43,33 +43,33 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>f63b0c1a7562b5a70c6f02db8f99e2c9b5b97cac</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20501.3" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20501.10" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>3e9ae8e5eee2930da0096ab4ca4976f5938df648</Sha>
+      <Sha>619a992fc38921ea0fedd8e0fad4c593be30fed8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20501.3" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20501.10" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>3e9ae8e5eee2930da0096ab4ca4976f5938df648</Sha>
+      <Sha>619a992fc38921ea0fedd8e0fad4c593be30fed8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20501.3" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20501.10" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>3e9ae8e5eee2930da0096ab4ca4976f5938df648</Sha>
+      <Sha>619a992fc38921ea0fedd8e0fad4c593be30fed8</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20501.3" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20501.10" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>3e9ae8e5eee2930da0096ab4ca4976f5938df648</Sha>
+      <Sha>619a992fc38921ea0fedd8e0fad4c593be30fed8</Sha>
     </Dependency>
-    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20501.3" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20501.10" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>3e9ae8e5eee2930da0096ab4ca4976f5938df648</Sha>
+      <Sha>619a992fc38921ea0fedd8e0fad4c593be30fed8</Sha>
     </Dependency>
-    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20501.3" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20501.10" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>3e9ae8e5eee2930da0096ab4ca4976f5938df648</Sha>
+      <Sha>619a992fc38921ea0fedd8e0fad4c593be30fed8</Sha>
     </Dependency>
-    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20501.3" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20501.10" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>3e9ae8e5eee2930da0096ab4ca4976f5938df648</Sha>
+      <Sha>619a992fc38921ea0fedd8e0fad4c593be30fed8</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="1.0.2-beta4.20420.1">
       <Uri>https://github.com/dotnet/test-templates</Uri>
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>8764c82892d6f028e45d49514660aa2026bd980e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20501.8">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20501.10">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>1faa5d2178311b2733b523775ee19cf68a6258ba</Sha>
+      <Sha>9e77ead294b3529cbbe6107cf2e7e285e251d965</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20501.8">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20501.10">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>1faa5d2178311b2733b523775ee19cf68a6258ba</Sha>
+      <Sha>9e77ead294b3529cbbe6107cf2e7e285e251d965</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -43,33 +43,33 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>4af0db78428b39315b4683f749237d9dd7b6020a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="6.0.0-alpha.1.20512.11" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="6.0.0-alpha.1.20512.13" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>701b294342ff2381bc9e291d2ec828191c28fd34</Sha>
+      <Sha>593005230fc9900564a74e38112bfb1133932679</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="6.0.0-alpha.1.20512.11" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="6.0.0-alpha.1.20512.13" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>701b294342ff2381bc9e291d2ec828191c28fd34</Sha>
+      <Sha>593005230fc9900564a74e38112bfb1133932679</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="6.0.0-alpha.1.20512.11" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="6.0.0-alpha.1.20512.13" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>701b294342ff2381bc9e291d2ec828191c28fd34</Sha>
+      <Sha>593005230fc9900564a74e38112bfb1133932679</Sha>
     </Dependency>
     <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20512.5" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>b866b765b3493c7943829ce830e509d61f958102</Sha>
     </Dependency>
-    <Dependency Name="dotnet-dev-certs" Version="6.0.0-alpha.1.20512.11" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-dev-certs" Version="6.0.0-alpha.1.20512.13" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>701b294342ff2381bc9e291d2ec828191c28fd34</Sha>
+      <Sha>593005230fc9900564a74e38112bfb1133932679</Sha>
     </Dependency>
-    <Dependency Name="dotnet-user-secrets" Version="6.0.0-alpha.1.20512.11" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-user-secrets" Version="6.0.0-alpha.1.20512.13" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>701b294342ff2381bc9e291d2ec828191c28fd34</Sha>
+      <Sha>593005230fc9900564a74e38112bfb1133932679</Sha>
     </Dependency>
-    <Dependency Name="dotnet-watch" Version="6.0.0-alpha.1.20512.11" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-watch" Version="6.0.0-alpha.1.20512.13" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>701b294342ff2381bc9e291d2ec828191c28fd34</Sha>
+      <Sha>593005230fc9900564a74e38112bfb1133932679</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="1.0.2-beta4.20420.1">
       <Uri>https://github.com/dotnet/test-templates</Uri>
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>39fa7665ccf365a2c0804109c6b09650d52ffff0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20512.11">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20513.1">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>426a9d8d3a0ea65dce97c4ce3d1120791d9a6974</Sha>
+      <Sha>9c9284800ba513b8a92b0c32159805759c41f56b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20512.11">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20513.1">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>426a9d8d3a0ea65dce97c4ce3d1120791d9a6974</Sha>
+      <Sha>9c9284800ba513b8a92b0c32159805759c41f56b</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">
@@ -104,18 +104,18 @@
       <Uri>https://github.com/dotnet/fsharp</Uri>
       <Sha>da6be68280c89131cdba2045525b80890401defd</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Test.Sdk" Version="16.8.0-release-20201009-01" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NET.Test.Sdk" Version="16.9.0-preview-20201013-01" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/microsoft/vstest</Uri>
-      <Sha>0b1e2e51743cc083d99b88673fe518672e2af9f0</Sha>
+      <Sha>d834b9b8c4337438622cb7b7d77f1520b479cb88</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.0-alpha.1.20512.2" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/mono/linker</Uri>
       <Sha>24c3616ee88623bea1e068605eba15009a8a3043</Sha>
       <RepoName>linker</RepoName>
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.9.0-1.20512.4" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.9.0-1.20513.5" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>df89f3868564dbf2a8cdf7cef985def16501cdf3</Sha>
+      <Sha>16db183b2b316d515cb4072cf925cff3a45a8ecb</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Build" Version="16.9.0-preview-20507-01" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/msbuild</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>8764c82892d6f028e45d49514660aa2026bd980e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20504.2">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20505.1">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>eabe646e825d32c522a59f266f268ea7a477ee2e</Sha>
+      <Sha>552e4b93eec289aa4c2c8f96a11b5a85edfecbf9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20504.2">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20505.1">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>eabe646e825d32c522a59f266f268ea7a477ee2e</Sha>
+      <Sha>552e4b93eec289aa4c2c8f96a11b5a85edfecbf9</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">
@@ -104,9 +104,9 @@
       <Uri>https://github.com/dotnet/fsharp</Uri>
       <Sha>f394b34045020afb92a4510a98c8c4bde9ac33f4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Test.Sdk" Version="16.9.0-preview-20200929-01" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NET.Test.Sdk" Version="16.9.0-preview-20201005-01" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/microsoft/vstest</Uri>
-      <Sha>6a774215a898bb38184e1115e2fb4801185fb0db</Sha>
+      <Sha>a319f62bfd966d584b3a19e20bad55288436cc97</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.0-alpha.1.20502.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/mono/linker</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>0589fb051fac78cde679708575087d4ec6e29971</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20508.18">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20508.19">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>ebec66211c2d04668c741a6d1b3dcd00369d5043</Sha>
+      <Sha>1eaacb12ea40f0e36cf2c859586460bd9921459a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20508.18">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20508.19">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>ebec66211c2d04668c741a6d1b3dcd00369d5043</Sha>
+      <Sha>1eaacb12ea40f0e36cf2c859586460bd9921459a</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">
@@ -117,9 +117,9 @@
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>38ec7d8512b5fa10aa9d567d7d13a6bfd8caf3e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build" Version="16.9.0-preview-20502-03" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.Build" Version="16.9.0-preview-20507-01" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>ca44138662e3aa90eb9305dd31d906ef02e962cb</Sha>
+      <Sha>a71067913c82bcb5d79a13f40ff8b12cbd384c1c</Sha>
     </Dependency>
     <Dependency Name="NuGet.Build.Tasks" Version="5.8.0-rc.6860" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/NuGet/NuGet.Client</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>39fa7665ccf365a2c0804109c6b09650d52ffff0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20512.3">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20512.9">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>2491722eef22909f6e95a97fe6cdca08faca060a</Sha>
+      <Sha>6b766be9d3d8d2de451d96fde65170ebfd4507f2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20512.3">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20512.9">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>2491722eef22909f6e95a97fe6cdca08faca060a</Sha>
+      <Sha>6b766be9d3d8d2de451d96fde65170ebfd4507f2</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">
@@ -113,9 +113,9 @@
       <Sha>24c3616ee88623bea1e068605eba15009a8a3043</Sha>
       <RepoName>linker</RepoName>
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.9.0-1.20512.2" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.9.0-1.20512.4" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>53f4d5b526c845d39387f8d2782e6c2bb7301ac9</Sha>
+      <Sha>df89f3868564dbf2a8cdf7cef985def16501cdf3</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Build" Version="16.9.0-preview-20507-01" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/msbuild</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>8764c82892d6f028e45d49514660aa2026bd980e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20506.8">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20506.10">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>7b27129e2cad2432c0e596096e56d69bdd2ce32b</Sha>
+      <Sha>e63abd20a6a57e7294b91d59b029f7b41d18b4a5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20506.8">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20506.10">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>7b27129e2cad2432c0e596096e56d69bdd2ce32b</Sha>
+      <Sha>e63abd20a6a57e7294b91d59b029f7b41d18b4a5</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">
@@ -113,9 +113,9 @@
       <Sha>b89cb90abdfdc4e1ccd0822b62d367fa35d30f00</Sha>
       <RepoName>linker</RepoName>
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.8.0-4.20475.8" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.9.0-1.20504.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>dd7319ea5e31ffe79f558c2c835067f4a9091902</Sha>
+      <Sha>88287e9625dd15e0bad4f2a9a33fb5af3b3d0315</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Build" Version="16.9.0-preview-20502-03" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/msbuild</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -43,33 +43,33 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>f63b0c1a7562b5a70c6f02db8f99e2c9b5b97cac</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20480.7" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20501.3" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>dd7d7772a608c78d44a5cce09627f132f8dad306</Sha>
+      <Sha>3e9ae8e5eee2930da0096ab4ca4976f5938df648</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20480.7" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20501.3" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>dd7d7772a608c78d44a5cce09627f132f8dad306</Sha>
+      <Sha>3e9ae8e5eee2930da0096ab4ca4976f5938df648</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20480.7" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20501.3" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>dd7d7772a608c78d44a5cce09627f132f8dad306</Sha>
+      <Sha>3e9ae8e5eee2930da0096ab4ca4976f5938df648</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20480.7" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20501.3" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>dd7d7772a608c78d44a5cce09627f132f8dad306</Sha>
+      <Sha>3e9ae8e5eee2930da0096ab4ca4976f5938df648</Sha>
     </Dependency>
-    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20480.7" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20501.3" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>dd7d7772a608c78d44a5cce09627f132f8dad306</Sha>
+      <Sha>3e9ae8e5eee2930da0096ab4ca4976f5938df648</Sha>
     </Dependency>
-    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20480.7" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20501.3" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>dd7d7772a608c78d44a5cce09627f132f8dad306</Sha>
+      <Sha>3e9ae8e5eee2930da0096ab4ca4976f5938df648</Sha>
     </Dependency>
-    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20480.7" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20501.3" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>dd7d7772a608c78d44a5cce09627f132f8dad306</Sha>
+      <Sha>3e9ae8e5eee2930da0096ab4ca4976f5938df648</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="1.0.2-beta4.20420.1">
       <Uri>https://github.com/dotnet/test-templates</Uri>
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>8764c82892d6f028e45d49514660aa2026bd980e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20501.7">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20501.8">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>551d66996909931839cae13eb7bdbd852a7c1819</Sha>
+      <Sha>1faa5d2178311b2733b523775ee19cf68a6258ba</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20501.7">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20501.8">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>551d66996909931839cae13eb7bdbd852a7c1819</Sha>
+      <Sha>1faa5d2178311b2733b523775ee19cf68a6258ba</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -43,33 +43,33 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>4fef87c65e7466000884aeb9dee6498b162fe2fa</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20508.16" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20508.21" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a84868a602ac45c85b30d706c3bfcb8900c804a2</Sha>
+      <Sha>c995f1c803a9ca329f681ed62f31ad4a028b8d7a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20508.16" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20508.21" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a84868a602ac45c85b30d706c3bfcb8900c804a2</Sha>
+      <Sha>c995f1c803a9ca329f681ed62f31ad4a028b8d7a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20508.16" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20508.21" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a84868a602ac45c85b30d706c3bfcb8900c804a2</Sha>
+      <Sha>c995f1c803a9ca329f681ed62f31ad4a028b8d7a</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20508.16" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20508.21" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a84868a602ac45c85b30d706c3bfcb8900c804a2</Sha>
+      <Sha>c995f1c803a9ca329f681ed62f31ad4a028b8d7a</Sha>
     </Dependency>
-    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20508.16" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20508.21" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a84868a602ac45c85b30d706c3bfcb8900c804a2</Sha>
+      <Sha>c995f1c803a9ca329f681ed62f31ad4a028b8d7a</Sha>
     </Dependency>
-    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20508.16" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20508.21" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a84868a602ac45c85b30d706c3bfcb8900c804a2</Sha>
+      <Sha>c995f1c803a9ca329f681ed62f31ad4a028b8d7a</Sha>
     </Dependency>
-    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20508.16" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20508.21" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>a84868a602ac45c85b30d706c3bfcb8900c804a2</Sha>
+      <Sha>c995f1c803a9ca329f681ed62f31ad4a028b8d7a</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="1.0.2-beta4.20420.1">
       <Uri>https://github.com/dotnet/test-templates</Uri>
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>0589fb051fac78cde679708575087d4ec6e29971</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20508.19">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20508.23">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>1eaacb12ea40f0e36cf2c859586460bd9921459a</Sha>
+      <Sha>8ff1d72ad28678dca5a06cd12ebdd03cb74e9bba</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20508.19">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20508.23">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>1eaacb12ea40f0e36cf2c859586460bd9921459a</Sha>
+      <Sha>8ff1d72ad28678dca5a06cd12ebdd03cb74e9bba</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>0589fb051fac78cde679708575087d4ec6e29971</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20508.11">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20508.13">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>acc78e6ff441e92a58a23fd2d6e5966ce7b49c30</Sha>
+      <Sha>d4eac864ce7b9b4daa85c2b77957880a171033f8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20508.11">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20508.13">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>acc78e6ff441e92a58a23fd2d6e5966ce7b49c30</Sha>
+      <Sha>d4eac864ce7b9b4daa85c2b77957880a171033f8</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>39fa7665ccf365a2c0804109c6b09650d52ffff0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20513.11">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20513.13">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>b492fb67ebbc325d0c698c2e36f07794ab65312d</Sha>
+      <Sha>8c059bc86d1d10af5c98c062010e289c5e014bde</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20513.11">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20513.13">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>b492fb67ebbc325d0c698c2e36f07794ab65312d</Sha>
+      <Sha>8c059bc86d1d10af5c98c062010e289c5e014bde</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">
@@ -117,9 +117,9 @@
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>c69d99cbdc5de6c330bf86a44ca7af1547906bb6</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build" Version="16.9.0-preview-20513-04" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.Build" Version="16.9.0-preview-20513-07" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>0d9652e75b74fc8b359c3cd4528b10e932b239c9</Sha>
+      <Sha>c10f34c4e00644e06120cb87f323c330f29a1e89</Sha>
     </Dependency>
     <Dependency Name="NuGet.Build.Tasks" Version="5.8.0-rc.6860" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/NuGet/NuGet.Client</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -43,33 +43,33 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>4af0db78428b39315b4683f749237d9dd7b6020a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20509.13" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="6.0.0-alpha.1.20512.11" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>ab973d23fb5fc3b00d37ba63182b5bb14dc02803</Sha>
+      <Sha>701b294342ff2381bc9e291d2ec828191c28fd34</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20509.13" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="6.0.0-alpha.1.20512.11" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>ab973d23fb5fc3b00d37ba63182b5bb14dc02803</Sha>
+      <Sha>701b294342ff2381bc9e291d2ec828191c28fd34</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20509.13" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="6.0.0-alpha.1.20512.11" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>ab973d23fb5fc3b00d37ba63182b5bb14dc02803</Sha>
+      <Sha>701b294342ff2381bc9e291d2ec828191c28fd34</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20509.13" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20512.5" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>ab973d23fb5fc3b00d37ba63182b5bb14dc02803</Sha>
+      <Sha>b866b765b3493c7943829ce830e509d61f958102</Sha>
     </Dependency>
-    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20509.13" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-dev-certs" Version="6.0.0-alpha.1.20512.11" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>ab973d23fb5fc3b00d37ba63182b5bb14dc02803</Sha>
+      <Sha>701b294342ff2381bc9e291d2ec828191c28fd34</Sha>
     </Dependency>
-    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20509.13" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-user-secrets" Version="6.0.0-alpha.1.20512.11" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>ab973d23fb5fc3b00d37ba63182b5bb14dc02803</Sha>
+      <Sha>701b294342ff2381bc9e291d2ec828191c28fd34</Sha>
     </Dependency>
-    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20509.13" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-watch" Version="6.0.0-alpha.1.20512.11" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>ab973d23fb5fc3b00d37ba63182b5bb14dc02803</Sha>
+      <Sha>701b294342ff2381bc9e291d2ec828191c28fd34</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="1.0.2-beta4.20420.1">
       <Uri>https://github.com/dotnet/test-templates</Uri>
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>39fa7665ccf365a2c0804109c6b09650d52ffff0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20512.9">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20512.11">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>6b766be9d3d8d2de451d96fde65170ebfd4507f2</Sha>
+      <Sha>426a9d8d3a0ea65dce97c4ce3d1120791d9a6974</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20512.9">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20512.11">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>6b766be9d3d8d2de451d96fde65170ebfd4507f2</Sha>
+      <Sha>426a9d8d3a0ea65dce97c4ce3d1120791d9a6974</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -43,33 +43,33 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>4fef87c65e7466000884aeb9dee6498b162fe2fa</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20508.23" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20508.27" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>6be66f507e4fc8cf14dcfcecbfb0eeffefbeddee</Sha>
+      <Sha>9402ebf905c7896c8f2fda77ea3e702d692fc37a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20508.23" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20508.27" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>6be66f507e4fc8cf14dcfcecbfb0eeffefbeddee</Sha>
+      <Sha>9402ebf905c7896c8f2fda77ea3e702d692fc37a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20508.23" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20508.27" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>6be66f507e4fc8cf14dcfcecbfb0eeffefbeddee</Sha>
+      <Sha>9402ebf905c7896c8f2fda77ea3e702d692fc37a</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20508.23" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20508.27" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>6be66f507e4fc8cf14dcfcecbfb0eeffefbeddee</Sha>
+      <Sha>9402ebf905c7896c8f2fda77ea3e702d692fc37a</Sha>
     </Dependency>
-    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20508.23" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20508.27" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>6be66f507e4fc8cf14dcfcecbfb0eeffefbeddee</Sha>
+      <Sha>9402ebf905c7896c8f2fda77ea3e702d692fc37a</Sha>
     </Dependency>
-    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20508.23" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20508.27" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>6be66f507e4fc8cf14dcfcecbfb0eeffefbeddee</Sha>
+      <Sha>9402ebf905c7896c8f2fda77ea3e702d692fc37a</Sha>
     </Dependency>
-    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20508.23" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20508.27" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>6be66f507e4fc8cf14dcfcecbfb0eeffefbeddee</Sha>
+      <Sha>9402ebf905c7896c8f2fda77ea3e702d692fc37a</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="1.0.2-beta4.20420.1">
       <Uri>https://github.com/dotnet/test-templates</Uri>
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>0589fb051fac78cde679708575087d4ec6e29971</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20508.27">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20509.2">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>e9b71c9c2aa0aa2a9275c10875bd187f358a84a2</Sha>
+      <Sha>f9e9d00b78c6e3ea3745089e8a002a8a342b5200</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20508.27">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20509.2">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>e9b71c9c2aa0aa2a9275c10875bd187f358a84a2</Sha>
+      <Sha>f9e9d00b78c6e3ea3745089e8a002a8a342b5200</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>8764c82892d6f028e45d49514660aa2026bd980e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20506.15">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20507.1">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>ded0b206b0589cdb7fec807efa542c3e5f137a32</Sha>
+      <Sha>d9e515f9795020c1ed2d2bff4559cfae7238b149</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20506.15">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20507.1">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>ded0b206b0589cdb7fec807efa542c3e5f137a32</Sha>
+      <Sha>d9e515f9795020c1ed2d2bff4559cfae7238b149</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">
@@ -113,9 +113,9 @@
       <Sha>b89cb90abdfdc4e1ccd0822b62d367fa35d30f00</Sha>
       <RepoName>linker</RepoName>
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.9.0-1.20507.5" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.9.0-1.20507.8" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>c4de37f9dd1c635b42b6e7376e0eaf9547f27ad4</Sha>
+      <Sha>bf030da2d44f6e81c376eba4f0a87701abdf8472</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Build" Version="16.9.0-preview-20502-03" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/msbuild</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -13,25 +13,25 @@
       <Uri>https://github.com/dotnet/windowsdesktop</Uri>
       <Sha>85186023c8de8237268033cadc41d738b7f2005e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-alpha.1.20505.12" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-alpha.1.20507.4" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>214458e2748c7857ab2e2cfdb3a3d32d65e95bfe</Sha>
+      <Sha>4fef87c65e7466000884aeb9dee6498b162fe2fa</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Internal" Version="6.0.0-alpha.1.20505.12" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.App.Internal" Version="6.0.0-alpha.1.20507.4" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>214458e2748c7857ab2e2cfdb3a3d32d65e95bfe</Sha>
+      <Sha>4fef87c65e7466000884aeb9dee6498b162fe2fa</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-alpha.1.20505.12" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-alpha.1.20507.4" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>214458e2748c7857ab2e2cfdb3a3d32d65e95bfe</Sha>
+      <Sha>4fef87c65e7466000884aeb9dee6498b162fe2fa</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Host.win-x64" Version="6.0.0-alpha.1.20505.12" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.App.Host.win-x64" Version="6.0.0-alpha.1.20507.4" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>214458e2748c7857ab2e2cfdb3a3d32d65e95bfe</Sha>
+      <Sha>4fef87c65e7466000884aeb9dee6498b162fe2fa</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="6.0.0-alpha.1.20505.12" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="6.0.0-alpha.1.20507.4" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>214458e2748c7857ab2e2cfdb3a3d32d65e95bfe</Sha>
+      <Sha>4fef87c65e7466000884aeb9dee6498b162fe2fa</Sha>
     </Dependency>
     <!-- Change blob version in GenerateLayout.targets if this is unpinned to service targeting pack -->
     <!-- No new netstandard.library planned for 3.1 timeframe at this time. -->
@@ -39,9 +39,9 @@
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>7d57652f33493fa022125b7f63aad0d70c52d810</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.0-alpha.1.20505.12" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.0-alpha.1.20507.4" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>214458e2748c7857ab2e2cfdb3a3d32d65e95bfe</Sha>
+      <Sha>4fef87c65e7466000884aeb9dee6498b162fe2fa</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20507.10" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>8764c82892d6f028e45d49514660aa2026bd980e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20508.3">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20508.5">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>3ed69b1b3d3e08bfed10b2969ade99ed9b377f3a</Sha>
+      <Sha>75674af716f72847b766fbef40f8b36cb062711c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20508.3">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20508.5">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>3ed69b1b3d3e08bfed10b2969ade99ed9b377f3a</Sha>
+      <Sha>75674af716f72847b766fbef40f8b36cb062711c</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -43,33 +43,33 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>4fef87c65e7466000884aeb9dee6498b162fe2fa</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20508.27" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20508.29" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9402ebf905c7896c8f2fda77ea3e702d692fc37a</Sha>
+      <Sha>b7b300143518f86d5e4ff6630688c7d578efda07</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20508.27" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20508.29" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9402ebf905c7896c8f2fda77ea3e702d692fc37a</Sha>
+      <Sha>b7b300143518f86d5e4ff6630688c7d578efda07</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20508.27" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20508.29" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9402ebf905c7896c8f2fda77ea3e702d692fc37a</Sha>
+      <Sha>b7b300143518f86d5e4ff6630688c7d578efda07</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20508.27" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20508.29" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9402ebf905c7896c8f2fda77ea3e702d692fc37a</Sha>
+      <Sha>b7b300143518f86d5e4ff6630688c7d578efda07</Sha>
     </Dependency>
-    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20508.27" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20508.29" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9402ebf905c7896c8f2fda77ea3e702d692fc37a</Sha>
+      <Sha>b7b300143518f86d5e4ff6630688c7d578efda07</Sha>
     </Dependency>
-    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20508.27" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20508.29" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9402ebf905c7896c8f2fda77ea3e702d692fc37a</Sha>
+      <Sha>b7b300143518f86d5e4ff6630688c7d578efda07</Sha>
     </Dependency>
-    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20508.27" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20508.29" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9402ebf905c7896c8f2fda77ea3e702d692fc37a</Sha>
+      <Sha>b7b300143518f86d5e4ff6630688c7d578efda07</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="1.0.2-beta4.20420.1">
       <Uri>https://github.com/dotnet/test-templates</Uri>
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>0589fb051fac78cde679708575087d4ec6e29971</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20509.2">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20509.5">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>f9e9d00b78c6e3ea3745089e8a002a8a342b5200</Sha>
+      <Sha>0024a88ea0ec25ae62f1c6b07520538f067ba46d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20509.2">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20509.5">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>f9e9d00b78c6e3ea3745089e8a002a8a342b5200</Sha>
+      <Sha>0024a88ea0ec25ae62f1c6b07520538f067ba46d</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -43,33 +43,33 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>4af0db78428b39315b4683f749237d9dd7b6020a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="6.0.0-alpha.1.20513.5" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="6.0.0-alpha.1.20513.8" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>95921cf68d99484c3a32e667388abfa46cf87fd0</Sha>
+      <Sha>be472db60f4711404ba5de268f7b9d4a887926f8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="6.0.0-alpha.1.20513.5" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="6.0.0-alpha.1.20513.8" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>95921cf68d99484c3a32e667388abfa46cf87fd0</Sha>
+      <Sha>be472db60f4711404ba5de268f7b9d4a887926f8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="6.0.0-alpha.1.20513.5" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="6.0.0-alpha.1.20513.8" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>95921cf68d99484c3a32e667388abfa46cf87fd0</Sha>
+      <Sha>be472db60f4711404ba5de268f7b9d4a887926f8</Sha>
     </Dependency>
     <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20512.5" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>b866b765b3493c7943829ce830e509d61f958102</Sha>
     </Dependency>
-    <Dependency Name="dotnet-dev-certs" Version="6.0.0-alpha.1.20513.5" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-dev-certs" Version="6.0.0-alpha.1.20513.8" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>95921cf68d99484c3a32e667388abfa46cf87fd0</Sha>
+      <Sha>be472db60f4711404ba5de268f7b9d4a887926f8</Sha>
     </Dependency>
-    <Dependency Name="dotnet-user-secrets" Version="6.0.0-alpha.1.20513.5" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-user-secrets" Version="6.0.0-alpha.1.20513.8" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>95921cf68d99484c3a32e667388abfa46cf87fd0</Sha>
+      <Sha>be472db60f4711404ba5de268f7b9d4a887926f8</Sha>
     </Dependency>
-    <Dependency Name="dotnet-watch" Version="6.0.0-alpha.1.20513.5" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-watch" Version="6.0.0-alpha.1.20513.8" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>95921cf68d99484c3a32e667388abfa46cf87fd0</Sha>
+      <Sha>be472db60f4711404ba5de268f7b9d4a887926f8</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="1.0.2-beta4.20420.1">
       <Uri>https://github.com/dotnet/test-templates</Uri>
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>39fa7665ccf365a2c0804109c6b09650d52ffff0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20513.13">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20514.1">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>8c059bc86d1d10af5c98c062010e289c5e014bde</Sha>
+      <Sha>516ec26623a03550ea73ea084d53ef783fe41439</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20513.13">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20514.1">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>8c059bc86d1d10af5c98c062010e289c5e014bde</Sha>
+      <Sha>516ec26623a03550ea73ea084d53ef783fe41439</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>8764c82892d6f028e45d49514660aa2026bd980e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20505.5">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20506.2">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>72a670673f277225073595e9d2e9e7ff456ebd92</Sha>
+      <Sha>79e3234b73c909d715cca6bc199d5c2b98c3248d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20505.5">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20506.2">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>72a670673f277225073595e9d2e9e7ff456ebd92</Sha>
+      <Sha>79e3234b73c909d715cca6bc199d5c2b98c3248d</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>39fa7665ccf365a2c0804109c6b09650d52ffff0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20513.6">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20513.7">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>78ad03bfaaefc968150d1c4356d691501fdcf232</Sha>
+      <Sha>6e9622afd0695115f46fa09dbdc30bfa2a89d378</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20513.6">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20513.7">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>78ad03bfaaefc968150d1c4356d691501fdcf232</Sha>
+      <Sha>6e9622afd0695115f46fa09dbdc30bfa2a89d378</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">
@@ -117,9 +117,9 @@
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>16db183b2b316d515cb4072cf925cff3a45a8ecb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build" Version="16.9.0-preview-20507-01" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.Build" Version="16.9.0-preview-20513-02" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>a71067913c82bcb5d79a13f40ff8b12cbd384c1c</Sha>
+      <Sha>5d8ae7e88b7d5371ec375eaa3aab2ad50fcb5869</Sha>
     </Dependency>
     <Dependency Name="NuGet.Build.Tasks" Version="5.8.0-rc.6860" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/NuGet/NuGet.Client</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -79,17 +79,17 @@
       <Uri>https://github.com/dotnet/test-templates</Uri>
       <Sha>a2b05d8171915c69ad97ab5d49bbb07d2c780a67</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="6.0.0-alpha.1.20508.2" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="6.0.0-alpha.1.20509.2" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>0589fb051fac78cde679708575087d4ec6e29971</Sha>
+      <Sha>ddf5f8e5de38c184ea015d9dc817cbfd4f4a3d4f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20509.5">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20509.7">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>0024a88ea0ec25ae62f1c6b07520538f067ba46d</Sha>
+      <Sha>e6e486ccf982d865cda602f460b59e1f46278855</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20509.5">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20509.7">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>0024a88ea0ec25ae62f1c6b07520538f067ba46d</Sha>
+      <Sha>e6e486ccf982d865cda602f460b59e1f46278855</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>8764c82892d6f028e45d49514660aa2026bd980e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20507.1">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20507.4">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>d9e515f9795020c1ed2d2bff4559cfae7238b149</Sha>
+      <Sha>f1ba8d1bed6473345918d02bf5a24dbc176fe052</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20507.1">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20507.4">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>d9e515f9795020c1ed2d2bff4559cfae7238b149</Sha>
+      <Sha>f1ba8d1bed6473345918d02bf5a24dbc176fe052</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">
@@ -113,9 +113,9 @@
       <Sha>b89cb90abdfdc4e1ccd0822b62d367fa35d30f00</Sha>
       <RepoName>linker</RepoName>
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.9.0-1.20507.8" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.9.0-1.20507.19" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>bf030da2d44f6e81c376eba4f0a87701abdf8472</Sha>
+      <Sha>38ec7d8512b5fa10aa9d567d7d13a6bfd8caf3e4</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Build" Version="16.9.0-preview-20502-03" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/msbuild</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -43,33 +43,33 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>22791d4e8830d4e94930c8fa84555fa6dacf8829</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20502.12" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20503.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>ca1f9f532f540f16732e8d8b4990fbae1578786b</Sha>
+      <Sha>c029cdf7caa9a4f722a3056dc079979fc248cedb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20502.12" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20503.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>ca1f9f532f540f16732e8d8b4990fbae1578786b</Sha>
+      <Sha>c029cdf7caa9a4f722a3056dc079979fc248cedb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20502.12" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20503.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>ca1f9f532f540f16732e8d8b4990fbae1578786b</Sha>
+      <Sha>c029cdf7caa9a4f722a3056dc079979fc248cedb</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20502.12" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20503.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>ca1f9f532f540f16732e8d8b4990fbae1578786b</Sha>
+      <Sha>c029cdf7caa9a4f722a3056dc079979fc248cedb</Sha>
     </Dependency>
-    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20502.12" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20503.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>ca1f9f532f540f16732e8d8b4990fbae1578786b</Sha>
+      <Sha>c029cdf7caa9a4f722a3056dc079979fc248cedb</Sha>
     </Dependency>
-    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20502.12" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20503.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>ca1f9f532f540f16732e8d8b4990fbae1578786b</Sha>
+      <Sha>c029cdf7caa9a4f722a3056dc079979fc248cedb</Sha>
     </Dependency>
-    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20502.12" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20503.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>ca1f9f532f540f16732e8d8b4990fbae1578786b</Sha>
+      <Sha>c029cdf7caa9a4f722a3056dc079979fc248cedb</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="1.0.2-beta4.20420.1">
       <Uri>https://github.com/dotnet/test-templates</Uri>
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>8764c82892d6f028e45d49514660aa2026bd980e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20503.3">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20503.4">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>d95c3f39ede9dfd9f04edc398820d307f18f62d7</Sha>
+      <Sha>45561dcbcb4939beaee4266f67c0536d9861089a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20503.3">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20503.4">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>d95c3f39ede9dfd9f04edc398820d307f18f62d7</Sha>
+      <Sha>45561dcbcb4939beaee4266f67c0536d9861089a</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -43,33 +43,33 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>214458e2748c7857ab2e2cfdb3a3d32d65e95bfe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20505.7" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20505.9" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>4fdc35d058dd86398ec2989dfc2fe25f7a95f0a4</Sha>
+      <Sha>dab6a2f611c329428607c58931343480021948a4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20505.7" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20505.9" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>4fdc35d058dd86398ec2989dfc2fe25f7a95f0a4</Sha>
+      <Sha>dab6a2f611c329428607c58931343480021948a4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20505.7" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20505.9" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>4fdc35d058dd86398ec2989dfc2fe25f7a95f0a4</Sha>
+      <Sha>dab6a2f611c329428607c58931343480021948a4</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20505.7" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20505.9" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>4fdc35d058dd86398ec2989dfc2fe25f7a95f0a4</Sha>
+      <Sha>dab6a2f611c329428607c58931343480021948a4</Sha>
     </Dependency>
-    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20505.7" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20505.9" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>4fdc35d058dd86398ec2989dfc2fe25f7a95f0a4</Sha>
+      <Sha>dab6a2f611c329428607c58931343480021948a4</Sha>
     </Dependency>
-    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20505.7" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20505.9" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>4fdc35d058dd86398ec2989dfc2fe25f7a95f0a4</Sha>
+      <Sha>dab6a2f611c329428607c58931343480021948a4</Sha>
     </Dependency>
-    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20505.7" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20505.9" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>4fdc35d058dd86398ec2989dfc2fe25f7a95f0a4</Sha>
+      <Sha>dab6a2f611c329428607c58931343480021948a4</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="1.0.2-beta4.20420.1">
       <Uri>https://github.com/dotnet/test-templates</Uri>
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>8764c82892d6f028e45d49514660aa2026bd980e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20506.10">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20506.12">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>e63abd20a6a57e7294b91d59b029f7b41d18b4a5</Sha>
+      <Sha>ed818b5677ea2202847096749d190055b677b3c1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20506.10">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20506.12">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>e63abd20a6a57e7294b91d59b029f7b41d18b4a5</Sha>
+      <Sha>ed818b5677ea2202847096749d190055b677b3c1</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>39fa7665ccf365a2c0804109c6b09650d52ffff0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20513.1">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20513.3">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>9c9284800ba513b8a92b0c32159805759c41f56b</Sha>
+      <Sha>57a05af647673186a892a84e8c2546842bf656bd</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20513.1">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20513.3">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>9c9284800ba513b8a92b0c32159805759c41f56b</Sha>
+      <Sha>57a05af647673186a892a84e8c2546842bf656bd</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">
@@ -108,9 +108,9 @@
       <Uri>https://github.com/microsoft/vstest</Uri>
       <Sha>d834b9b8c4337438622cb7b7d77f1520b479cb88</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.0-alpha.1.20512.2" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.0-alpha.1.20513.2" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/mono/linker</Uri>
-      <Sha>24c3616ee88623bea1e068605eba15009a8a3043</Sha>
+      <Sha>2bcc466760c8c5fd08f79eb35ca1e5beb888ae77</Sha>
       <RepoName>linker</RepoName>
     </Dependency>
     <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.9.0-1.20513.5" CoherentParentDependency="Microsoft.NET.Sdk">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -79,17 +79,17 @@
       <Uri>https://github.com/dotnet/test-templates</Uri>
       <Sha>a2b05d8171915c69ad97ab5d49bbb07d2c780a67</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="6.0.0-alpha.1.20512.1" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="6.0.0-alpha.1.20514.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>39fa7665ccf365a2c0804109c6b09650d52ffff0</Sha>
+      <Sha>b930c7c022425a92b0f153728bfee1df9d354477</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20514.1">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20514.3">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>516ec26623a03550ea73ea084d53ef783fe41439</Sha>
+      <Sha>d58fd52a5b3bd638fe786a06ae19729709714ad5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20514.1">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20514.3">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>516ec26623a03550ea73ea084d53ef783fe41439</Sha>
+      <Sha>d58fd52a5b3bd638fe786a06ae19729709714ad5</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -43,33 +43,33 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>54623ba202cbb62fb3c5c9d9117ab55dcd5469e4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20503.1" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20505.7" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>c029cdf7caa9a4f722a3056dc079979fc248cedb</Sha>
+      <Sha>4fdc35d058dd86398ec2989dfc2fe25f7a95f0a4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20503.1" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20505.7" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>c029cdf7caa9a4f722a3056dc079979fc248cedb</Sha>
+      <Sha>4fdc35d058dd86398ec2989dfc2fe25f7a95f0a4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20503.1" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20505.7" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>c029cdf7caa9a4f722a3056dc079979fc248cedb</Sha>
+      <Sha>4fdc35d058dd86398ec2989dfc2fe25f7a95f0a4</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20503.1" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20505.7" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>c029cdf7caa9a4f722a3056dc079979fc248cedb</Sha>
+      <Sha>4fdc35d058dd86398ec2989dfc2fe25f7a95f0a4</Sha>
     </Dependency>
-    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20503.1" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20505.7" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>c029cdf7caa9a4f722a3056dc079979fc248cedb</Sha>
+      <Sha>4fdc35d058dd86398ec2989dfc2fe25f7a95f0a4</Sha>
     </Dependency>
-    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20503.1" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20505.7" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>c029cdf7caa9a4f722a3056dc079979fc248cedb</Sha>
+      <Sha>4fdc35d058dd86398ec2989dfc2fe25f7a95f0a4</Sha>
     </Dependency>
-    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20503.1" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20505.7" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>c029cdf7caa9a4f722a3056dc079979fc248cedb</Sha>
+      <Sha>4fdc35d058dd86398ec2989dfc2fe25f7a95f0a4</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="1.0.2-beta4.20420.1">
       <Uri>https://github.com/dotnet/test-templates</Uri>
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>8764c82892d6f028e45d49514660aa2026bd980e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20505.1">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20505.5">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>552e4b93eec289aa4c2c8f96a11b5a85edfecbf9</Sha>
+      <Sha>72a670673f277225073595e9d2e9e7ff456ebd92</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20505.1">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20505.5">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>552e4b93eec289aa4c2c8f96a11b5a85edfecbf9</Sha>
+      <Sha>72a670673f277225073595e9d2e9e7ff456ebd92</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -43,33 +43,33 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>f63b0c1a7562b5a70c6f02db8f99e2c9b5b97cac</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20502.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20502.12" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>8c8cb4dce235b099d1e419b6a039217eb56a77e6</Sha>
+      <Sha>ca1f9f532f540f16732e8d8b4990fbae1578786b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20502.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20502.12" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>8c8cb4dce235b099d1e419b6a039217eb56a77e6</Sha>
+      <Sha>ca1f9f532f540f16732e8d8b4990fbae1578786b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20502.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20502.12" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>8c8cb4dce235b099d1e419b6a039217eb56a77e6</Sha>
+      <Sha>ca1f9f532f540f16732e8d8b4990fbae1578786b</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20502.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20502.12" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>8c8cb4dce235b099d1e419b6a039217eb56a77e6</Sha>
+      <Sha>ca1f9f532f540f16732e8d8b4990fbae1578786b</Sha>
     </Dependency>
-    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20502.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20502.12" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>8c8cb4dce235b099d1e419b6a039217eb56a77e6</Sha>
+      <Sha>ca1f9f532f540f16732e8d8b4990fbae1578786b</Sha>
     </Dependency>
-    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20502.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20502.12" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>8c8cb4dce235b099d1e419b6a039217eb56a77e6</Sha>
+      <Sha>ca1f9f532f540f16732e8d8b4990fbae1578786b</Sha>
     </Dependency>
-    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20502.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20502.12" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>8c8cb4dce235b099d1e419b6a039217eb56a77e6</Sha>
+      <Sha>ca1f9f532f540f16732e8d8b4990fbae1578786b</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="1.0.2-beta4.20420.1">
       <Uri>https://github.com/dotnet/test-templates</Uri>
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>8764c82892d6f028e45d49514660aa2026bd980e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20502.12">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20502.16">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>13c735b62443ef70ec017ec2bb690f57d79e9914</Sha>
+      <Sha>8888740832d541f91ff67ed9905544a687c18832</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20502.12">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20502.16">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>13c735b62443ef70ec017ec2bb690f57d79e9914</Sha>
+      <Sha>8888740832d541f91ff67ed9905544a687c18832</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -43,33 +43,33 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>4fef87c65e7466000884aeb9dee6498b162fe2fa</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20508.21" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20508.23" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>c995f1c803a9ca329f681ed62f31ad4a028b8d7a</Sha>
+      <Sha>6be66f507e4fc8cf14dcfcecbfb0eeffefbeddee</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20508.21" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20508.23" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>c995f1c803a9ca329f681ed62f31ad4a028b8d7a</Sha>
+      <Sha>6be66f507e4fc8cf14dcfcecbfb0eeffefbeddee</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20508.21" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20508.23" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>c995f1c803a9ca329f681ed62f31ad4a028b8d7a</Sha>
+      <Sha>6be66f507e4fc8cf14dcfcecbfb0eeffefbeddee</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20508.21" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20508.23" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>c995f1c803a9ca329f681ed62f31ad4a028b8d7a</Sha>
+      <Sha>6be66f507e4fc8cf14dcfcecbfb0eeffefbeddee</Sha>
     </Dependency>
-    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20508.21" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20508.23" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>c995f1c803a9ca329f681ed62f31ad4a028b8d7a</Sha>
+      <Sha>6be66f507e4fc8cf14dcfcecbfb0eeffefbeddee</Sha>
     </Dependency>
-    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20508.21" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20508.23" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>c995f1c803a9ca329f681ed62f31ad4a028b8d7a</Sha>
+      <Sha>6be66f507e4fc8cf14dcfcecbfb0eeffefbeddee</Sha>
     </Dependency>
-    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20508.21" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20508.23" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>c995f1c803a9ca329f681ed62f31ad4a028b8d7a</Sha>
+      <Sha>6be66f507e4fc8cf14dcfcecbfb0eeffefbeddee</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="1.0.2-beta4.20420.1">
       <Uri>https://github.com/dotnet/test-templates</Uri>
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>0589fb051fac78cde679708575087d4ec6e29971</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20508.23">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20508.27">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>8ff1d72ad28678dca5a06cd12ebdd03cb74e9bba</Sha>
+      <Sha>e9b71c9c2aa0aa2a9275c10875bd187f358a84a2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20508.23">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20508.27">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>8ff1d72ad28678dca5a06cd12ebdd03cb74e9bba</Sha>
+      <Sha>e9b71c9c2aa0aa2a9275c10875bd187f358a84a2</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -43,33 +43,33 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>214458e2748c7857ab2e2cfdb3a3d32d65e95bfe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20506.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20507.9" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9939b3358c886b725ac122b63bfcbf0d665d1d21</Sha>
+      <Sha>3fdbc2e90d9762324ef3809098c9ca25b0cb3284</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20506.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20507.9" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9939b3358c886b725ac122b63bfcbf0d665d1d21</Sha>
+      <Sha>3fdbc2e90d9762324ef3809098c9ca25b0cb3284</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20506.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20507.9" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9939b3358c886b725ac122b63bfcbf0d665d1d21</Sha>
+      <Sha>3fdbc2e90d9762324ef3809098c9ca25b0cb3284</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20506.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20507.9" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9939b3358c886b725ac122b63bfcbf0d665d1d21</Sha>
+      <Sha>3fdbc2e90d9762324ef3809098c9ca25b0cb3284</Sha>
     </Dependency>
-    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20506.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20507.9" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9939b3358c886b725ac122b63bfcbf0d665d1d21</Sha>
+      <Sha>3fdbc2e90d9762324ef3809098c9ca25b0cb3284</Sha>
     </Dependency>
-    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20506.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20507.9" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9939b3358c886b725ac122b63bfcbf0d665d1d21</Sha>
+      <Sha>3fdbc2e90d9762324ef3809098c9ca25b0cb3284</Sha>
     </Dependency>
-    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20506.10" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20507.9" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>9939b3358c886b725ac122b63bfcbf0d665d1d21</Sha>
+      <Sha>3fdbc2e90d9762324ef3809098c9ca25b0cb3284</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="1.0.2-beta4.20420.1">
       <Uri>https://github.com/dotnet/test-templates</Uri>
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>8764c82892d6f028e45d49514660aa2026bd980e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20507.4">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20508.1">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>f1ba8d1bed6473345918d02bf5a24dbc176fe052</Sha>
+      <Sha>5d644753eec24aed9d9b182403c7322f0a5e7ac1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20507.4">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20508.1">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>f1ba8d1bed6473345918d02bf5a24dbc176fe052</Sha>
+      <Sha>5d644753eec24aed9d9b182403c7322f0a5e7ac1</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>8764c82892d6f028e45d49514660aa2026bd980e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20501.6">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20501.7">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>ea5601c12d4e9bcc5cba42ab15039918b46d68da</Sha>
+      <Sha>551d66996909931839cae13eb7bdbd852a7c1819</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20501.6">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20501.7">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>ea5601c12d4e9bcc5cba42ab15039918b46d68da</Sha>
+      <Sha>551d66996909931839cae13eb7bdbd852a7c1819</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -43,33 +43,33 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>214458e2748c7857ab2e2cfdb3a3d32d65e95bfe</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20507.9" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20507.10" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>3fdbc2e90d9762324ef3809098c9ca25b0cb3284</Sha>
+      <Sha>dbdfca422299d4c613fbbed551f68f63de92975c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20507.9" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20507.10" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>3fdbc2e90d9762324ef3809098c9ca25b0cb3284</Sha>
+      <Sha>dbdfca422299d4c613fbbed551f68f63de92975c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20507.9" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20507.10" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>3fdbc2e90d9762324ef3809098c9ca25b0cb3284</Sha>
+      <Sha>dbdfca422299d4c613fbbed551f68f63de92975c</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20507.9" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20507.10" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>3fdbc2e90d9762324ef3809098c9ca25b0cb3284</Sha>
+      <Sha>dbdfca422299d4c613fbbed551f68f63de92975c</Sha>
     </Dependency>
-    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20507.9" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20507.10" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>3fdbc2e90d9762324ef3809098c9ca25b0cb3284</Sha>
+      <Sha>dbdfca422299d4c613fbbed551f68f63de92975c</Sha>
     </Dependency>
-    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20507.9" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20507.10" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>3fdbc2e90d9762324ef3809098c9ca25b0cb3284</Sha>
+      <Sha>dbdfca422299d4c613fbbed551f68f63de92975c</Sha>
     </Dependency>
-    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20507.9" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20507.10" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>3fdbc2e90d9762324ef3809098c9ca25b0cb3284</Sha>
+      <Sha>dbdfca422299d4c613fbbed551f68f63de92975c</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="1.0.2-beta4.20420.1">
       <Uri>https://github.com/dotnet/test-templates</Uri>
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>8764c82892d6f028e45d49514660aa2026bd980e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20508.1">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20508.3">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>5d644753eec24aed9d9b182403c7322f0a5e7ac1</Sha>
+      <Sha>3ed69b1b3d3e08bfed10b2969ade99ed9b377f3a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20508.1">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20508.3">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>5d644753eec24aed9d9b182403c7322f0a5e7ac1</Sha>
+      <Sha>3ed69b1b3d3e08bfed10b2969ade99ed9b377f3a</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>b930c7c022425a92b0f153728bfee1df9d354477</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20514.3">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20514.4">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>d58fd52a5b3bd638fe786a06ae19729709714ad5</Sha>
+      <Sha>a1e219f2d2ad43e7cd129e9d405fe728452e3bb0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20514.3">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20514.4">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>d58fd52a5b3bd638fe786a06ae19729709714ad5</Sha>
+      <Sha>a1e219f2d2ad43e7cd129e9d405fe728452e3bb0</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">
@@ -108,9 +108,9 @@
       <Uri>https://github.com/microsoft/vstest</Uri>
       <Sha>d834b9b8c4337438622cb7b7d77f1520b479cb88</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.0-alpha.1.20513.3" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.0-alpha.1.20514.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/mono/linker</Uri>
-      <Sha>35ca60df42b88fc66f75c15b8b189a213bbfa42c</Sha>
+      <Sha>6939a85f7ed2eb1a3b2f8c9384ebf675c7007464</Sha>
       <RepoName>linker</RepoName>
     </Dependency>
     <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.9.0-1.20513.7" CoherentParentDependency="Microsoft.NET.Sdk">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -43,33 +43,33 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>f63b0c1a7562b5a70c6f02db8f99e2c9b5b97cac</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20502.7" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rtm.20502.10" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>336e05577cd8bec2000ffcada926189199e4cef0</Sha>
+      <Sha>8c8cb4dce235b099d1e419b6a039217eb56a77e6</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20502.7" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20502.10" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>336e05577cd8bec2000ffcada926189199e4cef0</Sha>
+      <Sha>8c8cb4dce235b099d1e419b6a039217eb56a77e6</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20502.7" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rtm.20502.10" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>336e05577cd8bec2000ffcada926189199e4cef0</Sha>
+      <Sha>8c8cb4dce235b099d1e419b6a039217eb56a77e6</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20502.7" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="VS.Redist.Common.AspNetCore.TargetingPack.x64.5.0" Version="5.0.0-rtm.20502.10" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>336e05577cd8bec2000ffcada926189199e4cef0</Sha>
+      <Sha>8c8cb4dce235b099d1e419b6a039217eb56a77e6</Sha>
     </Dependency>
-    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20502.7" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-dev-certs" Version="5.0.0-rtm.20502.10" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>336e05577cd8bec2000ffcada926189199e4cef0</Sha>
+      <Sha>8c8cb4dce235b099d1e419b6a039217eb56a77e6</Sha>
     </Dependency>
-    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20502.7" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-user-secrets" Version="5.0.0-rtm.20502.10" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>336e05577cd8bec2000ffcada926189199e4cef0</Sha>
+      <Sha>8c8cb4dce235b099d1e419b6a039217eb56a77e6</Sha>
     </Dependency>
-    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20502.7" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="dotnet-watch" Version="5.0.0-rtm.20502.10" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>336e05577cd8bec2000ffcada926189199e4cef0</Sha>
+      <Sha>8c8cb4dce235b099d1e419b6a039217eb56a77e6</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="1.0.2-beta4.20420.1">
       <Uri>https://github.com/dotnet/test-templates</Uri>
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>8764c82892d6f028e45d49514660aa2026bd980e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20502.11">
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-alpha.1.20502.12">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>54dca82b90706e8bad26cb4795228443cb413079</Sha>
+      <Sha>13c735b62443ef70ec017ec2bb690f57d79e9914</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20502.11">
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-alpha.1.20502.12">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>54dca82b90706e8bad26cb4795228443cb413079</Sha>
+      <Sha>13c735b62443ef70ec017ec2bb690f57d79e9914</Sha>
     </Dependency>
     <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
     <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20417.1" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,21 +44,21 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20508.16</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20508.16</MicrosoftAspNetCoreAppRefPackageVersion>
-    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20508.16</MicrosoftAspNetCoreAppRefInternalPackageVersion>
-    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20508.16</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
-    <dotnetdevcertsPackageVersion>5.0.0-rtm.20508.16</dotnetdevcertsPackageVersion>
-    <dotnetusersecretsPackageVersion>5.0.0-rtm.20508.16</dotnetusersecretsPackageVersion>
-    <dotnetwatchPackageVersion>5.0.0-rtm.20508.16</dotnetwatchPackageVersion>
+    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20508.21</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20508.21</MicrosoftAspNetCoreAppRefPackageVersion>
+    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20508.21</MicrosoftAspNetCoreAppRefInternalPackageVersion>
+    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20508.21</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
+    <dotnetdevcertsPackageVersion>5.0.0-rtm.20508.21</dotnetdevcertsPackageVersion>
+    <dotnetusersecretsPackageVersion>5.0.0-rtm.20508.21</dotnetusersecretsPackageVersion>
+    <dotnetwatchPackageVersion>5.0.0-rtm.20508.21</dotnetwatchPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicroBuildCorePackageVersion>0.2.0</MicroBuildCorePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20508.19</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20508.19</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20508.23</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20508.23</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,8 +57,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20513.11</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20513.11</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20513.13</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20513.13</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,21 +44,21 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20506.10</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20506.10</MicrosoftAspNetCoreAppRefPackageVersion>
-    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20506.10</MicrosoftAspNetCoreAppRefInternalPackageVersion>
-    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20506.10</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
-    <dotnetdevcertsPackageVersion>5.0.0-rtm.20506.10</dotnetdevcertsPackageVersion>
-    <dotnetusersecretsPackageVersion>5.0.0-rtm.20506.10</dotnetusersecretsPackageVersion>
-    <dotnetwatchPackageVersion>5.0.0-rtm.20506.10</dotnetwatchPackageVersion>
+    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20507.9</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20507.9</MicrosoftAspNetCoreAppRefPackageVersion>
+    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20507.9</MicrosoftAspNetCoreAppRefInternalPackageVersion>
+    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20507.9</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
+    <dotnetdevcertsPackageVersion>5.0.0-rtm.20507.9</dotnetdevcertsPackageVersion>
+    <dotnetusersecretsPackageVersion>5.0.0-rtm.20507.9</dotnetusersecretsPackageVersion>
+    <dotnetwatchPackageVersion>5.0.0-rtm.20507.9</dotnetwatchPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicroBuildCorePackageVersion>0.2.0</MicroBuildCorePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20507.4</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20507.4</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20508.1</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20508.1</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,21 +44,21 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20505.7</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20505.7</MicrosoftAspNetCoreAppRefPackageVersion>
-    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20505.7</MicrosoftAspNetCoreAppRefInternalPackageVersion>
-    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20505.7</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
-    <dotnetdevcertsPackageVersion>5.0.0-rtm.20505.7</dotnetdevcertsPackageVersion>
-    <dotnetusersecretsPackageVersion>5.0.0-rtm.20505.7</dotnetusersecretsPackageVersion>
-    <dotnetwatchPackageVersion>5.0.0-rtm.20505.7</dotnetwatchPackageVersion>
+    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20505.9</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20505.9</MicrosoftAspNetCoreAppRefPackageVersion>
+    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20505.9</MicrosoftAspNetCoreAppRefInternalPackageVersion>
+    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20505.9</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
+    <dotnetdevcertsPackageVersion>5.0.0-rtm.20505.9</dotnetdevcertsPackageVersion>
+    <dotnetusersecretsPackageVersion>5.0.0-rtm.20505.9</dotnetusersecretsPackageVersion>
+    <dotnetwatchPackageVersion>5.0.0-rtm.20505.9</dotnetwatchPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicroBuildCorePackageVersion>0.2.0</MicroBuildCorePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20506.10</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20506.10</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20506.12</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20506.12</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,21 +44,21 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20505.9</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20505.9</MicrosoftAspNetCoreAppRefPackageVersion>
-    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20505.9</MicrosoftAspNetCoreAppRefInternalPackageVersion>
-    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20505.9</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
-    <dotnetdevcertsPackageVersion>5.0.0-rtm.20505.9</dotnetdevcertsPackageVersion>
-    <dotnetusersecretsPackageVersion>5.0.0-rtm.20505.9</dotnetusersecretsPackageVersion>
-    <dotnetwatchPackageVersion>5.0.0-rtm.20505.9</dotnetwatchPackageVersion>
+    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20506.10</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20506.10</MicrosoftAspNetCoreAppRefPackageVersion>
+    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20506.10</MicrosoftAspNetCoreAppRefInternalPackageVersion>
+    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20506.10</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
+    <dotnetdevcertsPackageVersion>5.0.0-rtm.20506.10</dotnetdevcertsPackageVersion>
+    <dotnetusersecretsPackageVersion>5.0.0-rtm.20506.10</dotnetusersecretsPackageVersion>
+    <dotnetwatchPackageVersion>5.0.0-rtm.20506.10</dotnetwatchPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicroBuildCorePackageVersion>0.2.0</MicroBuildCorePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20506.12</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20506.12</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20506.14</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20506.14</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,21 +44,21 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20503.1</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20503.1</MicrosoftAspNetCoreAppRefPackageVersion>
-    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20503.1</MicrosoftAspNetCoreAppRefInternalPackageVersion>
-    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20503.1</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
-    <dotnetdevcertsPackageVersion>5.0.0-rtm.20503.1</dotnetdevcertsPackageVersion>
-    <dotnetusersecretsPackageVersion>5.0.0-rtm.20503.1</dotnetusersecretsPackageVersion>
-    <dotnetwatchPackageVersion>5.0.0-rtm.20503.1</dotnetwatchPackageVersion>
+    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20505.7</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20505.7</MicrosoftAspNetCoreAppRefPackageVersion>
+    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20505.7</MicrosoftAspNetCoreAppRefInternalPackageVersion>
+    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20505.7</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
+    <dotnetdevcertsPackageVersion>5.0.0-rtm.20505.7</dotnetdevcertsPackageVersion>
+    <dotnetusersecretsPackageVersion>5.0.0-rtm.20505.7</dotnetusersecretsPackageVersion>
+    <dotnetwatchPackageVersion>5.0.0-rtm.20505.7</dotnetwatchPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicroBuildCorePackageVersion>0.2.0</MicroBuildCorePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20505.1</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20505.1</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20505.5</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20505.5</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -37,6 +37,7 @@
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/test-templates -->
     <MicrosoftDotNetTestProjectTemplates50PackageVersion>1.0.2-beta4.20420.1</MicrosoftDotNetTestProjectTemplates50PackageVersion>
+    <MicrosoftDotNetTestProjectTemplates60PackageVersion>1.0.2-beta4.20420.1</MicrosoftDotNetTestProjectTemplates60PackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- NUnit3.DotNetNew.Template versions do not 'flow in' -->
@@ -47,7 +48,7 @@
     <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>6.0.0-alpha.1.20513.8</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
     <MicrosoftAspNetCoreAppRefPackageVersion>6.0.0-alpha.1.20513.8</MicrosoftAspNetCoreAppRefPackageVersion>
     <MicrosoftAspNetCoreAppRefInternalPackageVersion>6.0.0-alpha.1.20513.8</MicrosoftAspNetCoreAppRefInternalPackageVersion>
-    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20512.5</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
+    <VSRedistCommonAspNetCoreTargetingPackx6460PackageVersion>6.0.0-alpha.1.20513.8</VSRedistCommonAspNetCoreTargetingPackx6460PackageVersion>
     <dotnetdevcertsPackageVersion>6.0.0-alpha.1.20513.8</dotnetdevcertsPackageVersion>
     <dotnetusersecretsPackageVersion>6.0.0-alpha.1.20513.8</dotnetusersecretsPackageVersion>
     <dotnetwatchPackageVersion>6.0.0-alpha.1.20513.8</dotnetwatchPackageVersion>
@@ -91,17 +92,29 @@
     <MicrosoftWindowsDesktopAppRuntimePackageVersion>$(MicrosoftWindowsDesktopAppRuntimewinx64PackageVersion)</MicrosoftWindowsDesktopAppRuntimePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
+    <!-- Cross-release dependency versions -->
+    <MicrosoftDotNetCommonItemTemplates50PackageVersion>6.0.0-alpha.1.20514.1</MicrosoftDotNetCommonItemTemplates50PackageVersion>
+    <MicrosoftAspNetCoreAppRuntime50PackageVersion>5.0.0-rc.2.20474.4</MicrosoftAspNetCoreAppRuntime50PackageVersion>
+  </PropertyGroup>
+  <PropertyGroup>
     <HostFxrVersion>$(MicrosoftNETCoreAppRuntimePackageVersion)</HostFxrVersion>
     <SharedHostVersion>$(MicrosoftNETCoreAppRuntimePackageVersion)</SharedHostVersion>
   </PropertyGroup>
   <PropertyGroup>
+    <!-- 6.0 Template versions -->
+    <MicrosoftDotnetWinFormsProjectTemplates60PackageVersion>$(MicrosoftDotnetWinFormsProjectTemplatesPackageVersion)</MicrosoftDotnetWinFormsProjectTemplates60PackageVersion>
+    <MicrosoftDotNetWpfProjectTemplates60PackageVersion>$(MicrosoftDotNetWpfProjectTemplatesPackageVersion)</MicrosoftDotNetWpfProjectTemplates60PackageVersion>
+    <NUnit3Templates60PackageVersion>$(NUnit3DotNetNewTemplatePackageVersion)</NUnit3Templates60PackageVersion>
+    <MicrosoftDotNetCommonItemTemplates60PackageVersion>$(MicrosoftDotNetCommonItemTemplatesPackageVersion)</MicrosoftDotNetCommonItemTemplates60PackageVersion>
+    <MicrosoftDotNetCommonProjectTemplates60PackageVersion>$(MicrosoftDotNetCommonItemTemplatesPackageVersion)</MicrosoftDotNetCommonProjectTemplates60PackageVersion>
+    <AspNetCorePackageVersionFor60Templates>$(MicrosoftAspNetCoreAppRuntimePackageVersion)</AspNetCorePackageVersionFor60Templates>
     <!-- 5.0 Template versions -->
     <MicrosoftDotnetWinFormsProjectTemplates50PackageVersion>$(MicrosoftDotnetWinFormsProjectTemplatesPackageVersion)</MicrosoftDotnetWinFormsProjectTemplates50PackageVersion>
     <MicrosoftDotNetWpfProjectTemplates50PackageVersion>$(MicrosoftDotNetWpfProjectTemplatesPackageVersion)</MicrosoftDotNetWpfProjectTemplates50PackageVersion>
     <NUnit3Templates50PackageVersion>$(NUnit3DotNetNewTemplatePackageVersion)</NUnit3Templates50PackageVersion>
-    <MicrosoftDotNetCommonItemTemplates50PackageVersion>$(MicrosoftDotNetCommonItemTemplatesPackageVersion)</MicrosoftDotNetCommonItemTemplates50PackageVersion>
-    <MicrosoftDotNetCommonProjectTemplates50PackageVersion>$(MicrosoftDotNetCommonItemTemplatesPackageVersion)</MicrosoftDotNetCommonProjectTemplates50PackageVersion>
-    <AspNetCorePackageVersionFor50Templates>$(MicrosoftAspNetCoreAppRuntimePackageVersion)</AspNetCorePackageVersionFor50Templates>
+    <MicrosoftDotNetCommonItemTemplates50PackageVersion>$(MicrosoftDotNetCommonItemTemplates50PackageVersion)</MicrosoftDotNetCommonItemTemplates50PackageVersion>
+    <MicrosoftDotNetCommonProjectTemplates50PackageVersion>$(MicrosoftDotNetCommonItemTemplates50PackageVersion)</MicrosoftDotNetCommonProjectTemplates50PackageVersion>
+    <AspNetCorePackageVersionFor50Templates>$(MicrosoftAspNetCoreAppRuntime50PackageVersion)</AspNetCorePackageVersionFor50Templates>
     <!-- 3.1 Template versions -->
     <MicrosoftDotnetWinFormsProjectTemplates31PackageVersion>4.8.1-servicing.19605.5</MicrosoftDotnetWinFormsProjectTemplates31PackageVersion>
     <MicrosoftDotNetWpfProjectTemplates31PackageVersion>3.1.2-servicing.20066.4</MicrosoftDotNetWpfProjectTemplates31PackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,8 +57,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20513.8</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20513.8</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20513.9</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20513.9</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,23 +57,23 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20503.4</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20503.4</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20504.1</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20504.1</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/corefx -->
-    <MicrosoftNETCorePlatformsPackageVersion>6.0.0-alpha.1.20502.2</MicrosoftNETCorePlatformsPackageVersion>
+    <MicrosoftNETCorePlatformsPackageVersion>6.0.0-alpha.1.20503.1</MicrosoftNETCorePlatformsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/core-setup -->
-    <MicrosoftNETCoreAppInternalPackageVersion>6.0.0-alpha.1.20502.2</MicrosoftNETCoreAppInternalPackageVersion>
-    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.0-alpha.1.20502.2</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftNETCoreAppHostwinx64PackageVersion>6.0.0-alpha.1.20502.2</MicrosoftNETCoreAppHostwinx64PackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>6.0.0-alpha.1.20502.2</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftNETCoreDotNetHostResolverPackageVersion>6.0.0-alpha.1.20502.2</MicrosoftNETCoreDotNetHostResolverPackageVersion>
+    <MicrosoftNETCoreAppInternalPackageVersion>6.0.0-alpha.1.20503.1</MicrosoftNETCoreAppInternalPackageVersion>
+    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.0-alpha.1.20503.1</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftNETCoreAppHostwinx64PackageVersion>6.0.0-alpha.1.20503.1</MicrosoftNETCoreAppHostwinx64PackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>6.0.0-alpha.1.20503.1</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreDotNetHostResolverPackageVersion>6.0.0-alpha.1.20503.1</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <NETStandardLibraryRefPackageVersion>2.1.0</NETStandardLibraryRefPackageVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,21 +44,21 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20508.27</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20508.27</MicrosoftAspNetCoreAppRefPackageVersion>
-    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20508.27</MicrosoftAspNetCoreAppRefInternalPackageVersion>
-    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20508.27</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
-    <dotnetdevcertsPackageVersion>5.0.0-rtm.20508.27</dotnetdevcertsPackageVersion>
-    <dotnetusersecretsPackageVersion>5.0.0-rtm.20508.27</dotnetusersecretsPackageVersion>
-    <dotnetwatchPackageVersion>5.0.0-rtm.20508.27</dotnetwatchPackageVersion>
+    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20508.29</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20508.29</MicrosoftAspNetCoreAppRefPackageVersion>
+    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20508.29</MicrosoftAspNetCoreAppRefInternalPackageVersion>
+    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20508.29</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
+    <dotnetdevcertsPackageVersion>5.0.0-rtm.20508.29</dotnetdevcertsPackageVersion>
+    <dotnetusersecretsPackageVersion>5.0.0-rtm.20508.29</dotnetusersecretsPackageVersion>
+    <dotnetwatchPackageVersion>5.0.0-rtm.20508.29</dotnetwatchPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicroBuildCorePackageVersion>0.2.0</MicroBuildCorePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20509.2</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20509.2</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20509.5</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20509.5</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,21 +44,21 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20501.3</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20501.3</MicrosoftAspNetCoreAppRefPackageVersion>
-    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20501.3</MicrosoftAspNetCoreAppRefInternalPackageVersion>
-    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20501.3</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
-    <dotnetdevcertsPackageVersion>5.0.0-rtm.20501.3</dotnetdevcertsPackageVersion>
-    <dotnetusersecretsPackageVersion>5.0.0-rtm.20501.3</dotnetusersecretsPackageVersion>
-    <dotnetwatchPackageVersion>5.0.0-rtm.20501.3</dotnetwatchPackageVersion>
+    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20501.10</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20501.10</MicrosoftAspNetCoreAppRefPackageVersion>
+    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20501.10</MicrosoftAspNetCoreAppRefInternalPackageVersion>
+    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20501.10</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
+    <dotnetdevcertsPackageVersion>5.0.0-rtm.20501.10</dotnetdevcertsPackageVersion>
+    <dotnetusersecretsPackageVersion>5.0.0-rtm.20501.10</dotnetusersecretsPackageVersion>
+    <dotnetwatchPackageVersion>5.0.0-rtm.20501.10</dotnetwatchPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicroBuildCorePackageVersion>0.2.0</MicroBuildCorePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20501.8</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20501.8</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20501.10</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20501.10</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/templating -->
-    <MicrosoftDotNetCommonItemTemplatesPackageVersion>6.0.0-alpha.1.20480.2</MicrosoftDotNetCommonItemTemplatesPackageVersion>
+    <MicrosoftDotNetCommonItemTemplatesPackageVersion>6.0.0-alpha.1.20501.1</MicrosoftDotNetCommonItemTemplatesPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/test-templates -->
@@ -57,8 +57,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20480.18</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20480.18</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20501.4</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20501.4</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,8 +57,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20508.5</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20508.5</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20508.6</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20508.6</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,21 +44,21 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20502.10</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20502.10</MicrosoftAspNetCoreAppRefPackageVersion>
-    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20502.10</MicrosoftAspNetCoreAppRefInternalPackageVersion>
-    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20502.10</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
-    <dotnetdevcertsPackageVersion>5.0.0-rtm.20502.10</dotnetdevcertsPackageVersion>
-    <dotnetusersecretsPackageVersion>5.0.0-rtm.20502.10</dotnetusersecretsPackageVersion>
-    <dotnetwatchPackageVersion>5.0.0-rtm.20502.10</dotnetwatchPackageVersion>
+    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20502.12</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20502.12</MicrosoftAspNetCoreAppRefPackageVersion>
+    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20502.12</MicrosoftAspNetCoreAppRefInternalPackageVersion>
+    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20502.12</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
+    <dotnetdevcertsPackageVersion>5.0.0-rtm.20502.12</dotnetdevcertsPackageVersion>
+    <dotnetusersecretsPackageVersion>5.0.0-rtm.20502.12</dotnetusersecretsPackageVersion>
+    <dotnetwatchPackageVersion>5.0.0-rtm.20502.12</dotnetwatchPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicroBuildCorePackageVersion>0.2.0</MicroBuildCorePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20502.12</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20502.12</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20502.16</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20502.16</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,8 +57,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20501.10</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20501.10</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20502.4</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20502.4</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,21 +44,21 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20509.13</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20509.13</MicrosoftAspNetCoreAppRefPackageVersion>
-    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20509.13</MicrosoftAspNetCoreAppRefInternalPackageVersion>
-    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20509.13</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
-    <dotnetdevcertsPackageVersion>5.0.0-rtm.20509.13</dotnetdevcertsPackageVersion>
-    <dotnetusersecretsPackageVersion>5.0.0-rtm.20509.13</dotnetusersecretsPackageVersion>
-    <dotnetwatchPackageVersion>5.0.0-rtm.20509.13</dotnetwatchPackageVersion>
+    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>6.0.0-alpha.1.20512.11</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftAspNetCoreAppRefPackageVersion>6.0.0-alpha.1.20512.11</MicrosoftAspNetCoreAppRefPackageVersion>
+    <MicrosoftAspNetCoreAppRefInternalPackageVersion>6.0.0-alpha.1.20512.11</MicrosoftAspNetCoreAppRefInternalPackageVersion>
+    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20512.5</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
+    <dotnetdevcertsPackageVersion>6.0.0-alpha.1.20512.11</dotnetdevcertsPackageVersion>
+    <dotnetusersecretsPackageVersion>6.0.0-alpha.1.20512.11</dotnetusersecretsPackageVersion>
+    <dotnetwatchPackageVersion>6.0.0-alpha.1.20512.11</dotnetwatchPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicroBuildCorePackageVersion>0.2.0</MicroBuildCorePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20512.9</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20512.9</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20512.11</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20512.11</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,8 +57,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20512.3</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20512.3</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20512.9</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20512.9</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,21 +44,21 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20507.10</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20507.10</MicrosoftAspNetCoreAppRefPackageVersion>
-    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20507.10</MicrosoftAspNetCoreAppRefInternalPackageVersion>
-    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20507.10</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
-    <dotnetdevcertsPackageVersion>5.0.0-rtm.20507.10</dotnetdevcertsPackageVersion>
-    <dotnetusersecretsPackageVersion>5.0.0-rtm.20507.10</dotnetusersecretsPackageVersion>
-    <dotnetwatchPackageVersion>5.0.0-rtm.20507.10</dotnetwatchPackageVersion>
+    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20508.6</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20508.6</MicrosoftAspNetCoreAppRefPackageVersion>
+    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20508.6</MicrosoftAspNetCoreAppRefInternalPackageVersion>
+    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20508.6</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
+    <dotnetdevcertsPackageVersion>5.0.0-rtm.20508.6</dotnetdevcertsPackageVersion>
+    <dotnetusersecretsPackageVersion>5.0.0-rtm.20508.6</dotnetusersecretsPackageVersion>
+    <dotnetwatchPackageVersion>5.0.0-rtm.20508.6</dotnetwatchPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicroBuildCorePackageVersion>0.2.0</MicroBuildCorePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20508.13</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20508.13</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20508.15</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20508.15</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,8 +57,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20504.2</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20504.2</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20505.1</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20505.1</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>
@@ -130,7 +130,7 @@
   <PropertyGroup>
     <VersionToolsVersion>2.2.0-beta.19072.10</VersionToolsVersion>
     <DotnetDebToolVersion>2.0.0</DotnetDebToolVersion>
-    <MicrosoftNETTestSdkVersion>16.9.0-preview-20200929-01</MicrosoftNETTestSdkVersion>
+    <MicrosoftNETTestSdkVersion>16.9.0-preview-20201005-01</MicrosoftNETTestSdkVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- pinned dependency. This package is not being produced outside of the 2.0 branch of corefx and should not change. -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,21 +44,21 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20508.21</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20508.21</MicrosoftAspNetCoreAppRefPackageVersion>
-    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20508.21</MicrosoftAspNetCoreAppRefInternalPackageVersion>
-    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20508.21</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
-    <dotnetdevcertsPackageVersion>5.0.0-rtm.20508.21</dotnetdevcertsPackageVersion>
-    <dotnetusersecretsPackageVersion>5.0.0-rtm.20508.21</dotnetusersecretsPackageVersion>
-    <dotnetwatchPackageVersion>5.0.0-rtm.20508.21</dotnetwatchPackageVersion>
+    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20508.23</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20508.23</MicrosoftAspNetCoreAppRefPackageVersion>
+    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20508.23</MicrosoftAspNetCoreAppRefInternalPackageVersion>
+    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20508.23</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
+    <dotnetdevcertsPackageVersion>5.0.0-rtm.20508.23</dotnetdevcertsPackageVersion>
+    <dotnetusersecretsPackageVersion>5.0.0-rtm.20508.23</dotnetusersecretsPackageVersion>
+    <dotnetwatchPackageVersion>5.0.0-rtm.20508.23</dotnetwatchPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicroBuildCorePackageVersion>0.2.0</MicroBuildCorePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20508.23</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20508.23</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20508.27</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20508.27</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,21 +44,21 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20480.7</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20480.7</MicrosoftAspNetCoreAppRefPackageVersion>
-    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20480.7</MicrosoftAspNetCoreAppRefInternalPackageVersion>
-    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20480.7</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
-    <dotnetdevcertsPackageVersion>5.0.0-rtm.20480.7</dotnetdevcertsPackageVersion>
-    <dotnetusersecretsPackageVersion>5.0.0-rtm.20480.7</dotnetusersecretsPackageVersion>
-    <dotnetwatchPackageVersion>5.0.0-rtm.20480.7</dotnetwatchPackageVersion>
+    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20501.3</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20501.3</MicrosoftAspNetCoreAppRefPackageVersion>
+    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20501.3</MicrosoftAspNetCoreAppRefInternalPackageVersion>
+    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20501.3</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
+    <dotnetdevcertsPackageVersion>5.0.0-rtm.20501.3</dotnetdevcertsPackageVersion>
+    <dotnetusersecretsPackageVersion>5.0.0-rtm.20501.3</dotnetusersecretsPackageVersion>
+    <dotnetwatchPackageVersion>5.0.0-rtm.20501.3</dotnetwatchPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicroBuildCorePackageVersion>0.2.0</MicroBuildCorePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20501.7</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20501.7</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20501.8</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20501.8</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,21 +44,21 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20502.7</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20502.7</MicrosoftAspNetCoreAppRefPackageVersion>
-    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20502.7</MicrosoftAspNetCoreAppRefInternalPackageVersion>
-    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20502.7</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
-    <dotnetdevcertsPackageVersion>5.0.0-rtm.20502.7</dotnetdevcertsPackageVersion>
-    <dotnetusersecretsPackageVersion>5.0.0-rtm.20502.7</dotnetusersecretsPackageVersion>
-    <dotnetwatchPackageVersion>5.0.0-rtm.20502.7</dotnetwatchPackageVersion>
+    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20502.10</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20502.10</MicrosoftAspNetCoreAppRefPackageVersion>
+    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20502.10</MicrosoftAspNetCoreAppRefInternalPackageVersion>
+    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20502.10</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
+    <dotnetdevcertsPackageVersion>5.0.0-rtm.20502.10</dotnetdevcertsPackageVersion>
+    <dotnetusersecretsPackageVersion>5.0.0-rtm.20502.10</dotnetusersecretsPackageVersion>
+    <dotnetwatchPackageVersion>5.0.0-rtm.20502.10</dotnetwatchPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicroBuildCorePackageVersion>0.2.0</MicroBuildCorePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20502.11</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20502.11</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20502.12</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20502.12</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,21 +44,21 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20479.8</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20479.8</MicrosoftAspNetCoreAppRefPackageVersion>
-    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20479.8</MicrosoftAspNetCoreAppRefInternalPackageVersion>
-    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20479.8</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
-    <dotnetdevcertsPackageVersion>5.0.0-rtm.20479.8</dotnetdevcertsPackageVersion>
-    <dotnetusersecretsPackageVersion>5.0.0-rtm.20479.8</dotnetusersecretsPackageVersion>
-    <dotnetwatchPackageVersion>5.0.0-rtm.20479.8</dotnetwatchPackageVersion>
+    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20480.7</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20480.7</MicrosoftAspNetCoreAppRefPackageVersion>
+    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20480.7</MicrosoftAspNetCoreAppRefInternalPackageVersion>
+    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20480.7</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
+    <dotnetdevcertsPackageVersion>5.0.0-rtm.20480.7</dotnetdevcertsPackageVersion>
+    <dotnetusersecretsPackageVersion>5.0.0-rtm.20480.7</dotnetusersecretsPackageVersion>
+    <dotnetwatchPackageVersion>5.0.0-rtm.20480.7</dotnetwatchPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicroBuildCorePackageVersion>0.2.0</MicroBuildCorePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20501.4</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20501.4</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20501.6</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20501.6</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,8 +57,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20506.3</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20506.3</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20506.8</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20506.8</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>
@@ -130,7 +130,7 @@
   <PropertyGroup>
     <VersionToolsVersion>2.2.0-beta.19072.10</VersionToolsVersion>
     <DotnetDebToolVersion>2.0.0</DotnetDebToolVersion>
-    <MicrosoftNETTestSdkVersion>16.9.0-preview-20201005-01</MicrosoftNETTestSdkVersion>
+    <MicrosoftNETTestSdkVersion>16.9.0-preview-20201006-01</MicrosoftNETTestSdkVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- pinned dependency. This package is not being produced outside of the 2.0 branch of corefx and should not change. -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,21 +44,21 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>6.0.0-alpha.1.20512.13</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftAspNetCoreAppRefPackageVersion>6.0.0-alpha.1.20512.13</MicrosoftAspNetCoreAppRefPackageVersion>
-    <MicrosoftAspNetCoreAppRefInternalPackageVersion>6.0.0-alpha.1.20512.13</MicrosoftAspNetCoreAppRefInternalPackageVersion>
+    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>6.0.0-alpha.1.20513.5</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftAspNetCoreAppRefPackageVersion>6.0.0-alpha.1.20513.5</MicrosoftAspNetCoreAppRefPackageVersion>
+    <MicrosoftAspNetCoreAppRefInternalPackageVersion>6.0.0-alpha.1.20513.5</MicrosoftAspNetCoreAppRefInternalPackageVersion>
     <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20512.5</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
-    <dotnetdevcertsPackageVersion>6.0.0-alpha.1.20512.13</dotnetdevcertsPackageVersion>
-    <dotnetusersecretsPackageVersion>6.0.0-alpha.1.20512.13</dotnetusersecretsPackageVersion>
-    <dotnetwatchPackageVersion>6.0.0-alpha.1.20512.13</dotnetwatchPackageVersion>
+    <dotnetdevcertsPackageVersion>6.0.0-alpha.1.20513.5</dotnetdevcertsPackageVersion>
+    <dotnetusersecretsPackageVersion>6.0.0-alpha.1.20513.5</dotnetusersecretsPackageVersion>
+    <dotnetwatchPackageVersion>6.0.0-alpha.1.20513.5</dotnetwatchPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicroBuildCorePackageVersion>0.2.0</MicroBuildCorePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20513.9</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20513.9</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20513.11</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20513.11</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -93,7 +93,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Cross-release dependency versions -->
-    <MicrosoftDotNetCommonItemTemplates50PackageVersion>6.0.0-alpha.1.20514.1</MicrosoftDotNetCommonItemTemplates50PackageVersion>
+    <MicrosoftDotNetCommonItemTemplates50PackageVersion>5.0.0-rc.2.20474.2</MicrosoftDotNetCommonItemTemplates50PackageVersion>
     <MicrosoftAspNetCoreAppRuntime50PackageVersion>5.0.0-rc.2.20474.4</MicrosoftAspNetCoreAppRuntime50PackageVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,21 +44,21 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20508.6</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20508.6</MicrosoftAspNetCoreAppRefPackageVersion>
-    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20508.6</MicrosoftAspNetCoreAppRefInternalPackageVersion>
-    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20508.6</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
-    <dotnetdevcertsPackageVersion>5.0.0-rtm.20508.6</dotnetdevcertsPackageVersion>
-    <dotnetusersecretsPackageVersion>5.0.0-rtm.20508.6</dotnetusersecretsPackageVersion>
-    <dotnetwatchPackageVersion>5.0.0-rtm.20508.6</dotnetwatchPackageVersion>
+    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20508.16</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20508.16</MicrosoftAspNetCoreAppRefPackageVersion>
+    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20508.16</MicrosoftAspNetCoreAppRefInternalPackageVersion>
+    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20508.16</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
+    <dotnetdevcertsPackageVersion>5.0.0-rtm.20508.16</dotnetdevcertsPackageVersion>
+    <dotnetusersecretsPackageVersion>5.0.0-rtm.20508.16</dotnetusersecretsPackageVersion>
+    <dotnetwatchPackageVersion>5.0.0-rtm.20508.16</dotnetwatchPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicroBuildCorePackageVersion>0.2.0</MicroBuildCorePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20508.15</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20508.15</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20508.18</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20508.18</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,8 +57,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20506.8</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20506.8</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20506.10</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20506.10</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,8 +57,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20508.11</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20508.11</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20508.13</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20508.13</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,8 +57,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20513.7</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20513.7</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20513.8</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20513.8</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,23 +57,23 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20514.4</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20514.4</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20514.6</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20514.6</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/corefx -->
-    <MicrosoftNETCorePlatformsPackageVersion>6.0.0-alpha.1.20510.8</MicrosoftNETCorePlatformsPackageVersion>
+    <MicrosoftNETCorePlatformsPackageVersion>6.0.0-alpha.1.20513.9</MicrosoftNETCorePlatformsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/core-setup -->
-    <MicrosoftNETCoreAppInternalPackageVersion>6.0.0-alpha.1.20510.8</MicrosoftNETCoreAppInternalPackageVersion>
-    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.0-alpha.1.20510.8</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftNETCoreAppHostwinx64PackageVersion>6.0.0-alpha.1.20510.8</MicrosoftNETCoreAppHostwinx64PackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>6.0.0-alpha.1.20510.8</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftNETCoreDotNetHostResolverPackageVersion>6.0.0-alpha.1.20510.8</MicrosoftNETCoreDotNetHostResolverPackageVersion>
+    <MicrosoftNETCoreAppInternalPackageVersion>6.0.0-alpha.1.20513.9</MicrosoftNETCoreAppInternalPackageVersion>
+    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.0-alpha.1.20513.9</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftNETCoreAppHostwinx64PackageVersion>6.0.0-alpha.1.20513.9</MicrosoftNETCoreAppHostwinx64PackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>6.0.0-alpha.1.20513.9</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreDotNetHostResolverPackageVersion>6.0.0-alpha.1.20513.9</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <NETStandardLibraryRefPackageVersion>2.1.0</NETStandardLibraryRefPackageVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/templating -->
-    <MicrosoftDotNetCommonItemTemplatesPackageVersion>6.0.0-alpha.1.20512.1</MicrosoftDotNetCommonItemTemplatesPackageVersion>
+    <MicrosoftDotNetCommonItemTemplatesPackageVersion>6.0.0-alpha.1.20514.1</MicrosoftDotNetCommonItemTemplatesPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/test-templates -->
@@ -57,8 +57,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20514.1</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20514.1</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20514.3</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20514.3</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,8 +57,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20506.15</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20506.15</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20507.1</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20507.1</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,23 +57,23 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20502.16</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20502.16</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20503.3</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20503.3</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/corefx -->
-    <MicrosoftNETCorePlatformsPackageVersion>6.0.0-alpha.1.20479.10</MicrosoftNETCorePlatformsPackageVersion>
+    <MicrosoftNETCorePlatformsPackageVersion>6.0.0-alpha.1.20502.2</MicrosoftNETCorePlatformsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/core-setup -->
-    <MicrosoftNETCoreAppInternalPackageVersion>6.0.0-alpha.1.20479.10</MicrosoftNETCoreAppInternalPackageVersion>
-    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.0-alpha.1.20479.10</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftNETCoreAppHostwinx64PackageVersion>6.0.0-alpha.1.20479.10</MicrosoftNETCoreAppHostwinx64PackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>6.0.0-alpha.1.20479.10</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftNETCoreDotNetHostResolverPackageVersion>6.0.0-alpha.1.20479.10</MicrosoftNETCoreDotNetHostResolverPackageVersion>
+    <MicrosoftNETCoreAppInternalPackageVersion>6.0.0-alpha.1.20502.2</MicrosoftNETCoreAppInternalPackageVersion>
+    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.0-alpha.1.20502.2</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftNETCoreAppHostwinx64PackageVersion>6.0.0-alpha.1.20502.2</MicrosoftNETCoreAppHostwinx64PackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>6.0.0-alpha.1.20502.2</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreDotNetHostResolverPackageVersion>6.0.0-alpha.1.20502.2</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <NETStandardLibraryRefPackageVersion>2.1.0</NETStandardLibraryRefPackageVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,8 +57,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20514.3</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20514.3</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20514.4</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20514.4</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,8 +57,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20505.5</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20505.5</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20506.2</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20506.2</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,8 +57,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20506.14</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20506.14</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20506.15</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20506.15</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,21 +44,21 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20508.23</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20508.23</MicrosoftAspNetCoreAppRefPackageVersion>
-    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20508.23</MicrosoftAspNetCoreAppRefInternalPackageVersion>
-    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20508.23</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
-    <dotnetdevcertsPackageVersion>5.0.0-rtm.20508.23</dotnetdevcertsPackageVersion>
-    <dotnetusersecretsPackageVersion>5.0.0-rtm.20508.23</dotnetusersecretsPackageVersion>
-    <dotnetwatchPackageVersion>5.0.0-rtm.20508.23</dotnetwatchPackageVersion>
+    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20508.27</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20508.27</MicrosoftAspNetCoreAppRefPackageVersion>
+    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20508.27</MicrosoftAspNetCoreAppRefInternalPackageVersion>
+    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20508.27</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
+    <dotnetdevcertsPackageVersion>5.0.0-rtm.20508.27</dotnetdevcertsPackageVersion>
+    <dotnetusersecretsPackageVersion>5.0.0-rtm.20508.27</dotnetusersecretsPackageVersion>
+    <dotnetwatchPackageVersion>5.0.0-rtm.20508.27</dotnetwatchPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicroBuildCorePackageVersion>0.2.0</MicroBuildCorePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20508.27</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20508.27</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20509.2</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20509.2</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/templating -->
-    <MicrosoftDotNetCommonItemTemplatesPackageVersion>6.0.0-alpha.1.20501.1</MicrosoftDotNetCommonItemTemplatesPackageVersion>
+    <MicrosoftDotNetCommonItemTemplatesPackageVersion>6.0.0-alpha.1.20508.2</MicrosoftDotNetCommonItemTemplatesPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/test-templates -->
@@ -57,8 +57,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20508.6</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20508.6</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20508.7</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20508.7</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,8 +57,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20513.1</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20513.1</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20513.3</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20513.3</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,8 +57,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20504.1</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20504.1</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20504.2</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20504.2</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,21 +44,21 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20502.12</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20502.12</MicrosoftAspNetCoreAppRefPackageVersion>
-    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20502.12</MicrosoftAspNetCoreAppRefInternalPackageVersion>
-    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20502.12</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
-    <dotnetdevcertsPackageVersion>5.0.0-rtm.20502.12</dotnetdevcertsPackageVersion>
-    <dotnetusersecretsPackageVersion>5.0.0-rtm.20502.12</dotnetusersecretsPackageVersion>
-    <dotnetwatchPackageVersion>5.0.0-rtm.20502.12</dotnetwatchPackageVersion>
+    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20503.1</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20503.1</MicrosoftAspNetCoreAppRefPackageVersion>
+    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20503.1</MicrosoftAspNetCoreAppRefInternalPackageVersion>
+    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20503.1</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
+    <dotnetdevcertsPackageVersion>5.0.0-rtm.20503.1</dotnetdevcertsPackageVersion>
+    <dotnetusersecretsPackageVersion>5.0.0-rtm.20503.1</dotnetusersecretsPackageVersion>
+    <dotnetwatchPackageVersion>5.0.0-rtm.20503.1</dotnetwatchPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicroBuildCorePackageVersion>0.2.0</MicroBuildCorePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20503.3</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20503.3</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20503.4</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20503.4</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/templating -->
-    <MicrosoftDotNetCommonItemTemplatesPackageVersion>6.0.0-alpha.1.20508.2</MicrosoftDotNetCommonItemTemplatesPackageVersion>
+    <MicrosoftDotNetCommonItemTemplatesPackageVersion>6.0.0-alpha.1.20509.2</MicrosoftDotNetCommonItemTemplatesPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/test-templates -->
@@ -57,8 +57,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20509.5</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20509.5</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20509.7</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20509.7</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,23 +57,23 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20508.3</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20508.3</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20508.5</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20508.5</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/corefx -->
-    <MicrosoftNETCorePlatformsPackageVersion>6.0.0-alpha.1.20505.12</MicrosoftNETCorePlatformsPackageVersion>
+    <MicrosoftNETCorePlatformsPackageVersion>6.0.0-alpha.1.20507.4</MicrosoftNETCorePlatformsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/core-setup -->
-    <MicrosoftNETCoreAppInternalPackageVersion>6.0.0-alpha.1.20505.12</MicrosoftNETCoreAppInternalPackageVersion>
-    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.0-alpha.1.20505.12</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftNETCoreAppHostwinx64PackageVersion>6.0.0-alpha.1.20505.12</MicrosoftNETCoreAppHostwinx64PackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>6.0.0-alpha.1.20505.12</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftNETCoreDotNetHostResolverPackageVersion>6.0.0-alpha.1.20505.12</MicrosoftNETCoreDotNetHostResolverPackageVersion>
+    <MicrosoftNETCoreAppInternalPackageVersion>6.0.0-alpha.1.20507.4</MicrosoftNETCoreAppInternalPackageVersion>
+    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.0-alpha.1.20507.4</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftNETCoreAppHostwinx64PackageVersion>6.0.0-alpha.1.20507.4</MicrosoftNETCoreAppHostwinx64PackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>6.0.0-alpha.1.20507.4</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreDotNetHostResolverPackageVersion>6.0.0-alpha.1.20507.4</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <NETStandardLibraryRefPackageVersion>2.1.0</NETStandardLibraryRefPackageVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,21 +44,21 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20501.10</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20501.10</MicrosoftAspNetCoreAppRefPackageVersion>
-    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20501.10</MicrosoftAspNetCoreAppRefInternalPackageVersion>
-    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20501.10</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
-    <dotnetdevcertsPackageVersion>5.0.0-rtm.20501.10</dotnetdevcertsPackageVersion>
-    <dotnetusersecretsPackageVersion>5.0.0-rtm.20501.10</dotnetusersecretsPackageVersion>
-    <dotnetwatchPackageVersion>5.0.0-rtm.20501.10</dotnetwatchPackageVersion>
+    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20502.7</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20502.7</MicrosoftAspNetCoreAppRefPackageVersion>
+    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20502.7</MicrosoftAspNetCoreAppRefInternalPackageVersion>
+    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20502.7</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
+    <dotnetdevcertsPackageVersion>5.0.0-rtm.20502.7</dotnetdevcertsPackageVersion>
+    <dotnetusersecretsPackageVersion>5.0.0-rtm.20502.7</dotnetusersecretsPackageVersion>
+    <dotnetwatchPackageVersion>5.0.0-rtm.20502.7</dotnetwatchPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicroBuildCorePackageVersion>0.2.0</MicroBuildCorePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20502.4</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20502.4</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20502.9</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20502.9</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,21 +44,21 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20507.9</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20507.9</MicrosoftAspNetCoreAppRefPackageVersion>
-    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20507.9</MicrosoftAspNetCoreAppRefInternalPackageVersion>
-    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20507.9</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
-    <dotnetdevcertsPackageVersion>5.0.0-rtm.20507.9</dotnetdevcertsPackageVersion>
-    <dotnetusersecretsPackageVersion>5.0.0-rtm.20507.9</dotnetusersecretsPackageVersion>
-    <dotnetwatchPackageVersion>5.0.0-rtm.20507.9</dotnetwatchPackageVersion>
+    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20507.10</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20507.10</MicrosoftAspNetCoreAppRefPackageVersion>
+    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20507.10</MicrosoftAspNetCoreAppRefInternalPackageVersion>
+    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20507.10</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
+    <dotnetdevcertsPackageVersion>5.0.0-rtm.20507.10</dotnetdevcertsPackageVersion>
+    <dotnetusersecretsPackageVersion>5.0.0-rtm.20507.10</dotnetusersecretsPackageVersion>
+    <dotnetwatchPackageVersion>5.0.0-rtm.20507.10</dotnetwatchPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicroBuildCorePackageVersion>0.2.0</MicroBuildCorePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20508.1</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20508.1</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20508.3</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20508.3</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,8 +57,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20507.1</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20507.1</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20507.4</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20507.4</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,8 +57,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20513.3</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20513.3</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20513.6</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20513.6</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,21 +44,21 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>6.0.0-alpha.1.20512.11</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftAspNetCoreAppRefPackageVersion>6.0.0-alpha.1.20512.11</MicrosoftAspNetCoreAppRefPackageVersion>
-    <MicrosoftAspNetCoreAppRefInternalPackageVersion>6.0.0-alpha.1.20512.11</MicrosoftAspNetCoreAppRefInternalPackageVersion>
+    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>6.0.0-alpha.1.20512.13</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftAspNetCoreAppRefPackageVersion>6.0.0-alpha.1.20512.13</MicrosoftAspNetCoreAppRefPackageVersion>
+    <MicrosoftAspNetCoreAppRefInternalPackageVersion>6.0.0-alpha.1.20512.13</MicrosoftAspNetCoreAppRefInternalPackageVersion>
     <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20512.5</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
-    <dotnetdevcertsPackageVersion>6.0.0-alpha.1.20512.11</dotnetdevcertsPackageVersion>
-    <dotnetusersecretsPackageVersion>6.0.0-alpha.1.20512.11</dotnetusersecretsPackageVersion>
-    <dotnetwatchPackageVersion>6.0.0-alpha.1.20512.11</dotnetwatchPackageVersion>
+    <dotnetdevcertsPackageVersion>6.0.0-alpha.1.20512.13</dotnetdevcertsPackageVersion>
+    <dotnetusersecretsPackageVersion>6.0.0-alpha.1.20512.13</dotnetusersecretsPackageVersion>
+    <dotnetwatchPackageVersion>6.0.0-alpha.1.20512.13</dotnetwatchPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicroBuildCorePackageVersion>0.2.0</MicroBuildCorePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20512.11</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20512.11</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20513.1</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20513.1</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>
@@ -130,7 +130,7 @@
   <PropertyGroup>
     <VersionToolsVersion>2.2.0-beta.19072.10</VersionToolsVersion>
     <DotnetDebToolVersion>2.0.0</DotnetDebToolVersion>
-    <MicrosoftNETTestSdkVersion>16.8.0-release-20201009-01</MicrosoftNETTestSdkVersion>
+    <MicrosoftNETTestSdkVersion>16.9.0-preview-20201013-01</MicrosoftNETTestSdkVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- pinned dependency. This package is not being produced outside of the 2.0 branch of corefx and should not change. -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,8 +57,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20508.18</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20508.18</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20508.19</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20508.19</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,23 +57,23 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20506.2</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20506.2</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20506.3</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20506.3</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/corefx -->
-    <MicrosoftNETCorePlatformsPackageVersion>6.0.0-alpha.1.20503.1</MicrosoftNETCorePlatformsPackageVersion>
+    <MicrosoftNETCorePlatformsPackageVersion>6.0.0-alpha.1.20505.12</MicrosoftNETCorePlatformsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/core-setup -->
-    <MicrosoftNETCoreAppInternalPackageVersion>6.0.0-alpha.1.20503.1</MicrosoftNETCoreAppInternalPackageVersion>
-    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.0-alpha.1.20503.1</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftNETCoreAppHostwinx64PackageVersion>6.0.0-alpha.1.20503.1</MicrosoftNETCoreAppHostwinx64PackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>6.0.0-alpha.1.20503.1</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftNETCoreDotNetHostResolverPackageVersion>6.0.0-alpha.1.20503.1</MicrosoftNETCoreDotNetHostResolverPackageVersion>
+    <MicrosoftNETCoreAppInternalPackageVersion>6.0.0-alpha.1.20505.12</MicrosoftNETCoreAppInternalPackageVersion>
+    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.0-alpha.1.20505.12</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftNETCoreAppHostwinx64PackageVersion>6.0.0-alpha.1.20505.12</MicrosoftNETCoreAppHostwinx64PackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>6.0.0-alpha.1.20505.12</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreDotNetHostResolverPackageVersion>6.0.0-alpha.1.20505.12</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <NETStandardLibraryRefPackageVersion>2.1.0</NETStandardLibraryRefPackageVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/templating -->
-    <MicrosoftDotNetCommonItemTemplatesPackageVersion>6.0.0-alpha.1.20509.2</MicrosoftDotNetCommonItemTemplatesPackageVersion>
+    <MicrosoftDotNetCommonItemTemplatesPackageVersion>6.0.0-alpha.1.20512.1</MicrosoftDotNetCommonItemTemplatesPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/test-templates -->
@@ -44,36 +44,36 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20509.5</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20509.5</MicrosoftAspNetCoreAppRefPackageVersion>
-    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20509.5</MicrosoftAspNetCoreAppRefInternalPackageVersion>
-    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20509.5</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
-    <dotnetdevcertsPackageVersion>5.0.0-rtm.20509.5</dotnetdevcertsPackageVersion>
-    <dotnetusersecretsPackageVersion>5.0.0-rtm.20509.5</dotnetusersecretsPackageVersion>
-    <dotnetwatchPackageVersion>5.0.0-rtm.20509.5</dotnetwatchPackageVersion>
+    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20509.13</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20509.13</MicrosoftAspNetCoreAppRefPackageVersion>
+    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20509.13</MicrosoftAspNetCoreAppRefInternalPackageVersion>
+    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20509.13</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
+    <dotnetdevcertsPackageVersion>5.0.0-rtm.20509.13</dotnetdevcertsPackageVersion>
+    <dotnetusersecretsPackageVersion>5.0.0-rtm.20509.13</dotnetusersecretsPackageVersion>
+    <dotnetwatchPackageVersion>5.0.0-rtm.20509.13</dotnetwatchPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicroBuildCorePackageVersion>0.2.0</MicroBuildCorePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20509.14</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20509.14</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20512.3</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20512.3</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/corefx -->
-    <MicrosoftNETCorePlatformsPackageVersion>6.0.0-alpha.1.20507.4</MicrosoftNETCorePlatformsPackageVersion>
+    <MicrosoftNETCorePlatformsPackageVersion>6.0.0-alpha.1.20510.8</MicrosoftNETCorePlatformsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/core-setup -->
-    <MicrosoftNETCoreAppInternalPackageVersion>6.0.0-alpha.1.20507.4</MicrosoftNETCoreAppInternalPackageVersion>
-    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.0-alpha.1.20507.4</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftNETCoreAppHostwinx64PackageVersion>6.0.0-alpha.1.20507.4</MicrosoftNETCoreAppHostwinx64PackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>6.0.0-alpha.1.20507.4</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftNETCoreDotNetHostResolverPackageVersion>6.0.0-alpha.1.20507.4</MicrosoftNETCoreDotNetHostResolverPackageVersion>
+    <MicrosoftNETCoreAppInternalPackageVersion>6.0.0-alpha.1.20510.8</MicrosoftNETCoreAppInternalPackageVersion>
+    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.0-alpha.1.20510.8</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftNETCoreAppHostwinx64PackageVersion>6.0.0-alpha.1.20510.8</MicrosoftNETCoreAppHostwinx64PackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>6.0.0-alpha.1.20510.8</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreDotNetHostResolverPackageVersion>6.0.0-alpha.1.20510.8</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <NETStandardLibraryRefPackageVersion>2.1.0</NETStandardLibraryRefPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
@@ -130,7 +130,7 @@
   <PropertyGroup>
     <VersionToolsVersion>2.2.0-beta.19072.10</VersionToolsVersion>
     <DotnetDebToolVersion>2.0.0</DotnetDebToolVersion>
-    <MicrosoftNETTestSdkVersion>16.9.0-preview-20201006-01</MicrosoftNETTestSdkVersion>
+    <MicrosoftNETTestSdkVersion>16.8.0-release-20201009-01</MicrosoftNETTestSdkVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- pinned dependency. This package is not being produced outside of the 2.0 branch of corefx and should not change. -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,8 +57,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20513.6</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20513.6</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20513.7</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20513.7</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,8 +57,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20508.7</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20508.7</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20508.11</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20508.11</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,21 +44,21 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>6.0.0-alpha.1.20513.5</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftAspNetCoreAppRefPackageVersion>6.0.0-alpha.1.20513.5</MicrosoftAspNetCoreAppRefPackageVersion>
-    <MicrosoftAspNetCoreAppRefInternalPackageVersion>6.0.0-alpha.1.20513.5</MicrosoftAspNetCoreAppRefInternalPackageVersion>
+    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>6.0.0-alpha.1.20513.8</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftAspNetCoreAppRefPackageVersion>6.0.0-alpha.1.20513.8</MicrosoftAspNetCoreAppRefPackageVersion>
+    <MicrosoftAspNetCoreAppRefInternalPackageVersion>6.0.0-alpha.1.20513.8</MicrosoftAspNetCoreAppRefInternalPackageVersion>
     <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20512.5</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
-    <dotnetdevcertsPackageVersion>6.0.0-alpha.1.20513.5</dotnetdevcertsPackageVersion>
-    <dotnetusersecretsPackageVersion>6.0.0-alpha.1.20513.5</dotnetusersecretsPackageVersion>
-    <dotnetwatchPackageVersion>6.0.0-alpha.1.20513.5</dotnetwatchPackageVersion>
+    <dotnetdevcertsPackageVersion>6.0.0-alpha.1.20513.8</dotnetdevcertsPackageVersion>
+    <dotnetusersecretsPackageVersion>6.0.0-alpha.1.20513.8</dotnetusersecretsPackageVersion>
+    <dotnetwatchPackageVersion>6.0.0-alpha.1.20513.8</dotnetwatchPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicroBuildCorePackageVersion>0.2.0</MicroBuildCorePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20513.13</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20513.13</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20514.1</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20514.1</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,8 +57,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20502.9</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20502.9</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20502.11</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20502.11</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,8 +57,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20501.6</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20501.6</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20501.7</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20501.7</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,21 +44,21 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20508.29</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20508.29</MicrosoftAspNetCoreAppRefPackageVersion>
-    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20508.29</MicrosoftAspNetCoreAppRefInternalPackageVersion>
-    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20508.29</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
-    <dotnetdevcertsPackageVersion>5.0.0-rtm.20508.29</dotnetdevcertsPackageVersion>
-    <dotnetusersecretsPackageVersion>5.0.0-rtm.20508.29</dotnetusersecretsPackageVersion>
-    <dotnetwatchPackageVersion>5.0.0-rtm.20508.29</dotnetwatchPackageVersion>
+    <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.0-rtm.20509.5</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftAspNetCoreAppRefPackageVersion>5.0.0-rtm.20509.5</MicrosoftAspNetCoreAppRefPackageVersion>
+    <MicrosoftAspNetCoreAppRefInternalPackageVersion>5.0.0-rtm.20509.5</MicrosoftAspNetCoreAppRefInternalPackageVersion>
+    <VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>5.0.0-rtm.20509.5</VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion>
+    <dotnetdevcertsPackageVersion>5.0.0-rtm.20509.5</dotnetdevcertsPackageVersion>
+    <dotnetusersecretsPackageVersion>5.0.0-rtm.20509.5</dotnetusersecretsPackageVersion>
+    <dotnetwatchPackageVersion>5.0.0-rtm.20509.5</dotnetwatchPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicroBuildCorePackageVersion>0.2.0</MicroBuildCorePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20509.7</MicrosoftNETSdkPackageVersion>
-    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20509.7</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
+    <MicrosoftNETSdkPackageVersion>6.0.100-alpha.1.20509.14</MicrosoftNETSdkPackageVersion>
+    <MicrosoftDotNetMSBuildSdkResolverPackageVersion>6.0.100-alpha.1.20509.14</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftDotnetToolsetInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetToolsetInternalPackageVersion>
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>

--- a/src/core-sdk-tasks/CalculateTemplateVersions.cs
+++ b/src/core-sdk-tasks/CalculateTemplateVersions.cs
@@ -23,7 +23,6 @@ namespace Microsoft.DotNet.Cli.Build
         [Required]
         public string ProductMonikerRid { get; set; }
 
-        [Required]
         public string InstallerExtension { get; set; }
 
         [Required]

--- a/src/core-sdk-tasks/CalculateTemplateVersions.cs
+++ b/src/core-sdk-tasks/CalculateTemplateVersions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using NuGet.Versioning;
@@ -9,26 +11,81 @@ namespace Microsoft.DotNet.Cli.Build
 {
     public class CalculateTemplateVersions : Task
     {
+        //  Group BundledTemplates by TemplateFrameworkVersion
+        //  In each group, get the version of the template with UseVersionForTemplateInstallPath=true
+        //  From that version number, get the BundledTemplateInstallPath, BundledTemplateMajorMinorVersion, and BundledTemplateMajorMinorPatchVersion
         [Required]
-        public string AspNetCorePackageVersionTemplate { get; set; }
+        public ITaskItem [] BundledTemplates { get; set; }
+
+        [Required]
+        public string FullNugetVersion { get; set; }
+
+        [Required]
+        public string ProductMonikerRid { get; set; }
+
+        [Required]
+        public string InstallerExtension { get; set; }
+
+        [Required]
+        public int CombinedBuildNumberAndRevision { get; set; }
+
+
+        //  Should be the BundledTemplates with BundledTemplateInstallPath metadata set to the value calculated for that group
+        [Output]
+        public ITaskItem [] BundledTemplatesWithInstallPaths { get; set; }
+
+        //  For each group of templates (grouped by TemplateFrameworkVersion), this should be the following
+        //  ItemSpec: NetCore60Templates
+        //  TemplateBaseFilename: dotnet-60templates
+        //  TemplatesMajorMinorVersion: 6.0 (from BundledTemplateMajorMinorVersion from group)
+        //  InstallerUpgradeCode: Guid generated using GenerateGuidFromName, combining TemplateBaseFilename, FullNugetVersion, ProductMonikerRid, and InstallerExtension
+        //  MSIVersion: Result of calling GenerateMsiVersionFromFullVersion logic with CombinedBuildNumberAndRevision and BundledTemplateMajorMinorPatchVersion from template group
 
         [Output]
-        public string BundledTemplateInstallPath { get; set; }
-
-        [Output]
-        public string BundledTemplateMajorMinorVersion { get; set; }
-
-        [Output]
-        public string BundledTemplateMajorMinorPatchVersion { get; set; }
+        public ITaskItem [] TemplatesComponents { get; set; }
 
         private const int _patchVersionResetOffset = 1;
 
         public override bool Execute()
         {
-            var result = Calculate(AspNetCorePackageVersionTemplate);
-            BundledTemplateInstallPath = result.BundledTemplateInstallPath;
-            BundledTemplateMajorMinorVersion = result.BundledTemplateMajorMinorVersion;
-            BundledTemplateMajorMinorPatchVersion = result.BundledTemplateMajorMinorPatchVersion;
+            var groups = BundledTemplates.GroupBy(bt => bt.GetMetadata("TemplateFrameworkVersion"))
+                .ToDictionary(g => g.Key, g =>
+                {
+                    var itemWithVersion = g.SingleOrDefault(i => i.GetMetadata("UseVersionForTemplateInstallPath").Equals("true", StringComparison.OrdinalIgnoreCase));
+                    if (itemWithVersion == null)
+                    {
+                        throw new InvalidOperationException("Could not find single item with UseVersionForTemplateInstallPath for templates with TemplateFrameworkVersion: " + g.Key);
+                    }
+
+                    return Calculate(itemWithVersion.GetMetadata("PackageVersion"));
+                });
+
+            BundledTemplatesWithInstallPaths = BundledTemplates.Select(t =>
+            {
+                var templateWithInstallPath = new TaskItem(t);
+                templateWithInstallPath.SetMetadata("BundledTemplateInstallPath", groups[t.GetMetadata("TemplateFrameworkVersion")].BundledTemplateInstallPath);
+                return templateWithInstallPath;
+            }).ToArray();
+
+            TemplatesComponents = groups.Select(g =>
+            {
+                string majorMinorWithoutDots = g.Value.BundledTemplateMajorMinorVersion.Replace(".", "");
+                var componentItem = new TaskItem($"NetCore{majorMinorWithoutDots}Templates");
+                var templateBaseFilename = $"dotnet-{majorMinorWithoutDots}templates";
+                componentItem.SetMetadata("TemplateBaseFilename", templateBaseFilename);
+                componentItem.SetMetadata("TemplatesMajorMinorVersion", g.Value.BundledTemplateMajorMinorVersion);
+                var installerUpgradeCode = GenerateGuidFromName.GenerateGuid(string.Join("-", templateBaseFilename, FullNugetVersion, ProductMonikerRid) + InstallerExtension).ToString().ToUpper();
+                componentItem.SetMetadata("InstallerUpgradeCode", installerUpgradeCode);
+                componentItem.SetMetadata("MSIVersion", GenerateMsiVersionFromFullVersion.GenerateMsiVersion(CombinedBuildNumberAndRevision, g.Value.BundledTemplateMajorMinorPatchVersion));
+
+                var brandName = System.Version.Parse(g.Key).Major >= 5 ?
+                    $"Microsoft .NET {g.Key} Templates" :
+                    $"Microsoft .NET Core {g.Key} Templates";
+
+                componentItem.SetMetadata("BrandNameWithoutVersion", brandName);
+
+                return componentItem;
+            }).ToArray();
 
             return true;
         }

--- a/src/core-sdk-tasks/CollatePackageDownloads.cs
+++ b/src/core-sdk-tasks/CollatePackageDownloads.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.DotNet.Cli.Build
+{
+    //  Multiple PackageDownload items for the same package are not supported.  Rather, to download multiple versions of the same
+    //  package, the PackageDownload items can have a semicolon-separated list of versions (each in brackets) as the Version metadata.
+    //  So this task groups a list of items with PackageVersion metadata into a list of items which can be used as PackageDownloads
+    public class CollatePackageDownloads : Task
+    {
+        [Required]
+        public ITaskItem[] Packages { get; set; }
+        
+        [Output]
+        public ITaskItem [] PackageDownloads { get; set; }
+
+        public override bool Execute()
+        {
+            PackageDownloads = Packages.GroupBy(p => p.ItemSpec)
+                .Select(g =>
+                {
+                    var packageDownloadItem = new TaskItem(g.Key);
+                    packageDownloadItem.SetMetadata("Version", string.Join(";",
+                        g.Select(p => "[" + p.GetMetadata("PackageVersion") + "]")));
+                    return packageDownloadItem;
+                }).ToArray();
+
+            return true;
+        }
+    }
+}

--- a/src/core-sdk-tasks/GenerateMsiVersionFromFullVersion.cs
+++ b/src/core-sdk-tasks/GenerateMsiVersionFromFullVersion.cs
@@ -20,19 +20,24 @@ namespace Microsoft.DotNet.Cli.Build
 
         public override bool Execute()
         {
-            var parsedVersion = NuGetVersion.Parse(VersionMajorMinorPatch);
+            MsiVersion = GenerateMsiVersion(VersionRevision, VersionMajorMinorPatch);
+
+            return true;
+        }
+
+        public static string GenerateMsiVersion(int versionRevision, string versionMajorMinorPatch)
+        {
+            var parsedVersion = NuGetVersion.Parse(versionMajorMinorPatch);
 
             var buildVersion = new Version()
             {
                 Major = parsedVersion.Major,
                 Minor = parsedVersion.Minor,
                 Patch = parsedVersion.Patch,
-                VersionRevision = VersionRevision
+                VersionRevision = versionRevision
             };
 
-            MsiVersion = buildVersion.GenerateMsiVersion();
-
-            return true;
+            return buildVersion.GenerateMsiVersion();
         }
     }
 }

--- a/src/redist/targets/Branding.targets
+++ b/src/redist/targets/Branding.targets
@@ -13,10 +13,6 @@
       <HostFxrBrandName>Microsoft .NET Host FX Resolver $(HostFxrVersion)</HostFxrBrandName>
       <SharedFrameworkName>Microsoft.NETCore.App</SharedFrameworkName>
       <SharedFrameworkNugetName>$(SharedFrameworkName)</SharedFrameworkNugetName>
-      <BundledTemplates50BrandName>Microsoft .NET Core 5.0 Templates $(Version)</BundledTemplates50BrandName>
-      <BundledTemplates31BrandName>Microsoft .NET Core 3.1 Templates $(Version)</BundledTemplates31BrandName>
-      <BundledTemplates30BrandName>Microsoft .NET Core 3.0 Templates $(Version)</BundledTemplates30BrandName>
-      <BundledTemplates21BrandName>Microsoft .NET Core 2.1 Templates $(Version)</BundledTemplates21BrandName>
     </PropertyGroup>
   </Target>
   

--- a/src/redist/targets/BuildCoreSdkTasks.targets
+++ b/src/redist/targets/BuildCoreSdkTasks.targets
@@ -39,5 +39,6 @@
   <UsingTask TaskName="GetRuntimePackRids" AssemblyFile="$(CoreSdkTaskDll)"/>
   <UsingTask TaskName="GenerateMSBuildExtensionsSWR" AssemblyFile="$(CoreSdkTaskDll)"/>
   <UsingTask TaskName="GetLinuxNativeInstallerDependencyVersions" AssemblyFile="$(CoreSdkTaskDll)"/>
+  <UsingTask TaskName="CollatePackageDownloads" AssemblyFile="$(CoreSdkTaskDll)"/>
 
 </Project>

--- a/src/redist/targets/BundledTemplates.targets
+++ b/src/redist/targets/BundledTemplates.targets
@@ -21,26 +21,28 @@
   </Target>
 
   <ItemGroup>
-    <Bundled60Templates Include="Microsoft.DotNet.Common.ItemTemplates" PackageVersion="$(MicrosoftDotNetCommonItemTemplates60PackageVersion)" 
-                        Condition="'$(MicrosoftDotNetCommonItemTemplates60PackageVersion)' != '$(MicrosoftDotNetCommonItemTemplates50PackageVersion)'" />
+    <Bundled60Templates Include="Microsoft.DotNet.Common.ItemTemplates" PackageVersion="$(MicrosoftDotNetCommonItemTemplates60PackageVersion)" />
     <!-- TODO: Update this package name to 6.0 when it starts getting produced that way -->
-    <Bundled60Templates Include="Microsoft.DotNet.Common.ProjectTemplates.5.0" PackageVersion="$(MicrosoftDotNetCommonProjectTemplates60PackageVersion)"
-                        Condition="'$(MicrosoftDotNetCommonProjectTemplates60PackageVersion)' != '$(MicrosoftDotNetCommonProjectTemplates50PackageVersion)'" />
-    <Bundled60Templates Include="Microsoft.DotNet.Test.ProjectTemplates.6.0" PackageVersion="$(MicrosoftDotNetTestProjectTemplates60PackageVersion)"
-                        Condition="'$(MicrosoftDotNetTestProjectTemplates60PackageVersion)' != '$(MicrosoftDotNetTestProjectTemplates50PackageVersion)'" />
-    <Bundled60Templates Include="Microsoft.Dotnet.Wpf.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWpfProjectTemplates60PackageVersion)"
-                        Condition="'$(MicrosoftDotnetWpfProjectTemplates60PackageVersion)' != '$(MicrosoftDotnetWpfProjectTemplates50PackageVersion)'" />
-    <Bundled60Templates Include="Microsoft.Dotnet.WinForms.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWinFormsProjectTemplates60PackageVersion)"
-                        Condition="'$(MicrosoftDotnetWinFormsProjectTemplates60PackageVersion)' != '$(MicrosoftDotnetWinFormsProjectTemplates50PackageVersion)'" />
-    <Bundled60Templates Include="Microsoft.DotNet.Web.ItemTemplates" PackageVersion="$(AspNetCorePackageVersionFor60Templates)"
-                        Condition="'$(AspNetCorePackageVersionFor60Templates)' != '$(AspNetCorePackageVersionFor50Templates)'" />
-    <Bundled60Templates Include="Microsoft.DotNet.Web.ProjectTemplates.6.0" PackageVersion="$(AspNetCorePackageVersionFor60Templates)"
-                        UseVersionForTemplateInstallPath="true"
-                        Condition="'$(AspNetCorePackageVersionFor60Templates)' != '$(AspNetCorePackageVersionFor50Templates)'"/>
-    <Bundled60Templates Include="Microsoft.DotNet.Web.Spa.ProjectTemplates.6.0" PackageVersion="$(AspNetCorePackageVersionFor60Templates)"
-                        Condition="'$(AspNetCorePackageVersionFor60Templates)' != '$(AspNetCorePackageVersionFor50Templates)'" />
-    <Bundled60Templates Include="NUnit3.DotNetNew.Template" PackageVersion="$(NUnit3Templates60PackageVersion)"
-                        Condition="'$(NUnit3Templates60PackageVersion)' != '$(NUnit3Templates50PackageVersion)'" />
+    <Bundled60Templates Include="Microsoft.DotNet.Common.ProjectTemplates.5.0" PackageVersion="$(MicrosoftDotNetCommonProjectTemplates60PackageVersion)" />
+    <Bundled60Templates Include="Microsoft.DotNet.Web.ItemTemplates" PackageVersion="$(AspNetCorePackageVersionFor60Templates)" />
+    <Bundled60Templates Include="Microsoft.DotNet.Web.ProjectTemplates.6.0" PackageVersion="$(AspNetCorePackageVersionFor60Templates)" UseVersionForTemplateInstallPath="true" />
+    <Bundled60Templates Include="Microsoft.DotNet.Web.Spa.ProjectTemplates.6.0" PackageVersion="$(AspNetCorePackageVersionFor60Templates)" />
+    
+    
+    <!-- Templates that don't yet have 6.0 versions.  Use the 5.0 versions until we do have them -->
+    <Bundled60Templates Include="Microsoft.DotNet.Test.ProjectTemplates.5.0" PackageVersion="$(MicrosoftDotNetTestProjectTemplates50PackageVersion)" />
+    <Bundled60Templates Include="Microsoft.Dotnet.Wpf.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWpfProjectTemplates50PackageVersion)" />
+    <Bundled60Templates Include="Microsoft.Dotnet.WinForms.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWinFormsProjectTemplates50PackageVersion)" />
+    <Bundled60Templates Include="NUnit3.DotNetNew.Template" PackageVersion="$(NUnit3Templates50PackageVersion)" />
+
+    <!-- Once we do have 6.0 versions of these templates, we should remove them from the previous list, and add the commented versions below. -->
+
+    <!--
+    <Bundled60Templates Include="Microsoft.DotNet.Test.ProjectTemplates.6.0" PackageVersion="$(MicrosoftDotNetTestProjectTemplates60PackageVersion)" />
+    <Bundled60Templates Include="Microsoft.Dotnet.Wpf.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWpfProjectTemplates60PackageVersion)" />
+    <Bundled60Templates Include="Microsoft.Dotnet.WinForms.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWinFormsProjectTemplates60PackageVersion)" />
+    <Bundled60Templates Include="NUnit3.DotNetNew.Template" PackageVersion="$(NUnit3Templates60PackageVersion)" />
+    -->
   </ItemGroup>
   
   <ItemGroup>
@@ -150,12 +152,6 @@
     <Copy SourceFiles="%(BundledTemplatesWithInstallPaths.RestoredNupkgPath)"
           DestinationFolder="$(RedistLayoutPath)templates/%(BundledTemplatesWithInstallPaths.BundledTemplateInstallPath)"
           Condition="'%(BundledTemplatesWithInstallPaths.TemplateFrameworkVersion)' == '6.0'"/>
-
-    <!-- Since not all the templates have 6.0 versions yet, include the 5.0 versions in the layout for now -->
-    <Copy SourceFiles="%(BundledTemplatesWithInstallPaths.RestoredNupkgPath)"
-          DestinationFolder="$(RedistLayoutPath)templates/%(BundledTemplatesWithInstallPaths.BundledTemplateInstallPath)"
-          Condition="'%(BundledTemplatesWithInstallPaths.TemplateFrameworkVersion)' == '5.0'"/>
-
   </Target>
 
   <Target Name="LayoutTemplatesForMSI"

--- a/src/redist/targets/BundledTemplates.targets
+++ b/src/redist/targets/BundledTemplates.targets
@@ -211,9 +211,16 @@
     <ItemGroup Condition="!$(ProductMonikerRid.StartsWith('win'))">
       <Bundled60Templates Remove="Microsoft.Dotnet.Wpf.ProjectTemplates" />
       <Bundled60Templates Remove="Microsoft.Dotnet.WinForms.ProjectTemplates" />
+      <Bundled50Templates Remove="Microsoft.Dotnet.Wpf.ProjectTemplates" />
+      <Bundled50Templates Remove="Microsoft.Dotnet.WinForms.ProjectTemplates" />
     </ItemGroup>
     <Copy SourceFiles="%(Bundled60Templates.RestoredNupkgPath)"
           DestinationFolder="$(RedistLayoutPath)templates/$(BundledTemplates60InstallPath)"/>
+
+    <!-- Since not all the templates have 6.0 versions yet, include the 5.0 versions in the layout for now -->
+    <Copy SourceFiles="%(Bundled50Templates.RestoredNupkgPath)"
+          DestinationFolder="$(RedistLayoutPath)templates/$(BundledTemplates60InstallPath)"/>
+
   </Target>
 
   <Target Name="LayoutTemplatesFor60MSI"

--- a/src/redist/targets/BundledTemplates.targets
+++ b/src/redist/targets/BundledTemplates.targets
@@ -116,12 +116,14 @@
     <TargetFramework>$(TargetFramework)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    @(BundledTemplatePackageDownload->'<BundledTemplatePackageDownload Include="%(Identity)" Version="%(Version)" />', '
+    @(BundledTemplatePackageDownload->'<PackageDownload Include="%(Identity)" Version="%(Version)" />', '
     ')
   </ItemGroup>
 </Project>
 ]]>
       </TemplatePackageDownloadProjectContent>
+      <!-- Escape semicolons as %3B in order to avoid being interpreted as line splits in WriteLinesToFile -->
+      <TemplatePackageDownloadProjectContent>$(TemplatePackageDownloadProjectContent.Replace(';', '%3B'))</TemplatePackageDownloadProjectContent>
       <TemplatePackageDownloadProjectDirectory>$(IntermediateOutputPath)TemplatePackageDownloader\</TemplatePackageDownloadProjectDirectory>
       <TemplatePackageDownloadProjectPath>$(TemplatePackageDownloadProjectDirectory)TemplatePackageDownloader.csproj</TemplatePackageDownloadProjectPath>
     </PropertyGroup>

--- a/src/redist/targets/BundledTemplates.targets
+++ b/src/redist/targets/BundledTemplates.targets
@@ -168,6 +168,7 @@
                               [$(MicrosoftDotNetCommonItemTemplates30PackageVersion)];
                               [$(MicrosoftDotNetCommonItemTemplates31PackageVersion)];
                               [$(MicrosoftDotNetCommonItemTemplates50PackageVersion)];
+                              [$(MicrosoftDotNetCommonItemTemplates60PackageVersion)];
                               " />
 
     <PackageDownload Update="Microsoft.DotNet.Web.Spa.ProjectTemplates"
@@ -179,6 +180,7 @@
                               [$(AspNetCorePackageVersionFor30Templates)];
                               [$(AspNetCorePackageVersionFor31Templates)];
                               [$(AspNetCorePackageVersionFor50Templates)];
+                              [$(AspNetCorePackageVersionFor60Templates)];
                               " />
 
     <PackageDownload Update="NUnit3.DotNetNew.Template"

--- a/src/redist/targets/BundledTemplates.targets
+++ b/src/redist/targets/BundledTemplates.targets
@@ -1,6 +1,12 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Target Name="CalculateTemplatesVersions" DependsOnTargets="SetupWixProperties">
 
+    <CalculateTemplateVersions AspNetCorePackageVersionTemplate="$(AspNetCorePackageVersionFor60Templates)">
+      <Output TaskParameter="BundledTemplateInstallPath" PropertyName="BundledTemplates60InstallPath" />
+      <Output TaskParameter="BundledTemplateMajorMinorVersion" PropertyName="BundledTemplates60MajorMinorVersion" />
+      <Output TaskParameter="BundledTemplateMajorMinorPatchVersion" PropertyName="BundledTemplates60MajorMinorPatchVersion" />
+    </CalculateTemplateVersions>
+    
     <CalculateTemplateVersions AspNetCorePackageVersionTemplate="$(AspNetCorePackageVersionFor50Templates)">
       <Output TaskParameter="BundledTemplateInstallPath" PropertyName="BundledTemplates50InstallPath" />
       <Output TaskParameter="BundledTemplateMajorMinorVersion" PropertyName="BundledTemplates50MajorMinorVersion" />
@@ -47,6 +53,28 @@
   </Target>
 
   <ItemGroup>
+    <Bundled60Templates Include="Microsoft.DotNet.Common.ItemTemplates" PackageVersion="$(MicrosoftDotNetCommonItemTemplates60PackageVersion)" 
+                        Condition="'$(MicrosoftDotNetCommonItemTemplates60PackageVersion)' != '$(MicrosoftDotNetCommonItemTemplates50PackageVersion)'" />
+    <Bundled60Templates Include="Microsoft.DotNet.Common.ProjectTemplates.6.0" PackageVersion="$(MicrosoftDotNetCommonProjectTemplates60PackageVersion)"
+                        Condition="'$(MicrosoftDotNetCommonProjectTemplates60PackageVersion)' != '$(MicrosoftDotNetCommonProjectTemplates50PackageVersion)'" />
+    <Bundled60Templates Include="Microsoft.DotNet.Test.ProjectTemplates.6.0" PackageVersion="$(MicrosoftDotNetTestProjectTemplates60PackageVersion)"
+                        Condition="'$(MicrosoftDotNetTestProjectTemplates60PackageVersion)' != '$(MicrosoftDotNetTestProjectTemplates50PackageVersion)'" />
+    <Bundled60Templates Include="Microsoft.Dotnet.Wpf.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWpfProjectTemplates60PackageVersion)"
+                        Condition="'$(MicrosoftDotnetWpfProjectTemplates60PackageVersion)' != '$(MicrosoftDotnetWpfProjectTemplates50PackageVersion)'" />
+    <Bundled60Templates Include="Microsoft.Dotnet.WinForms.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWinFormsProjectTemplates60PackageVersion)"
+                        Condition="'$(MicrosoftDotnetWinFormsProjectTemplates60PackageVersion)' != '$(MicrosoftDotnetWinFormsProjectTemplates50PackageVersion)'" />
+    <Bundled60Templates Include="Microsoft.DotNet.Web.ItemTemplates" PackageVersion="$(AspNetCorePackageVersionFor60Templates)"
+                        Condition="'$(AspNetCorePackageVersionFor60Templates)' != '$(AspNetCorePackageVersionFor50Templates)'" />
+    <Bundled60Templates Include="Microsoft.DotNet.Web.ProjectTemplates.6.0" PackageVersion="$(AspNetCorePackageVersionFor60Templates)"
+                        Condition="'$(AspNetCorePackageVersionFor60Templates)' != '$(AspNetCorePackageVersionFor50Templates)'"/>
+    <Bundled60Templates Include="Microsoft.DotNet.Web.Spa.ProjectTemplates.6.0" PackageVersion="$(AspNetCorePackageVersionFor60Templates)"
+                        Condition="'$(AspNetCorePackageVersionFor60Templates)' != '$(AspNetCorePackageVersionFor50Templates)'" />
+    <Bundled60Templates Include="NUnit3.DotNetNew.Template" PackageVersion="$(NUnit3Templates60PackageVersion)"
+                        Condition="'$(NUnit3Templates60PackageVersion)' != '$(NUnit3Templates50PackageVersion)'" />
+
+  </ItemGroup>
+  
+  <ItemGroup>
     <Bundled50Templates Include="Microsoft.DotNet.Common.ItemTemplates" PackageVersion="$(MicrosoftDotNetCommonItemTemplates50PackageVersion)" />
     <Bundled50Templates Include="Microsoft.DotNet.Common.ProjectTemplates.5.0" PackageVersion="$(MicrosoftDotNetCommonProjectTemplates50PackageVersion)" />
     <Bundled50Templates Include="Microsoft.DotNet.Test.ProjectTemplates.5.0" PackageVersion="$(MicrosoftDotNetTestProjectTemplates50PackageVersion)" />
@@ -91,6 +119,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Bundled60Templates Update="@(Bundled60Templates)">
+      <NupkgPathRelativeToPackageRoot>%(Identity)/%(PackageVersion)/%(Identity).%(PackageVersion).nupkg</NupkgPathRelativeToPackageRoot>
+      <RestoredNupkgPath>$(NuGetPackageRoot)$([MSBuild]::ValueOrDefault('%(NupkgPathRelativeToPackageRoot)', '').ToLower())</RestoredNupkgPath>
+      <Version>[%(PackageVersion)]</Version>
+    </Bundled60Templates>
+  </ItemGroup>
+  <ItemGroup>
     <Bundled50Templates Update="@(Bundled50Templates)">
       <NupkgPathRelativeToPackageRoot>%(Identity)/%(PackageVersion)/%(Identity).%(PackageVersion).nupkg</NupkgPathRelativeToPackageRoot>
       <RestoredNupkgPath>$(NuGetPackageRoot)$([MSBuild]::ValueOrDefault('%(NupkgPathRelativeToPackageRoot)', '').ToLower())</RestoredNupkgPath>
@@ -126,6 +161,7 @@
     <PackageDownload Include="@(Bundled30Templates)" Exclude="@(PackageDownload)" />
     <PackageDownload Include="@(Bundled31Templates)" Exclude="@(PackageDownload)" />
     <PackageDownload Include="@(Bundled50Templates)" Exclude="@(PackageDownload)" />
+    <PackageDownload Include="@(Bundled60Templates)" Exclude="@(PackageDownload)" />
 
     <PackageDownload Update="Microsoft.DotNet.Common.ItemTemplates"
                      Version="[$(MicrosoftDotNetCommonItemTemplates21PackageVersion)];
@@ -166,18 +202,24 @@
   </ItemGroup>
 
   <Target Name="LayoutTemplates"
-        DependsOnTargets="LayoutTemplatesForSDK;LayoutTemplatesFor50MSI;LayoutTemplatesFor31MSI;LayoutTemplatesFor30MSI;LayoutTemplatesFor21MSI" />
+        DependsOnTargets="LayoutTemplatesForSDK;LayoutTemplatesFor60MSI;LayoutTemplatesFor50MSI;LayoutTemplatesFor31MSI;LayoutTemplatesFor30MSI;LayoutTemplatesFor21MSI" />
 
   <Target Name="LayoutTemplatesForSDK"
           DependsOnTargets="SetupBundledComponents;CalculateTemplatesVersions">
     <ItemGroup Condition="!$(ProductMonikerRid.StartsWith('win'))">
-      <Bundled50Templates Remove="Microsoft.Dotnet.Wpf.ProjectTemplates" />
-      <Bundled50Templates Remove="Microsoft.Dotnet.WinForms.ProjectTemplates" />
+      <Bundled60Templates Remove="Microsoft.Dotnet.Wpf.ProjectTemplates" />
+      <Bundled60Templates Remove="Microsoft.Dotnet.WinForms.ProjectTemplates" />
     </ItemGroup>
-    <Copy SourceFiles="%(Bundled50Templates.RestoredNupkgPath)"
-          DestinationFolder="$(RedistLayoutPath)templates/$(BundledTemplates50InstallPath)"/>
+    <Copy SourceFiles="%(Bundled60Templates.RestoredNupkgPath)"
+          DestinationFolder="$(RedistLayoutPath)templates/$(BundledTemplates60InstallPath)"/>
   </Target>
 
+  <Target Name="LayoutTemplatesFor60MSI"
+        DependsOnTargets="SetupBundledComponents;CalculateTemplatesVersions"
+        Condition="$(ProductMonikerRid.StartsWith('win')) And '$(Architecture)' != 'arm'">
+    <Copy SourceFiles="%(Bundled60Templates.RestoredNupkgPath)"
+          DestinationFolder="$(Templates60LayoutPath)templates/$(BundledTemplates60InstallPath)"/>
+  </Target>
   <Target Name="LayoutTemplatesFor50MSI"
           DependsOnTargets="SetupBundledComponents;CalculateTemplatesVersions"
           Condition="$(ProductMonikerRid.StartsWith('win')) And '$(Architecture)' != 'arm'">

--- a/src/redist/targets/BundledTemplates.targets
+++ b/src/redist/targets/BundledTemplates.targets
@@ -1,55 +1,23 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Target Name="CalculateTemplatesVersions" DependsOnTargets="SetupWixProperties">
 
-    <CalculateTemplateVersions AspNetCorePackageVersionTemplate="$(AspNetCorePackageVersionFor60Templates)">
-      <Output TaskParameter="BundledTemplateInstallPath" PropertyName="BundledTemplates60InstallPath" />
-      <Output TaskParameter="BundledTemplateMajorMinorVersion" PropertyName="BundledTemplates60MajorMinorVersion" />
-      <Output TaskParameter="BundledTemplateMajorMinorPatchVersion" PropertyName="BundledTemplates60MajorMinorPatchVersion" />
-    </CalculateTemplateVersions>
-    
-    <CalculateTemplateVersions AspNetCorePackageVersionTemplate="$(AspNetCorePackageVersionFor50Templates)">
-      <Output TaskParameter="BundledTemplateInstallPath" PropertyName="BundledTemplates50InstallPath" />
-      <Output TaskParameter="BundledTemplateMajorMinorVersion" PropertyName="BundledTemplates50MajorMinorVersion" />
-      <Output TaskParameter="BundledTemplateMajorMinorPatchVersion" PropertyName="BundledTemplates50MajorMinorPatchVersion" />
-    </CalculateTemplateVersions>
-
-    <CalculateTemplateVersions AspNetCorePackageVersionTemplate="$(AspNetCorePackageVersionFor31Templates)">
-      <Output TaskParameter="BundledTemplateInstallPath" PropertyName="BundledTemplates31InstallPath" />
-      <Output TaskParameter="BundledTemplateMajorMinorVersion" PropertyName="BundledTemplates31MajorMinorVersion" />
-      <Output TaskParameter="BundledTemplateMajorMinorPatchVersion" PropertyName="BundledTemplates31MajorMinorPatchVersion" />
+    <CalculateTemplateVersions
+      BundledTemplates="@(BundledTemplates)"
+      FullNugetVersion="$(FullNugetVersion)"
+      ProductMonikerRid="$(ProductMonikerRid)"
+      InstallerExtension="$(InstallerExtension)"
+      CombinedBuildNumberAndRevision="$(CombinedBuildNumberAndRevision)"
+      >
+      <Output TaskParameter="BundledTemplatesWithInstallPaths" ItemName="BundledTemplatesWithInstallPaths" />
+      <Output TaskParameter="TemplatesComponents" ItemName="TemplatesComponents" />
     </CalculateTemplateVersions>
 
-    <CalculateTemplateVersions AspNetCorePackageVersionTemplate="$(AspNetCorePackageVersionFor30Templates)">
-      <Output TaskParameter="BundledTemplateInstallPath" PropertyName="BundledTemplates30InstallPath" />
-      <Output TaskParameter="BundledTemplateMajorMinorVersion" PropertyName="BundledTemplates30MajorMinorVersion" />
-      <Output TaskParameter="BundledTemplateMajorMinorPatchVersion" PropertyName="BundledTemplates30MajorMinorPatchVersion" />
-    </CalculateTemplateVersions>
+    <ItemGroup>
+      <TemplatesComponents>
+        <MSIInstallerFile>$(ArtifactsNonShippingPackagesDir)%(TemplatesComponents.TemplateBaseFilename)-$(FullNugetVersion)-$(ProductMonikerRid)$(InstallerExtension)</MSIInstallerFile>
+      </TemplatesComponents>
+    </ItemGroup>
 
-    <CalculateTemplateVersions AspNetCorePackageVersionTemplate="$(AspNetCorePackageVersionFor21Templates)">
-      <Output TaskParameter="BundledTemplateInstallPath" PropertyName="BundledTemplates21InstallPath" />
-      <Output TaskParameter="BundledTemplateMajorMinorVersion" PropertyName="BundledTemplates21MajorMinorVersion" />
-      <Output TaskParameter="BundledTemplateMajorMinorPatchVersion" PropertyName="BundledTemplates21MajorMinorPatchVersion" />
-    </CalculateTemplateVersions>
-
-    <GenerateMsiVersionFromFullVersion VersionRevision="$(CombinedBuildNumberAndRevision)"
-                                       VersionMajorMinorPatch="$(BundledTemplates50MajorMinorPatchVersion)">
-      <Output TaskParameter="MsiVersion" PropertyName="BundledTemplates50MSIVersion" />
-    </GenerateMsiVersionFromFullVersion>
-
-    <GenerateMsiVersionFromFullVersion VersionRevision="$(CombinedBuildNumberAndRevision)"
-                                       VersionMajorMinorPatch="$(BundledTemplates31MajorMinorPatchVersion)">
-      <Output TaskParameter="MsiVersion" PropertyName="BundledTemplates31MSIVersion" />
-    </GenerateMsiVersionFromFullVersion>
-
-    <GenerateMsiVersionFromFullVersion VersionRevision="$(CombinedBuildNumberAndRevision)"
-                                       VersionMajorMinorPatch="$(BundledTemplates30MajorMinorPatchVersion)">
-      <Output TaskParameter="MsiVersion" PropertyName="BundledTemplates30MSIVersion" />
-    </GenerateMsiVersionFromFullVersion>
-
-    <GenerateMsiVersionFromFullVersion VersionRevision="$(CombinedBuildNumberAndRevision)"
-                                       VersionMajorMinorPatch="$(BundledTemplates21MajorMinorPatchVersion)">
-      <Output TaskParameter="MsiVersion" PropertyName="BundledTemplates21MSIVersion" />
-    </GenerateMsiVersionFromFullVersion>
   </Target>
 
   <ItemGroup>
@@ -67,12 +35,12 @@
     <Bundled60Templates Include="Microsoft.DotNet.Web.ItemTemplates" PackageVersion="$(AspNetCorePackageVersionFor60Templates)"
                         Condition="'$(AspNetCorePackageVersionFor60Templates)' != '$(AspNetCorePackageVersionFor50Templates)'" />
     <Bundled60Templates Include="Microsoft.DotNet.Web.ProjectTemplates.6.0" PackageVersion="$(AspNetCorePackageVersionFor60Templates)"
+                        UseVersionForTemplateInstallPath="true"
                         Condition="'$(AspNetCorePackageVersionFor60Templates)' != '$(AspNetCorePackageVersionFor50Templates)'"/>
     <Bundled60Templates Include="Microsoft.DotNet.Web.Spa.ProjectTemplates.6.0" PackageVersion="$(AspNetCorePackageVersionFor60Templates)"
                         Condition="'$(AspNetCorePackageVersionFor60Templates)' != '$(AspNetCorePackageVersionFor50Templates)'" />
     <Bundled60Templates Include="NUnit3.DotNetNew.Template" PackageVersion="$(NUnit3Templates60PackageVersion)"
                         Condition="'$(NUnit3Templates60PackageVersion)' != '$(NUnit3Templates50PackageVersion)'" />
-
   </ItemGroup>
   
   <ItemGroup>
@@ -82,178 +50,119 @@
     <Bundled50Templates Include="Microsoft.Dotnet.Wpf.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWpfProjectTemplates50PackageVersion)" />
     <Bundled50Templates Include="Microsoft.Dotnet.WinForms.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWinFormsProjectTemplates50PackageVersion)" />
     <Bundled50Templates Include="Microsoft.DotNet.Web.ItemTemplates" PackageVersion="$(AspNetCorePackageVersionFor50Templates)" />
-    <Bundled50Templates Include="Microsoft.DotNet.Web.ProjectTemplates.5.0" PackageVersion="$(AspNetCorePackageVersionFor50Templates)" />
+    <Bundled50Templates Include="Microsoft.DotNet.Web.ProjectTemplates.5.0" PackageVersion="$(AspNetCorePackageVersionFor50Templates)" UseVersionForTemplateInstallPath="true" />
     <Bundled50Templates Include="Microsoft.DotNet.Web.Spa.ProjectTemplates.5.0" PackageVersion="$(AspNetCorePackageVersionFor50Templates)" />
     <Bundled50Templates Include="NUnit3.DotNetNew.Template" PackageVersion="$(NUnit3Templates50PackageVersion)" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="!$(Architecture.StartsWith('arm'))">
     <Bundled31Templates Include="Microsoft.DotNet.Common.ItemTemplates" PackageVersion="$(MicrosoftDotNetCommonItemTemplates31PackageVersion)" />
     <Bundled31Templates Include="Microsoft.DotNet.Common.ProjectTemplates.3.1" PackageVersion="$(MicrosoftDotNetCommonProjectTemplates31PackageVersion)" />
     <Bundled31Templates Include="Microsoft.DotNet.Test.ProjectTemplates.3.1" PackageVersion="$(MicrosoftDotNetTestProjectTemplates31PackageVersion)" />
     <Bundled31Templates Include="Microsoft.Dotnet.Wpf.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWpfProjectTemplates31PackageVersion)" />
     <Bundled31Templates Include="Microsoft.Dotnet.WinForms.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWinFormsProjectTemplates31PackageVersion)" />
     <Bundled31Templates Include="Microsoft.DotNet.Web.ItemTemplates" PackageVersion="$(AspNetCorePackageVersionFor31Templates)" />
-    <Bundled31Templates Include="Microsoft.DotNet.Web.ProjectTemplates.3.1" PackageVersion="$(AspNetCorePackageVersionFor31Templates)" />
+    <Bundled31Templates Include="Microsoft.DotNet.Web.ProjectTemplates.3.1" PackageVersion="$(AspNetCorePackageVersionFor31Templates)" UseVersionForTemplateInstallPath="true" />
     <Bundled31Templates Include="Microsoft.DotNet.Web.Spa.ProjectTemplates.3.1" PackageVersion="$(AspNetCorePackageVersionFor31Templates)" />
     <Bundled31Templates Include="Microsoft.AspNetCore.Components.WebAssembly.Templates" PackageVersion="$(MicrosoftAspNetCoreComponentsWebAssemblyTemplatesPackageVersion)" />
     <Bundled31Templates Include="NUnit3.DotNetNew.Template" PackageVersion="$(NUnit3Templates31PackageVersion)" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="!$(Architecture.StartsWith('arm'))">
     <Bundled30Templates Include="Microsoft.DotNet.Common.ItemTemplates" PackageVersion="$(MicrosoftDotNetCommonItemTemplates30PackageVersion)" />
     <Bundled30Templates Include="Microsoft.DotNet.Common.ProjectTemplates.3.0" PackageVersion="$(MicrosoftDotNetCommonProjectTemplates30PackageVersion)" />
     <Bundled30Templates Include="Microsoft.DotNet.Test.ProjectTemplates.3.0" PackageVersion="$(MicrosoftDotNetTestProjectTemplates30PackageVersion)" />
     <Bundled30Templates Include="Microsoft.Dotnet.Wpf.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWpfProjectTemplates30PackageVersion)" />
     <Bundled30Templates Include="Microsoft.Dotnet.WinForms.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWinFormsProjectTemplates30PackageVersion)" />
     <Bundled30Templates Include="Microsoft.DotNet.Web.ItemTemplates" PackageVersion="$(AspNetCorePackageVersionFor30Templates)" />
-    <Bundled30Templates Include="Microsoft.DotNet.Web.ProjectTemplates.3.0" PackageVersion="$(AspNetCorePackageVersionFor30Templates)" />
+    <Bundled30Templates Include="Microsoft.DotNet.Web.ProjectTemplates.3.0" PackageVersion="$(AspNetCorePackageVersionFor30Templates)" UseVersionForTemplateInstallPath="true" />
     <Bundled30Templates Include="Microsoft.DotNet.Web.Spa.ProjectTemplates.3.0" PackageVersion="$(AspNetCorePackageVersionFor30Templates)" />
     <Bundled30Templates Include="NUnit3.DotNetNew.Template" PackageVersion="$(NUnit3Templates30PackageVersion)" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="!$(Architecture.StartsWith('arm'))">
     <Bundled21Templates Include="Microsoft.DotNet.Common.ItemTemplates" PackageVersion="$(MicrosoftDotNetCommonItemTemplates21PackageVersion)" />
     <Bundled21Templates Include="Microsoft.DotNet.Common.ProjectTemplates.2.1" PackageVersion="$(MicrosoftDotNetCommonProjectTemplates21PackageVersion)" />
     <Bundled21Templates Include="Microsoft.DotNet.Test.ProjectTemplates.2.1" PackageVersion="$(MicrosoftDotNetTestProjectTemplates21PackageVersion)" />
     <Bundled21Templates Include="Microsoft.DotNet.Web.ItemTemplates" PackageVersion="$(AspNetCorePackageVersionFor21Templates)" />
-    <Bundled21Templates Include="Microsoft.DotNet.Web.ProjectTemplates.2.1" PackageVersion="$(AspNetCorePackageVersionFor21Templates)" />
+    <Bundled21Templates Include="Microsoft.DotNet.Web.ProjectTemplates.2.1" PackageVersion="$(AspNetCorePackageVersionFor21Templates)" UseVersionForTemplateInstallPath="true" />
     <Bundled21Templates Include="Microsoft.DotNet.Web.Spa.ProjectTemplates.2.1" PackageVersion="$(AspNetCorePackageVersionFor21Templates)" />
     <Bundled21Templates Include="NUnit3.DotNetNew.Template" PackageVersion="$(NUnit3Templates21PackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>
-    <Bundled60Templates Update="@(Bundled60Templates)">
+    <BundledTemplates Include="@(Bundled60Templates)" TemplateFrameworkVersion="6.0"/>
+    <BundledTemplates Include="@(Bundled50Templates)" TemplateFrameworkVersion="5.0"/>
+    <BundledTemplates Include="@(Bundled31Templates)" TemplateFrameworkVersion="3.1"/>
+    <BundledTemplates Include="@(Bundled30Templates)" TemplateFrameworkVersion="3.0"/>
+    <BundledTemplates Include="@(Bundled21Templates)" TemplateFrameworkVersion="2.1"/>
+  </ItemGroup>
+  
+  <ItemGroup>
+    <BundledTemplates Update="@(BundledTemplates)">
       <NupkgPathRelativeToPackageRoot>%(Identity)/%(PackageVersion)/%(Identity).%(PackageVersion).nupkg</NupkgPathRelativeToPackageRoot>
       <RestoredNupkgPath>$(NuGetPackageRoot)$([MSBuild]::ValueOrDefault('%(NupkgPathRelativeToPackageRoot)', '').ToLower())</RestoredNupkgPath>
-      <Version>[%(PackageVersion)]</Version>
-    </Bundled60Templates>
+    </BundledTemplates>
   </ItemGroup>
+  
+  <Target Name="DownloadBundledTemplateNupkgs">
+    <CollatePackageDownloads Packages="@(BundledTemplates)">
+      <Output TaskParameter="PackageDownloads" ItemName="BundledTemplatePackageDownload" />
+    </CollatePackageDownloads>
+    <!-- Create a separate project to for template PackageDownloads, as we want to use a task in core-sdk-tasks to collate them, but we
+       can't use those tasks before normal NuGet restore -->
+    <PropertyGroup>
+      <TemplatePackageDownloadProjectContent>
+        <![CDATA[
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$(TargetFramework)</TargetFramework>
+  </PropertyGroup>
   <ItemGroup>
-    <Bundled50Templates Update="@(Bundled50Templates)">
-      <NupkgPathRelativeToPackageRoot>%(Identity)/%(PackageVersion)/%(Identity).%(PackageVersion).nupkg</NupkgPathRelativeToPackageRoot>
-      <RestoredNupkgPath>$(NuGetPackageRoot)$([MSBuild]::ValueOrDefault('%(NupkgPathRelativeToPackageRoot)', '').ToLower())</RestoredNupkgPath>
-      <Version>[%(PackageVersion)]</Version>
-    </Bundled50Templates>
+    @(BundledTemplatePackageDownload->'<BundledTemplatePackageDownload Include="%(Identity)" Version="%(Version)" />', '
+    ')
   </ItemGroup>
-  <ItemGroup>
-    <Bundled31Templates Update="@(Bundled31Templates)">
-      <NupkgPathRelativeToPackageRoot>%(Identity)/%(PackageVersion)/%(Identity).%(PackageVersion).nupkg</NupkgPathRelativeToPackageRoot>
-      <RestoredNupkgPath>$(NuGetPackageRoot)$([MSBuild]::ValueOrDefault('%(NupkgPathRelativeToPackageRoot)', '').ToLower())</RestoredNupkgPath>
-      <Version>[%(PackageVersion)]</Version>
-    </Bundled31Templates>
-  </ItemGroup>
-  <ItemGroup>
-    <Bundled30Templates Update="@(Bundled30Templates)">
-      <NupkgPathRelativeToPackageRoot>%(Identity)/%(PackageVersion)/%(Identity).%(PackageVersion).nupkg</NupkgPathRelativeToPackageRoot>
-      <RestoredNupkgPath>$(NuGetPackageRoot)$([MSBuild]::ValueOrDefault('%(NupkgPathRelativeToPackageRoot)', '').ToLower())</RestoredNupkgPath>
-      <Version>[%(PackageVersion)]</Version>
-    </Bundled30Templates>
-  </ItemGroup>
-  <ItemGroup>
-    <Bundled21Templates Update="@(Bundled21Templates)">
-      <NupkgPathRelativeToPackageRoot>%(Identity)/%(PackageVersion)/%(Identity).%(PackageVersion).nupkg</NupkgPathRelativeToPackageRoot>
-      <RestoredNupkgPath>$(NuGetPackageRoot)$([MSBuild]::ValueOrDefault('%(NupkgPathRelativeToPackageRoot)', '').ToLower())</RestoredNupkgPath>
-      <Version>[%(PackageVersion)]</Version>
-    </Bundled21Templates>
-  </ItemGroup>
+</Project>
+]]>
+      </TemplatePackageDownloadProjectContent>
+      <TemplatePackageDownloadProjectDirectory>$(IntermediateOutputPath)TemplatePackageDownloader\</TemplatePackageDownloadProjectDirectory>
+      <TemplatePackageDownloadProjectPath>$(TemplatePackageDownloadProjectDirectory)TemplatePackageDownloader.csproj</TemplatePackageDownloadProjectPath>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <!-- PackageDownload items must not have duplicate itemspecs, handle packages with multiple versions specially below -->
+    <MakeDir Directories="$(TemplatePackageDownloadProjectDirectory)"/>
+    <WriteLinesToFile Lines="$(TemplatePackageDownloadProjectContent)"
+                      File="$(TemplatePackageDownloadProjectPath)"
+                      Overwrite="True" WriteOnlyWhenDifferent="True" />
 
-    <PackageDownload Include="@(Bundled21Templates)" Exclude="@(PackageDownload)" />
-    <PackageDownload Include="@(Bundled30Templates)" Exclude="@(PackageDownload)" />
-    <PackageDownload Include="@(Bundled31Templates)" Exclude="@(PackageDownload)" />
-    <PackageDownload Include="@(Bundled50Templates)" Exclude="@(PackageDownload)" />
-    <PackageDownload Include="@(Bundled60Templates)" Exclude="@(PackageDownload)" />
+    <MSBuild Projects="$(TemplatePackageDownloadProjectPath)"
+             Targets="Restore"/>
+  </Target>
 
-    <PackageDownload Update="Microsoft.DotNet.Common.ItemTemplates"
-                     Version="[$(MicrosoftDotNetCommonItemTemplates21PackageVersion)];
-                              [$(MicrosoftDotNetCommonItemTemplates30PackageVersion)];
-                              [$(MicrosoftDotNetCommonItemTemplates31PackageVersion)];
-                              [$(MicrosoftDotNetCommonItemTemplates50PackageVersion)];
-                              [$(MicrosoftDotNetCommonItemTemplates60PackageVersion)];
-                              " />
-
-    <PackageDownload Update="Microsoft.DotNet.Web.Spa.ProjectTemplates"
-                     Version="[$(AspNetCorePackageVersionFor21Templates)];
-                              " />
-
-    <PackageDownload Update="Microsoft.DotNet.Web.ItemTemplates"
-                     Version="[$(AspNetCorePackageVersionFor21Templates)];
-                              [$(AspNetCorePackageVersionFor30Templates)];
-                              [$(AspNetCorePackageVersionFor31Templates)];
-                              [$(AspNetCorePackageVersionFor50Templates)];
-                              [$(AspNetCorePackageVersionFor60Templates)];
-                              " />
-
-    <PackageDownload Update="NUnit3.DotNetNew.Template"
-                     Version="[$(NUnit3Templates21PackageVersion)];
-                              [$(NUnit3Templates30PackageVersion)];
-                              [$(NUnit3Templates31PackageVersion)];
-                              [$(NUnit3Templates50PackageVersion)];
-                              " />
-
-   <PackageDownload Update="Microsoft.Dotnet.Wpf.ProjectTemplates"
-                    Version="[$(MicrosoftDotnetWpfProjectTemplates30PackageVersion)];
-                             [$(MicrosoftDotnetWpfProjectTemplates31PackageVersion)];
-                             [$(MicrosoftDotnetWpfProjectTemplates50PackageVersion)];
-                             " />
-
-    <PackageDownload Update="Microsoft.Dotnet.Winforms.ProjectTemplates"
-                     Version="[$(MicrosoftDotnetWinFormsProjectTemplates30PackageVersion)];
-                              [$(MicrosoftDotnetWinFormsProjectTemplates31PackageVersion)];
-                              [$(MicrosoftDotnetWinFormsProjectTemplates50PackageVersion)];
-                             " />
-  </ItemGroup>
 
   <Target Name="LayoutTemplates"
-        DependsOnTargets="LayoutTemplatesForSDK;LayoutTemplatesFor60MSI;LayoutTemplatesFor50MSI;LayoutTemplatesFor31MSI;LayoutTemplatesFor30MSI;LayoutTemplatesFor21MSI" />
+        DependsOnTargets="LayoutTemplatesForSDK;LayoutTemplatesForMSI" />
 
   <Target Name="LayoutTemplatesForSDK"
-          DependsOnTargets="SetupBundledComponents;CalculateTemplatesVersions">
+          DependsOnTargets="SetupBundledComponents;CalculateTemplatesVersions;DownloadBundledTemplateNupkgs">
     <ItemGroup Condition="!$(ProductMonikerRid.StartsWith('win'))">
-      <Bundled60Templates Remove="Microsoft.Dotnet.Wpf.ProjectTemplates" />
-      <Bundled60Templates Remove="Microsoft.Dotnet.WinForms.ProjectTemplates" />
-      <Bundled50Templates Remove="Microsoft.Dotnet.Wpf.ProjectTemplates" />
-      <Bundled50Templates Remove="Microsoft.Dotnet.WinForms.ProjectTemplates" />
+      <BundledTemplatesWithInstallPaths Remove="Microsoft.Dotnet.Wpf.ProjectTemplates" />
+      <BundledTemplatesWithInstallPaths Remove="Microsoft.Dotnet.WinForms.ProjectTemplates" />
     </ItemGroup>
-    <Copy SourceFiles="%(Bundled60Templates.RestoredNupkgPath)"
-          DestinationFolder="$(RedistLayoutPath)templates/$(BundledTemplates60InstallPath)"/>
+    <Copy SourceFiles="%(BundledTemplatesWithInstallPaths.RestoredNupkgPath)"
+          DestinationFolder="$(RedistLayoutPath)templates/%(BundledTemplatesWithInstallPaths.BundledTemplateInstallPath)"
+          Condition="'%(BundledTemplatesWithInstallPaths.TemplateFrameworkVersion)' == '6.0'"/>
 
     <!-- Since not all the templates have 6.0 versions yet, include the 5.0 versions in the layout for now -->
-    <Copy SourceFiles="%(Bundled50Templates.RestoredNupkgPath)"
-          DestinationFolder="$(RedistLayoutPath)templates/$(BundledTemplates60InstallPath)"/>
+    <Copy SourceFiles="%(BundledTemplatesWithInstallPaths.RestoredNupkgPath)"
+          DestinationFolder="$(RedistLayoutPath)templates/%(BundledTemplatesWithInstallPaths.BundledTemplateInstallPath)"
+          Condition="'%(BundledTemplatesWithInstallPaths.TemplateFrameworkVersion)' == '5.0'"/>
 
   </Target>
 
-  <Target Name="LayoutTemplatesFor60MSI"
-        DependsOnTargets="SetupBundledComponents;CalculateTemplatesVersions"
-        Condition="$(ProductMonikerRid.StartsWith('win')) And '$(Architecture)' != 'arm'">
-    <Copy SourceFiles="%(Bundled60Templates.RestoredNupkgPath)"
-          DestinationFolder="$(Templates60LayoutPath)templates/$(BundledTemplates60InstallPath)"/>
-  </Target>
-  <Target Name="LayoutTemplatesFor50MSI"
+  <Target Name="LayoutTemplatesForMSI"
           DependsOnTargets="SetupBundledComponents;CalculateTemplatesVersions"
           Condition="$(ProductMonikerRid.StartsWith('win')) And '$(Architecture)' != 'arm'">
-    <Copy SourceFiles="%(Bundled50Templates.RestoredNupkgPath)"
-          DestinationFolder="$(Templates50LayoutPath)templates/$(BundledTemplates50InstallPath)"/>
-  </Target>
-  <Target Name="LayoutTemplatesFor31MSI"
-          DependsOnTargets="SetupBundledComponents;CalculateTemplatesVersions"
-          Condition="$(ProductMonikerRid.StartsWith('win')) And !$(Architecture.StartsWith('arm'))">
-    <Copy SourceFiles="%(Bundled31Templates.RestoredNupkgPath)"
-          DestinationFolder="$(Templates31LayoutPath)templates/$(BundledTemplates31InstallPath)"/>
+
+    <Copy SourceFiles="%(BundledTemplatesWithInstallPaths.RestoredNupkgPath)"
+          DestinationFolder="$(BaseOutputPath)$(Configuration)\templates-%(BundledTemplatesWithInstallPaths.TemplateFrameworkVersion)\templates/%(BundledTemplatesWithInstallPaths.BundledTemplateInstallPath)"/>
+    
   </Target>
 
-  <Target Name="LayoutTemplatesFor30MSI"
-          DependsOnTargets="SetupBundledComponents;CalculateTemplatesVersions"
-          Condition="$(ProductMonikerRid.StartsWith('win')) And !$(Architecture.StartsWith('arm'))">
-    <Copy SourceFiles="%(Bundled30Templates.RestoredNupkgPath)"
-          DestinationFolder="$(Templates30LayoutPath)templates/$(BundledTemplates30InstallPath)"/>
-  </Target>
-
-  <Target Name="LayoutTemplatesFor21MSI"
-          DependsOnTargets="SetupBundledComponents;CalculateTemplatesVersions"
-          Condition="$(ProductMonikerRid.StartsWith('win')) And !$(Architecture.StartsWith('arm'))">
-    <Copy SourceFiles="%(Bundled21Templates.RestoredNupkgPath)"
-          DestinationFolder="$(Templates21LayoutPath)templates/$(BundledTemplates21InstallPath)"/>
-  </Target>
 </Project>

--- a/src/redist/targets/BundledTemplates.targets
+++ b/src/redist/targets/BundledTemplates.targets
@@ -55,7 +55,8 @@
   <ItemGroup>
     <Bundled60Templates Include="Microsoft.DotNet.Common.ItemTemplates" PackageVersion="$(MicrosoftDotNetCommonItemTemplates60PackageVersion)" 
                         Condition="'$(MicrosoftDotNetCommonItemTemplates60PackageVersion)' != '$(MicrosoftDotNetCommonItemTemplates50PackageVersion)'" />
-    <Bundled60Templates Include="Microsoft.DotNet.Common.ProjectTemplates.6.0" PackageVersion="$(MicrosoftDotNetCommonProjectTemplates60PackageVersion)"
+    <!-- TODO: Update this package name to 6.0 when it starts getting produced that way -->
+    <Bundled60Templates Include="Microsoft.DotNet.Common.ProjectTemplates.5.0" PackageVersion="$(MicrosoftDotNetCommonProjectTemplates60PackageVersion)"
                         Condition="'$(MicrosoftDotNetCommonProjectTemplates60PackageVersion)' != '$(MicrosoftDotNetCommonProjectTemplates50PackageVersion)'" />
     <Bundled60Templates Include="Microsoft.DotNet.Test.ProjectTemplates.6.0" PackageVersion="$(MicrosoftDotNetTestProjectTemplates60PackageVersion)"
                         Condition="'$(MicrosoftDotNetTestProjectTemplates60PackageVersion)' != '$(MicrosoftDotNetTestProjectTemplates50PackageVersion)'" />

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -11,7 +11,7 @@
 
   <PropertyGroup>
     <!-- Blob storage directories are not stabilized, so these must refer to a package that does not stabilize -->
-    <AspNetCoreBlobVersion>$(VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion)</AspNetCoreBlobVersion>
+    <AspNetCoreBlobVersion>$(VSRedistCommonAspNetCoreTargetingPackx6460PackageVersion)</AspNetCoreBlobVersion>
     <CoreSetupBlobVersion>$(MicrosoftNETCoreAppInternalPackageVersion)</CoreSetupBlobVersion>
     <WindowsDesktopBlobVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</WindowsDesktopBlobVersion>
 
@@ -78,7 +78,7 @@
       <AspNetCoreSharedFxInstallerRid Condition="'$(InstallerExtension)' == '.deb' OR '$(InstallerExtension)' == '.rpm'">x64</AspNetCoreSharedFxInstallerRid>
 
       <DownloadedAspNetCoreSharedFxInstallerFileName Condition=" '$(InstallerExtension)' != '' AND !$([MSBuild]::IsOSPlatform('OSX')) ">aspnetcore-runtime-$(MicrosoftAspNetCoreAppRuntimePackageVersion)-$(AspNetCoreSharedFxInstallerRid)$(InstallerExtension)</DownloadedAspNetCoreSharedFxInstallerFileName>
-      <DownloadedAspNetCoreSharedFxInstallerFileName Condition=" '$(InstallerExtension)' == '.msi' ">aspnetcore-runtime-$(VSRedistCommonAspNetCoreTargetingPackx6450PackageVersion)-$(AspNetCoreSharedFxInstallerRid)$(InstallerExtension)</DownloadedAspNetCoreSharedFxInstallerFileName>
+      <DownloadedAspNetCoreSharedFxInstallerFileName Condition=" '$(InstallerExtension)' == '.msi' ">aspnetcore-runtime-$(VSRedistCommonAspNetCoreTargetingPackx6460PackageVersion)-$(AspNetCoreSharedFxInstallerRid)$(InstallerExtension)</DownloadedAspNetCoreSharedFxInstallerFileName>
       <!-- Note: we use the "-internal" archives and installers that contain only the aspnetcore shared framework, and shouldn't overlap with Microsoft.NETCore.App. -->
       <DownloadedAspNetCoreSharedFxWixLibFileName Condition=" '$(InstallerExtension)' == '.msi' ">aspnetcore-runtime-internal-$(MicrosoftAspNetCoreAppRuntimePackageVersion)-$(AspNetCoreSharedFxInstallerRid).wixlib</DownloadedAspNetCoreSharedFxWixLibFileName>
       <DownloadedAspNetTargetingPackInstallerFileName Condition=" '$(InstallerExtension)' != '' ">aspnetcore-targeting-pack-$(MicrosoftAspNetCoreAppRefPackageVersion)$(InstallerExtension)</DownloadedAspNetTargetingPackInstallerFileName>

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -2,10 +2,6 @@
   <PropertyGroup>
     <RedistLayoutPath>$(BaseOutputPath)$(Configuration)\dotnet\</RedistLayoutPath>
     <SdkInternalLayoutPath>$(BaseOutputPath)$(Configuration)\dotnet-internal\</SdkInternalLayoutPath>
-    <Templates50LayoutPath>$(BaseOutputPath)$(Configuration)\templates-5.0\</Templates50LayoutPath>
-    <Templates31LayoutPath>$(BaseOutputPath)$(Configuration)\templates-3.1\</Templates31LayoutPath>
-    <Templates30LayoutPath>$(BaseOutputPath)$(Configuration)\templates-3.0\</Templates30LayoutPath>
-    <Templates21LayoutPath>$(BaseOutputPath)$(Configuration)\templates-2.1\</Templates21LayoutPath>
     <DownloadsFolder>$(IntermediateOutputPath)downloads\</DownloadsFolder>
   </PropertyGroup>
 

--- a/src/redist/targets/GenerateMSIs.targets
+++ b/src/redist/targets/GenerateMSIs.targets
@@ -59,10 +59,6 @@
     <PropertyGroup>
       <SdkMSIInstallerFile>$(ArtifactsNonShippingPackagesDir)$(ArtifactNameWithVersionSdk)$(InstallerExtension)</SdkMSIInstallerFile>
       <SdkDependencyKeyName>Dotnet_CLI</SdkDependencyKeyName>
-      <Templates50MSIInstallerFile>$(ArtifactsNonShippingPackagesDir)dotnet-50templates-$(FullNugetVersion)-$(ProductMonikerRid)$(InstallerExtension)</Templates50MSIInstallerFile>
-      <Templates31MSIInstallerFile>$(ArtifactsNonShippingPackagesDir)dotnet-31templates-$(FullNugetVersion)-$(ProductMonikerRid)$(InstallerExtension)</Templates31MSIInstallerFile>
-      <Templates30MSIInstallerFile>$(ArtifactsNonShippingPackagesDir)dotnet-30templates-$(FullNugetVersion)-$(ProductMonikerRid)$(InstallerExtension)</Templates30MSIInstallerFile>
-      <Templates21MSIInstallerFile>$(ArtifactsNonShippingPackagesDir)dotnet-21templates-$(FullNugetVersion)-$(ProductMonikerRid)$(InstallerExtension)</Templates21MSIInstallerFile>
       <SdkPlaceholderMSIInstallerFile>$(ArtifactsNonShippingPackagesDir)dotnet-sdkplaceholder-$(FullNugetVersion)-$(ProductMonikerRid)$(InstallerExtension)</SdkPlaceholderMSIInstallerFile>
       <SdkPlaceholderDependencyKeyName>NetCore_SdkPlaceholder</SdkPlaceholderDependencyKeyName>
       <CombinedFrameworkSdkHostMSIInstallerFile>$(ArtifactsShippingPackagesDir)$(ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk)$(BundleExtension)</CombinedFrameworkSdkHostMSIInstallerFile>
@@ -100,10 +96,11 @@
   </Target>
 
   <Target Name="MsiTargetsSetupInputOutputs"
-          DependsOnTargets="GenerateLayout;SetupWixProperties">
+          DependsOnTargets="GenerateLayout;SetupWixProperties;SetupTemplatesMsis">
     <!-- Consumed By Publish -->
     <ItemGroup>
-      <GeneratedInstallers Include="$(SdkMSIInstallerFile);$(Templates50MSIInstallerFile);$(Templates31MSIInstallerFile);$(Templates30MSIInstallerFile);$(Templates21MSIInstallerFile);$(CombinedFrameworkSdkHostMSIInstallerFile);$(SdkPlaceholderMSIInstallerFile)" />
+      <GeneratedInstallers Include="$(SdkMSIInstallerFile);$(CombinedFrameworkSdkHostMSIInstallerFile);$(SdkPlaceholderMSIInstallerFile)" />
+      <GeneratedInstallers Include="@(TemplatesMsiComponent->'%(MSIInstallerFile)')" />
     </ItemGroup>
 
     <GenerateMsiVersion VersionRevision="$(CombinedBuildNumberAndRevision)"
@@ -116,26 +113,6 @@
     <GenerateGuidFromName Name="$(SdkMSIInstallerFile)">
       <Output TaskParameter="OutputGuid"
           PropertyName="SdkInstallerUpgradeCode" />
-    </GenerateGuidFromName>
-
-    <GenerateGuidFromName Name="$(Templates50MSIInstallerFile)">
-      <Output TaskParameter="OutputGuid"
-          PropertyName="Templates50InstallerUpgradeCode" />
-    </GenerateGuidFromName>
-
-    <GenerateGuidFromName Name="$(Templates31MSIInstallerFile)">
-      <Output TaskParameter="OutputGuid"
-          PropertyName="Templates31InstallerUpgradeCode" />
-    </GenerateGuidFromName>
-
-    <GenerateGuidFromName Name="$(Templates30MSIInstallerFile)">
-      <Output TaskParameter="OutputGuid"
-          PropertyName="Templates30InstallerUpgradeCode" />
-    </GenerateGuidFromName>
-
-    <GenerateGuidFromName Name="$(Templates21MSIInstallerFile)">
-      <Output TaskParameter="OutputGuid"
-          PropertyName="Templates21InstallerUpgradeCode" />
     </GenerateGuidFromName>
 
     <GenerateGuidFromName Name="$(SdkPlaceholderMSIInstallerFile)">
@@ -287,40 +264,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <TemplatesMsiComponent Include="NetCore50TemplatesMsi">
-        <LayoutPath>$(Templates50LayoutPath.TrimEnd('\'))</LayoutPath>
-        <MSIInstallerFile>$(Templates50MSIInstallerFile)</MSIInstallerFile>
-        <BrandName>$(BundledTemplates50BrandName)</BrandName>
-        <MsiVersion>$(BundledTemplates50MsiVersion)</MsiVersion>
-        <UpgradeCode>$(Templates50InstallerUpgradeCode)</UpgradeCode>
-        <DependencyKeyName>NetCore_Templates_5.0</DependencyKeyName>
-      </TemplatesMsiComponent>
-    </ItemGroup>
-
-    <ItemGroup Condition="!$(Architecture.StartsWith('arm'))">
-      <TemplatesMsiComponent Include="NetCore31TemplatesMsi">
-        <LayoutPath>$(Templates31LayoutPath.TrimEnd('\'))</LayoutPath>
-        <MSIInstallerFile>$(Templates31MSIInstallerFile)</MSIInstallerFile>
-        <BrandName>$(BundledTemplates31BrandName)</BrandName>
-        <MsiVersion>$(BundledTemplates31MsiVersion)</MsiVersion>
-        <UpgradeCode>$(Templates31InstallerUpgradeCode)</UpgradeCode>
-        <DependencyKeyName>NetCore_Templates_3.1</DependencyKeyName>
-      </TemplatesMsiComponent>
-      <TemplatesMsiComponent Include="NetCore30TemplatesMsi">
-        <LayoutPath>$(Templates30LayoutPath.TrimEnd('\'))</LayoutPath>
-        <MSIInstallerFile>$(Templates30MSIInstallerFile)</MSIInstallerFile>
-        <BrandName>$(BundledTemplates30BrandName)</BrandName>
-        <MsiVersion>$(BundledTemplates30MsiVersion)</MsiVersion>
-        <UpgradeCode>$(Templates30InstallerUpgradeCode)</UpgradeCode>
-        <DependencyKeyName>NetCore_Templates_3.0</DependencyKeyName>
-      </TemplatesMsiComponent>
-      <TemplatesMsiComponent Include="NetCore21TemplatesMsi">
-        <LayoutPath>$(Templates21LayoutPath.TrimEnd('\'))</LayoutPath>
-        <MSIInstallerFile>$(Templates21MSIInstallerFile)</MSIInstallerFile>
-        <BrandName>$(BundledTemplates21BrandName)</BrandName>
-        <MsiVersion>$(BundledTemplates21MsiVersion)</MsiVersion>
-        <UpgradeCode>$(Templates21InstallerUpgradeCode)</UpgradeCode>
-        <DependencyKeyName>NetCore_Templates_2.1</DependencyKeyName>
+      <TemplatesMsiComponent Include="@(TemplatesComponents)">
+        <LayoutPath>$(BaseOutputPath)$(Configuration)\templates-%(TemplatesComponents.TemplatesMajorMinorVersion)</LayoutPath>
+        <BrandName>%(TemplatesComponents.BrandNameWithoutVersion) $(Version)</BrandName>
+        <MsiVersion>%(TemplatesComponents.MSIVersion)</MsiVersion>
+        <UpgradeCode>%(TemplatesComponents.InstallerUpgradeCode)</UpgradeCode>
+        <DependencyKeyName>NetCore_Templates_%(TemplatesComponents.TemplatesMajorMinorVersion)</DependencyKeyName>
       </TemplatesMsiComponent>
     </ItemGroup>
   </Target>
@@ -334,6 +283,15 @@
                     $(DownloadedSharedHostInstallerFile);
                     $(SdkGenerateBundlePowershellScript)"
           Outputs="$(CombinedFrameworkSdkHostMSIInstallerFile)">
+
+    <!-- Choose "latest" template MSI to go in bundle. -->
+    <ItemGroup>
+      <LatestTemplateInstallerComponent Include="@(TemplatesMsiComponent)"
+                                        Condition="'%(TemplatesMajorMinorVersion)' == '$(MajorMinorVersion)'"/>
+    </ItemGroup>
+    <PropertyGroup>
+      <LatestTemplateMsiInstallerFile>@(LatestTemplateInstallerComponent->'%(MSIInstallerFile)')</LatestTemplateMsiInstallerFile>
+    </PropertyGroup>
     
     <Exec Command="powershell -NoProfile -NoLogo $(SdkGenerateBundlePowershellScript) ^
                       '$(SdkMSIInstallerFile)' ^
@@ -350,7 +308,7 @@
                       '$(DownloadsFolder)$(DownloadedArm64NetCoreAppHostPackInstallerFileName)' ^
                       '$(DownloadsFolder)$(DownloadedAspNetTargetingPackInstallerFileName)' ^
                       '$(DownloadsFolder)$(DownloadedWindowsDesktopTargetingPackInstallerFileName)' ^
-                      '$(Templates50MSIInstallerFile)' ^
+                      '$(LatestTemplateMsiInstallerFile)' ^
                       '$(CombinedFrameworkSdkHostMSIInstallerFile)' ^
                       '$(WixRoot)' ^
                       '$(SdkBrandName)' ^
@@ -442,27 +400,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <TemplatesNupkgComponent Include="NetCore50TemplatesNupkg">
-        <MSIInstallerFile>$(Templates50MSIInstallerFile)</MSIInstallerFile>
-        <NupkgFile>$(ArtifactsNonShippingPackagesDir)VS.Redist.Common.NetCore.Templates.$(BundledTemplates50MajorMinorVersion).$(FullNugetVersion).nupkg</NupkgFile>
-        <MajorMinorVersion>$(BundledTemplates50MajorMinorVersion)</MajorMinorVersion>
-      </TemplatesNupkgComponent>
-      <TemplatesNupkgComponent Include="NetCore31TemplatesNupkg">
-        <MSIInstallerFile>$(Templates31MSIInstallerFile)</MSIInstallerFile>
-        <NupkgFile>$(ArtifactsNonShippingPackagesDir)VS.Redist.Common.NetCore.Templates.$(BundledTemplates31MajorMinorVersion).$(FullNugetVersion).nupkg</NupkgFile>
-        <MajorMinorVersion>$(BundledTemplates31MajorMinorVersion)</MajorMinorVersion>
-      </TemplatesNupkgComponent>
-      <TemplatesNupkgComponent Include="NetCore30TemplatesNupkg">
-        <MSIInstallerFile>$(Templates30MSIInstallerFile)</MSIInstallerFile>
-        <NupkgFile>$(ArtifactsNonShippingPackagesDir)VS.Redist.Common.NetCore.Templates.$(BundledTemplates30MajorMinorVersion).$(FullNugetVersion).nupkg</NupkgFile>
-        <MajorMinorVersion>$(BundledTemplates30MajorMinorVersion)</MajorMinorVersion>
-      </TemplatesNupkgComponent>
-      <TemplatesNupkgComponent Include="NetCore21TemplatesNupkg">
-        <MSIInstallerFile>$(Templates21MSIInstallerFile)</MSIInstallerFile>
-        <NupkgFile>$(ArtifactsNonShippingPackagesDir)VS.Redist.Common.NetCore.Templates.$(BundledTemplates21MajorMinorVersion).$(FullNugetVersion).nupkg</NupkgFile>
-        <MajorMinorVersion>$(BundledTemplates21MajorMinorVersion)</MajorMinorVersion>
+      <TemplatesNupkgComponent Include="@(TemplatesComponents->'%(Identity)Nupkg')">
+        <NupkgFile>$(ArtifactsNonShippingPackagesDir)VS.Redist.Common.NetCore.Templates.%(TemplatesMajorMinorVersion).$(FullNugetVersion).nupkg</NupkgFile>
+        <MajorMinorVersion>%(TemplatesMajorMinorVersion)</MajorMinorVersion>
       </TemplatesNupkgComponent>
     </ItemGroup>
+
   </Target>
 
   <Target Name="GenerateVSToolsNupkg"

--- a/src/redist/targets/Signing.targets
+++ b/src/redist/targets/Signing.targets
@@ -180,18 +180,12 @@
 
   <Target Name="SignTemplatesMsis"
       Condition="'$(SignCoreSdk)' == 'true'"
-      DependsOnTargets="SetSignProps">
+      DependsOnTargets="SetSignProps;SetupTemplatesMsis">
 
     <ItemGroup>
-      <TemplatesMsiFilesToSign Include="$(Templates50MSIInstallerFile)" />
+      <TemplatesMsiFilesToSign Include="@(TemplatesMsiComponent->'%(MSIInstallerFile)')" />
     </ItemGroup>
 
-    <ItemGroup Condition="!$(Architecture.StartsWith('arm'))">
-      <TemplatesMsiFilesToSign Include="$(Templates31MSIInstallerFile)" />
-      <TemplatesMsiFilesToSign Include="$(Templates30MSIInstallerFile)" />
-      <TemplatesMsiFilesToSign Include="$(Templates21MSIInstallerFile)" />
-    </ItemGroup>
-    
     <ItemGroup>
       <TemplatesMsiFileSignInfo Include="@(TemplatesMsiFilesToSign->'%(Filename)%(Extension)')">
         <CertificateName>$(InternalCertificateId)</CertificateName>


### PR DESCRIPTION
Split out separate variables for 6.0 templates, and include them in layout.

Includes changes from #8725.