### PR TITLE
Remove MyGet reference

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -9,8 +9,6 @@
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="msbuild" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />
-    <add key="nuget-build" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />
     <add key="dotnet3-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3-transport/nuget/v3/index.json" />
     <add key="dotnet3.1-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1-transport/nuget/v3/index.json" />
     <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />


### PR DESCRIPTION
Found in response to dotnet/core-eng#11828. `dotnet.myget.org` was recently shut down in favor of Azure Artifacts. This reference was missed. 

I tested locally far enough to see that the `CopyToLatest` project builds and resolves packages. I haven't run it to completion as it looks to be a CI tool and I'm not sure the safe path. 