### PR TITLE
exclude javascript files from signcheck

### DIFF
--- a/eng/SignCheckExclusionsFile.txt
+++ b/eng/SignCheckExclusionsFile.txt
@@ -1,0 +1,4 @@
+;; Exclusions for SignCheck.
+;; Format: https://github.com/dotnet/arcade/blob/397316e195639450b6c76bfeb9823b40bee72d6d/src/SignCheck/Microsoft.SignCheck/Verification/Exclusion.cs#L23-L35
+
+*.js;; We do not sign JavaScript files.


### PR DESCRIPTION
.js files in this repo are not signed and should be excluded from signcheck.

These files were causing failures in the internal release [builds](https://dnceng.visualstudio.com/internal/_build/results?buildId=860387&view=logs&j=fd4f4f59-a9b8-56a9-f36f-3eb6b5b87215&t=751fc414-879a-54d5-b075-07fd5c4e1a4c)