### PR TITLE
Add support for building a PGO installer copy

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -116,7 +116,7 @@ stages:
             _DOTNET_CLI_UI_LANGUAGE: ''
             _AdditionalBuildParameters: '/p:PublishInternalAsset=true'
             _TestArg: $(_WindowsTestArg)
-            _pgoInstrument: true
+      pgoInstrument: true
 
   - template: /eng/build.yml
     parameters:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -98,6 +98,28 @@ stages:
 
   - template: /eng/build.yml
     parameters:
+      agentOs: Windows_NT
+      pool:
+        ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          name: NetCorePublic-Pool
+          queue: buildpool.windows.10.amd64.vs2017.open
+        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          name: NetCoreInternal-Pool
+          queue: buildpool.windows.10.amd64.vs2017
+      timeoutInMinutes: 180
+      strategy:
+        matrix:
+          # Always run builds
+          Build_Release_x64:
+            _BuildConfig: Release
+            _BuildArchitecture: x64
+            _DOTNET_CLI_UI_LANGUAGE: ''
+            _AdditionalBuildParameters: '/p:PublishInternalAsset=true'
+            _TestArg: $(_WindowsTestArg)
+            _pgoInstrument: true
+
+  - template: /eng/build.yml
+    parameters:
       agentOs: Linux
       pool:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
@@ -269,7 +291,7 @@ stages:
   - template: /eng/build.yml
     parameters:
       agentOs: Darwin
-      pool: 
+      pool:
         vmImage: 'macOS-10.15'
       timeoutInMinutes: 180
       strategy:
@@ -290,7 +312,7 @@ stages:
   # - template: /eng/build.yml
   #   parameters:
   #     agentOs: FreeBSD
-  #     queue: 
+  #     queue:
   #       name: dnceng-freebsd-internal
   #       timeoutInMinutes: 180
   #       matrix:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -18,7 +18,7 @@ variables:
 - name: _PublishUsingPipelines
   value: false
 - name: PostBuildSign
-  value: ${{ not(parameters.pgoInstrument) }}
+  value: true
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - group: DotNet-DotNetCli-Storage
   - group: DotNet-Blob-Feed
@@ -118,6 +118,7 @@ stages:
             _AdditionalBuildParameters: '/p:PublishInternalAsset=true'
             # Never run tests on PGO bits
             _TestArg: ''
+            PostBuildSign: false
       pgoInstrument: true
 
   - template: /eng/build.yml

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -118,7 +118,6 @@ stages:
             _AdditionalBuildParameters: '/p:PublishInternalAsset=true'
             # Never run tests on PGO bits
             _TestArg: ''
-            PostBuildSign: false
       pgoInstrument: true
 
   - template: /eng/build.yml

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -18,7 +18,7 @@ variables:
 - name: _PublishUsingPipelines
   value: false
 - name: PostBuildSign
-  value: true
+  value: ${{ not(parameters.pgoInstrument) }}
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - group: DotNet-DotNetCli-Storage
   - group: DotNet-Blob-Feed

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -116,7 +116,8 @@ stages:
             _BuildArchitecture: x64
             _DOTNET_CLI_UI_LANGUAGE: ''
             _AdditionalBuildParameters: '/p:PublishInternalAsset=true'
-            _TestArg: $(_WindowsTestArg)
+            # Never run tests on PGO bits
+            _TestArg: ''
       pgoInstrument: true
 
   - template: /eng/build.yml

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,6 +12,7 @@
     <Architecture Condition="'$(Architecture)' == '' AND '$(BuildArchitecture)' == 'arm64'">$(BuildArchitecture)</Architecture>
     <Architecture Condition="'$(Architecture)' == ''">x64</Architecture>
     <PgoSuffix Condition="'$(PgoInstrument)' == 'true'">.PGO</PgoSuffix>
+    <PgoTerm Condition="'$(PgoInstrument)' == 'true'">-pgo</PgoTerm>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,7 @@
     <BuildArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</BuildArchitecture>
     <Architecture Condition="'$(Architecture)' == '' AND '$(BuildArchitecture)' == 'arm64'">$(BuildArchitecture)</Architecture>
     <Architecture Condition="'$(Architecture)' == ''">x64</Architecture>
+    <PgoSuffix Condition="'$(PgoInstrument)' == 'true'">.PGO</PgoSuffix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,8 +11,10 @@
     <BuildArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</BuildArchitecture>
     <Architecture Condition="'$(Architecture)' == '' AND '$(BuildArchitecture)' == 'arm64'">$(BuildArchitecture)</Architecture>
     <Architecture Condition="'$(Architecture)' == ''">x64</Architecture>
-    <PgoSuffix Condition="'$(PgoInstrument)' == 'true'">.PGO</PgoSuffix>
-    <PgoTerm Condition="'$(PgoInstrument)' == 'true'">-pgo</PgoTerm>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(PgoInstrument)' == 'true'">
+    <SkipBuildingInstallers>true</SkipBuildingInstallers>
+    <PgoTerm>-pgo</PgoTerm>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -44,7 +44,7 @@ phases:
       - _BuildArgs: '/p:DotNetSignType=$(_SignType)'
       - _DOTNETCLIMSRC_READ_SAS_TOKEN: ''
 
-      - ${{ if pgoInstrument }}:
+      - ${{ if parameters.pgoInstrument }}:
         - _PgoInstrument: '/p:PgoInstrument=true'
 
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -37,12 +37,15 @@ phases:
     workspace:
       clean: all
 
-    variables: 
+    variables:
       - _AgentOSName: ${{ parameters.agentOs }}
       - _TeamName: Roslyn-Project-System
       - _SignType: test
       - _BuildArgs: '/p:DotNetSignType=$(_SignType)'
       - _DOTNETCLIMSRC_READ_SAS_TOKEN: ''
+
+      - ${{ if pgoInstrument }}:
+        - _PgoInstrument: '/p:PgoInstrument=true'
 
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         - group: DotNet-MSRC-Storage
@@ -61,6 +64,7 @@ phases:
                   /p:DotNetSignType=$(_SignType)
                   /p:TeamName=$(_TeamName)
                   /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
+                  $(_PgoInstrument)
 
     steps:
     - checkout: self
@@ -135,32 +139,32 @@ phases:
           publishFeedCredentials: 'DevDiv - VS package feed'
         condition: and(succeeded(), eq(variables['_PushToVSFeed'], 'true'), eq(variables['_DotNetPublishToBlobFeed'], 'true'), or(eq(variables['_BuildArchitecture'], 'x64'), eq(variables['_BuildArchitecture'], 'x86')))
 
-    - task: PublishTestResults@2	
-      displayName: Publish Test Results	
+    - task: PublishTestResults@2
+      displayName: Publish Test Results
       inputs:
-        testRunner: XUnit	
-        testResultsFiles: 'artifacts/TestResults/$(_BuildConfig)/*.xml'	
-        testRunTitle: '$(_AgentOSName)_$(Agent.JobName)'	
-        platform: '$(BuildPlatform)'	
-        configuration: '$(_BuildConfig)'	
+        testRunner: XUnit
+        testResultsFiles: 'artifacts/TestResults/$(_BuildConfig)/*.xml'
+        testRunTitle: '$(_AgentOSName)_$(Agent.JobName)'
+        platform: '$(BuildPlatform)'
+        configuration: '$(_BuildConfig)'
       condition: ne(variables['_TestArg'], '')
 
-    - task: CopyFiles@2	
-      displayName: Gather Logs	
+    - task: CopyFiles@2
+      displayName: Gather Logs
       inputs:
-        SourceFolder: '$(Build.SourcesDirectory)/artifacts'	
-        Contents: |	
-         log/$(_BuildConfig)/**/*	
-         TestResults/$(_BuildConfig)/**/*	
-        TargetFolder: '$(Build.ArtifactStagingDirectory)'	
-      continueOnError: true	
+        SourceFolder: '$(Build.SourcesDirectory)/artifacts'
+        Contents: |
+         log/$(_BuildConfig)/**/*
+         TestResults/$(_BuildConfig)/**/*
+        TargetFolder: '$(Build.ArtifactStagingDirectory)'
+      continueOnError: true
       condition: always()
 
-    - task: PublishBuildArtifacts@1	
-      displayName: Publish Logs to VSTS	
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Logs to VSTS
       inputs:
-        PathtoPublish: '$(Build.ArtifactStagingDirectory)'	
-        ArtifactName: '$(_AgentOSName)_$(Agent.JobName)_$(Build.BuildNumber)'	
-        publishLocation: Container	
-      continueOnError: true	
+        PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+        ArtifactName: '$(_AgentOSName)_$(Agent.JobName)_$(Build.BuildNumber)'
+        publishLocation: Container
+      continueOnError: true
       condition: always()

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -20,7 +20,7 @@ parameters:
 phases:
 - template: /eng/common/templates/job/job.yml
   parameters:
-    name: ${{ parameters.agentOs }}
+    name: ${{ parameters.agentOs }}${{ parameters.pgoInstrument }}
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
       enableMicrobuild: true

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -38,14 +38,14 @@ phases:
       clean: all
 
     variables:
+      - ${{ if parameters.pgoInstrument }}:
+        - _PgoInstrument: '/p:PgoInstrument=true'
+
       - _AgentOSName: ${{ parameters.agentOs }}
       - _TeamName: Roslyn-Project-System
       - _SignType: test
-      - _BuildArgs: '/p:DotNetSignType=$(_SignType)'
+      - _BuildArgs: '/p:DotNetSignType=$(_SignType) $(_PgoInstrument)'
       - _DOTNETCLIMSRC_READ_SAS_TOKEN: ''
-
-      - ${{ if parameters.pgoInstrument }}:
-        - _PgoInstrument: '/p:PgoInstrument=true'
 
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         - group: DotNet-MSRC-Storage

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -38,6 +38,8 @@ phases:
       clean: all
 
     variables:
+      - ${{ if not(parameters.pgoInstrument) }}:
+        - _PgoInstrument: ''
       - ${{ if parameters.pgoInstrument }}:
         - _PgoInstrument: '/p:PgoInstrument=true'
 

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -17,9 +17,6 @@ parameters:
   # Publish using pipelines
   enablePublishUsingPipelines: true
 
-  # Use PGO instrumentation bits to gather PGO data
-  pgoInstrument: false
-
 phases:
 - template: /eng/common/templates/job/job.yml
   parameters:

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -20,10 +20,10 @@ parameters:
 phases:
 - template: /eng/common/templates/job/job.yml
   parameters:
-  - ${{ parameters.pgoInstrument }}:
-    name: ${{ parameters.agentOs }} PGO
-  - ${{ not(parameters.pgoInstrument) }}:
-    name: ${{ parameters.agentOs }}
+    ${{ parameters.pgoInstrument }}:
+      name: ${{ parameters.agentOs }} PGO
+    ${{ not(parameters.pgoInstrument) }}:
+      name: ${{ parameters.agentOs }}
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
       enableMicrobuild: true

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -20,10 +20,10 @@ parameters:
 phases:
 - template: /eng/common/templates/job/job.yml
   parameters:
-    - ${{ parameters.pgoInstrument }}:
-      name: ${{ parameters.agentOs }} PGO
-    - ${{ not(parameters.pgoInstrument) }}:
-      name: ${{ parameters.agentOs }}
+  - ${{ parameters.pgoInstrument }}:
+    name: ${{ parameters.agentOs }} PGO
+  - ${{ not(parameters.pgoInstrument) }}:
+    name: ${{ parameters.agentOs }}
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
       enableMicrobuild: true

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -17,11 +17,14 @@ parameters:
   # Publish using pipelines
   enablePublishUsingPipelines: true
 
+  # Use PGO instrumentation bits to gather PGO data
+  pgoInstrument: false
+
 phases:
 - template: /eng/common/templates/job/job.yml
   parameters:
     ${{ parameters.pgoInstrument }}:
-      name: ${{ parameters.agentOs }} PGO
+      name: PGO ${{ parameters.agentOs }}
     ${{ not(parameters.pgoInstrument) }}:
       name: ${{ parameters.agentOs }}
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -23,9 +23,9 @@ parameters:
 phases:
 - template: /eng/common/templates/job/job.yml
   parameters:
-    ${{ parameters.pgoInstrument }}:
+    ${{ if parameters.pgoInstrument }}:
       name: PGO ${{ parameters.agentOs }}
-    ${{ not(parameters.pgoInstrument) }}:
+    ${{ if not(parameters.pgoInstrument) }}:
       name: ${{ parameters.agentOs }}
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     ${{ if eq(parameters.agentOs, 'Windows_NT') }}:

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -41,10 +41,14 @@ phases:
       clean: all
 
     variables:
-      - ${{ if not(parameters.pgoInstrument) }}:
-        - _PgoInstrument: ''
+      - _PgoInstrument: ''
+      - ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
+        - _PackArg: '-pack'
+      - ${{ if ne(parameters.agentOs, 'Windows_NT') }}:
+        - _PackArg: '--pack'
       - ${{ if parameters.pgoInstrument }}:
         - _PgoInstrument: '/p:PgoInstrument=true'
+        - _PackArg: ''
 
       - _AgentOSName: ${{ parameters.agentOs }}
       - _TeamName: Roslyn-Project-System
@@ -84,8 +88,8 @@ phases:
           env:
             Token: $(dn-bot-dnceng-artifact-feeds-rw)
       - script: build.cmd
-                  $(_TestArg)
-                  -pack -publish -ci -sign
+                  $(_TestArg) $(_PackArg)
+                  -publish -ci -sign
                   -Configuration $(_BuildConfig)
                   -Architecture $(_BuildArchitecture)
                   $(_BuildArgs)
@@ -106,8 +110,8 @@ phases:
             Token: $(dn-bot-dnceng-artifact-feeds-rw)
     - ${{ if eq(parameters.agentOs, 'Linux') }}:
       - script: ./build.sh
-                  $(_TestArg)
-                  --pack --publish --ci
+                  $(_TestArg) $(_PackArg)
+                  --publish --ci
                   --noprettyprint
                   --configuration $(_BuildConfig)
                   $(_DockerParameter)

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -21,7 +21,7 @@ phases:
 - template: /eng/common/templates/job/job.yml
   parameters:
     ${{ if parameters.pgoInstrument }}:
-      name: 'PGO ${{ parameters.agentOs }}'
+      name: PGO_${{ parameters.agentOs }}
     ${{ if not(parameters.pgoInstrument) }}:
       name: ${{ parameters.agentOs }}
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -20,7 +20,10 @@ parameters:
 phases:
 - template: /eng/common/templates/job/job.yml
   parameters:
-    name: ${{ parameters.agentOs }}${{ parameters.pgoInstrument }}
+    - ${{ parameters.pgoInstrument }}:
+      name: ${{ parameters.agentOs }} PGO
+    - ${{ not(parameters.pgoInstrument) }}:
+      name: ${{ parameters.agentOs }}
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
       enableMicrobuild: true

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -21,7 +21,7 @@ phases:
 - template: /eng/common/templates/job/job.yml
   parameters:
     ${{ if parameters.pgoInstrument }}:
-      name: PGO ${{ parameters.agentOs }}
+      name: 'PGO ${{ parameters.agentOs }}'
     ${{ if not(parameters.pgoInstrument) }}:
       name: ${{ parameters.agentOs }}
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}

--- a/run-build.ps1
+++ b/run-build.ps1
@@ -8,6 +8,7 @@ param(
     [string]$Configuration="Debug",
     [string]$Architecture="x64",
     [switch]$Sign=$false,
+    [switch]$PgoInstrument,
     [bool]$WarnAsError=$true,
     [Parameter(ValueFromRemainingArguments=$true)][String[]]$ExtraParameters
 )
@@ -16,6 +17,10 @@ $RepoRoot = "$PSScriptRoot"
 
 $Parameters = "/p:Architecture=$Architecture"
 $Parameters = "$Parameters -configuration $Configuration"
+
+if ($PgoInstrument) {
+  $Parameters = "$Parameters /p:PgoInstrument=true"
+}
 
 if ($Sign) {
   $Parameters = "$Parameters -sign /p:SignCoreSdk=true"

--- a/run-build.sh
+++ b/run-build.sh
@@ -42,6 +42,9 @@ while [[ $# > 0 ]]; do
         --linux-portable)
             args+=("/p:Rid=linux-x64 /p:OSName=\"linux\" /p:IslinuxPortable=\"true\"")
             ;;
+        --pgoInstrument)
+            args+=("/p:PgoInstrument=true")
+            ;;
         --help)
             echo "Usage: $0 [--configuration <CONFIGURATION>] [--architecture <ARCHITECTURE>] [--docker <IMAGENAME>] [--help]"
             echo ""

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -8,7 +8,7 @@
       Lines="$(PackageVersion)"
       Overwrite="true"
       Encoding="ASCII" />
-    
+
     <WriteLinesToFile
       File="$(ArtifactsShippingPackagesDir)sdk-productVersion.txt"
       Lines="$(PackageVersion)"
@@ -54,19 +54,19 @@
 
       <_NETCoreApp30RuntimePackVersion>3.0.3</_NETCoreApp30RuntimePackVersion>
       <_NETCoreApp30TargetingPackVersion>3.0.0</_NETCoreApp30TargetingPackVersion>
-      
+
       <_NETCoreApp31RuntimePackVersion>3.1.$(VersionFeature31)</_NETCoreApp31RuntimePackVersion>
       <_NETCoreApp31TargetingPackVersion>3.1.0</_NETCoreApp31TargetingPackVersion>
-      
+
       <_WindowsDesktop30RuntimePackVersion>3.0.3</_WindowsDesktop30RuntimePackVersion>
       <_WindowsDesktop30TargetingPackVersion>3.0.0</_WindowsDesktop30TargetingPackVersion>
-      
+
       <_WindowsDesktop31RuntimePackVersion>3.1.$(VersionFeature31)</_WindowsDesktop31RuntimePackVersion>
       <_WindowsDesktop31TargetingPackVersion>3.1.0</_WindowsDesktop31TargetingPackVersion>
-      
+
       <_AspNet30RuntimePackVersion>3.0.3</_AspNet30RuntimePackVersion>
       <_AspNet30TargetingPackVersion>3.0.1</_AspNet30TargetingPackVersion>
-      
+
       <_AspNet31RuntimePackVersion>3.1.$(VersionFeature31)</_AspNet31RuntimePackVersion>
       <_AspNet31TargetingPackVersion>3.1.10</_AspNet31TargetingPackVersion>
 
@@ -101,7 +101,7 @@
           @(NetCore31RuntimePackRids);
           linux-musl-arm;
           "/>
-      
+
       <Net50RuntimePackRids Include="
           @(Net50AppHostRids);
           ios-arm64;
@@ -159,7 +159,7 @@
     <GenerateDefaultRuntimeFrameworkVersion RuntimePackVersion="$(MicrosoftAspNetCoreAppRuntimePackageVersion)">
       <Output TaskParameter="DefaultRuntimeFrameworkVersion" PropertyName="MicrosoftAspNetCoreAppDefaultRuntimeFrameworkVersion" />
     </GenerateDefaultRuntimeFrameworkVersion>
-    
+
     <ItemGroup>
       <ImplicitPackageVariable Include="Microsoft.NETCore.App"
                                TargetFrameworkVersion="1.0"
@@ -199,11 +199,11 @@
                                DefaultVersion="2.2.0"
                                LatestVersion="2.2.8"/>
     </ItemGroup>
-    
+
     <PropertyGroup>
       <PortableProductMonikerRid Condition="'$(PortableProductMonikerRid)' == ''">$(ProductMonikerRid)</PortableProductMonikerRid>
     </PropertyGroup>
-      
+
 
     <PropertyGroup>
       <BundledVersionsPropsContent>
@@ -223,7 +223,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <NetCoreRoot Condition="'%24(NetCoreRoot)' == ''">%24([MSBuild]::NormalizePath('%24(MSBuildThisFileDirectory)..\..\'))</NetCoreRoot>
     <NetCoreTargetingPackRoot Condition="'%24(NetCoreTargetingPackRoot)' == ''">%24([MSBuild]::EnsureTrailingSlash('%24(NetCoreRoot)'))packs</NetCoreTargetingPackRoot>
-  
+
     <NETCoreAppMaximumVersion>$(_NETCoreAppTargetFrameworkVersion)</NETCoreAppMaximumVersion>
     <BundledNETCoreAppTargetFrameworkVersion>$(_NETCoreAppTargetFrameworkVersion)</BundledNETCoreAppTargetFrameworkVersion>
     <BundledNETCoreAppPackageVersion>$(_NETCoreAppPackageVersion)</BundledNETCoreAppPackageVersion>
@@ -265,7 +265,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                         Crossgen2PackVersion="$(MicrosoftNETCoreAppRuntimePackageVersion)"
                         Crossgen2RuntimeIdentifiers="@(Crossgen2SupportedRids, '%3B')"
                         />
-    
+
     <KnownFrameworkReference Include="Microsoft.WindowsDesktop.App"
                               TargetFramework="net6.0"
                               RuntimeFrameworkName="Microsoft.WindowsDesktop.App"
@@ -380,7 +380,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                         Crossgen2PackVersion="$(_NET50RuntimePackVersion)"
                         Crossgen2RuntimeIdentifiers="@(Net50Crossgen2SupportedRids, '%3B')"
                         />
-    
+
     <KnownFrameworkReference Include="Microsoft.WindowsDesktop.App"
                               TargetFramework="net5.0"
                               RuntimeFrameworkName="Microsoft.WindowsDesktop.App"
@@ -488,7 +488,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                       AppHostPackVersion="$(_NETCoreApp31RuntimePackVersion)"
                       AppHostRuntimeIdentifiers="@(NetCore31RuntimePackRids, '%3B')"
                       />
-    
+
     <KnownFrameworkReference Include="Microsoft.WindowsDesktop.App"
                               TargetFramework="netcoreapp3.1"
                               RuntimeFrameworkName="Microsoft.WindowsDesktop.App"
@@ -558,7 +558,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                       AppHostPackVersion="$(_NETCoreApp30RuntimePackVersion)"
                       AppHostRuntimeIdentifiers="@(NetCore30RuntimePackRids, '%3B')"
                       />
-    
+
     <KnownFrameworkReference Include="Microsoft.WindowsDesktop.App"
                               TargetFramework="netcoreapp3.0"
                               RuntimeFrameworkName="Microsoft.WindowsDesktop.App"
@@ -607,7 +607,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                               RuntimePackNamePatterns="Microsoft.AspNetCore.App.Runtime.**RID**"
                               RuntimePackRuntimeIdentifiers="@(AspNetCore30RuntimePackRids, '%3B')"
                               />
-                              
+
     <KnownFrameworkReference Include="NETStandard.Library"
                               TargetFramework="netstandard2.1"
                               TargetingPackName="NETStandard.Library.Ref"
@@ -665,13 +665,13 @@ Copyright (c) .NET Foundation. All rights reserved.
           DependsOnTargets="GenerateBundledVersionsProps">
 
     <Copy SourceFiles="$(NuGetPackageRoot)/microsoft.netcore.platforms/$(_NETCorePlatformsPackageVersion)/runtime.json"
-          DestinationFiles="$(SdkOutputDirectory)RuntimeIdentifierGraph.json" 
+          DestinationFiles="$(SdkOutputDirectory)RuntimeIdentifierGraph.json"
           SkipUnchangedFiles="true"/>
 
     <GenerateSdkRuntimeIdentifierChain
           RuntimeIdentifier="$(PortableProductMonikerRid)"
           RuntimeIdentifierGraphPath="$(SdkOutputDirectory)RuntimeIdentifierGraph.json"
           RuntimeIdentifierChainOutputPath="$(SdkOutputDirectory)NETCoreSdkRuntimeIdentifierChain.txt"/>
-    
+
   </Target>
 </Project>

--- a/src/redist/targets/GenerateInstallers.targets
+++ b/src/redist/targets/GenerateInstallers.targets
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <Target Name="GenerateInstallers"
+          Condition="'$(PgoInstrument)' != 'true'"
           BeforeTargets="Pack"
           DependsOnTargets="$(_BuildUnlessNoBuild);
                             GetCurrentRuntimeInformation;

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -34,6 +34,7 @@
 
       <!-- only the runtime OSX .pkgs have a `-internal` suffix -->
       <InstallerStartSuffix Condition="$([MSBuild]::IsOSPlatform('OSX'))">-internal</InstallerStartSuffix>
+      <InstallerStartSuffix Condition="'$(PgoInstrument)' == 'true'">-pgo</InstallerStartSuffix>
 
       <!-- Downloaded Installers + Archives -->
 
@@ -70,7 +71,8 @@
       <SharedFrameworkRid>$(CoreSetupRid)</SharedFrameworkRid>
       <SharedFrameworkRid Condition="$(ProductMonikerRid.StartsWith('linux-musl'))">$(ProductMonikerRid)</SharedFrameworkRid>
       <SharedFrameworkRid Condition=" '$(UsePortableLinuxSharedFramework)' == 'true' ">linux-$(Architecture)</SharedFrameworkRid>
-      <CombinedFrameworkHostArchiveFileName>dotnet-runtime-$(MicrosoftNETCoreAppRuntimePackageVersion)-$(SharedFrameworkRid)$(ArchiveExtension)</CombinedFrameworkHostArchiveFileName>
+      <PgoTerm Condition="'$(PgoInstrument)' == 'true'">-pgo</PgoTerm>
+      <CombinedFrameworkHostArchiveFileName>dotnet-runtime$(PgoTerm)-$(MicrosoftNETCoreAppRuntimePackageVersion)-$(SharedFrameworkRid)$(ArchiveExtension)</CombinedFrameworkHostArchiveFileName>
       <WinFormsAndWpfSharedFxArchiveFileName>windowsdesktop-runtime-$(MicrosoftWindowsDesktopAppRuntimePackageVersion)-$(SharedFrameworkRid)$(ArchiveExtension)</WinFormsAndWpfSharedFxArchiveFileName>
 
       <AspNetCoreSharedFxInstallerRid Condition="'$(AspNetCoreSharedFxInstallerRid)' == ''">$(SharedFrameworkRid)</AspNetCoreSharedFxInstallerRid>

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -71,7 +71,6 @@
       <SharedFrameworkRid>$(CoreSetupRid)</SharedFrameworkRid>
       <SharedFrameworkRid Condition="$(ProductMonikerRid.StartsWith('linux-musl'))">$(ProductMonikerRid)</SharedFrameworkRid>
       <SharedFrameworkRid Condition=" '$(UsePortableLinuxSharedFramework)' == 'true' ">linux-$(Architecture)</SharedFrameworkRid>
-      <PgoTerm Condition="'$(PgoInstrument)' == 'true'">-pgo</PgoTerm>
       <CombinedFrameworkHostArchiveFileName>dotnet-runtime$(PgoTerm)-$(MicrosoftNETCoreAppRuntimePackageVersion)-$(SharedFrameworkRid)$(ArchiveExtension)</CombinedFrameworkHostArchiveFileName>
       <WinFormsAndWpfSharedFxArchiveFileName>windowsdesktop-runtime-$(MicrosoftWindowsDesktopAppRuntimePackageVersion)-$(SharedFrameworkRid)$(ArchiveExtension)</WinFormsAndWpfSharedFxArchiveFileName>
 

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -34,7 +34,7 @@
 
       <!-- only the runtime OSX .pkgs have a `-internal` suffix -->
       <InstallerStartSuffix Condition="$([MSBuild]::IsOSPlatform('OSX'))">-internal</InstallerStartSuffix>
-      <InstallerStartSuffix Condition="'$(PgoInstrument)' == 'true'">-pgo</InstallerStartSuffix>
+      <InstallerStartSuffix>$(InstallerStartSuffix)$(PgoTerm)</InstallerStartSuffix>
 
       <!-- Downloaded Installers + Archives -->
 

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -3,6 +3,8 @@
     <RedistLayoutPath>$(BaseOutputPath)$(Configuration)\dotnet\</RedistLayoutPath>
     <SdkInternalLayoutPath>$(BaseOutputPath)$(Configuration)\dotnet-internal\</SdkInternalLayoutPath>
     <DownloadsFolder>$(IntermediateOutputPath)downloads\</DownloadsFolder>
+    <!-- add -internal to use the internal builds, except for Mac which already uses internal builds -->
+    <PgoArchiveTerm Condition="'$(PgoTerm)' != '' AND !$([MSBuild]::IsOSPlatform('OSX'))">-internal$(PgoTerm)</PgoArchiveTerm>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -34,7 +36,6 @@
 
       <!-- only the runtime OSX .pkgs have a `-internal` suffix -->
       <InstallerStartSuffix Condition="$([MSBuild]::IsOSPlatform('OSX'))">-internal</InstallerStartSuffix>
-      <InstallerStartSuffix>$(InstallerStartSuffix)$(PgoTerm)</InstallerStartSuffix>
 
       <!-- Downloaded Installers + Archives -->
 
@@ -50,7 +51,7 @@
       <AlternateArchitecture Condition="'$(Architecture)' == 'x64'">x86</AlternateArchitecture>
       <DownloadedSharedHostInstallerFileName Condition=" '$(InstallerExtension)' != '' ">dotnet-host$(InstallerStartSuffix)-$(SharedHostVersion)-$(SharedFrameworkInstallerFileRid)$(InstallerExtension)</DownloadedSharedHostInstallerFileName>
       <DownloadedHostFxrInstallerFileName Condition=" '$(InstallerExtension)' != '' ">dotnet-hostfxr$(InstallerStartSuffix)-$(HostFxrVersion)-$(SharedFrameworkInstallerFileRid)$(InstallerExtension)</DownloadedHostFxrInstallerFileName>
-      <DownloadedSharedFrameworkInstallerFileName Condition=" '$(InstallerExtension)' != '' ">dotnet-runtime$(InstallerStartSuffix)-$(MicrosoftNETCoreAppRuntimePackageVersion)-$(SharedFrameworkInstallerFileRid)$(InstallerExtension)</DownloadedSharedFrameworkInstallerFileName>
+      <DownloadedSharedFrameworkInstallerFileName Condition=" '$(InstallerExtension)' != '' ">dotnet-runtime$(InstallerStartSuffix)$(PgoArchiveTerm)-$(MicrosoftNETCoreAppRuntimePackageVersion)-$(SharedFrameworkInstallerFileRid)$(InstallerExtension)</DownloadedSharedFrameworkInstallerFileName>
       <DownloadedRuntimeDepsInstallerFileName Condition=" '$(InstallerExtension)' != '' ">dotnet-runtime-deps-$(SharedHostVersion)-$(RuntimeDepsInstallerFileRid)$(InstallerExtension)</DownloadedRuntimeDepsInstallerFileName>
       <DownloadedWinFormsAndWpfSharedFrameworkInstallerFileName Condition=" '$(InstallerExtension)' != '' ">windowsdesktop-runtime-$(MicrosoftWindowsDesktopAppRuntimePackageVersion)-$(SharedFrameworkInstallerFileRid)$(InstallerExtension)</DownloadedWinFormsAndWpfSharedFrameworkInstallerFileName>
       <DownloadedNetCoreAppTargetingPackInstallerFileName Condition=" '$(InstallerExtension)' != '' ">dotnet-targeting-pack-$(MicrosoftNETCoreAppRefPackageVersion)-$(SharedFrameworkInstallerFileRid)$(InstallerExtension)</DownloadedNetCoreAppTargetingPackInstallerFileName>

--- a/src/redist/targets/GenerateMSIs.targets
+++ b/src/redist/targets/GenerateMSIs.targets
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">  
   <PropertyGroup>
     <MicrosoftDotNetBuildTasksInstallersTaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(NuGetPackageRoot)microsoft.dotnet.build.tasks.installers\$(MicrosoftDotNetBuildTasksInstallersPackageVersion)\tools\netcoreapp3.1\Microsoft.DotNet.Build.Tasks.Installers.dll</MicrosoftDotNetBuildTasksInstallersTaskAssembly>
     <MicrosoftDotNetBuildTasksInstallersTaskAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(NuGetPackageRoot)microsoft.dotnet.build.tasks.installers\$(MicrosoftDotNetBuildTasksInstallersPackageVersion)\tools\net472\Microsoft.DotNet.Build.Tasks.Installers.dll</MicrosoftDotNetBuildTasksInstallersTaskAssembly>
   </PropertyGroup>
 
   <UsingTask TaskName="CreateLightCommandPackageDrop" AssemblyFile="$(MicrosoftDotNetBuildTasksInstallersTaskAssembly)" />
-
+  
   <Target Name="SetupWixProperties" DependsOnTargets="GetCurrentRuntimeInformation">
     <!-- AcquireWix Properties -->
     <PropertyGroup>
@@ -83,8 +83,8 @@
       <CombinedBuildNumberAndRevision>$(_PatchNumber)</CombinedBuildNumberAndRevision>
       <!-- Fallback to commit count when patch number is not set. This happens only during CI. -->
       <CombinedBuildNumberAndRevision Condition=" '$(CombinedBuildNumberAndRevision)' == '' ">$(GitCommitCount)</CombinedBuildNumberAndRevision>
-
-      <!-- This number comes from arcade and combines the date based build number id and the revision (incremental number per day) -->
+      
+      <!-- This number comes from arcade and combines the date based build number id and the revision (incremental number per day) -->    
       <SDKBundleVersion>$(FileVersion)</SDKBundleVersion>
       <!-- Fallback to commit count when patch number is not set. This happens only during CI. -->
       <SDKBundleVersion Condition=" '$(SDKBundleVersion)' == '' ">$(VersionPrefix).$(CombinedBuildNumberAndRevision)</SDKBundleVersion>
@@ -149,7 +149,7 @@
 
   <Target Name="GenerateSdkMsi"
           DependsOnTargets="GenerateLayout;AcquireWix;MsiTargetsSetupInputOutputs;SetSdkBrandingInfo"
-          Condition="'$(OS)' == 'Windows_NT' AND '$(PgoInstrument)' != 'true'"
+          Condition=" '$(OS)' == 'Windows_NT' "
           Inputs="$(SdkInternalLayoutPath)**/*;
                     $(SdkGenerateMsiPowershellScript)"
           Outputs="$(SdkMSIInstallerFile)">
@@ -280,7 +280,7 @@
     <PropertyGroup>
       <ManifestsGenerateMsiPowershellScript>$(MSBuildThisFileDirectory)packaging/windows/clisdk/generatemanifestsmsi.ps1</ManifestsGenerateMsiPowershellScript>
     </PropertyGroup>
-
+    
     <Exec Command="powershell -NoProfile -NoLogo $(ManifestsGenerateMsiPowershellScript) ^
                       '$(ManifestsLayoutPath)' ^
                       '$(ManifestsMSIInstallerFile)' ^
@@ -313,7 +313,7 @@
 
   <Target Name="GenerateSdkBundle"
           DependsOnTargets="GenerateLayout;AcquireWix;MsiTargetsSetupInputOutputs;GenerateSdkMsi;SignSdkMsi;GenerateTemplatesMsis;GenerateManifestsMsi;SignTemplatesMsis"
-          Condition="'$(OS)' == 'Windows_NT' AND '$(PgoInstrument)' != 'true'"
+          Condition=" '$(OS)' == 'Windows_NT' "
           Inputs="$(SdkMSIInstallerFile);
                     $(DownloadedSharedFrameworkInstallerFile);
                     $(DownloadedHostFxrInstallerFile);
@@ -329,7 +329,7 @@
     <PropertyGroup>
       <LatestTemplateMsiInstallerFile>@(LatestTemplateInstallerComponent->'%(MSIInstallerFile)')</LatestTemplateMsiInstallerFile>
     </PropertyGroup>
-
+    
     <Exec Command="powershell -NoProfile -NoLogo $(SdkGenerateBundlePowershellScript) ^
                       '$(SdkMSIInstallerFile)' ^
                       '$(DownloadsFolder)$(DownloadedAspNetCoreSharedFxWixLibFileName)' ^
@@ -380,7 +380,7 @@
 
   <Target Name="GenerateToolsetNupkg"
           DependsOnTargets="GenerateLayout;MsiTargetsSetupInputOutputs;GenerateSdkMsi;SignSdkMsi"
-          Condition="'$(OS)' == 'Windows_NT' and '$(PgoInstrument)' != 'true'"
+          Condition=" '$(OS)' == 'Windows_NT' "
           Inputs="$(SdkMSIInstallerFile);
                     $(ToolsetInstallerNuspecFile);
                     $(GenerateNupkgPowershellScript)"
@@ -493,7 +493,7 @@
                       '$(FullNugetVersion)' ^
                       '$(SdkMSBuildExtensionsNuspecFile)' ^
                       '$(SdkMSBuildExtensionsNupkgFile)'" />
-
+      
       <GenerateMSBuildExtensionsSWR MSBuildExtensionsLayoutDirectory="$(MSBuildExtensionsLayoutDirectory)"
                                     OutputFile="$(SdkMSBuildExtensionsSwrFile)"/>
 

--- a/src/redist/targets/GenerateMSIs.targets
+++ b/src/redist/targets/GenerateMSIs.targets
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">  
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MicrosoftDotNetBuildTasksInstallersTaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(NuGetPackageRoot)microsoft.dotnet.build.tasks.installers\$(MicrosoftDotNetBuildTasksInstallersPackageVersion)\tools\netcoreapp3.1\Microsoft.DotNet.Build.Tasks.Installers.dll</MicrosoftDotNetBuildTasksInstallersTaskAssembly>
     <MicrosoftDotNetBuildTasksInstallersTaskAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(NuGetPackageRoot)microsoft.dotnet.build.tasks.installers\$(MicrosoftDotNetBuildTasksInstallersPackageVersion)\tools\net472\Microsoft.DotNet.Build.Tasks.Installers.dll</MicrosoftDotNetBuildTasksInstallersTaskAssembly>
   </PropertyGroup>
 
   <UsingTask TaskName="CreateLightCommandPackageDrop" AssemblyFile="$(MicrosoftDotNetBuildTasksInstallersTaskAssembly)" />
-  
+
   <Target Name="SetupWixProperties" DependsOnTargets="GetCurrentRuntimeInformation">
     <!-- AcquireWix Properties -->
     <PropertyGroup>
@@ -83,8 +83,8 @@
       <CombinedBuildNumberAndRevision>$(_PatchNumber)</CombinedBuildNumberAndRevision>
       <!-- Fallback to commit count when patch number is not set. This happens only during CI. -->
       <CombinedBuildNumberAndRevision Condition=" '$(CombinedBuildNumberAndRevision)' == '' ">$(GitCommitCount)</CombinedBuildNumberAndRevision>
-      
-      <!-- This number comes from arcade and combines the date based build number id and the revision (incremental number per day) -->    
+
+      <!-- This number comes from arcade and combines the date based build number id and the revision (incremental number per day) -->
       <SDKBundleVersion>$(FileVersion)</SDKBundleVersion>
       <!-- Fallback to commit count when patch number is not set. This happens only during CI. -->
       <SDKBundleVersion Condition=" '$(SDKBundleVersion)' == '' ">$(VersionPrefix).$(CombinedBuildNumberAndRevision)</SDKBundleVersion>
@@ -149,7 +149,7 @@
 
   <Target Name="GenerateSdkMsi"
           DependsOnTargets="GenerateLayout;AcquireWix;MsiTargetsSetupInputOutputs;SetSdkBrandingInfo"
-          Condition=" '$(OS)' == 'Windows_NT' "
+          Condition="'$(OS)' == 'Windows_NT' AND '$(PgoInstrument)' != 'true'"
           Inputs="$(SdkInternalLayoutPath)**/*;
                     $(SdkGenerateMsiPowershellScript)"
           Outputs="$(SdkMSIInstallerFile)">
@@ -280,7 +280,7 @@
     <PropertyGroup>
       <ManifestsGenerateMsiPowershellScript>$(MSBuildThisFileDirectory)packaging/windows/clisdk/generatemanifestsmsi.ps1</ManifestsGenerateMsiPowershellScript>
     </PropertyGroup>
-    
+
     <Exec Command="powershell -NoProfile -NoLogo $(ManifestsGenerateMsiPowershellScript) ^
                       '$(ManifestsLayoutPath)' ^
                       '$(ManifestsMSIInstallerFile)' ^
@@ -313,7 +313,7 @@
 
   <Target Name="GenerateSdkBundle"
           DependsOnTargets="GenerateLayout;AcquireWix;MsiTargetsSetupInputOutputs;GenerateSdkMsi;SignSdkMsi;GenerateTemplatesMsis;GenerateManifestsMsi;SignTemplatesMsis"
-          Condition=" '$(OS)' == 'Windows_NT' "
+          Condition="'$(OS)' == 'Windows_NT' AND '$(PgoInstrument)' != 'true'"
           Inputs="$(SdkMSIInstallerFile);
                     $(DownloadedSharedFrameworkInstallerFile);
                     $(DownloadedHostFxrInstallerFile);
@@ -329,7 +329,7 @@
     <PropertyGroup>
       <LatestTemplateMsiInstallerFile>@(LatestTemplateInstallerComponent->'%(MSIInstallerFile)')</LatestTemplateMsiInstallerFile>
     </PropertyGroup>
-    
+
     <Exec Command="powershell -NoProfile -NoLogo $(SdkGenerateBundlePowershellScript) ^
                       '$(SdkMSIInstallerFile)' ^
                       '$(DownloadsFolder)$(DownloadedAspNetCoreSharedFxWixLibFileName)' ^
@@ -380,7 +380,7 @@
 
   <Target Name="GenerateToolsetNupkg"
           DependsOnTargets="GenerateLayout;MsiTargetsSetupInputOutputs;GenerateSdkMsi;SignSdkMsi"
-          Condition=" '$(OS)' == 'Windows_NT' "
+          Condition="'$(OS)' == 'Windows_NT' and '$(PgoInstrument)' != 'true'"
           Inputs="$(SdkMSIInstallerFile);
                     $(ToolsetInstallerNuspecFile);
                     $(GenerateNupkgPowershellScript)"
@@ -493,7 +493,7 @@
                       '$(FullNugetVersion)' ^
                       '$(SdkMSBuildExtensionsNuspecFile)' ^
                       '$(SdkMSBuildExtensionsNupkgFile)'" />
-      
+
       <GenerateMSBuildExtensionsSWR MSBuildExtensionsLayoutDirectory="$(MSBuildExtensionsLayoutDirectory)"
                                     OutputFile="$(SdkMSBuildExtensionsSwrFile)"/>
 

--- a/src/redist/targets/GetRuntimeInformation.targets
+++ b/src/redist/targets/GetRuntimeInformation.targets
@@ -12,7 +12,7 @@
 
       <Rid Condition=" '$(Rid)' == '' ">$(OSName)-$(Architecture)</Rid>
     </PropertyGroup>
-    
+
     <PropertyGroup>
       <IsDebianBaseDistro Condition=" $(HostRid.StartsWith('ubuntu')) OR $(HostRid.StartsWith('debian')) ">true</IsDebianBaseDistro>
       <IsRPMBasedDistro Condition=" $(HostRid.StartsWith('rhel')) AND '$(HostRid)' != 'rhel.6-x64' ">true</IsRPMBasedDistro>
@@ -26,13 +26,13 @@
                                    '$(Rid)' == 'linux-musl-x64' ">$(Rid)</ProductMonikerRid>
       <ProductMonikerRid Condition=" '$(ProductMonikerRid)' == '' ">$(OSName)-$(Architecture)</ProductMonikerRid>
 
-      <ArtifactNameSdk>dotnet-sdk-internal</ArtifactNameSdk>
-      <ArtifactNameCombinedHostHostFxrFrameworkSdk>dotnet-sdk</ArtifactNameCombinedHostHostFxrFrameworkSdk>
+      <ArtifactNameSdk>dotnet-sdk-internal$(PgoTerm)</ArtifactNameSdk>
+      <ArtifactNameCombinedHostHostFxrFrameworkSdk>dotnet-sdk$(PgoTerm)</ArtifactNameCombinedHostHostFxrFrameworkSdk>
 
       <ArtifactNameWithVersionSdk>$(ArtifactNameSdk)-$(Version)-$(ProductMonikerRid)</ArtifactNameWithVersionSdk>
       <ArtifactNameWithVersionMSBuildExtensions>dotnet-standard-support-vs2015-$(Version)-$(ProductMonikerRid)</ArtifactNameWithVersionMSBuildExtensions>
       <ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>$(ArtifactNameCombinedHostHostFxrFrameworkSdk)-$(Version)-$(ProductMonikerRid)</ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>
-      <!-- Warning: changing the value "ProductBandCombinedHostHostFxrFrameworkSdkName" can only occur on a product-band boundary [CliProductBandVersion], 
+      <!-- Warning: changing the value "ProductBandCombinedHostHostFxrFrameworkSdkName" can only occur on a product-band boundary [CliProductBandVersion],
                Changing "ProductBandCombinedHostHostFxrFrameworkSdkName" mid-product-band will break the upgradablilty of the SDK bundle installer. -->
       <ProductBandCombinedHostHostFxrFrameworkSdkName>Dotnet SDK Bundle Installer $(CliProductBandVersion) $(ProductMonikerRid)</ProductBandCombinedHostHostFxrFrameworkSdkName>
       <DistroSpecificArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>$(ArtifactNameCombinedHostHostFxrFrameworkSdk)-$(Version)-$(Architecture)</DistroSpecificArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>


### PR DESCRIPTION
Uses the uninstrumented profiling PGO bits from the runtime when the
'-pgoinstrument' flag is set.
