### PR TITLE
Fix broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Installers and Binaries
 You can download the .NET Core SDK as either an installer (MSI, PKG) or a zip (zip, tar.gz). The .NET Core SDK contains both the .NET Core runtime and CLI tools.
 
 **Note:** Be aware that the following installers are the **latest bits**. If you
-want to install the latest released versions, check out the [preceding section](#looking-for-v2-of-the-net-core-tooling).
+want to install the latest released versions, check out the [preceding section](#looking-for-released-versions-of-the-net-core-tooling).
 With development builds, internal NuGet feeds are necessary for some scenarios (for example, to acquire the runtime pack for self-contained apps). You can use the following NuGet.config to configure these feeds. See the following document [Configuring NuGet behavior](https://docs.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior) for more information on where to modify your NuGet.config to apply the changes.
 > Example:
 


### PR DESCRIPTION
Fix broken link to download .NET Core tooling latest releases in readme file.