### PR TITLE
Add KnownFrameworkReference items for .NET 6

### DIFF
--- a/TestAssets/TestProjects/UseCswinrt/consolecswinrt.csproj
+++ b/TestAssets/TestProjects/UseCswinrt/consolecswinrt.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net5.0</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
 		<TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
 	</PropertyGroup>
 </Project>

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -28,7 +28,8 @@
       <_NETStandardLibraryPackageVersion>$(NETStandardLibraryRefPackageVersion)</_NETStandardLibraryPackageVersion>
       <_NETCorePlatformsPackageVersion>$(MicrosoftNETCorePlatformsPackageVersion)</_NETCorePlatformsPackageVersion>
 
-      <!-- TODO: Once .NET 5.0 has released, update these version numbers to 5.0.0 -->
+      <!-- TODO: Once .NET 5.0 has released, update these version numbers to 5.0.0
+           https://github.com/dotnet/installer/issues/8974 -->
       <_NET50DefaultRuntimeFrameworkVersion>5.0.0-rc.2.20475.5</_NET50DefaultRuntimeFrameworkVersion>
       <_NET50RuntimePackVersion>5.0.0-rc.2.20475.5</_NET50RuntimePackVersion>
       <_NET50TargetingPackVersion>5.0.0-rc.2.20475.5</_NET50TargetingPackVersion>
@@ -113,7 +114,7 @@
         " />
 
       <Net50Crossgen2SupportedRids Include="linux-musl-x64;linux-x64;win-x64" />
-      <Crossgen2SupportedRids Include="@(Crossgen2SupportedRids)" />
+      <Crossgen2SupportedRids Include="@(Net50Crossgen2SupportedRids)" />
 
       <AspNetCore31RuntimePackRids Include="@(AspNetCore30RuntimePackRids)" />
       <AspNetCore50RuntimePackRids Include="@(AspNetCore31RuntimePackRids);win-arm64" />

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -28,23 +28,27 @@
       <_NETStandardLibraryPackageVersion>$(NETStandardLibraryRefPackageVersion)</_NETStandardLibraryPackageVersion>
       <_NETCorePlatformsPackageVersion>$(MicrosoftNETCorePlatformsPackageVersion)</_NETCorePlatformsPackageVersion>
 
-      <_NETCoreApp30RuntimePackVersion>3.0.3</_NETCoreApp30RuntimePackVersion>
-      <_NETCoreApp30TargetingPackVersion>3.0.0</_NETCoreApp30TargetingPackVersion>
-      
+      <!-- TODO: Once .NET 5.0 has released, update these version numbers to 5.0.0 -->
+      <_NET50RuntimePackVersion>5.0.0-rc.2.20475.5</_NET50RuntimePackVersion>
+      <_NET50TargetingPackVersion>5.0.0-rc.2.20475.5</_NET50TargetingPackVersion>
+      <_WindowsDesktop50RuntimePackVersion>5.0.0-rc.2.20475.6</_WindowsDesktop50RuntimePackVersion>
+      <_WindowsDesktop50TargetingPackVersion>5.0.0-rc.2.20475.6</_WindowsDesktop50TargetingPackVersion>
+      <_AspNet50RuntimePackVersion>5.0.0-rc.2.20475.17</_AspNet50RuntimePackVersion>
+      <_AspNet50TargetingPackVersion>5.0.0-rc.2.20475.17</_AspNet50TargetingPackVersion>
+
       <_NETCoreApp31RuntimePackVersion>3.1.7</_NETCoreApp31RuntimePackVersion>
       <_NETCoreApp31TargetingPackVersion>3.1.0</_NETCoreApp31TargetingPackVersion>
-      
-      <_WindowsDesktop30RuntimePackVersion>3.0.3</_WindowsDesktop30RuntimePackVersion>
-      <_WindowsDesktop30TargetingPackVersion>3.0.0</_WindowsDesktop30TargetingPackVersion>
-      
       <_WindowsDesktop31RuntimePackVersion>3.1.2</_WindowsDesktop31RuntimePackVersion>
       <_WindowsDesktop31TargetingPackVersion>3.1.0</_WindowsDesktop31TargetingPackVersion>
-      
-      <_AspNet30RuntimePackVersion>3.0.3</_AspNet30RuntimePackVersion>
-      <_AspNet30TargetingPackVersion>3.0.1</_AspNet30TargetingPackVersion>
-      
       <_AspNet31RuntimePackVersion>3.1.9</_AspNet31RuntimePackVersion>
       <_AspNet31TargetingPackVersion>3.1.8</_AspNet31TargetingPackVersion>
+
+      <_NETCoreApp30RuntimePackVersion>3.0.3</_NETCoreApp30RuntimePackVersion>
+      <_NETCoreApp30TargetingPackVersion>3.0.0</_NETCoreApp30TargetingPackVersion>
+      <_WindowsDesktop30RuntimePackVersion>3.0.3</_WindowsDesktop30RuntimePackVersion>
+      <_WindowsDesktop30TargetingPackVersion>3.0.0</_WindowsDesktop30TargetingPackVersion>
+      <_AspNet30RuntimePackVersion>3.0.3</_AspNet30RuntimePackVersion>
+      <_AspNet30TargetingPackVersion>3.0.1</_AspNet30TargetingPackVersion>
 
       <!-- Use only major and minor in target framework version -->
       <_NETCoreAppTargetFrameworkVersion>$(_NETCoreAppPackageVersion.Split('.')[0]).$(_NETCoreAppPackageVersion.Split('.')[1])</_NETCoreAppTargetFrameworkVersion>
@@ -73,10 +77,10 @@
 
       <NetCore31RuntimePackRids Include="@(NetCore30RuntimePackRids)"/>
 
-      <NetCore5AppHostRids Include="@(NetCore31RuntimePackRids)"/>
+      <Net50AppHostRids Include="@(NetCore31RuntimePackRids)"/>
       
-      <NetCore5RuntimePackRids Include="
-          @(NetCore5AppHostRids);
+      <Net50RuntimePackRids Include="
+          @(Net50AppHostRids);
           ios-arm64;
           ios-arm;
           ios-x64;
@@ -90,8 +94,8 @@
           browser-wasm;
           " />
 
-      <NetCoreAppHostRids Include="@(NetCore5AppHostRids)" />
-      <NetCoreRuntimePackRids Include="@(NetCore5RuntimePackRids)" />
+      <NetCoreAppHostRids Include="@(Net50AppHostRids)" />
+      <NetCoreRuntimePackRids Include="@(Net50RuntimePackRids)" />
 
       <AspNetCore30RuntimePackRids Include="
         win-x64;
@@ -105,7 +109,8 @@
         linux-arm64;
         " />
 
-      <Crossgen2SupportedRids Include="linux-musl-x64;linux-x64;win-x64" />
+      <Net50Crossgen2SupportedRids Include="linux-musl-x64;linux-x64;win-x64" />
+      <Crossgen2SupportedRids Include="@(Crossgen2SupportedRids)" />
 
       <AspNetCore31RuntimePackRids Include="@(AspNetCore30RuntimePackRids)" />
       <AspNetCore50RuntimePackRids Include="@(AspNetCore31RuntimePackRids);win-arm64" />
@@ -113,7 +118,8 @@
 
       <WindowsDesktop30RuntimePackRids Include="win-x64;win-x86" />
       <WindowsDesktop31RuntimePackRids Include="@(WindowsDesktop30RuntimePackRids)" />
-      <WindowsDesktopRuntimePackRids Include="@(WindowsDesktop31RuntimePackRids)" />
+      <WindowsDesktop50RuntimePackRids Include="@(WindowsDesktop31RuntimePackRids)" />
+      <WindowsDesktopRuntimePackRids Include="@(WindowsDesktop50RuntimePackRids)" />
       <!-- TODO: remove this once WPF is available on ARM64 and replace usage
             of this group for WindowsDesktopRuntimePackRids. -->
       <WindowsDesktopRuntimePackWinformsRids Include="@(WindowsDesktopRuntimePackRids);win-arm64" />
@@ -206,8 +212,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     @(ImplicitPackageVariable->'<ImplicitPackageReferenceVersion Include="%(Identity)" TargetFrameworkVersion="%(TargetFrameworkVersion)" DefaultVersion="%(DefaultVersion)" LatestVersion="%(LatestVersion)"/>', '
     ')
 
+    <!-- .NET 6.0 -->
     <KnownFrameworkReference Include="Microsoft.NETCore.App"
-                              TargetFramework="netcoreapp5.0"
+                              TargetFramework="netcoreapp6.0"
                               RuntimeFrameworkName="Microsoft.NETCore.App"
                               DefaultRuntimeFrameworkVersion="$(MicrosoftNETCoreAppDefaultRuntimeFrameworkVersion)"
                               LatestRuntimeFrameworkVersion="$(MicrosoftNETCoreAppRuntimePackageVersion)"
@@ -219,21 +226,21 @@ Copyright (c) .NET Foundation. All rights reserved.
                               />
 
     <KnownAppHostPack Include="Microsoft.NETCore.App"
-                      TargetFramework="netcoreapp5.0"
+                      TargetFramework="netcoreapp6.0"
                       AppHostPackNamePattern="Microsoft.NETCore.App.Host.**RID**"
                       AppHostPackVersion="$(_NETCoreAppPackageVersion)"
                       AppHostRuntimeIdentifiers="@(NetCoreAppHostRids, '%3B')"
                       />
 
     <KnownCrossgen2Pack Include="Microsoft.NETCore.App.Crossgen2"
-                        TargetFramework="netcoreapp5.0"
+                        TargetFramework="netcoreapp6.0"
                         Crossgen2PackNamePattern="Microsoft.NETCore.App.Crossgen2.**RID**"
                         Crossgen2PackVersion="$(MicrosoftNETCoreAppRuntimePackageVersion)"
                         Crossgen2RuntimeIdentifiers="@(Crossgen2SupportedRids, '%3B')"
                         />
     
     <KnownFrameworkReference Include="Microsoft.WindowsDesktop.App"
-                              TargetFramework="netcoreapp5.0"
+                              TargetFramework="netcoreapp6.0"
                               RuntimeFrameworkName="Microsoft.WindowsDesktop.App"
                               DefaultRuntimeFrameworkVersion="$(MicrosoftWindowsDesktopAppDefaultRuntimeFrameworkVersion)"
                               LatestRuntimeFrameworkVersion="$(MicrosoftWindowsDesktopAppRuntimePackageVersion)"
@@ -245,7 +252,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                               />
 
     <KnownFrameworkReference Include="Microsoft.WindowsDesktop.App.WPF"
-                              TargetFramework="netcoreapp5.0"
+                              TargetFramework="netcoreapp6.0"
                               RuntimeFrameworkName="Microsoft.WindowsDesktop.App"
                               DefaultRuntimeFrameworkVersion="$(MicrosoftWindowsDesktopAppDefaultRuntimeFrameworkVersion)"
                               LatestRuntimeFrameworkVersion="$(MicrosoftWindowsDesktopAppRuntimePackageVersion)"
@@ -258,7 +265,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                               />
 
     <KnownFrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms"
-                              TargetFramework="netcoreapp5.0"
+                              TargetFramework="netcoreapp6.0"
                               RuntimeFrameworkName="Microsoft.WindowsDesktop.App"
                               DefaultRuntimeFrameworkVersion="$(MicrosoftWindowsDesktopAppDefaultRuntimeFrameworkVersion)"
                               LatestRuntimeFrameworkVersion="$(MicrosoftWindowsDesktopAppRuntimePackageVersion)"
@@ -271,12 +278,127 @@ Copyright (c) .NET Foundation. All rights reserved.
                               />
 
     <KnownFrameworkReference Include="Microsoft.AspNetCore.App"
-                              TargetFramework="netcoreapp5.0"
+                              TargetFramework="netcoreapp6.0"
                               RuntimeFrameworkName="Microsoft.AspNetCore.App"
                               DefaultRuntimeFrameworkVersion="$(MicrosoftAspNetCoreAppDefaultRuntimeFrameworkVersion)"
                               LatestRuntimeFrameworkVersion="$(MicrosoftAspNetCoreAppRuntimePackageVersion)"
                               TargetingPackName="Microsoft.AspNetCore.App.Ref"
                               TargetingPackVersion="$(MicrosoftAspNetCoreAppRefPackageVersion)"
+                              RuntimePackNamePatterns="Microsoft.AspNetCore.App.Runtime.**RID**"
+                              RuntimePackRuntimeIdentifiers="@(AspNetCore60RuntimePackRids, '%3B')"
+                              />
+
+    <KnownFrameworkReference Include="Microsoft.Windows.SDK.NET.Ref"
+                              TargetFramework="net6.0-windows10.0.17763.0"
+                              RuntimeFrameworkName="Microsoft.Windows.SDK.NET.Ref"
+                              DefaultRuntimeFrameworkVersion="$(MicrosoftWindowsSDKNETRef10_0_17763PackageVersion)"
+                              LatestRuntimeFrameworkVersion="$(MicrosoftWindowsSDKNETRef10_0_17763PackageVersion)"
+                              TargetingPackName="Microsoft.Windows.SDK.NET.Ref"
+                              TargetingPackVersion="$(MicrosoftWindowsSDKNETRef10_0_17763PackageVersion)"
+                              RuntimePackAlwaysCopyLocal="true"
+                              RuntimePackNamePatterns="Microsoft.Windows.SDK.NET.Ref"
+                              RuntimePackRuntimeIdentifiers="any"
+                              IsWindowsOnly="true"
+                              />
+
+    <KnownFrameworkReference Include="Microsoft.Windows.SDK.NET.Ref"
+                              TargetFramework="net6.0-windows10.0.18362.0"
+                              RuntimeFrameworkName="Microsoft.Windows.SDK.NET.Ref"
+                              DefaultRuntimeFrameworkVersion="$(MicrosoftWindowsSDKNETRef10_0_18362PackageVersion)"
+                              LatestRuntimeFrameworkVersion="$(MicrosoftWindowsSDKNETRef10_0_18362PackageVersion)"
+                              TargetingPackName="Microsoft.Windows.SDK.NET.Ref"
+                              TargetingPackVersion="$(MicrosoftWindowsSDKNETRef10_0_18362PackageVersion)"
+                              RuntimePackAlwaysCopyLocal="true"
+                              RuntimePackNamePatterns="Microsoft.Windows.SDK.NET.Ref"
+                              RuntimePackRuntimeIdentifiers="any"
+                              IsWindowsOnly="true"
+                              />
+
+    <KnownFrameworkReference Include="Microsoft.Windows.SDK.NET.Ref"
+                              TargetFramework="net6.0-windows10.0.19041.0"
+                              RuntimeFrameworkName="Microsoft.Windows.SDK.NET.Ref"
+                              DefaultRuntimeFrameworkVersion="$(MicrosoftWindowsSDKNETRef10_0_19041PackageVersion)"
+                              LatestRuntimeFrameworkVersion="$(MicrosoftWindowsSDKNETRef10_0_19041PackageVersion)"
+                              TargetingPackName="Microsoft.Windows.SDK.NET.Ref"
+                              TargetingPackVersion="$(MicrosoftWindowsSDKNETRef10_0_19041PackageVersion)"
+                              RuntimePackAlwaysCopyLocal="true"
+                              RuntimePackNamePatterns="Microsoft.Windows.SDK.NET.Ref"
+                              RuntimePackRuntimeIdentifiers="any"
+                              IsWindowsOnly="true"
+                              />
+
+    <!-- .NET 5.0 -->
+    <KnownFrameworkReference Include="Microsoft.NETCore.App"
+                              TargetFramework="netcoreapp5.0"
+                              RuntimeFrameworkName="Microsoft.NETCore.App"
+                              DefaultRuntimeFrameworkVersion="5.0.0"
+                              LatestRuntimeFrameworkVersion="$(_NET50RuntimePackVersion)"
+                              TargetingPackName="Microsoft.NETCore.App.Ref"
+                              TargetingPackVersion="$(_NET50TargetingPackVersion)"
+                              RuntimePackNamePatterns="Microsoft.NETCore.App.Runtime.**RID**"
+                              RuntimePackRuntimeIdentifiers="@(Net50RuntimePackRids, '%3B')"
+                              IsTrimmable="true"
+                              />
+
+    <KnownAppHostPack Include="Microsoft.NETCore.App"
+                      TargetFramework="netcoreapp5.0"
+                      AppHostPackNamePattern="Microsoft.NETCore.App.Host.**RID**"
+                      AppHostPackVersion="$(_NET50RuntimePackVersion)"
+                      AppHostRuntimeIdentifiers="@(Net50AppHostRids, '%3B')"
+                      />
+
+    <KnownCrossgen2Pack Include="Microsoft.NETCore.App.Crossgen2"
+                        TargetFramework="netcoreapp5.0"
+                        Crossgen2PackNamePattern="Microsoft.NETCore.App.Crossgen2.**RID**"
+                        Crossgen2PackVersion="$(_NET50RuntimePackVersion)"
+                        Crossgen2RuntimeIdentifiers="@(Net50Crossgen2SupportedRids, '%3B')"
+                        />
+    
+    <KnownFrameworkReference Include="Microsoft.WindowsDesktop.App"
+                              TargetFramework="netcoreapp5.0"
+                              RuntimeFrameworkName="Microsoft.WindowsDesktop.App"
+                              DefaultRuntimeFrameworkVersion="5.0.0"
+                              LatestRuntimeFrameworkVersion="$(_WindowsDesktop50RuntimePackVersion)"
+                              TargetingPackName="Microsoft.WindowsDesktop.App.Ref"
+                              TargetingPackVersion="$(_WindowsDesktop50TargetingPackVersion)"
+                              RuntimePackNamePatterns="Microsoft.WindowsDesktop.App.Runtime.**RID**"
+                              RuntimePackRuntimeIdentifiers="@(WindowsDesktop50RuntimePackRids, '%3B')"
+                              IsWindowsOnly="true"
+                              />
+
+    <KnownFrameworkReference Include="Microsoft.WindowsDesktop.App.WPF"
+                              TargetFramework="netcoreapp5.0"
+                              RuntimeFrameworkName="Microsoft.WindowsDesktop.App"
+                              DefaultRuntimeFrameworkVersion="5.0.0"
+                              LatestRuntimeFrameworkVersion="$(_WindowsDesktop50RuntimePackVersion)"
+                              TargetingPackName="Microsoft.WindowsDesktop.App.Ref"
+                              TargetingPackVersion="$(_WindowsDesktop50TargetingPackVersion)"
+                              RuntimePackNamePatterns="Microsoft.WindowsDesktop.App.Runtime.**RID**"
+                              RuntimePackRuntimeIdentifiers="@(WindowsDesktop50RuntimePackRids, '%3B')"
+                              IsWindowsOnly="true"
+                              Profile="WPF"
+                              />
+
+    <KnownFrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms"
+                              TargetFramework="netcoreapp5.0"
+                              RuntimeFrameworkName="Microsoft.WindowsDesktop.App"
+                              DefaultRuntimeFrameworkVersion="5.0.0"
+                              LatestRuntimeFrameworkVersion="$(_WindowsDesktop50RuntimePackVersion)"
+                              TargetingPackName="Microsoft.WindowsDesktop.App.Ref"
+                              TargetingPackVersion="$(_WindowsDesktop50TargetingPackVersion)"
+                              RuntimePackNamePatterns="Microsoft.WindowsDesktop.App.Runtime.**RID**"
+                              RuntimePackRuntimeIdentifiers="@(WindowsDesktopRuntimePackWinformsRids, '%3B')"
+                              IsWindowsOnly="true"
+                              Profile="WindowsForms"
+                              />
+
+    <KnownFrameworkReference Include="Microsoft.AspNetCore.App"
+                              TargetFramework="netcoreapp5.0"
+                              RuntimeFrameworkName="Microsoft.AspNetCore.App"
+                              DefaultRuntimeFrameworkVersion="5.0.0"
+                              LatestRuntimeFrameworkVersion="$(_AspNet50RuntimePackVersion)"
+                              TargetingPackName="Microsoft.AspNetCore.App.Ref"
+                              TargetingPackVersion="$(_AspNet50TargetingPackVersion)"
                               RuntimePackNamePatterns="Microsoft.AspNetCore.App.Runtime.**RID**"
                               RuntimePackRuntimeIdentifiers="@(AspNetCore50RuntimePackRids, '%3B')"
                               />

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -29,10 +29,13 @@
       <_NETCorePlatformsPackageVersion>$(MicrosoftNETCorePlatformsPackageVersion)</_NETCorePlatformsPackageVersion>
 
       <!-- TODO: Once .NET 5.0 has released, update these version numbers to 5.0.0 -->
+      <_NET50DefaultRuntimeFrameworkVersion>5.0.0-rc.2.20475.5</_NET50DefaultRuntimeFrameworkVersion>
       <_NET50RuntimePackVersion>5.0.0-rc.2.20475.5</_NET50RuntimePackVersion>
       <_NET50TargetingPackVersion>5.0.0-rc.2.20475.5</_NET50TargetingPackVersion>
+      <_WindowsDesktop50DefaultRuntimeFrameworkVersion>5.0.0-rc.2.20475.6</_WindowsDesktop50DefaultRuntimeFrameworkVersion>
       <_WindowsDesktop50RuntimePackVersion>5.0.0-rc.2.20475.6</_WindowsDesktop50RuntimePackVersion>
       <_WindowsDesktop50TargetingPackVersion>5.0.0-rc.2.20475.6</_WindowsDesktop50TargetingPackVersion>
+      <_AspNet50DefaultRuntimeFrameworkVersion>5.0.0-rc.2.20475.17</_AspNet50DefaultRuntimeFrameworkVersion>
       <_AspNet50RuntimePackVersion>5.0.0-rc.2.20475.17</_AspNet50RuntimePackVersion>
       <_AspNet50TargetingPackVersion>5.0.0-rc.2.20475.17</_AspNet50TargetingPackVersion>
 
@@ -331,7 +334,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <KnownFrameworkReference Include="Microsoft.NETCore.App"
                               TargetFramework="net5.0"
                               RuntimeFrameworkName="Microsoft.NETCore.App"
-                              DefaultRuntimeFrameworkVersion="5.0.0"
+                              DefaultRuntimeFrameworkVersion="$(_NET50DefaultRuntimeFrameworkVersion)"
                               LatestRuntimeFrameworkVersion="$(_NET50RuntimePackVersion)"
                               TargetingPackName="Microsoft.NETCore.App.Ref"
                               TargetingPackVersion="$(_NET50TargetingPackVersion)"
@@ -357,7 +360,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <KnownFrameworkReference Include="Microsoft.WindowsDesktop.App"
                               TargetFramework="net5.0"
                               RuntimeFrameworkName="Microsoft.WindowsDesktop.App"
-                              DefaultRuntimeFrameworkVersion="5.0.0"
+                              DefaultRuntimeFrameworkVersion="$(_WindowsDesktop50DefaultRuntimeFrameworkVersion)"
                               LatestRuntimeFrameworkVersion="$(_WindowsDesktop50RuntimePackVersion)"
                               TargetingPackName="Microsoft.WindowsDesktop.App.Ref"
                               TargetingPackVersion="$(_WindowsDesktop50TargetingPackVersion)"
@@ -369,7 +372,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <KnownFrameworkReference Include="Microsoft.WindowsDesktop.App.WPF"
                               TargetFramework="net5.0"
                               RuntimeFrameworkName="Microsoft.WindowsDesktop.App"
-                              DefaultRuntimeFrameworkVersion="5.0.0"
+                              DefaultRuntimeFrameworkVersion="$(_WindowsDesktop50DefaultRuntimeFrameworkVersion)"
                               LatestRuntimeFrameworkVersion="$(_WindowsDesktop50RuntimePackVersion)"
                               TargetingPackName="Microsoft.WindowsDesktop.App.Ref"
                               TargetingPackVersion="$(_WindowsDesktop50TargetingPackVersion)"
@@ -382,7 +385,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <KnownFrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms"
                               TargetFramework="net5.0"
                               RuntimeFrameworkName="Microsoft.WindowsDesktop.App"
-                              DefaultRuntimeFrameworkVersion="5.0.0"
+                              DefaultRuntimeFrameworkVersion="$(_WindowsDesktop50DefaultRuntimeFrameworkVersion)"
                               LatestRuntimeFrameworkVersion="$(_WindowsDesktop50RuntimePackVersion)"
                               TargetingPackName="Microsoft.WindowsDesktop.App.Ref"
                               TargetingPackVersion="$(_WindowsDesktop50TargetingPackVersion)"
@@ -395,7 +398,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <KnownFrameworkReference Include="Microsoft.AspNetCore.App"
                               TargetFramework="net5.0"
                               RuntimeFrameworkName="Microsoft.AspNetCore.App"
-                              DefaultRuntimeFrameworkVersion="5.0.0"
+                              DefaultRuntimeFrameworkVersion="$(_AspNet50DefaultRuntimeFrameworkVersion)"
                               LatestRuntimeFrameworkVersion="$(_AspNet50RuntimePackVersion)"
                               TargetingPackName="Microsoft.AspNetCore.App.Ref"
                               TargetingPackVersion="$(_AspNet50TargetingPackVersion)"

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -214,7 +214,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- .NET 6.0 -->
     <KnownFrameworkReference Include="Microsoft.NETCore.App"
-                              TargetFramework="netcoreapp6.0"
+                              TargetFramework="net6.0"
                               RuntimeFrameworkName="Microsoft.NETCore.App"
                               DefaultRuntimeFrameworkVersion="$(MicrosoftNETCoreAppDefaultRuntimeFrameworkVersion)"
                               LatestRuntimeFrameworkVersion="$(MicrosoftNETCoreAppRuntimePackageVersion)"
@@ -226,21 +226,21 @@ Copyright (c) .NET Foundation. All rights reserved.
                               />
 
     <KnownAppHostPack Include="Microsoft.NETCore.App"
-                      TargetFramework="netcoreapp6.0"
+                      TargetFramework="net6.0"
                       AppHostPackNamePattern="Microsoft.NETCore.App.Host.**RID**"
                       AppHostPackVersion="$(_NETCoreAppPackageVersion)"
                       AppHostRuntimeIdentifiers="@(NetCoreAppHostRids, '%3B')"
                       />
 
     <KnownCrossgen2Pack Include="Microsoft.NETCore.App.Crossgen2"
-                        TargetFramework="netcoreapp6.0"
+                        TargetFramework="net6.0"
                         Crossgen2PackNamePattern="Microsoft.NETCore.App.Crossgen2.**RID**"
                         Crossgen2PackVersion="$(MicrosoftNETCoreAppRuntimePackageVersion)"
                         Crossgen2RuntimeIdentifiers="@(Crossgen2SupportedRids, '%3B')"
                         />
     
     <KnownFrameworkReference Include="Microsoft.WindowsDesktop.App"
-                              TargetFramework="netcoreapp6.0"
+                              TargetFramework="net6.0"
                               RuntimeFrameworkName="Microsoft.WindowsDesktop.App"
                               DefaultRuntimeFrameworkVersion="$(MicrosoftWindowsDesktopAppDefaultRuntimeFrameworkVersion)"
                               LatestRuntimeFrameworkVersion="$(MicrosoftWindowsDesktopAppRuntimePackageVersion)"
@@ -252,7 +252,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                               />
 
     <KnownFrameworkReference Include="Microsoft.WindowsDesktop.App.WPF"
-                              TargetFramework="netcoreapp6.0"
+                              TargetFramework="net6.0"
                               RuntimeFrameworkName="Microsoft.WindowsDesktop.App"
                               DefaultRuntimeFrameworkVersion="$(MicrosoftWindowsDesktopAppDefaultRuntimeFrameworkVersion)"
                               LatestRuntimeFrameworkVersion="$(MicrosoftWindowsDesktopAppRuntimePackageVersion)"
@@ -265,7 +265,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                               />
 
     <KnownFrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms"
-                              TargetFramework="netcoreapp6.0"
+                              TargetFramework="net6.0"
                               RuntimeFrameworkName="Microsoft.WindowsDesktop.App"
                               DefaultRuntimeFrameworkVersion="$(MicrosoftWindowsDesktopAppDefaultRuntimeFrameworkVersion)"
                               LatestRuntimeFrameworkVersion="$(MicrosoftWindowsDesktopAppRuntimePackageVersion)"
@@ -278,7 +278,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                               />
 
     <KnownFrameworkReference Include="Microsoft.AspNetCore.App"
-                              TargetFramework="netcoreapp6.0"
+                              TargetFramework="net6.0"
                               RuntimeFrameworkName="Microsoft.AspNetCore.App"
                               DefaultRuntimeFrameworkVersion="$(MicrosoftAspNetCoreAppDefaultRuntimeFrameworkVersion)"
                               LatestRuntimeFrameworkVersion="$(MicrosoftAspNetCoreAppRuntimePackageVersion)"
@@ -329,7 +329,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- .NET 5.0 -->
     <KnownFrameworkReference Include="Microsoft.NETCore.App"
-                              TargetFramework="netcoreapp5.0"
+                              TargetFramework="net5.0"
                               RuntimeFrameworkName="Microsoft.NETCore.App"
                               DefaultRuntimeFrameworkVersion="5.0.0"
                               LatestRuntimeFrameworkVersion="$(_NET50RuntimePackVersion)"
@@ -341,21 +341,21 @@ Copyright (c) .NET Foundation. All rights reserved.
                               />
 
     <KnownAppHostPack Include="Microsoft.NETCore.App"
-                      TargetFramework="netcoreapp5.0"
+                      TargetFramework="net5.0"
                       AppHostPackNamePattern="Microsoft.NETCore.App.Host.**RID**"
                       AppHostPackVersion="$(_NET50RuntimePackVersion)"
                       AppHostRuntimeIdentifiers="@(Net50AppHostRids, '%3B')"
                       />
 
     <KnownCrossgen2Pack Include="Microsoft.NETCore.App.Crossgen2"
-                        TargetFramework="netcoreapp5.0"
+                        TargetFramework="net5.0"
                         Crossgen2PackNamePattern="Microsoft.NETCore.App.Crossgen2.**RID**"
                         Crossgen2PackVersion="$(_NET50RuntimePackVersion)"
                         Crossgen2RuntimeIdentifiers="@(Net50Crossgen2SupportedRids, '%3B')"
                         />
     
     <KnownFrameworkReference Include="Microsoft.WindowsDesktop.App"
-                              TargetFramework="netcoreapp5.0"
+                              TargetFramework="net5.0"
                               RuntimeFrameworkName="Microsoft.WindowsDesktop.App"
                               DefaultRuntimeFrameworkVersion="5.0.0"
                               LatestRuntimeFrameworkVersion="$(_WindowsDesktop50RuntimePackVersion)"
@@ -367,7 +367,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                               />
 
     <KnownFrameworkReference Include="Microsoft.WindowsDesktop.App.WPF"
-                              TargetFramework="netcoreapp5.0"
+                              TargetFramework="net5.0"
                               RuntimeFrameworkName="Microsoft.WindowsDesktop.App"
                               DefaultRuntimeFrameworkVersion="5.0.0"
                               LatestRuntimeFrameworkVersion="$(_WindowsDesktop50RuntimePackVersion)"
@@ -380,7 +380,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                               />
 
     <KnownFrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms"
-                              TargetFramework="netcoreapp5.0"
+                              TargetFramework="net5.0"
                               RuntimeFrameworkName="Microsoft.WindowsDesktop.App"
                               DefaultRuntimeFrameworkVersion="5.0.0"
                               LatestRuntimeFrameworkVersion="$(_WindowsDesktop50RuntimePackVersion)"
@@ -393,7 +393,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                               />
 
     <KnownFrameworkReference Include="Microsoft.AspNetCore.App"
-                              TargetFramework="netcoreapp5.0"
+                              TargetFramework="net5.0"
                               RuntimeFrameworkName="Microsoft.AspNetCore.App"
                               DefaultRuntimeFrameworkVersion="5.0.0"
                               LatestRuntimeFrameworkVersion="$(_AspNet50RuntimePackVersion)"

--- a/test/EndToEnd/GivenWeWantToRequireWindowsForDesktopApps.cs
+++ b/test/EndToEnd/GivenWeWantToRequireWindowsForDesktopApps.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.Tests.EndToEnd
         {
             var testProjectCreator = new TestProjectCreator()
             {
-                MinorVersion = "5.0"
+                MinorVersion = "6.0"
             };
 
             testProjectCreator.AdditionalProperties["RestorePackagesPath"] = @"$(MSBuildProjectDirectory)\packages";

--- a/test/EndToEnd/GivenWindowsApp.cs
+++ b/test/EndToEnd/GivenWindowsApp.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace EndToEnd
 {
-    public class GivenWindows50App : TestBase
+    public class GivenWindowsApp : TestBase
     {
         [WindowsOnlyTheory]
         [InlineData("10.0.17763.0")]

--- a/test/EndToEnd/ProjectBuildTests.cs
+++ b/test/EndToEnd/ProjectBuildTests.cs
@@ -13,6 +13,20 @@ namespace EndToEnd.Tests
 {
     public class ProjectBuildTests : TestBase
     {
+        //  TODO: Once console template is updated to target net6.0, remove this logic
+        void RetargetProject(string projectDirectory)
+        {
+            var projectFile = Directory.GetFiles(projectDirectory, "*.csproj").Single();
+
+            var projectXml = XDocument.Load(projectFile);
+            var ns = projectXml.Root.Name.Namespace;
+
+            projectXml.Root.Element(ns + "PropertyGroup")
+                .Element(ns + "TargetFramework").Value = "net6.0";
+
+            projectXml.Save(projectFile);
+        }
+
         [Fact]
         public void ItCanNewRestoreBuildRunCleanMSBuildProject()
         {
@@ -24,6 +38,8 @@ namespace EndToEnd.Tests
                 .WithWorkingDirectory(projectDirectory)
                 .Execute(newArgs)
                 .Should().Pass();
+
+            RetargetProject(projectDirectory);
 
             new RestoreCommand()
                 .WithWorkingDirectory(projectDirectory)
@@ -62,6 +78,8 @@ namespace EndToEnd.Tests
                 .WithWorkingDirectory(projectDirectory)
                 .Execute(newArgs)
                 .Should().Pass();
+
+            RetargetProject(projectDirectory);
 
             string projectPath = Path.Combine(projectDirectory, directory.Name + ".csproj");
 

--- a/test/EndToEnd/ProjectBuildTests.cs
+++ b/test/EndToEnd/ProjectBuildTests.cs
@@ -14,6 +14,7 @@ namespace EndToEnd.Tests
     public class ProjectBuildTests : TestBase
     {
         //  TODO: Once console template is updated to target net6.0, remove this logic
+        //  https://github.com/dotnet/installer/issues/8974
         void RetargetProject(string projectDirectory)
         {
             var projectFile = Directory.GetFiles(projectDirectory, "*.csproj").Single();

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Assertions/FileInfoAssertions.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Assertions/FileInfoAssertions.cs
@@ -40,16 +40,5 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
                 .FailWith($"Expected File {_fileInfo.FullName} to not exist, but it does.");
             return new AndConstraint<FileInfoAssertions>(this);
         }
-
-        public AndWhichConstraint<FileInfoAssertions, DateTimeOffset> HaveLastWriteTimeUtc(string because = "", params object[] reasonArgs)
-        {
-            var lastWriteTimeUtc = _fileInfo.LastWriteTimeUtc;
-
-            Execute.Assertion
-                .ForCondition(lastWriteTimeUtc != null)
-                .BecauseOf(because, reasonArgs) 
-                .FailWith($"Expected File {_fileInfo.FullName} to have a LastWriteTimeUTC, but it is null.");
-            return new AndWhichConstraint<FileInfoAssertions, DateTimeOffset>(this, lastWriteTimeUtc);
-        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/13950

This hardcodes the 5.0 versions to the RC2 versions, we will need to update those once 5.0 is released.