### PR TITLE
Enable post-build signing

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -16,6 +16,8 @@ variables:
   value: https://dotnetclichecksums.blob.core.windows.net/dotnet/index.json
 - name: _PublishUsingPipelines
   value: false
+- name: PostBuildSign
+  value: true
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - group: DotNet-DotNetCli-Storage
   - group: DotNet-Blob-Feed


### PR DESCRIPTION
Enables post build signing. This repo will discontinue signing in-build and instead the entire product will sign all at once in the staging pipelines.