### PR TITLE
Rename iOS simulator targets from 'ios' to 'iossimulator' RID

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -107,10 +107,12 @@
           @(Net50AppHostRids);
           ios-arm64;
           ios-arm;
-          ios-x64;
-          ios-x86;
+          iossimulator-arm64;
+          iossimulator-x64;
+          iossimulator-x86;
           tvos-arm64;
-          tvos-x64;
+          tvossimulator-arm64;
+          tvossimulator-x64;
           maccatalyst-x64;
           maccatalyst-arm64;
           android-arm64;


### PR DESCRIPTION
See https://github.com/dotnet/runtime/pull/49305 and https://github.com/dotnet/runtime/issues/48216