### PR TITLE
Replace legacy packages with VS insertion packages for non-shipping version numbers.

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -5,13 +5,17 @@
       <Uri>https://github.com/dotnet/windowsdesktop</Uri>
       <Sha>c0d88e97c24130c78429dbee4444e4941b1c26f6</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="6.0.0-alpha.1.20559.4" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="VS.Redist.Common.WindowsDesktop.SharedFramework.x64.6.0" Version="6.0.0-alpha.1.20559.4" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/windowsdesktop</Uri>
       <Sha>c0d88e97c24130c78429dbee4444e4941b1c26f6</Sha>
     </Dependency>
     <Dependency Name="Microsoft.WindowsDesktop.App.Runtime.win-x64" Version="6.0.0-alpha.1.20559.4" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/windowsdesktop</Uri>
       <Sha>c0d88e97c24130c78429dbee4444e4941b1c26f6</Sha>
+    </Dependency>
+    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.6.0" Version="6.0.0-alpha.1.20557.2" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>6cfef20c1524b8d4c1495a652dfe9e898c5a486b</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-alpha.1.20557.2" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -70,7 +70,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/core-setup -->
-    <MicrosoftNETCoreAppInternalPackageVersion>6.0.0-alpha.1.20557.2</MicrosoftNETCoreAppInternalPackageVersion>
+    <VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>6.0.0-alpha.1.20557.2</VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>
     <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.0-alpha.1.20557.2</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
     <MicrosoftNETCoreAppHostwinx64PackageVersion>6.0.0-alpha.1.20557.2</MicrosoftNETCoreAppHostwinx64PackageVersion>
     <MicrosoftNETCoreAppRefPackageVersion>6.0.0-alpha.1.20557.2</MicrosoftNETCoreAppRefPackageVersion>
@@ -79,7 +79,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/windowsdesktop -->
-    <MicrosoftWindowsDesktopAppPackageVersion>6.0.0-alpha.1.20559.4</MicrosoftWindowsDesktopAppPackageVersion>
+    <VSRedistCommonWindowsDesktopSharedFrameworkx6460PackageVersion>6.0.0-alpha.1.20559.4</VSRedistCommonWindowsDesktopSharedFrameworkx6460PackageVersion>
     <MicrosoftWindowsDesktopAppRuntimewinx64PackageVersion>6.0.0-alpha.1.20559.4</MicrosoftWindowsDesktopAppRuntimewinx64PackageVersion>
     <MicrosoftWindowsDesktopAppRefPackageVersion>6.0.0-alpha.1.20559.4</MicrosoftWindowsDesktopAppRefPackageVersion>
   </PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "dotnet": "5.0.100-rc.2.20479.15",
     "runtimes": {
       "dotnet": [
-        "$(MicrosoftNETCoreAppRuntimePackageVersion)"
+        "$(VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion)"
       ]
     }
   },

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "dotnet": "5.0.100-rc.2.20479.15",
     "runtimes": {
       "dotnet": [
-        "$(MicrosoftNETCoreAppInternalPackageVersion)"
+        "$(MicrosoftNETCoreAppRuntimePackageVersion)"
       ]
     }
   },

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -8,8 +8,8 @@
   <PropertyGroup>
     <!-- Blob storage directories are not stabilized, so these must refer to a package that does not stabilize -->
     <AspNetCoreBlobVersion>$(VSRedistCommonAspNetCoreSharedFrameworkx6460PackageVersion)</AspNetCoreBlobVersion>
-    <CoreSetupBlobVersion>$(MicrosoftNETCoreAppInternalPackageVersion)</CoreSetupBlobVersion>
-    <WindowsDesktopBlobVersion>$(MicrosoftWindowsDesktopAppPackageVersion)</WindowsDesktopBlobVersion>
+    <CoreSetupBlobVersion>$(VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion)</CoreSetupBlobVersion>
+    <WindowsDesktopBlobVersion>$(VSRedistCommonWindowsDesktopSharedFrameworkx6460PackageVersion)</WindowsDesktopBlobVersion>
 
     <!-- Change these individually to or $(CoreSetupBlobVersion), $(AspNetCoreBlobVersion), or appropriate fixed version depending if corresponding .Ref packages are unpinned. -->
     <NETCoreAppTargetingPackBlobVersion>$(CoreSetupBlobVersion)</NETCoreAppTargetingPackBlobVersion>


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/38457 and https://github.com/dotnet/windowsdesktop/pull/909 we're removing the Microsoft.NETCore.App.Internal and Microsoft.WindowsDesktop.App legacy packages respectively. This PR moves the usage in dotnet/installer to use the VS insertion packages to get the non-shipping version numbers similar to the usage for ASP.NET Core.