### PR TITLE
Update README.md and table generator for linux-musl-arm

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ Please do not directly edit the table below. Use https://github.com/dotnet/insta
 | **Linux arm** | [![][linux-arm-badge-master]][linux-arm-version-master]<br>[tar.gz][linux-arm-targz-master] - [Checksum][linux-arm-targz-checksum-master] | [![][linux-arm-badge-5.0.2XX]][linux-arm-version-5.0.2XX]<br>[tar.gz][linux-arm-targz-5.0.2XX] - [Checksum][linux-arm-targz-checksum-5.0.2XX] | [![][linux-arm-badge-5.0.1XX-rtm]][linux-arm-version-5.0.1XX-rtm]<br>[tar.gz][linux-arm-targz-5.0.1XX-rtm] - [Checksum][linux-arm-targz-checksum-5.0.1XX-rtm] | [![][linux-arm-badge-3.1.4XX]][linux-arm-version-3.1.4XX]<br>[tar.gz][linux-arm-targz-3.1.4XX] - [Checksum][linux-arm-targz-checksum-3.1.4XX] | [![][linux-arm-badge-3.1.1XX]][linux-arm-version-3.1.1XX]<br>[tar.gz][linux-arm-targz-3.1.1XX] - [Checksum][linux-arm-targz-checksum-3.1.1XX] |
 | **Linux arm64** | [![][linux-arm64-badge-master]][linux-arm64-version-master]<br>[tar.gz][linux-arm64-targz-master] - [Checksum][linux-arm64-targz-checksum-master] | [![][linux-arm64-badge-5.0.2XX]][linux-arm64-version-5.0.2XX]<br>[tar.gz][linux-arm64-targz-5.0.2XX] - [Checksum][linux-arm64-targz-checksum-5.0.2XX] | [![][linux-arm64-badge-5.0.1XX-rtm]][linux-arm64-version-5.0.1XX-rtm]<br>[tar.gz][linux-arm64-targz-5.0.1XX-rtm] - [Checksum][linux-arm64-targz-checksum-5.0.1XX-rtm] | [![][linux-arm64-badge-3.1.4XX]][linux-arm64-version-3.1.4XX]<br>[tar.gz][linux-arm64-targz-3.1.4XX] - [Checksum][linux-arm64-targz-checksum-3.1.4XX] | [![][linux-arm64-badge-3.1.1XX]][linux-arm64-version-3.1.1XX]<br>[tar.gz][linux-arm64-targz-3.1.1XX] - [Checksum][linux-arm64-targz-checksum-3.1.1XX] |
 | **Linux-musl-x64** | [![][linux-musl-x64-badge-master]][linux-musl-x64-version-master]<br>[tar.gz][linux-musl-x64-targz-master] - [Checksum][linux-musl-x64-targz-checksum-master] | [![][linux-musl-x64-badge-5.0.2XX]][linux-musl-x64-version-5.0.2XX]<br>[tar.gz][linux-musl-x64-targz-5.0.2XX] - [Checksum][linux-musl-x64-targz-checksum-5.0.2XX] | [![][linux-musl-x64-badge-5.0.1XX-rtm]][linux-musl-x64-version-5.0.1XX-rtm]<br>[tar.gz][linux-musl-x64-targz-5.0.1XX-rtm] - [Checksum][linux-musl-x64-targz-checksum-5.0.1XX-rtm] | [![][linux-musl-x64-badge-3.1.4XX]][linux-musl-x64-version-3.1.4XX]<br>[tar.gz][linux-musl-x64-targz-3.1.4XX] - [Checksum][linux-musl-x64-targz-checksum-3.1.4XX] | [![][linux-musl-x64-badge-3.1.1XX]][linux-musl-x64-version-3.1.1XX]<br>[tar.gz][linux-musl-x64-targz-3.1.1XX] - [Checksum][linux-musl-x64-targz-checksum-3.1.1XX] |
-| **Linux-musl-arm** | [![][linux-musl-arm-badge-master]][linux-musl-arm-version-master]<br>[tar.gz][linux-musl-arm-targz-master] - [Checksum][linux-musl-arm-targz-checksum-master] | **N/A** | **N/A** | **N/A** | **N/A** |
-| **Linux-musl-arm64** | [![][linux-musl-arm64-badge-master]][linux-musl-arm64-version-master]<br>[tar.gz][linux-musl-arm64-targz-master] - [Checksum][linux-musl-arm64-targz-checksum-master] | **N/A** | **N/A** | **N/A** | **N/A** |
+| **Linux-musl-arm** | [![][linux-musl-arm-badge-master]][linux-musl-arm-version-master]<br>[tar.gz][linux-musl-arm-targz-master] - [Checksum][linux-musl-arm-targz-checksum-master] | [![][linux-musl-arm-badge-5.0.2XX]][linux-musl-arm-version-5.0.2XX]<br>[tar.gz][linux-musl-arm-targz-5.0.2XX] - [Checksum][linux-musl-arm-targz-checksum-5.0.2XX] | **N/A** | **N/A** | **N/A** |
+| **Linux-musl-arm64** | [![][linux-musl-arm64-badge-master]][linux-musl-arm64-version-master]<br>[tar.gz][linux-musl-arm64-targz-master] - [Checksum][linux-musl-arm64-targz-checksum-master] | [![][linux-musl-arm64-badge-5.0.2XX]][linux-musl-arm64-version-5.0.2XX]<br>[tar.gz][linux-musl-arm64-targz-5.0.2XX] - [Checksum][linux-musl-arm64-targz-checksum-5.0.2XX] | **N/A** | **N/A** | **N/A** |
 | **RHEL 6** | **N/A** | **N/A** | **N/A** | [![][rhel-6-badge-3.1.4XX]][rhel-6-version-3.1.4XX]<br>[tar.gz][rhel-6-targz-3.1.4XX] - [Checksum][rhel-6-targz-checksum-3.1.4XX] | [![][rhel-6-badge-3.1.1XX]][rhel-6-version-3.1.1XX]<br>[tar.gz][rhel-6-targz-3.1.1XX] - [Checksum][rhel-6-targz-checksum-3.1.1XX] |
 
 Reference notes:
@@ -354,10 +354,20 @@ Reference notes:
 [linux-musl-arm-targz-master]: https://aka.ms/dotnet/net6/dev/Sdk/dotnet-sdk-linux-musl-arm.tar.gz
 [linux-musl-arm-targz-checksum-master]: https://aka.ms/dotnet/net6/dev/Sdk/dotnet-sdk-linux-musl-arm.tar.gz.sha
 
+[linux-musl-arm-badge-5.0.2XX]: https://aka.ms/dotnet/net5/5.0.2xx/daily/Sdk/linux_musl_arm_Release_version_badge.svg
+[linux-musl-arm-version-5.0.2XX]: https://aka.ms/dotnet/net5/5.0.2xx/daily/Sdk/productCommit-linux-musl-arm.txt
+[linux-musl-arm-targz-5.0.2XX]: https://aka.ms/dotnet/net5/5.0.2xx/daily/Sdk/dotnet-sdk-linux-musl-arm.tar.gz
+[linux-musl-arm-targz-checksum-5.0.2XX]: https://aka.ms/dotnet/net5/5.0.2xx/daily/Sdk/dotnet-sdk-linux-musl-arm.tar.gz.sha
+
 [linux-musl-arm64-badge-master]: https://aka.ms/dotnet/net6/dev/Sdk/linux_musl_arm64_Release_version_badge.svg
 [linux-musl-arm64-version-master]: https://aka.ms/dotnet/net6/dev/Sdk/productCommit-linux-musl-arm64.txt
 [linux-musl-arm64-targz-master]: https://aka.ms/dotnet/net6/dev/Sdk/dotnet-sdk-linux-musl-arm64.tar.gz
 [linux-musl-arm64-targz-checksum-master]: https://aka.ms/dotnet/net6/dev/Sdk/dotnet-sdk-linux-musl-arm64.tar.gz.sha
+
+[linux-musl-arm64-badge-5.0.2XX]: https://aka.ms/dotnet/net5/5.0.2xx/daily/Sdk/linux_musl_arm64_Release_version_badge.svg
+[linux-musl-arm64-version-5.0.2XX]: https://aka.ms/dotnet/net5/5.0.2xx/daily/Sdk/productCommit-linux-musl-arm64.txt
+[linux-musl-arm64-targz-5.0.2XX]: https://aka.ms/dotnet/net5/5.0.2xx/daily/Sdk/dotnet-sdk-linux-musl-arm64.tar.gz
+[linux-musl-arm64-targz-checksum-5.0.2XX]: https://aka.ms/dotnet/net5/5.0.2xx/daily/Sdk/dotnet-sdk-linux-musl-arm64.tar.gz.sha
 
 [win-arm-badge-master]: https://aka.ms/dotnet/net6/dev/Sdk/win_arm_Release_version_badge.svg
 [win-arm-version-master]: https://aka.ms/dotnet/net6/dev/Sdk/productCommit-win-arm.txt

--- a/tools/sdk-readme-table-generator/TableGenerator.Tests/DomainTests.fs
+++ b/tools/sdk-readme-table-generator/TableGenerator.Tests/DomainTests.fs
@@ -36,6 +36,7 @@ let ``it can get major and minor version of a branch``() =
            (MajorMinor
                ({ Major = 3
                   Minor = 1
+                  Patch = 199
                   Release = ""}))
            
 [<Fact>]
@@ -49,6 +50,7 @@ let ``it can get major and minor version of a preview branch``() =
            (MajorMinor
                ({ Major = 5
                   Minor = 0
+                  Patch = 199
                   Release = "preview2"}))
 
 [<Fact>]

--- a/tools/sdk-readme-table-generator/TableGenerator/Reference.fs
+++ b/tools/sdk-readme-table-generator/TableGenerator/Reference.fs
@@ -155,14 +155,14 @@ let linuxMuslArmReferenceTemplate branch =
     let format branch = formatTemplate "linux-musl-arm" linuxMuslReferenceTemplate branch
     match getMajorMinor branch with
         | Master -> format branch
-        | MajorMinor { Major = major; Minor = _minor } when major >= 6 -> format branch
+        | MajorMinor { Major = major; Minor = _minor; Patch = patch } when major >= 6 || (major >= 5 && patch >= 299) -> format branch
         | _ -> None
 
 let linuxMuslArm64ReferenceTemplate branch =
     let format branch = formatTemplate "linux-musl-arm64" linuxMuslReferenceTemplate branch
     match getMajorMinor branch with
         | Master -> format branch
-        | MajorMinor { Major = major; Minor = _minor } when major >= 6 -> format branch
+        | MajorMinor { Major = major; Minor = _minor; Patch = patch } when major >= 6 || (major >= 5 && patch >= 299) -> format branch
         | _ -> None
 
 let winArmMuslReferenceTemplate branch =

--- a/tools/sdk-readme-table-generator/TableGenerator/Shared.fs
+++ b/tools/sdk-readme-table-generator/TableGenerator/Shared.fs
@@ -18,6 +18,7 @@ let branchNameShorten (branch: Branch): string =
 type BranchMajorMinorVersion =
     { Major: int
       Minor: int
+      Patch: int
       Release: string}
 
 type BranchMajorMinorVersionOrMaster =
@@ -38,5 +39,6 @@ let getMajorMinor (branch: Branch): BranchMajorMinorVersionOrMaster =
                 MajorMinor
                     { Major = version.Major
                       Minor = version.Minor
+                      Patch = version.Patch
                       Release = version.Release}
             | _ -> NoVersion

--- a/tools/sdk-readme-table-generator/TableGenerator/Table.fs
+++ b/tools/sdk-readme-table-generator/TableGenerator/Table.fs
@@ -79,7 +79,7 @@ let linuxMuslRowArm branches =
     let tableTemplateForThisArch branch =
         match getMajorMinor branch with
         | Master -> format branch
-        | MajorMinor { Major = major; Minor = _minor } when major >= 6 -> format branch
+        | MajorMinor { Major = major; Minor = _minor; Patch = patch } when major >= 6 || (major >= 5 && patch >= 299) -> format branch
         | _ -> notAvailable
     formRow "**Linux-musl-arm**" tableTemplateForThisArch branches
 
@@ -88,7 +88,7 @@ let linuxMuslRowArm64 branches =
     let tableTemplateForThisArch branch =
         match getMajorMinor branch with
         | Master -> format branch
-        | MajorMinor { Major = major; Minor = _minor } when major >= 6 -> format branch
+        | MajorMinor { Major = major; Minor = _minor; Patch = patch } when major >= 6 || (major >= 5 && patch >= 299) -> format branch
         | _ -> notAvailable
     formRow "**Linux-musl-arm64**" tableTemplateForThisArch branches
 


### PR DESCRIPTION
This change adds 5.0.2xx entries for linux-musl-arm and linux-musl-arm64 into the readme table and updates the table generator / tests.
