### PR TITLE
Remove Microsoft.NETCore.App.Internal dependency (no longer produced)

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -21,10 +21,6 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>fd5609d44cfa904334864e113f253ed9c5e660b8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Internal" Version="6.0.0-alpha.1.20561.11" CoherentParentDependency="Microsoft.NET.Sdk">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f56a56f90ff9124c85e4d889faeeca0824d2d437</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-alpha.1.21054.6" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>fd5609d44cfa904334864e113f253ed9c5e660b8</Sha>


### PR DESCRIPTION
Removes stale dependency.