### PR TITLE
[release/3.1.4xx] Update Aspnetcore 21 template version

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -45,9 +45,9 @@
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>1b1646a5a6b6898b0433fd3b7f4f34fbd4b28ef7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="3.1.10-servicing.20560.6">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="3.1.10-servicing.20520.4">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>1b1646a5a6b6898b0433fd3b7f4f34fbd4b28ef7</Sha>
+      <Sha>e3187077455f953200e3c930430808a30f48b82e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="3.1.11">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -38,7 +38,7 @@
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
     <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>3.1.11</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
     <MicrosoftAspNetCoreAppRefPackageVersion>3.1.10</MicrosoftAspNetCoreAppRefPackageVersion>
-    <MicrosoftAspNetCoreAppRefInternalPackageVersion>3.1.10-servicing.20560.6</MicrosoftAspNetCoreAppRefInternalPackageVersion>
+    <MicrosoftAspNetCoreAppRefInternalPackageVersion>3.1.10-servicing.20520.4</MicrosoftAspNetCoreAppRefInternalPackageVersion>
     <MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>3.1.11-servicing.20560.10</MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>
     <dotnetdevcertsPackageVersion>3.1.11-servicing.20560.10</dotnetdevcertsPackageVersion>
     <dotnetusersecretsPackageVersion>3.1.11-servicing.20560.10</dotnetusersecretsPackageVersion>
@@ -105,7 +105,7 @@
     <MicrosoftDotNetCommonItemTemplates21PackageVersion>1.0.2-beta3</MicrosoftDotNetCommonItemTemplates21PackageVersion>
     <MicrosoftDotNetCommonProjectTemplates21PackageVersion>$(MicrosoftDotNetCommonItemTemplates21PackageVersion)</MicrosoftDotNetCommonProjectTemplates21PackageVersion>
     <MicrosoftDotNetTestProjectTemplates21PackageVersion>1.0.2-beta4.20105.2</MicrosoftDotNetTestProjectTemplates21PackageVersion>
-    <AspNetCorePackageVersionFor21Templates>2.1.23</AspNetCorePackageVersionFor21Templates>
+    <AspNetCorePackageVersionFor21Templates>2.1.24</AspNetCorePackageVersionFor21Templates>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->
   <PropertyGroup>


### PR DESCRIPTION
Also fix `Microsoft.AspNetCore.App.Ref.Internal` version to match what we actually shipped in 3.1.10