### PR TITLE
ArPow stage 1: local source-build infrastructure

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -1,0 +1,31 @@
+<Project>
+
+  <PropertyGroup>
+    <GitHubRepositoryName>installer</GitHubRepositoryName>
+    <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
+  </PropertyGroup>
+
+  <Target Name="ApplySourceBuildPatchFiles"
+          AfterTargets="PrepareInnerSourceBuildRepoRoot"
+          BeforeTargets="RunInnerSourceBuildCommand">
+
+    <ItemGroup>
+      <SourceBuildPatchFile Include="$(RepositoryEngineeringDir)source-build-patches\*.patch" />
+    </ItemGroup>
+
+    <Exec
+      Command="git apply --ignore-whitespace --whitespace=nowarn &quot;%(SourceBuildPatchFile.FullPath)&quot;"
+      WorkingDirectory="$(InnerSourceBuildRepoRoot)"
+      Condition="'@(SourceBuildPatchFile)' != ''" />
+  </Target>
+
+  <Target Name="ConfigureInnerBuildArg" BeforeTargets="GetSourceBuildCommandConfiguration">
+    <PropertyGroup>
+      <InnerBuildArgs>$(InnerBuildArgs) /p:SkipBuildingInstallers=true</InnerBuildArgs>
+      <InnerBuildArgs>$(InnerBuildArgs) /p:IncludeNuGetPackageArchive=false</InnerBuildArgs>
+      <InnerBuildArgs>$(InnerBuildArgs) /p:IncludeAdditionalSharedFrameworks=false</InnerBuildArgs>
+      <InnerBuildArgs>$(InnerBuildArgs) /p:IncludeSharedFrameworksForBackwardsCompatibilityTests=false</InnerBuildArgs>
+    </PropertyGroup>
+  </Target>
+
+</Project>

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,0 +1,5 @@
+<UsageData>
+  <IgnorePatterns>
+    <UsagePattern IdentityGlob="*/*" />
+  </IgnorePatterns>
+</UsageData>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -139,6 +139,7 @@
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.21207.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>86aee6d02b2fb8534b9466db0da25483d7c399a9</Sha>
+      <SourceBuild RepoName="arcade" ManagedOnly="true"/>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="6.0.0-beta.21207.4">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/eng/source-build-patches/0001-Exclude-test-folder-from-source-build.patch
+++ b/eng/source-build-patches/0001-Exclude-test-folder-from-source-build.patch
@@ -1,0 +1,24 @@
+From 17bdd83006fbd27b64453ecddcf785c17eaaef1b Mon Sep 17 00:00:00 2001
+From: dseefeld <dseefeld@microsoft.com>
+Date: Mon, 29 Jun 2020 15:14:07 -0400
+Subject: [PATCH 1/3] Exclude test folder from source-build
+
+---
+ test/Directory.Build.props | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/test/Directory.Build.props b/test/Directory.Build.props
+index a953b97cc..26d486322 100644
+--- a/test/Directory.Build.props
++++ b/test/Directory.Build.props
+@@ -1,4 +1,7 @@
+ <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+   <Import Project="..\Directory.Build.props" />
+   <Import Project="..\eng\TestVersions.props" />
++  <PropertyGroup>
++    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
++  </PropertyGroup>
+ </Project>
+-- 
+2.18.0
+

--- a/eng/source-build-patches/0002-Add-target-rid-to-AppHostRuntimeIdentifiers.patch
+++ b/eng/source-build-patches/0002-Add-target-rid-to-AppHostRuntimeIdentifiers.patch
@@ -1,0 +1,37 @@
+From e09da5670bfc8df488b65aee94de992a1c75a6a4 Mon Sep 17 00:00:00 2001
+From: Davis Goodin <dagood@microsoft.com>
+Date: Mon, 14 Sep 2020 18:43:27 -0500
+Subject: [PATCH] Add target rid to NetCoreAppHostRids
+
+---
+ src/redist/targets/GenerateBundledVersions.targets | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/src/redist/targets/GenerateBundledVersions.targets b/src/redist/targets/GenerateBundledVersions.targets
+index 7c6f72967..3ee0284e1 100644
+--- a/src/redist/targets/GenerateBundledVersions.targets
++++ b/src/redist/targets/GenerateBundledVersions.targets
+@@ -99,6 +99,20 @@
+       <NetCoreAppHostRids Include="@(Net50AppHostRids);osx-arm64" />
+       <NetCoreRuntimePackRids Include="@(Net50RuntimePackRids);osx-arm64" />
+ 
++      <!--
++        In source-build, we build the current RID from source, which may be
++        non-portable and/or not an official RID. However, we can only use the
++        apphost pack, not the runtime pack, because:
++        - Apphost packs are distributed in the SDK.
++        - Runtime packs are not shipped with the SDK, only on NuGet.
++
++        Adding the ability to distribute and use source-built runtime packs is
++        tracked by: https://github.com/dotnet/source-build/issues/1215
++      -->
++      <NetCoreAppHostRids
++        Condition="'$(DotNetBuildFromSource)' == 'true'"
++        Include="$(ProductMonikerRid)" />
++
+       <AspNetCore30RuntimePackRids Include="
+         win-x64;
+         win-x86;
+-- 
+2.27.0.windows.1
+

--- a/eng/source-build-patches/0002-Add-target-rid-to-AppHostRuntimeIdentifiers.patch
+++ b/eng/source-build-patches/0002-Add-target-rid-to-AppHostRuntimeIdentifiers.patch
@@ -12,8 +12,8 @@ index 7c6f72967..3ee0284e1 100644
 --- a/src/redist/targets/GenerateBundledVersions.targets
 +++ b/src/redist/targets/GenerateBundledVersions.targets
 @@ -99,6 +99,20 @@
-       <NetCoreAppHostRids Include="@(Net50AppHostRids);osx-arm64" />
-       <NetCoreRuntimePackRids Include="@(Net50RuntimePackRids);osx-arm64" />
+       <NetCoreAppHostRids Include="@(Net60AppHostRids)" />
+       <NetCoreRuntimePackRids Include="@(Net60RuntimePackRids)" />
  
 +      <!--
 +        In source-build, we build the current RID from source, which may be
@@ -29,9 +29,9 @@ index 7c6f72967..3ee0284e1 100644
 +        Condition="'$(DotNetBuildFromSource)' == 'true'"
 +        Include="$(ProductMonikerRid)" />
 +
-       <AspNetCore30RuntimePackRids Include="
-         win-x64;
-         win-x86;
+       <MonoRuntimePackRids Include="
+           @(NetCoreRuntimePackRids);
+           browser-wasm;
 -- 
 2.27.0.windows.1
 

--- a/eng/source-build-patches/0003-Use-PVP-for-PlatformAbstractions-and-NuGet.Versionin.patch
+++ b/eng/source-build-patches/0003-Use-PVP-for-PlatformAbstractions-and-NuGet.Versionin.patch
@@ -1,0 +1,43 @@
+From 1959179503f952730a239ffe02bc851c6e717aa8 Mon Sep 17 00:00:00 2001
+From: dseefeld <dseefeld@microsoft.com>
+Date: Thu, 4 Feb 2021 21:27:04 +0000
+Subject: [PATCH] Use PVP for PlatformAbstractions and NuGet.Versioning
+
+---
+ eng/Versions.props                       | 4 ++
+ src/core-sdk-tasks/core-sdk-tasks.csproj | 4 ++--
+2 files changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/eng/Versions.props b/eng/Versions.props
+index be68d9a..993a87d 100644
+--- a/eng/Versions.props
++++ b/eng/Versions.props
+@@ -91,6 +91,10 @@
+     <MicrosoftWindowsDesktopAppRuntimePackageVersion>$(MicrosoftWindowsDesktopAppRuntimewinx64PackageVersion)</MicrosoftWindowsDesktopAppRuntimePackageVersion>
+   </PropertyGroup>
+   <PropertyGroup>
++    <!-- Dependencies from https://github.com/NuGet/NuGet.Client -->
++    <NuGetVersioningPackageVersion>5.8.0</NuGetVersioningPackageVersion>
++  </PropertyGroup>
++  <PropertyGroup>
+     <!-- Cross-release dependency versions -->
+     <MicrosoftDotNetCommonItemTemplates50PackageVersion>5.0.3</MicrosoftDotNetCommonItemTemplates50PackageVersion>
+     <MicrosoftAspNetCoreAppRuntime50PackageVersion>5.0.0-rc.2.20474.4</MicrosoftAspNetCoreAppRuntime50PackageVersion>
+diff --git a/src/core-sdk-tasks/core-sdk-tasks.csproj b/src/core-sdk-tasks/core-sdk-tasks.csproj
+index 00420b6ba..2e03bd0d1 100644
+--- a/src/core-sdk-tasks/core-sdk-tasks.csproj
++++ b/src/core-sdk-tasks/core-sdk-tasks.csproj
+@@ -11,8 +11,8 @@
+     <PackageReference Include="Microsoft.Build" Version="15.7.179" />
+     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.7.179" />
+     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+-    <PackageReference Include="NuGet.Versioning" Version="5.8.0" />
+-    <PackageReference Include="NuGet.Packaging" Version="5.8.0" />
++    <PackageReference Include="NuGet.Versioning" Version="$(NuGetVersioningPackageVersion)" />
++    <PackageReference Include="NuGet.Packaging" Version="$(NuGetVersioningPackageVersion)" />
+     <PackageReference Include="System.Reflection.Metadata" Version="1.4.2" />
+     <PackageReference Include="WindowsAzure.Storage" Version="8.4.0" Condition="'$(DotNetBuildFromSource)' != 'true'" />
+   </ItemGroup>
+-- 
+2.21.3
+

--- a/eng/source-build-patches/0004-ExcludeFromSourceBuild-not-working-again.patch
+++ b/eng/source-build-patches/0004-ExcludeFromSourceBuild-not-working-again.patch
@@ -1,0 +1,103 @@
+From d6aa940075f63d41603cbb2f3524958356d9abcf Mon Sep 17 00:00:00 2001
+From: Chris Rummel <crummel@microsoft.com>
+Date: Fri, 4 Sep 2020 02:23:15 -0500
+Subject: [PATCH 4/4] ExcludeFromSourceBuild not working again
+
+---
+ Microsoft.DotNet.Cli.sln           |  7 ------
+ src/SdkResolver/SdkResolver.csproj | 39 ------------------------------
+ src/redist/redist.csproj           |  4 ++--
+ 3 files changed, 2 insertion(+), 48 deletions(-)
+ delete mode 100644 src/SdkResolver/SdkResolver.csproj
+
+diff --git a/Microsoft.DotNet.Cli.sln b/Microsoft.DotNet.Cli.sln
+index 22d771abd..3ab6577a8 100644
+--- a/Microsoft.DotNet.Cli.sln
++++ b/Microsoft.DotNet.Cli.sln
+@@ -15,8 +15,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "core-sdk-tasks", "src\core-
+ EndProject
+ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Tools.Tests.Utilities", "test\Microsoft.DotNet.Tools.Tests.Utilities\Microsoft.DotNet.Tools.Tests.Utilities.csproj", "{78E15EC1-7732-41E3-8591-934E9F583254}"
+ EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SdkResolver", "src\SdkResolver\SdkResolver.csproj", "{7EE15292-2CAD-44FA-8A1F-BAC4688A49E0}"
+-EndProject
+ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Dotnet.Sdk.Internal", "src\Microsoft.Dotnet.Sdk.Internal\Microsoft.Dotnet.Sdk.Internal.csproj", "{73F07908-981B-41BB-B9BD-F3420274A6F7}"
+ EndProject
+ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SdkTests", "test\SdkTests\SdkTests.csproj", "{CB1EE94E-CB83-4071-9DD0-9929AE2B7282}"
+@@ -45,10 +43,6 @@ Global
+ 		{78E15EC1-7732-41E3-8591-934E9F583254}.Debug|Any CPU.Build.0 = Debug|Any CPU
+ 		{78E15EC1-7732-41E3-8591-934E9F583254}.Release|Any CPU.ActiveCfg = Release|Any CPU
+ 		{78E15EC1-7732-41E3-8591-934E9F583254}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{7EE15292-2CAD-44FA-8A1F-BAC4688A49E0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{7EE15292-2CAD-44FA-8A1F-BAC4688A49E0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{7EE15292-2CAD-44FA-8A1F-BAC4688A49E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{7EE15292-2CAD-44FA-8A1F-BAC4688A49E0}.Release|Any CPU.Build.0 = Release|Any CPU
+ 		{73F07908-981B-41BB-B9BD-F3420274A6F7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+ 		{73F07908-981B-41BB-B9BD-F3420274A6F7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+ 		{73F07908-981B-41BB-B9BD-F3420274A6F7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+@@ -70,7 +64,6 @@ Global
+ 		{1BFF54F9-4E35-49DB-893C-AF2047722FC6} = {17735A9D-BFD9-4585-A7CB-3208CA6EA8A7}
+ 		{53AF2D01-B69F-4CD0-86A7-8FD95967D23C} = {ED2FE3E2-F7E7-4389-8231-B65123F2076F}
+ 		{78E15EC1-7732-41E3-8591-934E9F583254} = {17735A9D-BFD9-4585-A7CB-3208CA6EA8A7}
+-		{7EE15292-2CAD-44FA-8A1F-BAC4688A49E0} = {ED2FE3E2-F7E7-4389-8231-B65123F2076F}
+ 		{CB1EE94E-CB83-4071-9DD0-9929AE2B7282} = {17735A9D-BFD9-4585-A7CB-3208CA6EA8A7}
+ 		{658EF9BE-452C-4D31-AA24-B9E2235799A8} = {17735A9D-BFD9-4585-A7CB-3208CA6EA8A7}
+ 	EndGlobalSection
+--- a/src/SdkResolver/SdkResolver.csproj
++++ /dev/null
+@@ -1,39 +0,0 @@
+-﻿<Project Sdk="Microsoft.NET.Sdk">
+-
+-  <PropertyGroup>
+-    <TargetFramework>$(CoreSdkTargetFramework)</TargetFramework>
+-    <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
+-    <GenerateDependencyFile>false</GenerateDependencyFile>
+-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+-    <GenerateRuntimeCofigurationFiles>false</GenerateRuntimeCofigurationFiles>
+-    <AssemblyName>UNUSED</AssemblyName>
+-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+-  </PropertyGroup>
+-
+-  <ItemGroup>
+-    <PackageReference Include="Microsoft.DotNet.MSBuildSdkResolver" Version="$(MicrosoftDotNetMSBuildSdkResolverPackageVersion)" ExcludeAssets="all" GeneratePathProperty="true"/>
+-    <PackageReference Include="runtime.win-x86.Microsoft.NETCore.DotNetHostResolver" Version="$(MicrosoftNETCoreDotNetHostResolverPackageVersion)" ExcludeAssets="all" GeneratePathProperty="true" />
+-    <PackageReference Include="runtime.win-x64.Microsoft.NETCore.DotNetHostResolver" Version="$(MicrosoftNETCoreDotNetHostResolverPackageVersion)" ExcludeAssets="all" GeneratePathProperty="true" />
+-  </ItemGroup>
+-
+-  <Target
+-    Name="GenerateLayout" 
+-    Condition=" '$(OS)' == 'Windows_NT' "
+-    BeforeTargets="AfterBuild"
+-    >
+-    <Message Importance="High" Text="$(MSBuildProjectName) -&gt; $(OutputPath)" />
+-
+-    <RemoveDir Directories="$(OutputPath)" />
+-    <MakeDir Directories="$(OutputPath)" />
+-
+-    <ItemGroup>
+-      <_SdkResolverSrc Include="$(Pkgruntime_win-x86_Microsoft_NETCore_DotNetHostResolver)\runtimes\win-x86\native\hostfxr.dll" Arch="x86\" />
+-      <_SdkResolverSrc Include="$(Pkgruntime_win-x64_Microsoft_NETCore_DotNetHostResolver)\runtimes\win-x64\native\hostfxr.dll" Arch="x64\" />
+-      <_SdkResolverSrc Include="$(PkgMicrosoft_DotNet_MSBuildSdkResolver)\lib\net472\**\*.dll" Arch="" />
+-      <_SdkResolverDst Include="@(_SdkResolverSrc->'$(OutputPath)%(Arch)%(RecursiveDir)%(Filename)%(Extension)')" />
+-    </ItemGroup>
+-
+-    <Copy SourceFiles="@(_SdkResolverSrc)" DestinationFiles="@(_SdkResolverDst)" />
+-  </Target>
+-
+-</Project>
+diff --git a/src/redist/redist.csproj b/src/redist/redist.csproj
+index 35c3d4ad9..15601e98f 100644
+--- a/src/redist/redist.csproj
++++ b/src/redist/redist.csproj
+@@ -12,7 +12,7 @@
+                         RuntimeFrameworkVersion="$(MicrosoftNETCoreAppRuntimePackageVersion)"
+                         />
+ 
+-    <ProjectReference Include="..\SdkResolver\SdkResolver.csproj" ReferenceOutputAssembly="false" />
++    <ProjectReference Include="..\SdkResolver\SdkResolver.csproj" ReferenceOutputAssembly="false" Condition="'$(DotNetBuildFromSource)' != 'true'" />
+-    <ProjectReference Include="..\VSTemplateLocator\VSTemplateLocator.csproj" ReferenceOutputAssembly="false" />
++    <ProjectReference Include="..\VSTemplateLocator\VSTemplateLocator.csproj" ReferenceOutputAssembly="false" Condition="'$(DotNetBuildFromSource)' != 'true'" />
+   </ItemGroup>
+ 
+-- 
+2.18.0
+

--- a/eng/source-build-patches/0005-Don-t-do-this-in-source-build-aspnetcore-targeting-p.patch
+++ b/eng/source-build-patches/0005-Don-t-do-this-in-source-build-aspnetcore-targeting-p.patch
@@ -1,0 +1,35 @@
+From 5f34f12928157f5ed1c351dc217bf4bf5b62befe Mon Sep 17 00:00:00 2001
+From: Chris Rummel <crummel@microsoft.com>
+Date: Mon, 14 Sep 2020 09:47:04 -0500
+Subject: [PATCH 5/5] Don't do this in source-build -
+ aspnetcore-targeting-pack.tar.gz not available.
+
+---
+ src/redist/targets/GeneratePKG.targets | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/redist/targets/GeneratePKG.targets b/src/redist/targets/GeneratePKG.targets
+index 82e55b18c..c78dc7b55 100644
+--- a/src/redist/targets/GeneratePKG.targets
++++ b/src/redist/targets/GeneratePKG.targets
+@@ -128,7 +128,7 @@
+             Inputs="@(GenerateSdkPkgInputs)"
+             Outputs="$(SdkPKGInstallerFile)"
+             DependsOnTargets="GenerateLayout;SetupPkgInputsOutputs"
+-            Condition=" '$(OSName)' == 'osx' ">
++            Condition=" '$(OSName)' == 'osx' and '$(DotNetBuildFromSource)' != 'true' ">
+ 
+       <ItemGroup>
+         <TemplateFiles Include="$(RedistLayoutPath)templates/**/*" />
+@@ -172,7 +172,7 @@
+             Inputs="@(GenerateSdkProductArchiveInputs)"
+             Outputs="$(CombinedFrameworkSdkHostPKGInstallerFile)"
+             DependsOnTargets="GenerateSdkPkg"
+-            Condition=" '$(OSName)' == 'osx' ">
++            Condition=" '$(OSName)' == 'osx' and '$(DotNetBuildFromSource)' != 'true' ">
+       <ItemGroup>
+         <PkgComponentsSourceFiles Include="$(SdkPKGInstallerFile);
+                                 $(DownloadsFolder)$(DownloadedSharedFrameworkInstallerFileName);
+-- 
+2.18.0
+

--- a/eng/source-build-patches/0007-Don-t-restore-WinForms-and-WPF-templates-for-source-.patch
+++ b/eng/source-build-patches/0007-Don-t-restore-WinForms-and-WPF-templates-for-source-.patch
@@ -1,0 +1,52 @@
+From 250fe198182eb00285710213480a6785b6eab451 Mon Sep 17 00:00:00 2001
+From: dseefeld <dseefeld@microsoft.com>
+Date: Thu, 4 Feb 2021 22:08:48 +0000
+Subject: [PATCH] Don't restore WinForms and WPF templates for source-build.
+
+---
+ src/redist/targets/BundledTemplates.targets | 8 --------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/src/redist/targets/BundledTemplates.targets b/src/redist/targets/BundledTemplates.targets
+index d1e84fdaa..ce7697c7c 100644
+--- a/src/redist/targets/BundledTemplates.targets
++++ b/src/redist/targets/BundledTemplates.targets
+@@ -28,8 +28,6 @@
+     <Bundled60Templates Include="Microsoft.DotNet.Web.Spa.ProjectTemplates.6.0" PackageVersion="$(AspNetCorePackageVersionFor60Templates)" />
+     
+     
+-    <Bundled60Templates Include="Microsoft.Dotnet.Wpf.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWpfProjectTemplates50PackageVersion)" />
+-    <Bundled60Templates Include="Microsoft.Dotnet.WinForms.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWinFormsProjectTemplates50PackageVersion)" />
+ 
+     <!-- NUnit templates are shipped in Test.ProjectTemplates -->
+     <Bundled60Templates Include="Microsoft.DotNet.Test.ProjectTemplates.6.0" PackageVersion="$(MicrosoftDotNetTestProjectTemplates60PackageVersion)" />
+@@ -45,8 +43,6 @@
+     <Bundled50Templates Include="Microsoft.DotNet.Common.ItemTemplates" PackageVersion="$(MicrosoftDotNetCommonItemTemplates50PackageVersion)" />
+     <Bundled50Templates Include="Microsoft.DotNet.Common.ProjectTemplates.5.0" PackageVersion="$(MicrosoftDotNetCommonProjectTemplates50PackageVersion)" />
+     <Bundled50Templates Include="Microsoft.DotNet.Test.ProjectTemplates.5.0" PackageVersion="$(MicrosoftDotNetTestProjectTemplates50PackageVersion)" />
+-    <Bundled50Templates Include="Microsoft.Dotnet.Wpf.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWpfProjectTemplates50PackageVersion)" />
+-    <Bundled50Templates Include="Microsoft.Dotnet.WinForms.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWinFormsProjectTemplates50PackageVersion)" />
+     <Bundled50Templates Include="Microsoft.DotNet.Web.ItemTemplates" PackageVersion="$(AspNetCorePackageVersionFor50Templates)" />
+     <Bundled50Templates Include="Microsoft.DotNet.Web.ProjectTemplates.5.0" PackageVersion="$(AspNetCorePackageVersionFor50Templates)" UseVersionForTemplateInstallPath="true" />
+     <Bundled50Templates Include="Microsoft.DotNet.Web.Spa.ProjectTemplates.5.0" PackageVersion="$(AspNetCorePackageVersionFor50Templates)" />
+@@ -56,8 +52,6 @@
+     <Bundled31Templates Include="Microsoft.DotNet.Common.ItemTemplates" PackageVersion="$(MicrosoftDotNetCommonItemTemplates31PackageVersion)" />
+     <Bundled31Templates Include="Microsoft.DotNet.Common.ProjectTemplates.3.1" PackageVersion="$(MicrosoftDotNetCommonProjectTemplates31PackageVersion)" />
+     <Bundled31Templates Include="Microsoft.DotNet.Test.ProjectTemplates.3.1" PackageVersion="$(MicrosoftDotNetTestProjectTemplates31PackageVersion)" />
+-    <Bundled31Templates Include="Microsoft.Dotnet.Wpf.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWpfProjectTemplates31PackageVersion)" />
+-    <Bundled31Templates Include="Microsoft.Dotnet.WinForms.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWinFormsProjectTemplates31PackageVersion)" />
+     <Bundled31Templates Include="Microsoft.DotNet.Web.ItemTemplates" PackageVersion="$(AspNetCorePackageVersionFor31Templates)" />
+     <Bundled31Templates Include="Microsoft.DotNet.Web.ProjectTemplates.3.1" PackageVersion="$(AspNetCorePackageVersionFor31Templates)" UseVersionForTemplateInstallPath="true" />
+     <Bundled31Templates Include="Microsoft.DotNet.Web.Spa.ProjectTemplates.3.1" PackageVersion="$(AspNetCorePackageVersionFor31Templates)" />
+@@ -68,8 +62,6 @@
+     <Bundled30Templates Include="Microsoft.DotNet.Common.ItemTemplates" PackageVersion="$(MicrosoftDotNetCommonItemTemplates30PackageVersion)" />
+     <Bundled30Templates Include="Microsoft.DotNet.Common.ProjectTemplates.3.0" PackageVersion="$(MicrosoftDotNetCommonProjectTemplates30PackageVersion)" />
+     <Bundled30Templates Include="Microsoft.DotNet.Test.ProjectTemplates.3.0" PackageVersion="$(MicrosoftDotNetTestProjectTemplates30PackageVersion)" />
+-    <Bundled30Templates Include="Microsoft.Dotnet.Wpf.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWpfProjectTemplates30PackageVersion)" />
+-    <Bundled30Templates Include="Microsoft.Dotnet.WinForms.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWinFormsProjectTemplates30PackageVersion)" />
+     <Bundled30Templates Include="Microsoft.DotNet.Web.ItemTemplates" PackageVersion="$(AspNetCorePackageVersionFor30Templates)" />
+     <Bundled30Templates Include="Microsoft.DotNet.Web.ProjectTemplates.3.0" PackageVersion="$(AspNetCorePackageVersionFor30Templates)" UseVersionForTemplateInstallPath="true" />
+     <Bundled30Templates Include="Microsoft.DotNet.Web.Spa.ProjectTemplates.3.0" PackageVersion="$(AspNetCorePackageVersionFor30Templates)" />
+-- 
+2.21.3
+

--- a/eng/source-build-patches/0008-Update-blob-versions-to-use-ref-pkg-versions-to-trac.patch
+++ b/eng/source-build-patches/0008-Update-blob-versions-to-use-ref-pkg-versions-to-trac.patch
@@ -1,0 +1,28 @@
+From 992512755a9df08ccfd531f7507c298aa5b22112 Mon Sep 17 00:00:00 2001
+From: dseefeld <dseefeld@microsoft.com>
+Date: Thu, 29 Oct 2020 16:01:59 +0000
+Subject: [PATCH] Update blob versions to use ref pkg versions to track stable
+ versions
+
+---
+ src/redist/targets/GenerateLayout.targets | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/redist/targets/GenerateLayout.targets b/src/redist/targets/GenerateLayout.targets
+index 9e7249d..f1b11d4 100644
+--- a/src/redist/targets/GenerateLayout.targets
++++ b/src/redist/targets/GenerateLayout.targets
+@@ -7,8 +7,8 @@
+ 
+   <PropertyGroup>
+     <!-- Blob storage directories are not stabilized, so these must refer to a package that does not stabilize -->
+-    <AspNetCoreBlobVersion>$(VSRedistCommonAspNetCoreSharedFrameworkx6460PackageVersion)</AspNetCoreBlobVersion>
+-    <CoreSetupBlobVersion>$(VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion)</CoreSetupBlobVersion>
++    <AspNetCoreBlobVersion>$(MicrosoftAspNetCoreAppRuntimePackageVersion)</AspNetCoreBlobVersion>
++    <CoreSetupBlobVersion>$(MicrosoftNETCoreAppRuntimePackageVersion)</CoreSetupBlobVersion>
+     <WindowsDesktopBlobVersion>$(VSRedistCommonWindowsDesktopSharedFrameworkx6460PackageVersion)</WindowsDesktopBlobVersion>
+ 
+     <!-- Change these individually to or $(CoreSetupBlobVersion), $(AspNetCoreBlobVersion), or appropriate fixed version depending if corresponding .Ref packages are unpinned. -->
+-- 
+1.8.3.1
+

--- a/eng/source-build-patches/0009-Exclude-internal-tarball-from-source-build.patch
+++ b/eng/source-build-patches/0009-Exclude-internal-tarball-from-source-build.patch
@@ -1,0 +1,25 @@
+From 13b15d6ef5ac2bf593825bd1c1b85020585e1751 Mon Sep 17 00:00:00 2001
+From: Michael Simons <msimons@microsoft.com>
+Date: Thu, 8 Apr 2021 20:59:02 +0000
+Subject: [PATCH] Exclude internal tarball from source-build
+
+---
+ src/redist/targets/GenerateArchives.targets | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/redist/targets/GenerateArchives.targets b/src/redist/targets/GenerateArchives.targets
+index e59e5d4..8a66679 100644
+--- a/src/redist/targets/GenerateArchives.targets
++++ b/src/redist/targets/GenerateArchives.targets
+@@ -28,7 +28,7 @@
+         IgnoreExitCode="$(IgnoreTarExitCode)"/>
+ 
+     <TarGzFileCreateFromDirectory
+-        Condition=" '$(OSName)' != 'win' "
++        Condition=" '$(OSName)' != 'win' and '$(DotNetBuildFromSource)' != 'true'"
+         SourceDirectory="$(SdkInternalLayoutPath)"
+         DestinationArchive="$(ArtifactsNonShippingPackagesDir)$(ArtifactNameWithVersionSdk).tar.gz"
+         OverwriteDestination="true"
+-- 
+1.8.3.1
+

--- a/eng/source-build-patches/0010-Update-GenerateMSI.targets-build-task-ref-to-net5.0.patch
+++ b/eng/source-build-patches/0010-Update-GenerateMSI.targets-build-task-ref-to-net5.0.patch
@@ -1,0 +1,25 @@
+From dfb963f3b5115c6f1fde734dc9e62c553b49151a Mon Sep 17 00:00:00 2001
+From: Michael Simons <msimons@microsoft.com>
+Date: Thu, 8 Apr 2021 21:53:33 +0000
+Subject: [PATCH] Update GenerateMSI.targets build task ref to net5.0
+
+---
+ src/redist/targets/GenerateMSIs.targets | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/redist/targets/GenerateMSIs.targets b/src/redist/targets/GenerateMSIs.targets
+index 0c69a4d..397fb82 100644
+--- a/src/redist/targets/GenerateMSIs.targets
++++ b/src/redist/targets/GenerateMSIs.targets
+@@ -1,7 +1,7 @@
+ <?xml version="1.0" encoding="utf-8"?>
+ <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">  
+   <PropertyGroup>
+-    <MicrosoftDotNetBuildTasksInstallersTaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(NuGetPackageRoot)microsoft.dotnet.build.tasks.installers\$(MicrosoftDotNetBuildTasksInstallersPackageVersion)\tools\netcoreapp3.1\Microsoft.DotNet.Build.Tasks.Installers.dll</MicrosoftDotNetBuildTasksInstallersTaskAssembly>
++    <MicrosoftDotNetBuildTasksInstallersTaskAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(NuGetPackageRoot)microsoft.dotnet.build.tasks.installers\$(MicrosoftDotNetBuildTasksInstallersPackageVersion)\tools\net5.0\Microsoft.DotNet.Build.Tasks.Installers.dll</MicrosoftDotNetBuildTasksInstallersTaskAssembly>
+     <MicrosoftDotNetBuildTasksInstallersTaskAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(NuGetPackageRoot)microsoft.dotnet.build.tasks.installers\$(MicrosoftDotNetBuildTasksInstallersPackageVersion)\tools\net472\Microsoft.DotNet.Build.Tasks.Installers.dll</MicrosoftDotNetBuildTasksInstallersTaskAssembly>
+   </PropertyGroup>
+ 
+-- 
+1.8.3.1
+


### PR DESCRIPTION
This PR adds the local build infrastructure that lets ArPow (arcade-powered source-build) run in this repo. See <https://github.com/dotnet/source-build/blob/master/Documentation/planning/arcade-powered-source-build/onboarding/local-onboarding.md> for more details about how it works.

To try it out locally, run this on Linux: `./build.sh -c Release --restore --build --pack /p:ArcadeBuildFromSource=true -bl`

This PR should have no effect on ordinary builds, or CI. ArPow stage 2 will add source-build to CI: PR validation and official builds.

For <https://github.com/dotnet/source-build/blob/master/Documentation/planning/arcade-powered-source-build/implementation-plan.md>

Related to https://github.com/dotnet/source-build/issues/2077

Note: All patches come from the existing source-build repo expect for the last two are new.
