### PR TITLE
Enable Apple Silicon SDK builds

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -268,13 +268,21 @@ stages:
     parameters:
       agentOs: Darwin
       pool: 
-        name: Hosted macOS
+        vmImage: 'macOS-10.15'
       timeoutInMinutes: 180
       strategy:
         matrix:
-          Build_Release:
+          Build_Release_x64:
             _BuildConfig: Release
+            _RuntimeIdentifier: ''
+            _BuildArchitecture: 'x64'
             _TestArg: $(_NonWindowsTestArg)
+          Build_Release_arm64:
+            _BuildConfig: Release
+            _RuntimeIdentifier: '--runtime-id osx-arm64'
+            _BuildArchitecture: 'arm64'
+            # Never run tests on arm64
+            _TestArg: ''
 
   # https://github.com/dotnet/core-sdk/issues/248
   # - template: /eng/build.yml
@@ -286,6 +294,7 @@ stages:
   #       matrix:
   #         Build_Release:
   #           _BuildConfig: Release
+  #           _BuildArchitecture: 'x64'
   #           _AdditionalBuildParameters: '/p:DisableSourceLink=true /p:DISABLE_CROSSGEN=true'
 
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ With development builds, internal NuGet feeds are necessary for some scenarios (
 | **Linux-musl-arm** | [![][linux-musl-arm-badge-master]][linux-musl-arm-version-master]<br>[tar.gz][linux-musl-arm-targz-master] - [Checksum][linux-musl-arm-targz-checksum-master] | **N/A** | **N/A** | **N/A** | **N/A** |
 | **Linux-musl-arm64** | [![][linux-musl-arm64-badge-master]][linux-musl-arm64-version-master]<br>[tar.gz][linux-musl-arm64-targz-master] - [Checksum][linux-musl-arm64-targz-checksum-master] | **N/A** | **N/A** | **N/A** | **N/A** |
 | **RHEL 6** | **N/A** | **N/A** | **N/A** | [![][rhel-6-badge-3.1.4XX]][rhel-6-version-3.1.4XX]<br>[tar.gz][rhel-6-targz-3.1.4XX] - [Checksum][rhel-6-targz-checksum-3.1.4XX] | [![][rhel-6-badge-3.1.1XX]][rhel-6-version-3.1.1XX]<br>[tar.gz][rhel-6-targz-3.1.1XX] - [Checksum][rhel-6-targz-checksum-3.1.1XX] |
-| **macOS** | [![][osx-badge-master]][osx-version-master]<br>[Installer][osx-installer-master] - [Checksum][osx-installer-checksum-master]<br>[tar.gz][osx-targz-master] - [Checksum][osx-targz-checksum-master] | [![][osx-badge-5.0.2XX]][osx-version-5.0.2XX]<br>[Installer][osx-installer-5.0.2XX] - [Checksum][osx-installer-checksum-5.0.2XX]<br>[tar.gz][osx-targz-5.0.2XX] - [Checksum][osx-targz-checksum-5.0.2XX] | [![][osx-badge-5.0.1XX-rtm]][osx-version-5.0.1XX-rtm]<br>[Installer][osx-installer-5.0.1XX-rtm] - [Checksum][osx-installer-checksum-5.0.1XX-rtm]<br>[tar.gz][osx-targz-5.0.1XX-rtm] - [Checksum][osx-targz-checksum-5.0.1XX-rtm] | [![][osx-badge-3.1.4XX]][osx-version-3.1.4XX]<br>[Installer][osx-installer-3.1.4XX] - [Checksum][osx-installer-checksum-3.1.4XX]<br>[tar.gz][osx-targz-3.1.4XX] - [Checksum][osx-targz-checksum-3.1.4XX] | [![][osx-badge-3.1.1XX]][osx-version-3.1.1XX]<br>[Installer][osx-installer-3.1.1XX] - [Checksum][osx-installer-checksum-3.1.1XX]<br>[tar.gz][osx-targz-3.1.1XX] - [Checksum][osx-targz-checksum-3.1.1XX] |
+| **macOS x64** | [![][osx-x64-badge-master]][osx-x64-version-master]<br>[Installer][osx-x64-installer-master] - [Checksum][osx-x64-installer-checksum-master]<br>[tar.gz][osx-x64-targz-master] - [Checksum][osx-x64-targz-checksum-master] | [![][osx-x64-badge-5.0.2XX]][osx-x64-version-5.0.2XX]<br>[Installer][osx-x64-installer-5.0.2XX] - [Checksum][osx-x64-installer-checksum-5.0.2XX]<br>[tar.gz][osx-x64-targz-5.0.2XX] - [Checksum][osx-x64-targz-checksum-5.0.2XX] | [![][osx-x64-badge-5.0.1XX-rtm]][osx-x64-version-5.0.1XX-rtm]<br>[Installer][osx-x64-installer-5.0.1XX-rtm] - [Checksum][osx-x64-installer-checksum-5.0.1XX-rtm]<br>[tar.gz][osx-x64-targz-5.0.1XX-rtm] - [Checksum][osx-x64-targz-checksum-5.0.1XX-rtm] | [![][osx-x64-badge-3.1.4XX]][osx-x64-version-3.1.4XX]<br>[Installer][osx-x64-installer-3.1.4XX] - [Checksum][osx-x64-installer-checksum-3.1.4XX]<br>[tar.gz][osx-x64-targz-3.1.4XX] - [Checksum][osx-x64-targz-checksum-3.1.4XX] | [![][osx-x64-badge-3.1.1XX]][osx-x64-version-3.1.1XX]<br>[Installer][osx-x64-installer-3.1.1XX] - [Checksum][osx-x64-installer-checksum-3.1.1XX]<br>[tar.gz][osx-x64-targz-3.1.1XX] - [Checksum][osx-x64-targz-checksum-3.1.1XX] |
+| **macOS arm64** | [![][osx-arm64-badge-master]][osx-arm64-version-master]<br>[Installer][osx-arm64-installer-master] - [Checksum][osx-arm64-installer-checksum-master]<br>[tar.gz][osx-arm64-targz-master] - [Checksum][osx-arm64-targz-checksum-master] | **N/A** | **N/A** | **N/A** | **N/A** |
 
 Reference notes:
 > **1**: Our Debian packages are put together slightly differently than the other OS specific installers. Instead of combining everything, we have separate component packages that depend on each other. If you're installing the SDK from the .deb file (via dpkg or similar), then you'll need to install the corresponding dependencies first:
@@ -159,40 +160,47 @@ Reference notes:
 [win-x86-zip-3.1.1XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/dotnet-sdk-latest-win-x86.zip
 [win-x86-zip-checksum-3.1.1XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/dotnet-sdk-latest-win-x86.zip.sha
 
-[osx-badge-master]: https://aka.ms/dotnet/net6/dev/Sdk/osx_x64_Release_version_badge.svg
-[osx-version-master]: https://aka.ms/dotnet/net6/dev/Sdk/productCommit-osx-x64.txt
-[osx-installer-master]: https://aka.ms/dotnet/net6/dev/Sdk/dotnet-sdk-osx-x64.pkg
-[osx-installer-checksum-master]: https://aka.ms/dotnet/net6/dev/Sdk/dotnet-sdk-osx-x64.pkg.sha
-[osx-targz-master]: https://aka.ms/dotnet/net6/dev/Sdk/dotnet-sdk-osx-x64.tar.gz
-[osx-targz-checksum-master]: https://aka.ms/dotnet/net6/dev/Sdk/dotnet-sdk-osx-x64.pkg.tar.gz.sha
+[osx-x64-badge-master]: https://aka.ms/dotnet/net6/dev/Sdk/osx_x64_Release_version_badge.svg
+[osx-x64-version-master]: https://aka.ms/dotnet/net6/dev/Sdk/productCommit-osx-x64.txt
+[osx-x64-installer-master]: https://aka.ms/dotnet/net6/dev/Sdk/dotnet-sdk-osx-x64.pkg
+[osx-x64-installer-checksum-master]: https://aka.ms/dotnet/net6/dev/Sdk/dotnet-sdk-osx-x64.pkg.sha
+[osx-x64-targz-master]: https://aka.ms/dotnet/net6/dev/Sdk/dotnet-sdk-osx-x64.tar.gz
+[osx-x64-targz-checksum-master]: https://aka.ms/dotnet/net6/dev/Sdk/dotnet-sdk-osx-x64.pkg.tar.gz.sha
 
-[osx-badge-5.0.2XX]: https://aka.ms/dotnet/net5/5.0.2xx/daily/Sdk/osx_x64_Release_version_badge.svg
-[osx-version-5.0.2XX]: https://aka.ms/dotnet/net5/5.0.2xx/daily/Sdk/productCommit-osx-x64.txt
-[osx-installer-5.0.2XX]: https://aka.ms/dotnet/net5/5.0.2xx/daily/Sdk/dotnet-sdk-osx-x64.pkg
-[osx-installer-checksum-5.0.2XX]: https://aka.ms/dotnet/net5/5.0.2xx/daily/Sdk/dotnet-sdk-osx-x64.pkg.sha
-[osx-targz-5.0.2XX]: https://aka.ms/dotnet/net5/5.0.2xx/daily/Sdk/dotnet-sdk-osx-x64.tar.gz
-[osx-targz-checksum-5.0.2XX]: https://aka.ms/dotnet/net5/5.0.2xx/daily/Sdk/dotnet-sdk-osx-x64.pkg.tar.gz.sha
+[osx-x64-badge-5.0.2XX]: https://aka.ms/dotnet/net5/5.0.2xx/daily/Sdk/osx_x64_Release_version_badge.svg
+[osx-x64-version-5.0.2XX]: https://aka.ms/dotnet/net5/5.0.2xx/daily/Sdk/productCommit-osx-x64.txt
+[osx-x64-installer-5.0.2XX]: https://aka.ms/dotnet/net5/5.0.2xx/daily/Sdk/dotnet-sdk-osx-x64.pkg
+[osx-x64-installer-checksum-5.0.2XX]: https://aka.ms/dotnet/net5/5.0.2xx/daily/Sdk/dotnet-sdk-osx-x64.pkg.sha
+[osx-x64-targz-5.0.2XX]: https://aka.ms/dotnet/net5/5.0.2xx/daily/Sdk/dotnet-sdk-osx-x64.tar.gz
+[osx-x64-targz-checksum-5.0.2XX]: https://aka.ms/dotnet/net5/5.0.2xx/daily/Sdk/dotnet-sdk-osx-x64.pkg.tar.gz.sha
 
-[osx-badge-5.0.1XX-rtm]: https://aka.ms/dotnet/net5/5.0.1xx/daily/Sdk/osx_x64_Release_version_badge.svg
-[osx-version-5.0.1XX-rtm]: https://aka.ms/dotnet/net5/5.0.1xx/daily/Sdk/productCommit-osx-x64.txt
-[osx-installer-5.0.1XX-rtm]: https://aka.ms/dotnet/net5/5.0.1xx/daily/Sdk/dotnet-sdk-osx-x64.pkg
-[osx-installer-checksum-5.0.1XX-rtm]: https://aka.ms/dotnet/net5/5.0.1xx/daily/Sdk/dotnet-sdk-osx-x64.pkg.sha
-[osx-targz-5.0.1XX-rtm]: https://aka.ms/dotnet/net5/5.0.1xx/daily/Sdk/dotnet-sdk-osx-x64.tar.gz
-[osx-targz-checksum-5.0.1XX-rtm]: https://aka.ms/dotnet/net5/5.0.1xx/daily/Sdk/dotnet-sdk-osx-x64.pkg.tar.gz.sha
+[osx-x64-badge-5.0.1XX-rtm]: https://aka.ms/dotnet/net5/5.0.1xx/daily/Sdk/osx_x64_Release_version_badge.svg
+[osx-x64-version-5.0.1XX-rtm]: https://aka.ms/dotnet/net5/5.0.1xx/daily/Sdk/productCommit-osx-x64.txt
+[osx-x64-installer-5.0.1XX-rtm]: https://aka.ms/dotnet/net5/5.0.1xx/daily/Sdk/dotnet-sdk-osx-x64.pkg
+[osx-x64-installer-checksum-5.0.1XX-rtm]: https://aka.ms/dotnet/net5/5.0.1xx/daily/Sdk/dotnet-sdk-osx-x64.pkg.sha
+[osx-x64-targz-5.0.1XX-rtm]: https://aka.ms/dotnet/net5/5.0.1xx/daily/Sdk/dotnet-sdk-osx-x64.tar.gz
+[osx-x64-targz-checksum-5.0.1XX-rtm]: https://aka.ms/dotnet/net5/5.0.1xx/daily/Sdk/dotnet-sdk-osx-x64.pkg.tar.gz.sha
 
-[osx-badge-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/osx_x64_Release_version_badge.svg
-[osx-version-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/latest.version
-[osx-installer-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-osx-x64.pkg
-[osx-installer-checksum-3.1.4XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-osx-x64.pkg.sha
-[osx-targz-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-osx-x64.tar.gz
-[osx-targz-checksum-3.1.4XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-osx-x64.tar.gz.sha
+[osx-x64-badge-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/osx_x64_Release_version_badge.svg
+[osx-x64-version-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/latest.version
+[osx-x64-installer-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-osx-x64.pkg
+[osx-x64-installer-checksum-3.1.4XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-osx-x64.pkg.sha
+[osx-x64-targz-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-osx-x64.tar.gz
+[osx-x64-targz-checksum-3.1.4XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-osx-x64.tar.gz.sha
 
-[osx-badge-3.1.1XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/osx_x64_Release_version_badge.svg
-[osx-version-3.1.1XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/latest.version
-[osx-installer-3.1.1XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/dotnet-sdk-latest-osx-x64.pkg
-[osx-installer-checksum-3.1.1XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/dotnet-sdk-latest-osx-x64.pkg.sha
-[osx-targz-3.1.1XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/dotnet-sdk-latest-osx-x64.tar.gz
-[osx-targz-checksum-3.1.1XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/dotnet-sdk-latest-osx-x64.tar.gz.sha
+[osx-x64-badge-3.1.1XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/osx_x64_Release_version_badge.svg
+[osx-x64-version-3.1.1XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/latest.version
+[osx-x64-installer-3.1.1XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/dotnet-sdk-latest-osx-x64.pkg
+[osx-x64-installer-checksum-3.1.1XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/dotnet-sdk-latest-osx-x64.pkg.sha
+[osx-x64-targz-3.1.1XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/dotnet-sdk-latest-osx-x64.tar.gz
+[osx-x64-targz-checksum-3.1.1XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/dotnet-sdk-latest-osx-x64.tar.gz.sha
+
+[osx-arm64-badge-master]: https://aka.ms/dotnet/net6/dev/Sdk/osx_arm64_Release_version_badge.svg
+[osx-arm64-version-master]: https://aka.ms/dotnet/net6/dev/Sdk/productCommit-osx-arm64.txt
+[osx-arm64-installer-master]: https://aka.ms/dotnet/net6/dev/Sdk/dotnet-sdk-osx-arm64.pkg
+[osx-arm64-installer-checksum-master]: https://aka.ms/dotnet/net6/dev/Sdk/dotnet-sdk-osx-arm64.pkg.sha
+[osx-arm64-targz-master]: https://aka.ms/dotnet/net6/dev/Sdk/dotnet-sdk-osx-arm64.tar.gz
+[osx-arm64-targz-checksum-master]: https://aka.ms/dotnet/net6/dev/Sdk/dotnet-sdk-osx-arm64.pkg.tar.gz.sha
 
 [linux-badge-master]: https://aka.ms/dotnet/net6/dev/Sdk/linux_x64_Release_version_badge.svg
 [linux-version-master]: https://aka.ms/dotnet/net6/dev/Sdk/productCommit-linux-x64.txt

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -117,6 +117,8 @@ phases:
                   --pack --publish --ci
                   --noprettyprint
                   --configuration $(_BuildConfig)
+                  --architecture $(_BuildArchitecture)
+                  $(_RuntimeIdentifier)
                   $(_BuildArgs)
                   $(_AdditionalBuildParameters)
         displayName: Build

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -97,8 +97,8 @@
           browser-wasm;
           " />
 
-      <NetCoreAppHostRids Include="@(Net50AppHostRids)" />
-      <NetCoreRuntimePackRids Include="@(Net50RuntimePackRids)" />
+      <NetCoreAppHostRids Include="@(Net50AppHostRids);osx-arm64" />
+      <NetCoreRuntimePackRids Include="@(Net50RuntimePackRids);osx-arm64" />
 
       <AspNetCore30RuntimePackRids Include="
         win-x64;
@@ -117,7 +117,7 @@
 
       <AspNetCore31RuntimePackRids Include="@(AspNetCore30RuntimePackRids)" />
       <AspNetCore50RuntimePackRids Include="@(AspNetCore31RuntimePackRids);linux-musl-arm;win-arm64" />
-      <AspNetCoreRuntimePackRids Include="@(AspNetCore50RuntimePackRids)" />
+      <AspNetCoreRuntimePackRids Include="@(AspNetCore50RuntimePackRids)" /><!-- Add ;osx-arm64 when bits are available -->
 
       <WindowsDesktop30RuntimePackRids Include="win-x64;win-x86" />
       <WindowsDesktop31RuntimePackRids Include="@(WindowsDesktop30RuntimePackRids)" />

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -117,7 +117,7 @@
 
       <AspNetCore31RuntimePackRids Include="@(AspNetCore30RuntimePackRids)" />
       <AspNetCore50RuntimePackRids Include="@(AspNetCore31RuntimePackRids);linux-musl-arm;win-arm64" />
-      <AspNetCoreRuntimePackRids Include="@(AspNetCore50RuntimePackRids)" /><!-- Add ;osx-arm64 when bits are available -->
+      <AspNetCoreRuntimePackRids Include="@(AspNetCore50RuntimePackRids);osx-arm64" />
 
       <WindowsDesktop30RuntimePackRids Include="win-x64;win-x86" />
       <WindowsDesktop31RuntimePackRids Include="@(WindowsDesktop30RuntimePackRids)" />

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -164,25 +164,25 @@
       </BundledInstallerComponent>
 
       <BundledInstallerComponent Include="DownloadedSharedFrameworkInstallerFile"
-                                 Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64')">
+                                 Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64' or '$(Rid)' == 'osx-arm64')">
         <BaseUrl>$(CoreSetupRootUrl)$(CoreSetupBlobVersion)</BaseUrl>
         <DownloadFileName>$(DownloadedSharedFrameworkInstallerFileName)</DownloadFileName>
       </BundledInstallerComponent>
 
       <BundledInstallerComponent Include="DownloadedSharedHostInstallerFile"
-                                 Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64')">
+                                 Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64' or '$(Rid)' == 'osx-arm64')">
         <BaseUrl>$(CoreSetupRootUrl)$(CoreSetupBlobVersion)</BaseUrl>
         <DownloadFileName>$(DownloadedSharedHostInstallerFileName)</DownloadFileName>
       </BundledInstallerComponent>
 
       <BundledInstallerComponent Include="DownloadedHostFxrInstallerFile"
-                                 Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64')">
+                                 Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64' or '$(Rid)' == 'osx-arm64')">
         <BaseUrl>$(CoreSetupRootUrl)$(CoreSetupBlobVersion)</BaseUrl>
         <DownloadFileName>$(DownloadedHostFxrInstallerFileName)</DownloadFileName>
       </BundledInstallerComponent>
 
       <BundledInstallerComponent Include="DownloadedNetCoreAppTargetingPackInstallerFile"
-                                 Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64')">
+                                 Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64' or '$(Rid)' == 'osx-arm64')">
         <BaseUrl>$(CoreSetupRootUrl)$(NETCoreAppTargetingPackBlobVersion)</BaseUrl>
         <DownloadFileName>$(DownloadedNetCoreAppTargetingPackInstallerFileName)</DownloadFileName>
       </BundledInstallerComponent>
@@ -196,7 +196,7 @@
       </BundledInstallerComponent>
 
       <BundledInstallerComponent Include="DownloadedNetCoreAppHostPackInstallerFile"
-                     Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64')">
+                     Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64' or '$(Rid)' == 'osx-arm64')">
         <BaseUrl>$(CoreSetupRootUrl)$(CoreSetupBlobVersion)</BaseUrl>
         <DownloadFileName>$(DownloadedNetCoreAppHostPackInstallerFileName)</DownloadFileName>
       </BundledInstallerComponent>
@@ -242,7 +242,7 @@
       <!-- The AspNet does not provide native MacOS PKG installers at this time; we use AspNet archives.
            https://github.com/aspnet/AspNetCore/issues/8806 -->
       <BundledLayoutComponent Include="DownloadedAspNetTargetingPackArchiveFile"
-                              Condition="'$(InstallerExtension)' == '.pkg' And '$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And !$(Architecture.StartsWith('arm'))">
+                              Condition="'$(InstallerExtension)' == '.pkg' And '$(SkipBuildingInstallers)' != 'true' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'osx-arm64')">
         <BaseUrl>$(AspNetCoreSharedFxRootUrl)$(AspNetCoreTargetingPackBlobVersion)</BaseUrl>
         <DownloadFileName>$(AspNetTargetingPackArchiveFileName)</DownloadFileName>
         <RelativeLayoutPath></RelativeLayoutPath>
@@ -273,7 +273,7 @@
       </BundledInstallerComponent>
 
       <BundledInstallerComponent Include="AspNetCoreSharedFxBaseRuntimeVersionFile"
-                                 Condition="!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64'">
+                                 Condition="!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64' or '$(Rid)' == 'osx-arm64'">
         <BaseUrl>$(AspNetCoreSharedFxRootUrl)$(AspNetCoreBlobVersion)</BaseUrl>
         <DownloadFileName>$(AspNetCoreSharedFxBaseRuntimeVersionFileName)</DownloadFileName>
       </BundledInstallerComponent>
@@ -299,7 +299,7 @@
       </BundledLayoutComponent>
 
       <BundledInstallerComponent Include="DownloadedWinFormsAndWpfSharedFrameworkInstallerFile"
-                                 Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64')">
+                                 Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64' or '$(Rid)' == 'osx-arm64')">
         <BaseUrl>$(WinFormsAndWpfSharedFxRootUrl)$(WindowsDesktopBlobVersion)</BaseUrl>
         <DownloadFileName>$(DownloadedWinFormsAndWpfSharedFrameworkInstallerFileName)</DownloadFileName>
       </BundledInstallerComponent>

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -59,6 +59,11 @@
       <DownloadedArm64NetCoreAppHostPackInstallerFileName Condition=" '$(InstallerExtension)' != '' ">dotnet-apphost-pack-$(MicrosoftNETCoreAppHostPackageVersion)-$(SharedFrameworkInstallerFileRid)_arm64$(InstallerExtension)</DownloadedArm64NetCoreAppHostPackInstallerFileName>
       <DownloadedWindowsDesktopTargetingPackInstallerFileName Condition=" '$(InstallerExtension)' != '' ">windowsdesktop-targeting-pack-$(MicrosoftWindowsDesktopAppRefPackageVersion)-$(SharedFrameworkInstallerFileRid)$(InstallerExtension)</DownloadedWindowsDesktopTargetingPackInstallerFileName>
       <DownloadedNetStandardTargetingPackInstallerFileName Condition=" '$(InstallerExtension)' != '' ">netstandard-targeting-pack-$(NETStandardLibraryRefPackageVersion)-$(SharedFrameworkInstallerFileRid)$(InstallerExtension)</DownloadedNetStandardTargetingPackInstallerFileName>
+      <!-- osx-arm64 netstandard targeting pack pkg is unavailable. Use osx-x64.
+          This should be OK, because the package is just a compressed file containing reference assemblies and
+          runtime independent manifest text files.
+      -->
+      <DownloadedNetStandardTargetingPackInstallerFileName Condition="'$(SharedFrameworkInstallerFileRid)' == 'osx-arm64'">netstandard-targeting-pack-$(NETStandardLibraryRefPackageVersion)-osx-x64$(InstallerExtension)</DownloadedNetStandardTargetingPackInstallerFileName>
       <NetStandardTargetingPackTargetFramework>netstandard$(NETStandardLibraryRefPackageVersion.Split('.')[0])$(NETStandardLibraryRefPackageVersion.Split('.')[1])</NetStandardTargetingPackTargetFramework>
 
       <!-- Use the portable "linux-x64" Rid when downloading Linux shared framework compressed file. -->
@@ -189,7 +194,7 @@
 
       <!-- TODO: Should we somehow obtain a .NET Standard ARM64 package? -->
       <BundledInstallerComponent Include="DownloadedNetStandardTargetingPackInstallerFile"
-                           Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And !$(Architecture.StartsWith('arm'))">
+                           Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'osx-arm64')">
         <BaseUrl>$(CoreSetupRootUrl)$(NETCoreAppTargetingPackBlobVersion)</BaseUrl>
         <BaseUrl>$(CoreSetupRootUrl)3.0.0</BaseUrl>
         <DownloadFileName>$(DownloadedNetStandardTargetingPackInstallerFileName)</DownloadFileName>

--- a/src/redist/targets/GeneratePKG.targets
+++ b/src/redist/targets/GeneratePKG.targets
@@ -4,14 +4,14 @@
       <PkgIntermediateDirectory>$(IntermediateOutputPath)pkgs/$(Version)</PkgIntermediateDirectory>
 
       <!-- Properties for pkg build -->
-      <SharedHostComponentId>com.microsoft.dotnet.sharedhost.$(SharedHostVersion).component.osx.x64</SharedHostComponentId>
-      <HostFxrComponentId>com.microsoft.dotnet.hostfxr.$(HostFxrVersion).component.osx.x64</HostFxrComponentId>
-      <SharedFrameworkComponentId>com.microsoft.dotnet.sharedframework.$(SharedFrameworkNugetName).$(MicrosoftNETCoreAppPackageVersion).component.osx.x64</SharedFrameworkComponentId>
-      <NetCoreAppTargetingPackComponentId>com.microsoft.dotnet.pack.targeting.$(MicrosoftNETCoreAppRefPackageVersion).component.osx.x64</NetCoreAppTargetingPackComponentId>
-      <NetCoreAppHostPackComponentId>com.microsoft.dotnet.pack.apphost.$(MicrosoftNETCoreAppHostPackageVersion).component.osx.x64</NetCoreAppHostPackComponentId>
-      <NetStandardTargetingPackComponentId>com.microsoft.standard.pack.targeting.$(NETStandardLibraryRefPackageVersion).component.osx.x64</NetStandardTargetingPackComponentId>
-      <SdkComponentId>com.microsoft.dotnet.dev.$(Version).component.osx.x64</SdkComponentId>
-      <SdkProductArchiveId>com.microsoft.dotnet.dev.$(Version).osx.x64</SdkProductArchiveId>
+      <SharedHostComponentId>com.microsoft.dotnet.sharedhost.$(SharedHostVersion).component.osx.$(Architecture)</SharedHostComponentId>
+      <HostFxrComponentId>com.microsoft.dotnet.hostfxr.$(HostFxrVersion).component.osx.$(Architecture)</HostFxrComponentId>
+      <SharedFrameworkComponentId>com.microsoft.dotnet.sharedframework.$(SharedFrameworkNugetName).$(MicrosoftNETCoreAppPackageVersion).component.osx.$(Architecture)</SharedFrameworkComponentId>
+      <NetCoreAppTargetingPackComponentId>com.microsoft.dotnet.pack.targeting.$(MicrosoftNETCoreAppRefPackageVersion).component.osx.$(Architecture)</NetCoreAppTargetingPackComponentId>
+      <NetCoreAppHostPackComponentId>com.microsoft.dotnet.pack.apphost.$(MicrosoftNETCoreAppHostPackageVersion).component.osx.$(Architecture)</NetCoreAppHostPackComponentId>
+      <NetStandardTargetingPackComponentId>com.microsoft.standard.pack.targeting.$(NETStandardLibraryRefPackageVersion).component.osx.$(Architecture)</NetStandardTargetingPackComponentId>
+      <SdkComponentId>com.microsoft.dotnet.dev.$(Version).component.osx.$(Architecture)</SdkComponentId>
+      <SdkProductArchiveId>com.microsoft.dotnet.dev.$(Version).osx.$(Architecture)</SdkProductArchiveId>
 
       <PkgInstallDirectory>/usr/local/share/dotnet</PkgInstallDirectory>
 

--- a/src/redist/targets/GeneratePKG.targets
+++ b/src/redist/targets/GeneratePKG.targets
@@ -85,6 +85,9 @@
         <DistributionTemplateReplacement Include="{HostFxrBrandName}">
           <ReplacementString>$(HostFxrBrandName)</ReplacementString>
         </DistributionTemplateReplacement>
+        <DistributionTemplateReplacement Include="{arch}">
+          <ReplacementString>$(Architecture)</ReplacementString>
+        </DistributionTemplateReplacement>
 
         <PostInstallScriptReplacement Include="%SDK_VERSION%">
           <ReplacementString>$(Version)</ReplacementString>
@@ -99,6 +102,22 @@
         <ResourcesReplacement Include="{ASPNETCOREVERSION}">
           <ReplacementString>$(MicrosoftAspNetCoreAppRuntimePackageVersion)</ReplacementString>
         </ResourcesReplacement>
+      </ItemGroup>
+      <ItemGroup Condition="'$(Architecture)' != 'arm64'" >
+        <DistributionTemplateReplacement Include="{NetStandardTargetingPackDisableBegin}">
+          <ReplacementString></ReplacementString>
+        </DistributionTemplateReplacement>
+        <DistributionTemplateReplacement Include="{NetStandardTargetingPackDisableEnd}">
+          <ReplacementString></ReplacementString>
+        </DistributionTemplateReplacement>
+      </ItemGroup>
+      <ItemGroup Condition="'$(Architecture)' == 'arm64'" >
+        <DistributionTemplateReplacement Include="{NetStandardTargetingPackDisableBegin}">
+          <ReplacementString><![CDATA[<!--]]></ReplacementString>
+        </DistributionTemplateReplacement>
+        <DistributionTemplateReplacement Include="{NetStandardTargetingPackDisableEnd}">
+          <ReplacementString><![CDATA[-->]]></ReplacementString>
+        </DistributionTemplateReplacement>
       </ItemGroup>
       
       <!-- Consumed By Publish -->
@@ -178,16 +197,16 @@
                                 $(DownloadsFolder)$(DownloadedSharedFrameworkInstallerFileName);
                                 $(DownloadsFolder)$(DownloadedNetCoreAppTargetingPackInstallerFileName);
                                 $(DownloadsFolder)$(DownloadedNetCoreAppHostPackInstallerFileName);
-                                $(DownloadsFolder)$(DownloadedNetStandardTargetingPackInstallerFileName);
                                 $(DownloadsFolder)$(DownloadedHostFxrInstallerFileName);
                                 $(DownloadsFolder)$(DownloadedSharedHostInstallerFileName)" />
+        <PkgComponentsSourceFiles Condition="'$(Architecture)' != 'arm64'" Include="$(DownloadsFolder)$(DownloadedNetStandardTargetingPackInstallerFileName)" />
         <PkgComponentsDestinationFiles Include="$(SdkPkgIntermediatePath);
                                                 $(SharedFrameworkPkgIntermediatePath);
                                                 $(NetCoreAppTargetingPackPkgIntermediatePath);
                                                 $(NetCoreAppHostPackPkgIntermediatePath);
-                                                $(NetStandardTargetingPackPkgIntermediatePath);
                                                 $(HostFxrPkgIntermediatePath);
                                                 $(SharedHostPkgIntermediatePath)" />
+        <PkgComponentsDestinationFiles Condition="'$(Architecture)' != 'arm64'" Include="$(NetStandardTargetingPackPkgIntermediatePath)" />
       </ItemGroup>
 
       <!-- Move ProductArchive pkg components into place with component ids in the filenames -->

--- a/src/redist/targets/GeneratePKG.targets
+++ b/src/redist/targets/GeneratePKG.targets
@@ -103,22 +103,6 @@
           <ReplacementString>$(MicrosoftAspNetCoreAppRuntimePackageVersion)</ReplacementString>
         </ResourcesReplacement>
       </ItemGroup>
-      <ItemGroup Condition="'$(Architecture)' != 'arm64'" >
-        <DistributionTemplateReplacement Include="{NetStandardTargetingPackDisableBegin}">
-          <ReplacementString></ReplacementString>
-        </DistributionTemplateReplacement>
-        <DistributionTemplateReplacement Include="{NetStandardTargetingPackDisableEnd}">
-          <ReplacementString></ReplacementString>
-        </DistributionTemplateReplacement>
-      </ItemGroup>
-      <ItemGroup Condition="'$(Architecture)' == 'arm64'" >
-        <DistributionTemplateReplacement Include="{NetStandardTargetingPackDisableBegin}">
-          <ReplacementString><![CDATA[<!--]]></ReplacementString>
-        </DistributionTemplateReplacement>
-        <DistributionTemplateReplacement Include="{NetStandardTargetingPackDisableEnd}">
-          <ReplacementString><![CDATA[-->]]></ReplacementString>
-        </DistributionTemplateReplacement>
-      </ItemGroup>
       
       <!-- Consumed By Publish -->
       <ItemGroup>
@@ -197,16 +181,16 @@
                                 $(DownloadsFolder)$(DownloadedSharedFrameworkInstallerFileName);
                                 $(DownloadsFolder)$(DownloadedNetCoreAppTargetingPackInstallerFileName);
                                 $(DownloadsFolder)$(DownloadedNetCoreAppHostPackInstallerFileName);
+                                $(DownloadsFolder)$(DownloadedNetStandardTargetingPackInstallerFileName);
                                 $(DownloadsFolder)$(DownloadedHostFxrInstallerFileName);
                                 $(DownloadsFolder)$(DownloadedSharedHostInstallerFileName)" />
-        <PkgComponentsSourceFiles Condition="'$(Architecture)' != 'arm64'" Include="$(DownloadsFolder)$(DownloadedNetStandardTargetingPackInstallerFileName)" />
         <PkgComponentsDestinationFiles Include="$(SdkPkgIntermediatePath);
                                                 $(SharedFrameworkPkgIntermediatePath);
                                                 $(NetCoreAppTargetingPackPkgIntermediatePath);
                                                 $(NetCoreAppHostPackPkgIntermediatePath);
+                                                $(NetStandardTargetingPackPkgIntermediatePath);
                                                 $(HostFxrPkgIntermediatePath);
                                                 $(SharedHostPkgIntermediatePath)" />
-        <PkgComponentsDestinationFiles Condition="'$(Architecture)' != 'arm64'" Include="$(NetStandardTargetingPackPkgIntermediatePath)" />
       </ItemGroup>
 
       <!-- Move ProductArchive pkg components into place with component ids in the filenames -->

--- a/src/redist/targets/packaging/osx/clisdk/Distribution-Template
+++ b/src/redist/targets/packaging/osx/clisdk/Distribution-Template
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <installer-gui-script minSpecVersion="1">
-    <title>{CLISdkBrandName} (x64)</title>
+    <title>{CLISdkBrandName} ({arch})</title>
     <background file="dotnetbackground.png" mime-type="image/png"/>
     <options customize="never" require-scripts="false" />
     <welcome file="welcome.html" mime-type="text/html" />
@@ -12,36 +12,42 @@
     </volume-check>
     <choices-outline>
         <line choice="{NetCoreAppTargetingPackComponentId}.pkg" />
+        {NetStandardTargetingPackDisableBegin}
         <line choice="{NetStandardTargetingPackComponentId}.pkg" />
+        {NetStandardTargetingPackDisableEnd}
         <line choice="{NetCoreAppHostPackComponentId}.pkg" />
         <line choice="{SharedFxComponentId}.pkg" />
         <line choice="{HostFxrComponentId}.pkg" />
         <line choice="{SharedHostComponentId}.pkg" />
         <line choice="{CLISdkComponentId}.pkg"/>
     </choices-outline>
-    <choice id="{NetCoreAppTargetingPackComponentId}.pkg" visible="true" title="{NetCoreAppTargetingPackBrandName} (x64)" description="The .NET Targeting Pack">
+    <choice id="{NetCoreAppTargetingPackComponentId}.pkg" visible="true" title="{NetCoreAppTargetingPackBrandName} ({arch})" description="The .NET Targeting Pack">
         <pkg-ref id="{NetCoreAppTargetingPackComponentId}.pkg" />
     </choice>
-    <choice id="{NetStandardTargetingPackComponentId}.pkg" visible="true" title="{NetStandardTargetingPackBrandName} (x64)" description="The .NET Standard 2.1 Targeting Pack">
+    {NetStandardTargetingPackDisableBegin}
+    <choice id="{NetStandardTargetingPackComponentId}.pkg" visible="true" title="{NetStandardTargetingPackBrandName} ({arch})" description="The .NET Standard 2.1 Targeting Pack">
         <pkg-ref id="{NetStandardTargetingPackComponentId}.pkg" />
     </choice>
-    <choice id="{NetCoreAppHostPackComponentId}.pkg" visible="true" title="{NetCoreAppHostPackBrandName} (x64)" description="The .NET App Host Pack">
+    {NetStandardTargetingPackDisableEnd}
+    <choice id="{NetCoreAppHostPackComponentId}.pkg" visible="true" title="{NetCoreAppHostPackBrandName} ({arch})" description="The .NET App Host Pack">
         <pkg-ref id="{NetCoreAppHostPackComponentId}.pkg" />
     </choice>
-    <choice id="{SharedFxComponentId}.pkg" visible="true" title="{SharedFxBrandName} (x64)" description="The .NET Shared Framework">
+    <choice id="{SharedFxComponentId}.pkg" visible="true" title="{SharedFxBrandName} ({arch})" description="The .NET Shared Framework">
         <pkg-ref id="{SharedFxComponentId}.pkg" />
     </choice>
-    <choice id="{HostFxrComponentId}.pkg" visible="true" title="{HostFxrBrandName} (x64)" description="The .NET Host FX Resolver">
+    <choice id="{HostFxrComponentId}.pkg" visible="true" title="{HostFxrBrandName} ({arch})" description="The .NET Host FX Resolver">
         <pkg-ref id="{HostFxrComponentId}.pkg" />
     </choice>
-    <choice id="{SharedHostComponentId}.pkg" visible="true" title="{SharedHostBrandName} (x64)" description="The .NET Shared Host.">
+    <choice id="{SharedHostComponentId}.pkg" visible="true" title="{SharedHostBrandName} ({arch})" description="The .NET Shared Host.">
         <pkg-ref id="{SharedHostComponentId}.pkg" />
     </choice>
-    <choice id="{CLISdkComponentId}.pkg" visible="true" title="{CLISdkBrandName} (x64)" description="The .NET SDK">
+    <choice id="{CLISdkComponentId}.pkg" visible="true" title="{CLISdkBrandName} ({arch})" description="The .NET SDK">
         <pkg-ref id="{CLISdkComponentId}.pkg"/>
     </choice>
     <pkg-ref id="{NetCoreAppTargetingPackComponentId}.pkg">{NetCoreAppTargetingPackComponentId}.pkg</pkg-ref>
+    {NetStandardTargetingPackDisableBegin}
     <pkg-ref id="{NetStandardTargetingPackComponentId}.pkg">{NetStandardTargetingPackComponentId}.pkg</pkg-ref>
+    {NetStandardTargetingPackDisableEnd}
     <pkg-ref id="{NetCoreAppHostPackComponentId}.pkg">{NetCoreAppHostPackComponentId}.pkg</pkg-ref>
     <pkg-ref id="{SharedFxComponentId}.pkg">{SharedFxComponentId}.pkg</pkg-ref>
     <pkg-ref id="{HostFxrComponentId}.pkg">{HostFxrComponentId}.pkg</pkg-ref>

--- a/src/redist/targets/packaging/osx/clisdk/Distribution-Template
+++ b/src/redist/targets/packaging/osx/clisdk/Distribution-Template
@@ -12,9 +12,7 @@
     </volume-check>
     <choices-outline>
         <line choice="{NetCoreAppTargetingPackComponentId}.pkg" />
-        {NetStandardTargetingPackDisableBegin}
         <line choice="{NetStandardTargetingPackComponentId}.pkg" />
-        {NetStandardTargetingPackDisableEnd}
         <line choice="{NetCoreAppHostPackComponentId}.pkg" />
         <line choice="{SharedFxComponentId}.pkg" />
         <line choice="{HostFxrComponentId}.pkg" />
@@ -24,11 +22,9 @@
     <choice id="{NetCoreAppTargetingPackComponentId}.pkg" visible="true" title="{NetCoreAppTargetingPackBrandName} ({arch})" description="The .NET Targeting Pack">
         <pkg-ref id="{NetCoreAppTargetingPackComponentId}.pkg" />
     </choice>
-    {NetStandardTargetingPackDisableBegin}
     <choice id="{NetStandardTargetingPackComponentId}.pkg" visible="true" title="{NetStandardTargetingPackBrandName} ({arch})" description="The .NET Standard 2.1 Targeting Pack">
         <pkg-ref id="{NetStandardTargetingPackComponentId}.pkg" />
     </choice>
-    {NetStandardTargetingPackDisableEnd}
     <choice id="{NetCoreAppHostPackComponentId}.pkg" visible="true" title="{NetCoreAppHostPackBrandName} ({arch})" description="The .NET App Host Pack">
         <pkg-ref id="{NetCoreAppHostPackComponentId}.pkg" />
     </choice>
@@ -45,9 +41,7 @@
         <pkg-ref id="{CLISdkComponentId}.pkg"/>
     </choice>
     <pkg-ref id="{NetCoreAppTargetingPackComponentId}.pkg">{NetCoreAppTargetingPackComponentId}.pkg</pkg-ref>
-    {NetStandardTargetingPackDisableBegin}
     <pkg-ref id="{NetStandardTargetingPackComponentId}.pkg">{NetStandardTargetingPackComponentId}.pkg</pkg-ref>
-    {NetStandardTargetingPackDisableEnd}
     <pkg-ref id="{NetCoreAppHostPackComponentId}.pkg">{NetCoreAppHostPackComponentId}.pkg</pkg-ref>
     <pkg-ref id="{SharedFxComponentId}.pkg">{SharedFxComponentId}.pkg</pkg-ref>
     <pkg-ref id="{HostFxrComponentId}.pkg">{HostFxrComponentId}.pkg</pkg-ref>


### PR DESCRIPTION
Enable Apple Silicon SDK builds

- Add `macos arm64` to readme
- Enable `osx-arm64` builds
- Use `vmImage: 'macOS-10.15'`

Fixes #8840

The build is likely to be unstable for general usage.  Known issues.
- Runtime hasn't fully implemented the Apple Silicon ABI.  This means interop with native `C` is not working. It may affect lots of areas. One known area is in the call to fork a process
- The runtime is missing the FlushProcessWriteBuffers changes needed for Apple Silicon.  This means there could be GC issues 
- The runtime stack probing code doesn't support 165k pages
- The ASP.NET runtime doesn't have native binaries for Apple Silicon.  Some scenarios will not work yet.
