### PR TITLE
Update List of Assemblies to Crossgen

### DIFF
--- a/src/redist/targets/Crossgen.targets
+++ b/src/redist/targets/Crossgen.targets
@@ -59,7 +59,6 @@
       <RemainingFiles Include="$(SdkOutputDirectory)Sdks\Microsoft.NET.Sdk.WindowsDesktop\tools\netcoreapp*\**\*" />
       <RemainingFiles Include="$(SdkOutputDirectory)Sdks\Microsoft.NET.ILLink.Tasks\tools\net5.0\**\*" />
       <RemainingFiles Include="$(SdkOutputDirectory)Sdks\Microsoft.NET.Sdk.Publish\tools\net6.0\**\*" />
-      <RemainingFiles Include="$(SdkOutputDirectory)Sdks\Microsoft.NET.Sdk.Web\analyzers\cs\**\*" />
       <RemainingFiles Include="$(SdkOutputDirectory)Sdks\Microsoft.NET.Sdk.Web\tools\net6.0\**\*" />
       <RemainingFiles Include="$(SdkOutputDirectory)Sdks\Microsoft.NET.Sdk.Web.ProjectSystem\tools\net6.0\**\*" />
       <RemainingFiles Include="$(SdkOutputDirectory)Sdks\Microsoft.NET.Sdk.Worker\tools\net6.0\**\*" />

--- a/src/redist/targets/Crossgen.targets
+++ b/src/redist/targets/Crossgen.targets
@@ -51,13 +51,18 @@
       <RemainingFiles Remove="$(SdkOutputDirectory)**\Microsoft.TestPlatform.Extensions.EventLogCollector.dll" />
 
       <!-- Add back the .NET Core assemblies in the Sdks folder -->
-      <RemainingFiles Include="$(SdkOutputDirectory)Sdks\Microsoft.NET.Sdk\tools\netcoreapp*\**\*" />
+      <RemainingFiles Include="$(SdkOutputDirectory)Sdks\Microsoft.NET.Sdk\tools\net6.0\**\*" />
+      <RemainingFiles Include="$(SdkOutputDirectory)Sdks\Microsoft.NET.Sdk.BlazorWebAssembly\tools\net6.0\**\*" />
       <RemainingFiles Include="$(SdkOutputDirectory)Sdks\NuGet.Build.Tasks.Pack\CoreCLR\**\*" />
-      <RemainingFiles Include="$(SdkOutputDirectory)Sdks\Microsoft.NET.Sdk.Razor\tasks\netcoreapp*\*" />
-      <RemainingFiles Include="$(SdkOutputDirectory)Sdks\Microsoft.NET.Sdk.Razor\tools\netcoreapp*\**\*" />
+      <RemainingFiles Include="$(SdkOutputDirectory)Sdks\Microsoft.NET.Sdk.Razor\tasks\net6.0\**\*" />
+      <RemainingFiles Include="$(SdkOutputDirectory)Sdks\Microsoft.NET.Sdk.Razor\tools\**\*" />
       <RemainingFiles Include="$(SdkOutputDirectory)Sdks\Microsoft.NET.Sdk.WindowsDesktop\tools\netcoreapp*\**\*" />
-      <RemainingFiles Include="$(SdkOutputDirectory)Sdks\ILLink.Tasks\tools\netcoreapp*\**\*" />
-      <RemainingFiles Include="$(SdkOutputDirectory)Sdks\Microsoft.NET.Sdk.Publish\tools\netcoreapp*\**\*" />
+      <RemainingFiles Include="$(SdkOutputDirectory)Sdks\Microsoft.NET.ILLink.Tasks\tools\net5.0\**\*" />
+      <RemainingFiles Include="$(SdkOutputDirectory)Sdks\Microsoft.NET.Sdk.Publish\tools\net6.0\**\*" />
+      <RemainingFiles Include="$(SdkOutputDirectory)Sdks\Microsoft.NET.Sdk.Web\analyzers\cs\**\*" />
+      <RemainingFiles Include="$(SdkOutputDirectory)Sdks\Microsoft.NET.Sdk.Web\tools\net6.0\**\*" />
+      <RemainingFiles Include="$(SdkOutputDirectory)Sdks\Microsoft.NET.Sdk.Web.ProjectSystem\tools\net6.0\**\*" />
+      <RemainingFiles Include="$(SdkOutputDirectory)Sdks\Microsoft.NET.Sdk.Worker\tools\net6.0\**\*" />
 
       <!-- Don't try to CrossGen .NET Framework support assemblies for .NET Standard -->
       <RemainingFiles Remove="$(SdkOutputDirectory)Microsoft\Microsoft.NET.Build.Extensions\net*\**\*" />


### PR DESCRIPTION
Contributes to https://github.com/dotnet/sdk/issues/15558.

### Context
The installer is responsible for precompiling the libraries that compose the final SDK.  Over time, several new SDKs have been added, and several have been upgraded, which has resulted in a number of SDK assemblies that are not pre-compiled, and thus contribute to higher JIT times and overall wall-clock latency.

### Changes Made
Updated paths to assemblies in crossgen.targets that contain assemblies that should be pre-compiled.

### Testing
 - Verified that basic SDK scenarios work.
 - Captured before/after profiles to confirm wins.

### Notes
This PR contains the following performance wins:
 - -548 drop in method jitting overall
 - 210.1ms improvement in JIT time (26.1%)
 - 7% improvement overall

I have filed #9634 to track work to catch this if/when it happens again.

cc: @stephentoub, @DamianEdwards, @marcpopMSFT