### PR TITLE
Fix string stating the minimum vs version required.

### DIFF
--- a/src/redist/targets/packaging/windows/clisdk/LCID/1033/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1033/bundle.wxl
@@ -76,7 +76,7 @@ Resources
   <String Id="InstallationNoteTitle">Installation note</String>
   <String Id="InstallationNote">A command will be run during the install process that will improve project restore speed and enable offline access. It will take up to a minute to complete.
   </String>
-  <String Id="VisualStudioWarning">If you plan to use .NET 6.0 with Visual Studio, Visual Studio 2019 16.8 or newer is required. &lt;A HREF=&quot;https://aka.ms/dotnet6-release-notes&quot;&gt;Learn more&lt;/A&gt;.
+  <String Id="VisualStudioWarning">If you plan to use .NET 6.0 with Visual Studio, Visual Studio 2019 16.9 or newer is required. &lt;A HREF=&quot;https://aka.ms/dotnet6-release-notes&quot;&gt;Learn more&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">By clicking Install, you agree to the following terms:</String>
 </WixLocalization>


### PR DESCRIPTION
Fixes https://github.com/dotnet/installer/issues/9622.

- Please add description for changes you are making.
- If there is an issue related to this PR, please add the reference.
This PR fixes an issue with the .NET 6 installers that states the wrong VS version that is minimum within the installer. https://github.com/dotnet/installer/issues/9622