### PR TITLE
Add Mac Catalyst to the list of runtime pack IDs.

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -89,6 +89,8 @@
           ios-x86;
           tvos-arm64;
           tvos-x64;
+          maccatalyst-x64;
+          maccatalyst-arm64;
           android-arm64;
           android-arm;
           android-x64;


### PR DESCRIPTION
This is like #7034, just for Mac Catalyst.

/cc @dsplaisted @akoeplinger @steveisok 