### PR TITLE
Revert "Enable post-build signing"

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -16,8 +16,6 @@ variables:
   value: https://dotnetclichecksums.blob.core.windows.net/dotnet/index.json
 - name: _PublishUsingPipelines
   value: false
-- name: PostBuildSign
-  value: true
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - group: DotNet-DotNetCli-Storage
   - group: DotNet-Blob-Feed


### PR DESCRIPTION
Reverts dotnet/installer#9122

Hi folks,

We noticed that Installer builds on master are failing after this PR was merged, so we're going to revert it.  

Tracking issue: https://github.com/dotnet/core-eng/issues/11514 

Thanks,
Missy