### PR TITLE
Move dotnet-sdk snaps from dotnet/runtime

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# Users referenced in this file will automatically be requested as reviewers for PRs that modify the given paths.
+# See https://help.github.com/articles/about-code-owners/
+
+# Snaps
+
+/src/snaps/ @rbhanda

--- a/src/snaps/arm/dotnet-sdk-3.1/snap/snapcraft.yaml
+++ b/src/snaps/arm/dotnet-sdk-3.1/snap/snapcraft.yaml
@@ -1,0 +1,40 @@
+name: dotnet-sdk
+version: 3.1.201
+summary: Cross-Platform .NET Core SDK
+description: |
+  .NET Core SDK. https://dot.net/core.
+
+grade: stable
+confinement: classic
+
+apps:
+  dotnet:
+    command: dotnet
+
+architectures:
+  - build-on: [amd64]
+    run-on: [armhf]
+
+base: core
+
+parts:
+  dotnet-sdk:
+      plugin: dump
+      source: https://download.visualstudio.microsoft.com/download/pr/ccbcbf70-9911-40b1-a8cf-e018a13e720e/03c0621c6510f9c6f4cca6951f2cc1a4/dotnet-sdk-3.1.201-linux-arm.tar.gz
+      source-checksum: sha512/f37d0e55c9f593c6951bea5a6bb1ea3194486956efe08a2a0f266b419d912cdcbf4ac279358976f0bfa1fe560c333ca5d5437f8e8c718bb5963991e4395e0cd7
+      stage-packages:
+        - libicu55
+        - libssl1.0.0
+        - libcurl3
+        - libgssapi-krb5-2
+        - libstdc++6
+        - zlib1g
+        - libgcc1
+        - libtinfo5
+        - liblttng-ust0
+        - liburcu4
+
+  runtime-wrapper:
+      plugin: dump
+      source: .
+

--- a/src/snaps/arm/dotnet-sdk-5.0/snap/snapcraft.yaml
+++ b/src/snaps/arm/dotnet-sdk-5.0/snap/snapcraft.yaml
@@ -1,0 +1,40 @@
+name: dotnet-sdk
+version: 5.0.100-preview.2.20176.6
+summary: Cross-Platform .NET Core SDK
+description: |
+  .NET Core SDK. https://dot.net/core.
+
+grade: stable
+confinement: classic
+
+apps:
+  dotnet:
+    command: dotnet
+
+architectures:
+  - build-on: [amd64]
+    run-on: [armhf]
+
+base: core
+
+parts:
+  dotnet-sdk:
+      plugin: dump
+      source: https://download.visualstudio.microsoft.com/download/pr/f87574ee-c128-4e91-b436-68c99d801daf/b296bea9d987a4edaa71df47cd2e7aca/dotnet-sdk-5.0.100-preview.2.20176.6-linux-arm64.tar.gz
+      source-checksum: sha512/53cbf213e2e97b909b256d931f061178f26e5647424f144266d4af2e12d6443ef7398207a8f4e6f220c61db9ce49de3dc09d88417288a6a61d9b05e1def6b279
+      stage-packages:
+        - libicu55
+        - libssl1.0.0
+        - libcurl3
+        - libgssapi-krb5-2
+        - libstdc++6
+        - zlib1g
+        - libgcc1
+        - libtinfo5
+        - liblttng-ust0
+        - liburcu4
+
+  runtime-wrapper:
+      plugin: dump
+      source: .
+

--- a/src/snaps/arm64/dotnet-sdk-5.0/snap/snapcraft.yaml
+++ b/src/snaps/arm64/dotnet-sdk-5.0/snap/snapcraft.yaml
@@ -1,0 +1,40 @@
+name: dotnet-sdk
+version: 5.0.100-preview.2.20176.6
+summary: Cross-Platform .NET Core SDK
+description: |
+  .NET Core SDK. https://dot.net/core.
+
+grade: stable
+confinement: classic
+
+apps:
+  dotnet:
+    command: dotnet
+
+architectures:
+  - build-on: [amd64]
+    run-on: [arm64]
+
+base: core18
+
+parts:
+  dotnet-sdk:
+      plugin: dump
+      source: https://download.visualstudio.microsoft.com/download/pr/f87574ee-c128-4e91-b436-68c99d801daf/b296bea9d987a4edaa71df47cd2e7aca/dotnet-sdk-5.0.100-preview.2.20176.6-linux-arm64.tar.gz
+      source-checksum: sha512/53cbf213e2e97b909b256d931f061178f26e5647424f144266d4af2e12d6443ef7398207a8f4e6f220c61db9ce49de3dc09d88417288a6a61d9b05e1def6b279
+      stage-packages:
+        - libicu60
+        - libssl1.0.0
+        - libcurl3
+        - libgssapi-krb5-2
+        - libstdc++6
+        - zlib1g
+        - libgcc1
+        - libtinfo5
+        - liblttng-ust0
+        - liburcu6
+
+  runtime-wrapper:
+      plugin: dump
+      source: .
+

--- a/src/snaps/dotnet-sdk-2.1/snap/snapcraft.yaml
+++ b/src/snaps/dotnet-sdk-2.1/snap/snapcraft.yaml
@@ -1,0 +1,37 @@
+name: dotnet-sdk
+version: 2.1.814
+summary: Cross-Platform .NET Core SDK
+description: |
+  .NET Core SDK. https://dot.net/core.
+
+grade: stable
+confinement: classic
+
+apps:
+  dotnet:
+    command: dotnet
+
+base: core18
+
+parts:
+  dotnet-sdk:
+      plugin: dump
+      source: https://download.visualstudio.microsoft.com/download/pr/b44d40e6-fa23-4f2d-a0a9-4199731f0b1e/5e62077a9e8014d8d4c74aee5406e0c7/dotnet-sdk-2.1.814-linux-x64.tar.gz
+      source-checksum: sha512/79408996f53650d0c3ac39348fa102537d14190ba5dcc4b9152cdb8fc72566608ad7430f196731eeb62dcfacdb0f2fa37577b5d51e165afd9dd9ae15f9d2aabc
+      stage-packages:
+        - libicu60
+        - libssl1.0.0
+        - libcurl3
+        - libgssapi-krb5-2
+        - libstdc++6
+        - zlib1g
+        - libgcc1
+        - libtinfo5
+        - liblttng-ust0
+        - liburcu6
+        - lldb
+
+  runtime-wrapper:
+      plugin: dump
+      source: .
+

--- a/src/snaps/dotnet-sdk-3.1/snap/snapcraft.yaml
+++ b/src/snaps/dotnet-sdk-3.1/snap/snapcraft.yaml
@@ -1,0 +1,36 @@
+name: dotnet-sdk
+version: 3.1.407
+summary: Cross-Platform .NET Core SDK
+description: |
+  .NET Core SDK. https://dot.net/core.
+
+grade: stable
+confinement: classic
+
+apps:
+  dotnet:
+    command: dotnet
+
+base: core18
+
+parts:
+  dotnet-sdk:
+      plugin: dump
+      source: https://download.visualstudio.microsoft.com/download/pr/ab82011d-2549-4e23-a8a9-a2b522a31f27/6e615d6177e49c3e874d05ee3566e8bf/dotnet-sdk-3.1.407-linux-x64.tar.gz
+      source-checksum: sha512/b9c61061464a38df0a3eb5894a4a1229cd27d2ccba4168e434f4609b763630c01fbe1b2564826194d6d9b5ad86047e586312c0f35eafc3755dfe0ff9ba075c0c
+      stage-packages:
+        - libicu60
+        - libssl1.0.0
+        - libcurl3
+        - libgssapi-krb5-2
+        - libstdc++6
+        - zlib1g
+        - libgcc1
+        - libtinfo5
+        - liblttng-ust0
+        - liburcu6
+
+  runtime-wrapper:
+      plugin: dump
+      source: .
+

--- a/src/snaps/dotnet-sdk-5.0/snap/snapcraft.yaml
+++ b/src/snaps/dotnet-sdk-5.0/snap/snapcraft.yaml
@@ -1,0 +1,36 @@
+name: dotnet-sdk
+version: 5.0.201
+summary: Cross-Platform .NET Core SDK
+description: |
+  .NET Core SDK. https://dot.net/core.
+
+grade: stable
+confinement: classic
+
+apps:
+  dotnet:
+    command: dotnet
+
+base: core18
+
+parts:
+  dotnet-sdk:
+      plugin: dump
+      source: https://download.visualstudio.microsoft.com/download/pr/73a9cb2a-1acd-4d20-b864-d12797ca3d40/075dbe1dc3bba4aa85ca420167b861b6/dotnet-sdk-5.0.201-linux-x64.tar.gz
+      source-checksum: sha512/099084cc7935482e363bd7802d2fdd909b3d72d2e9706e9ba4df95e3d142a28b780d2b85e5fb4662dcaad18e91c7e06519184fae981a521425eed605770c3c5a
+      stage-packages:
+        - libicu60
+        - libssl1.0.0
+        - libcurl3
+        - libgssapi-krb5-2
+        - libstdc++6
+        - zlib1g
+        - libgcc1
+        - libtinfo5
+        - liblttng-ust0
+        - liburcu6
+
+  runtime-wrapper:
+      plugin: dump
+      source: .
+

--- a/src/snaps/dotnet-sdk-6.0/snap/snapcraft.yaml
+++ b/src/snaps/dotnet-sdk-6.0/snap/snapcraft.yaml
@@ -1,0 +1,36 @@
+name: dotnet-sdk
+version: 6.0.100-preview.2.21155.3
+summary: Cross-Platform .NET Core SDK
+description: |
+  .NET Core SDK. https://dot.net/core.
+
+grade: stable
+confinement: classic
+
+apps:
+  dotnet:
+    command: dotnet
+
+base: core18
+
+parts:
+  dotnet-sdk:
+      plugin: dump
+      source: https://download.visualstudio.microsoft.com/download/pr/25c7e38e-0a6a-4d66-ac4e-b550a44b8a98/49128be84b903799259e7bebe8e9d969/dotnet-sdk-6.0.100-preview.2.21155.3-linux-x64.tar.gz
+      source-checksum: sha512/90d9b6070f7732dcf75f5a09a4f10f9b23c835a3bb144e0c3f1fa451cadd3d49c9781973b180f70a4d2798358a7c00f3c0b9b3bf35326fe4c94e470e84ac8c35
+      stage-packages:
+        - libicu60
+        - libssl1.0.0
+        - libcurl3
+        - libgssapi-krb5-2
+        - libstdc++6
+        - zlib1g
+        - libgcc1
+        - libtinfo5
+        - liblttng-ust0
+        - liburcu6
+
+  runtime-wrapper:
+      plugin: dump
+      source: .
+

--- a/src/snaps/dotnet-sdk/snap/snapcraft.yaml
+++ b/src/snaps/dotnet-sdk/snap/snapcraft.yaml
@@ -1,0 +1,36 @@
+name: dotnet-sdk
+version: $(DOTNET_SDK_VERSION)
+summary: Cross-Platform .NET Core SDK
+description: |
+  .NET Core SDK. https://dot.net/core.
+
+grade: devel
+confinement: classic
+
+apps:
+  dotnet:
+    command: dotnet
+
+base: core18
+
+parts:
+  dotnet-sdk:
+    plugin: dump
+    source: $(SOURCE_TARGZ)
+    source-checksum: sha512/$(SOURCE_TARGZ_SHA)
+    stage-packages:
+      - libicu60
+      - libssl1.0.0
+      - libcurl3
+      - libgssapi-krb5-2
+      - libstdc++6
+      - zlib1g
+      - libgcc1
+      - lldb
+      - libunwind8
+      - libtinfo5
+      - liblttng-ust0
+      - liburcu6
+  runtime-wrapper:
+      plugin: dump
+      source: .


### PR DESCRIPTION
Dotnet/runtime was the home of the snap files for both dotnet-runtime
dotnet dotnet-sdk snap files. Moving the dotnet-sdk snap files into
dotnet/installer next to the installers.

Kept the +x file permissions to not regress https://github.com/dotnet/core-setup/commit/875a48cef8683292f19a1b93916bd50345b9593c.

Contributes to https://github.com/dotnet/runtime/issues/49374