### PR TITLE
Add macOS RIDs for crossgen2

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -138,7 +138,7 @@
         " />
 
       <Net50Crossgen2SupportedRids Include="linux-musl-x64;linux-x64;win-x64" />
-      <Crossgen2SupportedRids Include="@(Net50Crossgen2SupportedRids)" />
+      <Crossgen2SupportedRids Include="@(Net50Crossgen2SupportedRids);osx-x64;osx-arm64" />
 
       <AspNetCore31RuntimePackRids Include="@(AspNetCore30RuntimePackRids)" />
       <AspNetCore50RuntimePackRids Include="@(AspNetCore31RuntimePackRids);linux-musl-arm;win-arm64" />


### PR DESCRIPTION
The NuGet packages for these are available for .NET 6 (https://www.nuget.org/packages?q=Microsoft.NETCore.App.Crossgen2) but are not able to be used by default, which is why the download numbers are low.

Since the packages are on public NuGet, I see no reason why the RIDs shouldn't be here too but let me know if I'm mistaken!