### PR TITLE
Reenable and fix post build signing

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -16,6 +16,8 @@ variables:
   value: https://dotnetclichecksums.blob.core.windows.net/dotnet/index.json
 - name: _PublishUsingPipelines
   value: false
+- name: PostBuildSign
+  value: true
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - group: DotNet-DotNetCli-Storage
   - group: DotNet-Blob-Feed

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -115,6 +115,18 @@
         <RelativeBlobPath>$(BlobStoragePartialRelativePath)/$(FullNugetVersion)/$([System.String]::Copy('%(Filename)%(Extension)'))</RelativeBlobPath>
       </ChecksumsToPushToBlobFeed>
     </ItemGroup>
+    
+    <ItemGroup Condition="'$(PostBuildSign)' == 'true'">
+      <ItemsToSignPostBuildWithPaths Include="$(ArtifactsShippingPackagesDir)*.zip" Condition=" '$(PublishBinariesAndBadge)' == 'true' " />
+      <ItemsToSignPostBuildWithPaths Include="$(ArtifactsShippingPackagesDir)*.exe" />
+      <ItemsToSignPostBuildWithPaths Include="$(ArtifactsShippingPackagesDir)*.msi" />
+      <ItemsToSignPostBuildWithPaths Include="$(ArtifactsShippingPackagesDir)*.nupkg" />
+      <ItemsToSignPostBuildWithPaths Include="$(ArtifactsNonShippingPackagesDir)*.msi" />
+      <ItemsToSignPostBuildWithPaths Include="$(ArtifactsNonShippingPackagesDir)*.zip" Condition=" '$(PublishBinariesAndBadge)' == 'true' " />
+      <ItemsToSignPostBuildWithPaths Include="$(ArtifactsNonShippingPackagesDir)*.nupkg" />
+      <ItemsToSignPostBuild Remove="@(ItemsToSignPostBuild)" />
+      <ItemsToSignPostBuild Include="@(ItemsToSignPostBuildWithPaths->'%(Filename)%(Extension)')" />
+    </ItemGroup>
 
     <PropertyGroup>
       <IsStableBuild>false</IsStableBuild>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -2,17 +2,10 @@
 
   <ItemGroup>
     <!-- Do not sign non-shipping packages when doing in-build signing -->
-    <ItemsToSign Remove="$(ArtifactsNonShippingPackagesDir)**\*.nupkg" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(PostBuildSign)' == 'true'">
-    <ItemsToSignPostBuild Include="$(ArtifactsShippingPackagesDir)*.zip" />
-    <ItemsToSignPostBuild Include="$(ArtifactsShippingPackagesDir)*.exe" />
-    <ItemsToSignPostBuild Include="$(ArtifactsShippingPackagesDir)*.msi" />
-    <ItemsToSignPostBuild Include="$(ArtifactsShippingPackagesDir)*.nupkg" />
-    <ItemsToSignPostBuild Include="$(ArtifactsNonShippingPackagesDir)*.msi" />
-    <ItemsToSignPostBuild Include="$(ArtifactsNonShippingPackagesDir)*.zip" />
-    <ItemsToSignPostBuild Include="$(ArtifactsNonShippingPackagesDir)*.nupkg" />
+    <ItemsToSign Remove="$(ArtifactsNonShippingPackagesDir)**\*.nupkg" Condition="'$(PostBuildSign)' != 'true'" />
+    <!-- Remove the wixpacks from items to sign post build. These will be added explicitly by the
+         custom publishing target. And should not be picked up by arcade's default publishing logic. -->
+    <ItemsToSignPostBuild Remove="*.wixpack.zip" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -24,6 +17,7 @@
       It is therefore expected that <ItemsToSign> could be an empty set.
     -->
     <AllowEmptySignList>true</AllowEmptySignList>
+    <AllowEmptySignPostBuildList>true</AllowEmptySignPostBuildList>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes post build signing so that the manifests are conformant with the requirement that items to sign should also appear in the artifacts section of a manifest.

- Please add description for changes you are making.
- If there is an issue related to this PR, please add the reference.
