### PR TITLE
Fix linux-musl-arm apphost

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -76,11 +76,13 @@
 
       <NetCore31RuntimePackRids Include="@(NetCore30RuntimePackRids)"/>
 
-      <Net50AppHostRids Include="@(NetCore31RuntimePackRids)"/>
+      <Net50AppHostRids Include="
+          @(NetCore31RuntimePackRids);
+          linux-musl-arm;
+          "/>
       
       <Net50RuntimePackRids Include="
           @(Net50AppHostRids);
-          linux-musl-arm;
           ios-arm64;
           ios-arm;
           ios-x64;


### PR DESCRIPTION
The linux-musl-arm RID in the GenerateBundledVersions.targets was accidentally
added in Net50RuntimePackRids instead of Net50AppHostRids. That caused a wrong
host (linux-arm) to be extracted during dotnet publish.
