### PR TITLE
[release/5.0.2xx] Enable linux-musl-arm* builds in CI

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -156,7 +156,7 @@ stages:
               _LinuxPortable: '--linux-portable'
               _RuntimeIdentifier: '--runtime-id linux-arm'
               _BuildArchitecture: 'arm'
-              # Never run tests on arm64
+              # Never run tests on arm
               _TestArg: ''
             Build_Arm64_Debug:
               _BuildConfig: Debug
@@ -166,12 +166,32 @@ stages:
               _BuildArchitecture: 'arm64'
               # Never run tests on arm64
               _TestArg: ''
+            Build_Linux_musl_Debug_arm:
+              _BuildConfig: Debug
+              # linux-musl-arm cross gen depends on glibc 2.27 (this OS has it)
+              _DockerParameter: '--docker ubuntu.18.04'
+              _LinuxPortable: ''
+              _RuntimeIdentifier: '--runtime-id linux-musl-arm'
+              _BuildArchitecture: 'arm'
+              _AdditionalBuildParameters: '/p:OSName="linux-musl"'
+              # Never run tests on arm
+              _TestArg: ''
+            Build_Linux_musl_Debug_arm64:
+              _BuildConfig: Debug
+              _DockerParameter: ''
+              _LinuxPortable: ''
+              _RuntimeIdentifier: '--runtime-id linux-musl-arm64'
+              _BuildArchitecture: 'arm64'
+              _AdditionalBuildParameters: '/p:OSName="linux-musl"'
+              # Never run tests on arm64
+              _TestArg: ''
             Build_Linux_musl_Debug_x64:
               _BuildConfig: Debug
               _DockerParameter: '--docker alpine.3.6'
               _LinuxPortable: ''
               _RuntimeIdentifier: '--runtime-id linux-musl-x64'
               _BuildArchitecture: 'x64'
+              _AdditionalBuildParameters: '/p:OSName="linux-musl"'
               _TestArg: $(_NonWindowsTestArg)
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
             Build_Arm_Release:
@@ -180,7 +200,7 @@ stages:
               _LinuxPortable: '--linux-portable'
               _RuntimeIdentifier: '--runtime-id linux-arm'
               _BuildArchitecture: 'arm'
-              # Never run tests on arm64
+              # Never run tests on arm
               _TestArg: ''
             Build_Arm64_Release:
               _BuildConfig: Release
@@ -190,12 +210,32 @@ stages:
               _BuildArchitecture: 'arm64'
               # Never run tests on arm64
               _TestArg: ''
+            Build_Linux_musl_Release_arm:
+              _BuildConfig: Release
+              # linux-musl-arm cross gen depends on glibc 2.27 (this OS has it)
+              _DockerParameter: '--docker ubuntu.18.04'
+              _LinuxPortable: ''
+              _RuntimeIdentifier: '--runtime-id linux-musl-arm'
+              _BuildArchitecture: 'arm'
+              _AdditionalBuildParameters: '/p:OSName="linux-musl"'
+              # Never run tests on arm
+              _TestArg: ''
+            Build_Linux_musl_Release_arm64:
+              _BuildConfig: Release
+              _DockerParameter: ''
+              _LinuxPortable: ''
+              _RuntimeIdentifier: '--runtime-id linux-musl-arm64'
+              _BuildArchitecture: 'arm64'
+              _AdditionalBuildParameters: '/p:OSName="linux-musl"'
+              # Never run tests on arm64
+              _TestArg: ''
             Build_Linux_musl_Release_x64:
               _BuildConfig: Release
               _DockerParameter: '--docker alpine.3.6'
               _LinuxPortable: ''
               _RuntimeIdentifier: '--runtime-id linux-musl-x64'
               _BuildArchitecture: 'x64'
+              _AdditionalBuildParameters: '/p:OSName="linux-musl"'
             Build_Linux_Portable_Deb_Release_x64:
               _BuildConfig: Release
               _DockerParameter: '--docker ubuntu.16.04'

--- a/src/redist/targets/Crossgen.targets
+++ b/src/redist/targets/Crossgen.targets
@@ -7,11 +7,11 @@
       <RuntimeNETCoreAppPackageName>microsoft.netcore.app.runtime.$(SharedFrameworkRid)</RuntimeNETCoreAppPackageName>
       <_crossDir Condition="'$(Architecture)' == 'arm64' and '$(BuildArchitecture)' != 'arm64'">/x64_arm64</_crossDir>
       <_crossDir Condition="'$(Architecture)' == 'arm' And '$(OSName)' == 'win'">/x86_arm</_crossDir>
-      <_crossDir Condition="'$(Architecture)' == 'arm' And '$(OSName)' == 'linux'">/x64_arm</_crossDir>
+      <_crossDir Condition="'$(Architecture)' == 'arm' And '$(OSName)' != 'win'">/x64_arm</_crossDir>
       <CrossgenPath>$(NuGetPackageRoot)/$(RuntimeNETCoreAppPackageName)/$(MicrosoftNETCoreAppRuntimePackageVersion)/tools$(_crossDir)/crossgen$(ExeExtension)</CrossgenPath>
       <LibCLRJitRid Condition="'$(Architecture)' == 'arm64' and '$(BuildArchitecture)' == 'x64'">x64_arm64</LibCLRJitRid>
       <LibCLRJitRid Condition="'$(Architecture)' == 'arm' And '$(OSName)' == 'win'">x86_arm</LibCLRJitRid>
-      <LibCLRJitRid Condition="'$(Architecture)' == 'arm' And '$(OSName)' == 'linux'">x64_arm</LibCLRJitRid>
+      <LibCLRJitRid Condition="'$(Architecture)' == 'arm' And '$(OSName)' != 'win'">x64_arm</LibCLRJitRid>
       <LibCLRJitRid Condition="'$(LibCLRJitRid)' == ''">$(SharedFrameworkRid)</LibCLRJitRid>
       <LibCLRJitPath>$(NuGetPackageRoot)/$(RuntimeNETCoreAppPackageName)/$(MicrosoftNETCoreAppRuntimePackageVersion)/runtimes/$(LibCLRJitRid)/native/$(DynamicLibPrefix)clrjit$(DynamicLibExtension)</LibCLRJitPath>
       <SharedFrameworkNameVersionPath>$(RedistLayoutPath)shared/$(SharedFrameworkName)/$(MicrosoftNETCoreAppRuntimePackageVersion)</SharedFrameworkNameVersionPath>

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -77,6 +77,7 @@
       
       <NetCore5RuntimePackRids Include="
           @(NetCore5AppHostRids);
+          linux-musl-arm;
           ios-arm64;
           ios-arm;
           ios-x64;
@@ -108,7 +109,7 @@
       <Crossgen2SupportedRids Include="linux-musl-x64;linux-x64;win-x64" />
 
       <AspNetCore31RuntimePackRids Include="@(AspNetCore30RuntimePackRids)" />
-      <AspNetCore50RuntimePackRids Include="@(AspNetCore31RuntimePackRids);win-arm64" />
+      <AspNetCore50RuntimePackRids Include="@(AspNetCore31RuntimePackRids);linux-musl-arm;win-arm64" />
       <AspNetCoreRuntimePackRids Include="@(AspNetCore50RuntimePackRids)" />
 
       <WindowsDesktop30RuntimePackRids Include="win-x64;win-x86" />

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -67,7 +67,7 @@
 
       <!-- Use the portable "linux-x64" Rid when downloading Linux shared framework compressed file. -->
       <SharedFrameworkRid>$(CoreSetupRid)</SharedFrameworkRid>
-      <SharedFrameworkRid Condition=" '$(ProductMonikerRid)' == 'linux-musl-x64' ">$(ProductMonikerRid)</SharedFrameworkRid>
+      <SharedFrameworkRid Condition="$(ProductMonikerRid.StartsWith('linux-musl'))">$(ProductMonikerRid)</SharedFrameworkRid>
       <SharedFrameworkRid Condition=" '$(UsePortableLinuxSharedFramework)' == 'true' ">linux-$(Architecture)</SharedFrameworkRid>
       <CombinedFrameworkHostArchiveFileName>dotnet-runtime-$(MicrosoftNETCoreAppRuntimePackageVersion)-$(SharedFrameworkRid)$(ArchiveExtension)</CombinedFrameworkHostArchiveFileName>
       <WinFormsAndWpfSharedFxArchiveFileName>windowsdesktop-runtime-$(MicrosoftWindowsDesktopAppRuntimePackageVersion)-$(SharedFrameworkRid)$(ArchiveExtension)</WinFormsAndWpfSharedFxArchiveFileName>

--- a/src/redist/targets/GetRuntimeInformation.targets
+++ b/src/redist/targets/GetRuntimeInformation.targets
@@ -16,7 +16,7 @@
     <PropertyGroup>
       <IsDebianBaseDistro Condition=" $(HostRid.StartsWith('ubuntu')) OR $(HostRid.StartsWith('debian')) ">true</IsDebianBaseDistro>
       <IsRPMBasedDistro Condition=" $(HostRid.StartsWith('rhel')) AND '$(HostRid)' != 'rhel.6-x64' ">true</IsRPMBasedDistro>
-      <PublishNativeInstallers Condition=" '$(IslinuxPortable)' != 'true' AND '$(HostRid)' != 'rhel.6-x64' AND '$(HostRid)' != 'linux-musl-x64'">true</PublishNativeInstallers>
+      <PublishNativeInstallers Condition=" '$(IslinuxPortable)' != 'true' AND '$(HostRid)' != 'rhel.6-x64' AND !$(Rid.StartsWith('linux-musl'))">true</PublishNativeInstallers>
       <PublishArchives Condition=" '$(IslinuxPortable)' == 'true' OR ('$(IsDebianBaseDistro)' != 'true' AND '$(IsRPMBasedDistro)' != 'true') ">true</PublishArchives>
     </PropertyGroup>
 

--- a/src/redist/targets/SetBuildDefaults.targets
+++ b/src/redist/targets/SetBuildDefaults.targets
@@ -12,11 +12,11 @@
         OR $(Rid.StartsWith('ubuntu.18.04')))">true</SkipBuildingInstallers>
       <SkipBuildingInstallers Condition=" '$(SkipBuildingInstallers)' == '' ">false</SkipBuildingInstallers>
 
-      <UsePortableLinuxSharedFramework Condition=" '$(UsePortableLinuxSharedFramework)' == '' AND '$(IsLinux)' == 'True' AND '$(Rid)' != 'rhel.6-x64' AND '$(Rid)' != 'linux-musl-x64' ">true</UsePortableLinuxSharedFramework>
+      <UsePortableLinuxSharedFramework Condition=" '$(UsePortableLinuxSharedFramework)' == '' AND '$(IsLinux)' == 'True' AND '$(Rid)' != 'rhel.6-x64' AND !$(Rid.StartsWith('linux-musl')) ">true</UsePortableLinuxSharedFramework>
       <!--<IncludeSharedFrameworksForBackwardsCompatibilityTests Condition=" $(IncludeSharedFrameworksForBackwardsCompatibilityTests) == ''
         AND '$(Rid)' != 'linux-x64'
         AND '$(Rid)' != 'rhel.6-x64'
-        AND '$(Rid)' != 'linux-musl-x64'
+        AND (!$(Rid.StartsWith('linux-musl')))
         AND '$(Rid)' != 'ubuntu.18.04-x64'">true</IncludeSharedFrameworksForBackwardsCompatibilityTests>-->
       <HighEntropyVA>true</HighEntropyVA>
 


### PR DESCRIPTION
Port #8984 to release/5.0.2xx

#### Description
Enable linux-musl-arm* builds in CI

Revise recent build table

Reorder platform table more naturally
- Windows -> Linux -> Linux-musl -> RHEL -> macOS
- x64 -> arm -> arm64

Rename linux-musl -> linux-musl-x64
Add linux-musl-arm* rows

#### Customer Impact
With this fix, customers can target linux-musl-arm using dotnet sdk. We already had runtime and aspnet nuget packages ready in 5.0.1, but change in the installer was missing.

#### Regression?
No

#### Risk
Low, the libraries tests are consistently passing with this new RID, so I have a high confidence about it.

#### Is there a packaging impact
Yes, new packages will be created as the linux-musl-arm didn't exist before
