### PR TITLE
Remove usage of dotnet-deb-tool

### DIFF
--- a/src/core-sdk-tasks/DotNetDebTool.cs
+++ b/src/core-sdk-tasks/DotNetDebTool.cs
@@ -1,23 +1,14 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.Cli.Build
 {
-    public class DotNetDebTool : DotNetTool
+    public class DotNetDebTool : ToolTask
     {
-        protected override string Command
-        {
-            get { return "deb-tool"; }
-        }
-
-        protected override string Args
-        {
-            get { return $"{GetInputDir()} {GetOutputFile()} {GetPackageName()} {GetPackageVersion()}"; }
-        }
-
         [Required]
         public string InputDirectory { get; set; }
 
@@ -29,6 +20,10 @@ namespace Microsoft.DotNet.Cli.Build
 
         [Required]
         public string PackageVersion { get; set; }
+
+        public string WorkingDirectory { get; set; }
+
+        protected override string ToolName => "package_tool.sh";
 
         private string GetInputDir()
         {
@@ -48,6 +43,63 @@ namespace Microsoft.DotNet.Cli.Build
         private string GetPackageVersion()
         {
             return $"-v {PackageVersion}";
+        }
+
+        protected override MessageImportance StandardOutputLoggingImportance
+        {
+            get { return MessageImportance.High; } // or else the output doesn't get logged by default
+        }
+
+        protected override string GenerateFullPathToTool()
+        {
+            string path = ToolPath;
+
+            // if ToolPath was not provided by the MSBuild script 
+            if (string.IsNullOrEmpty(path))
+            {
+                Log.LogError($"Could not find the Path to {ToolName}");
+
+                return string.Empty;
+            }
+
+            return path;
+        }
+
+        protected override string GetWorkingDirectory()
+        {
+            return WorkingDirectory ?? base.GetWorkingDirectory();
+        }
+
+        protected override string GenerateCommandLineCommands()
+        {
+            var commandLineCommands = $"{GetInputDir()} {GetOutputFile()} {GetPackageName()} {GetPackageVersion()}";
+
+            LogToolCommand($"package_tool.sh {commandLineCommands}");
+
+            return commandLineCommands;
+        }
+
+        protected override void LogToolCommand(string message)
+        {
+            base.LogToolCommand($"{GetWorkingDirectory()}> {message}");
+        }
+
+        protected override ProcessStartInfo GetProcessStartInfo(
+            string pathToTool,
+            string commandLineCommands,
+            string responseFileSwitch)
+        {
+            var psi = base.GetProcessStartInfo(
+                pathToTool,
+                commandLineCommands,
+                responseFileSwitch);
+
+            foreach (var environmentVariableName in new EnvironmentFilter().GetEnvironmentVariableNamesToRemove())
+            {
+                psi.Environment.Remove(environmentVariableName);
+            }
+
+            return psi;
         }
     }
 }

--- a/src/core-sdk-tasks/DotNetDebTool.cs
+++ b/src/core-sdk-tasks/DotNetDebTool.cs
@@ -84,6 +84,11 @@ namespace Microsoft.DotNet.Cli.Build
             base.LogToolCommand($"{GetWorkingDirectory()}> {message}");
         }
 
+        protected override void LogEventsFromTextOutput(string singleLine, MessageImportance messageImportance)
+        {
+            Log.LogMessage(messageImportance, singleLine, null);
+        }
+
         protected override ProcessStartInfo GetProcessStartInfo(
             string pathToTool,
             string commandLineCommands,

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -17,6 +17,10 @@
   </ItemGroup>
 
   <ItemGroup>
+     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Installers" Version="$(MicrosoftDotNetBuildTasksInstallersPackageVersion)" GeneratePathProperty="True" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="targets\DownloadPackage.csproj" />
     <None Include="targets\LayoutTool.csproj" />
   </ItemGroup>

--- a/src/redist/targets/GenerateDebs.targets
+++ b/src/redist/targets/GenerateDebs.targets
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!-- dotnet deb-tool -->
-  <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-deb-tool" Version="$(DotnetDebToolVersion)" />
-  </ItemGroup>
+  <PropertyGroup>
+    <DebPackageToolPath>$(PkgMicrosoft_DotNet_Build_Tasks_Installers)/build/deb-package-tool/package_tool.sh</DebPackageToolPath>
+  </PropertyGroup>
   
   <Target Name="SetupDebProps"
         DependsOnTargets="GetCurrentRuntimeInformation;
@@ -230,7 +229,6 @@
   <Target Name="BuildSdkDeb"
       Condition=" '$(IsDebianBaseDistro)' == 'True' AND '$(DebuildPresent)'  == 'true' "
       DependsOnTargets="PrepareDotnetDebDirectories;
-                        PrepareDotnetDebTool;
                         GetAspNetSharedFxInstallArgs;"
       Inputs="@(CLISdkFiles);@(TemplatesFiles)"
       Outputs="$(SdkDebInstallerFile)" >
@@ -286,7 +284,7 @@
         ReplacementItems="@(DebianConfigTokenValues)" />
 
       <!-- Build SDK Deb package -->
-      <DotNetDebTool ToolPath="$([System.IO.Path]::GetDirectoryName($(DotNetTool)))"
+      <DotNetDebTool ToolPath="$(DebPackageToolPath)"
                      InputDirectory="$(LayoutDirectory)"
                      OutputDirectory="$(DotNetDebToolOutputDirectory)"
                      PackageName="$(SdkDebianPackageName)"
@@ -416,12 +414,6 @@
     <MakeDir Directories="@(WorkspaceDirectories)" />
     <MakeDir Directories="@(LayoutSubDirectories)" />
     <MakeDir Directories="$(DotNetDebToolOutputDirectory)" />
-  </Target>
-
-  <Target Name="PrepareDotnetDebTool">
-
-    <!--<DotNetRestore ToolPath="$(PreviousStageDirectory)"
-                   WorkingDirectory="$(DotnetDebToolDir)" />-->
   </Target>
 
   <Target Name="TestDebuild">

--- a/src/redist/targets/GenerateDebs.targets
+++ b/src/redist/targets/GenerateDebs.targets
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <DebPackageToolPath>$(PkgMicrosoft_DotNet_Build_Tasks_Installers)/build/deb-package-tool/package_tool.sh</DebPackageToolPath>
+    <DebPackageToolPath>$(PkgMicrosoft_DotNet_Build_Tasks_Installers)/build/deb-package-tool</DebPackageToolPath>
   </PropertyGroup>
   
   <Target Name="SetupDebProps"

--- a/src/redist/targets/GenerateMSIs.targets
+++ b/src/redist/targets/GenerateMSIs.targets
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
-     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Installers" Version="$(MicrosoftDotNetBuildTasksInstallersPackageVersion)" />
-  </ItemGroup>
-  
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">  
   <PropertyGroup>
     <MicrosoftDotNetBuildTasksInstallersTaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(NuGetPackageRoot)microsoft.dotnet.build.tasks.installers\$(MicrosoftDotNetBuildTasksInstallersPackageVersion)\tools\netcoreapp2.1\Microsoft.DotNet.Build.Tasks.Installers.dll</MicrosoftDotNetBuildTasksInstallersTaskAssembly>
     <MicrosoftDotNetBuildTasksInstallersTaskAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(NuGetPackageRoot)microsoft.dotnet.build.tasks.installers\$(MicrosoftDotNetBuildTasksInstallersPackageVersion)\tools\net472\Microsoft.DotNet.Build.Tasks.Installers.dll</MicrosoftDotNetBuildTasksInstallersTaskAssembly>


### PR DESCRIPTION
Use the package_tool.sh script that dotnet-deb-tool wraps directly and is currently maintained in Arcade instead of the old dotnet-deb-tool CLI tool package.

This will allow us to delete dotnet-deb-tool from dotnet/runtime.