### PR TITLE
Add more RuntimeIdentifier information to .NET SDK

### DIFF
--- a/src/core-sdk-tasks/GenerateSdkRuntimeIdentifierChain.cs
+++ b/src/core-sdk-tasks/GenerateSdkRuntimeIdentifierChain.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using NuGet.RuntimeModel;
+
+namespace Microsoft.DotNet.Cli.Build
+{
+    public class GenerateSdkRuntimeIdentifierChain : Task
+    {
+        [Required]
+        public string RuntimeIdentifier { get; set; }
+
+        [Required]
+        public string RuntimeIdentifierGraphPath { get; set; }
+
+        [Required]
+        public string RuntimeIdentifierChainOutputPath { get; set; }
+
+        public override bool Execute()
+        {
+            var runtimeIdentifierGraph = JsonRuntimeFormat.ReadRuntimeGraph(RuntimeIdentifierGraphPath);
+
+            var chainContents = string.Join("\n", runtimeIdentifierGraph.ExpandRuntime(RuntimeIdentifier));
+            File.WriteAllText(RuntimeIdentifierChainOutputPath, chainContents);
+
+            return true;
+        }
+    }
+}

--- a/src/core-sdk-tasks/core-sdk-tasks.csproj
+++ b/src/core-sdk-tasks/core-sdk-tasks.csproj
@@ -11,7 +11,8 @@
     <PackageReference Include="Microsoft.Build" Version="15.7.179" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.7.179" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="NuGet.Versioning" Version="4.3.0" />
+    <PackageReference Include="NuGet.Versioning" Version="5.8.0" />
+    <PackageReference Include="NuGet.Packaging" Version="5.8.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.4.2" />
     <PackageReference Include="WindowsAzure.Storage" Version="8.4.0" Condition="'$(DotNetBuildFromSource)' != 'true'" />
   </ItemGroup>

--- a/src/redist/targets/BuildCoreSdkTasks.targets
+++ b/src/redist/targets/BuildCoreSdkTasks.targets
@@ -39,5 +39,6 @@
   <UsingTask TaskName="GetRuntimePackRids" AssemblyFile="$(CoreSdkTaskDll)"/>
   <UsingTask TaskName="GenerateMSBuildExtensionsSWR" AssemblyFile="$(CoreSdkTaskDll)"/>
   <UsingTask TaskName="GetLinuxNativeInstallerDependencyVersions" AssemblyFile="$(CoreSdkTaskDll)"/>
+  <UsingTask TaskName="GenerateSdkRuntimeIdentifierChain" AssemblyFile="$(CoreSdkTaskDll)"/>
 
 </Project>

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -168,6 +168,11 @@
                                DefaultVersion="2.2.0"
                                LatestVersion="2.2.8"/>
     </ItemGroup>
+    
+    <PropertyGroup>
+      <PortableProduktMonikerRid Condition="'$(PortableProduktMonikerRid)' == ''">$(ProductMonikerRid)</PortableProduktMonikerRid>
+    </PropertyGroup>
+      
 
     <PropertyGroup>
       <BundledVersionsPropsContent>
@@ -197,6 +202,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <BundledRuntimeIdentifierGraphFile>%24(MSBuildThisFileDirectory)RuntimeIdentifierGraph.json</BundledRuntimeIdentifierGraphFile>
     <NETCoreSdkVersion>$(Version)</NETCoreSdkVersion>
     <NETCoreSdkRuntimeIdentifier>$(ProductMonikerRid)</NETCoreSdkRuntimeIdentifier>
+    <NETCoreSdkPortableRuntimeIdentifier>$(PortableProduktMonikerRid)</NETCoreSdkPortableRuntimeIdentifier>
     <_NETCoreSdkIsPreview>$(_NETCoreSdkBeingBuiltIsPreview)</_NETCoreSdkIsPreview>
   </PropertyGroup>
   <ItemGroup>

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -170,7 +170,7 @@
     </ItemGroup>
     
     <PropertyGroup>
-      <PortableProduktMonikerRid Condition="'$(PortableProduktMonikerRid)' == ''">$(ProductMonikerRid)</PortableProduktMonikerRid>
+      <PortableProductMonikerRid Condition="'$(PortableProductMonikerRid)' == ''">$(ProductMonikerRid)</PortableProductMonikerRid>
     </PropertyGroup>
       
 
@@ -202,7 +202,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <BundledRuntimeIdentifierGraphFile>%24(MSBuildThisFileDirectory)RuntimeIdentifierGraph.json</BundledRuntimeIdentifierGraphFile>
     <NETCoreSdkVersion>$(Version)</NETCoreSdkVersion>
     <NETCoreSdkRuntimeIdentifier>$(ProductMonikerRid)</NETCoreSdkRuntimeIdentifier>
-    <NETCoreSdkPortableRuntimeIdentifier>$(PortableProduktMonikerRid)</NETCoreSdkPortableRuntimeIdentifier>
+    <NETCoreSdkPortableRuntimeIdentifier>$(PortableProductMonikerRid)</NETCoreSdkPortableRuntimeIdentifier>
     <_NETCoreSdkIsPreview>$(_NETCoreSdkBeingBuiltIsPreview)</_NETCoreSdkIsPreview>
   </PropertyGroup>
   <ItemGroup>
@@ -523,7 +523,7 @@ Copyright (c) .NET Foundation. All rights reserved.
           SkipUnchangedFiles="true"/>
 
     <GenerateSdkRuntimeIdentifierChain
-          RuntimeIdentifier="$(PortableProduktMonikerRid)"
+          RuntimeIdentifier="$(PortableProductMonikerRid)"
           RuntimeIdentifierGraphPath="$(SdkOutputDirectory)RuntimeIdentifierGraph.json"
           RuntimeIdentifierChainOutputPath="$(SdkOutputDirectory)NETCoreSdkRuntimeIdentifierChain.txt"/>
     

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -520,7 +520,12 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <Copy SourceFiles="$(NuGetPackageRoot)/microsoft.netcore.platforms/$(_NETCorePlatformsPackageVersion)/runtime.json"
           DestinationFiles="$(SdkOutputDirectory)RuntimeIdentifierGraph.json" 
-          SkipUnchangedFiles="true"/> 
+          SkipUnchangedFiles="true"/>
+
+    <GenerateSdkRuntimeIdentifierChain
+          RuntimeIdentifier="$(PortableProduktMonikerRid)"
+          RuntimeIdentifierGraphPath="$(SdkOutputDirectory)RuntimeIdentifierGraph.json"
+          RuntimeIdentifierChainOutputPath="$(SdkOutputDirectory)NETCoreSdkRuntimeIdentifierChain.txt"/>
     
   </Target>
 </Project>


### PR DESCRIPTION
- Add `NETCoreSdkPortableRuntimeIdentifier` to bundled versions.  This is the first step to allow us to use a consistent, portable RuntimeIdentifier as the default for the `--use-current-runtime` parameter.  See https://github.com/dotnet/sdk/issues/14296
- Add a NETCoreSdkRuntimeIdentifierChain.txt file to the SDK folder.  This is a list of RuntimeIdentifiers compatible with `NETCoreSdkPortableRuntimeIdentifier`, starting from the best match and walking up the tree.  This will allow the workload resolver to better handle RID-specific workload packs, without bringing in additional dependencies (NuGet APIs for processing the RID graph as well as .NET Core APIs for getting the current runtime) which would be difficult to run in an MSBuild resolver that has to run on .NET Framework.

@mhutch @wli3