### PR TITLE
[release/5.0.2xx] - Fix linux-musl-arm apphost

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -73,11 +73,13 @@
 
       <NetCore31RuntimePackRids Include="@(NetCore30RuntimePackRids)"/>
 
-      <NetCore5AppHostRids Include="@(NetCore31RuntimePackRids)"/>
+      <NetCore5AppHostRids Include="
+          @(NetCore31RuntimePackRids);
+          linux-musl-arm;
+          "/>
       
       <NetCore5RuntimePackRids Include="
           @(NetCore5AppHostRids);
-          linux-musl-arm;
           ios-arm64;
           ios-arm;
           ios-x64;


### PR DESCRIPTION
Port #9475 to release/5.0.2xx

#### Description
The linux-musl-arm RID in the GenerateBundledVersions.targets was accidentally
added in Net50RuntimePackRids instead of Net50AppHostRids. That caused a wrong
host (linux-arm) to be extracted during dotnet publish.

#### Customer Impact
With this fix, customers can finally target linux-musl-arm using dotnet sdk. 

#### Regression?
No

#### Risk
Low, this change only fixes the host that was wrong before.
