### PR TITLE
Use 6.0 test-template

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -83,6 +83,10 @@
       <Uri>https://github.com/dotnet/test-templates</Uri>
       <Sha>c315018ff9ea75ce160337c2b162fe4ef5804185</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.6.0" Version="1.0.2-beta4.21064.1">
+      <Uri>https://github.com/dotnet/test-templates</Uri>
+      <Sha>c315018ff9ea75ce160337c2b162fe4ef5804185</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="6.0.0-alpha.1.21064.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>499f3e1169c62b16e7378a21a0208c69d0598d76</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -37,7 +37,7 @@
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/test-templates -->
     <MicrosoftDotNetTestProjectTemplates50PackageVersion>1.0.2-beta4.21064.1</MicrosoftDotNetTestProjectTemplates50PackageVersion>
-    <MicrosoftDotNetTestProjectTemplates60PackageVersion>1.0.2-beta4.20420.1</MicrosoftDotNetTestProjectTemplates60PackageVersion>
+    <MicrosoftDotNetTestProjectTemplates60PackageVersion>1.0.2-beta4.21064.1</MicrosoftDotNetTestProjectTemplates60PackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- NUnit3.DotNetNew.Template versions do not 'flow in' -->

--- a/src/redist/targets/BundledTemplates.targets
+++ b/src/redist/targets/BundledTemplates.targets
@@ -28,19 +28,16 @@
     <Bundled60Templates Include="Microsoft.DotNet.Web.Spa.ProjectTemplates.6.0" PackageVersion="$(AspNetCorePackageVersionFor60Templates)" />
     
     
-    <!-- Templates that don't yet have 6.0 versions.  Use the 5.0 versions until we do have them -->
-    <Bundled60Templates Include="Microsoft.DotNet.Test.ProjectTemplates.5.0" PackageVersion="$(MicrosoftDotNetTestProjectTemplates50PackageVersion)" />
     <Bundled60Templates Include="Microsoft.Dotnet.Wpf.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWpfProjectTemplates50PackageVersion)" />
     <Bundled60Templates Include="Microsoft.Dotnet.WinForms.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWinFormsProjectTemplates50PackageVersion)" />
-    <Bundled60Templates Include="NUnit3.DotNetNew.Template" PackageVersion="$(NUnit3Templates50PackageVersion)" />
 
+    <!-- NUnit templates are shipped in Test.ProjectTemplates -->
+    <Bundled60Templates Include="Microsoft.DotNet.Test.ProjectTemplates.6.0" PackageVersion="$(MicrosoftDotNetTestProjectTemplates60PackageVersion)" />
     <!-- Once we do have 6.0 versions of these templates, we should remove them from the previous list, and add the commented versions below. -->
 
     <!--
-    <Bundled60Templates Include="Microsoft.DotNet.Test.ProjectTemplates.6.0" PackageVersion="$(MicrosoftDotNetTestProjectTemplates60PackageVersion)" />
     <Bundled60Templates Include="Microsoft.Dotnet.Wpf.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWpfProjectTemplates60PackageVersion)" />
     <Bundled60Templates Include="Microsoft.Dotnet.WinForms.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWinFormsProjectTemplates60PackageVersion)" />
-    <Bundled60Templates Include="NUnit3.DotNetNew.Template" PackageVersion="$(NUnit3Templates60PackageVersion)" />
     -->
   </ItemGroup>
   


### PR DESCRIPTION
Use 6.0 test templates, and remove the pulling of NUnit templates into net6.0 because we ship them in the nuget package together with test templates.