### PR TITLE
Apple Silicon Distribution-Template

### DIFF
--- a/src/redist/targets/GeneratePKG.targets
+++ b/src/redist/targets/GeneratePKG.targets
@@ -88,6 +88,14 @@
         <DistributionTemplateReplacement Include="{arch}">
           <ReplacementString>$(Architecture)</ReplacementString>
         </DistributionTemplateReplacement>
+        <DistributionTemplateReplacement Include="{hostArchitectures}">
+          <ReplacementString>$(Architecture)</ReplacementString>
+          <ReplacementString Condition="'$(Architecture)' == 'x64'" >x86_64</ReplacementString>
+        </DistributionTemplateReplacement>
+        <DistributionTemplateReplacement Include="{minOsVersion}">
+          <ReplacementString>10.13</ReplacementString>
+          <ReplacementString Condition="'$(Architecture)' == 'arm64'" >11.0</ReplacementString>
+        </DistributionTemplateReplacement>
 
         <PostInstallScriptReplacement Include="%SDK_VERSION%">
           <ReplacementString>$(Version)</ReplacementString>

--- a/src/redist/targets/packaging/osx/clisdk/Distribution-Template
+++ b/src/redist/targets/packaging/osx/clisdk/Distribution-Template
@@ -2,12 +2,12 @@
 <installer-gui-script minSpecVersion="1">
     <title>{CLISdkBrandName} ({arch})</title>
     <background file="dotnetbackground.png" mime-type="image/png"/>
-    <options customize="never" require-scripts="false" />
+    <options customize="never" require-scripts="false" hostArchitectures="{hostArchitectures}" />
     <welcome file="welcome.html" mime-type="text/html" />
     <conclusion file="conclusion.html" mime-type="text/html" />
     <volume-check>
         <allowed-os-versions>
-            <os-version min="10.13" />
+            <os-version min="{minOsVersion}" />
         </allowed-os-versions>
     </volume-check>
     <choices-outline>


### PR DESCRIPTION
Add hostArchitectures attribute to stop installer from requiring Rosetta

Update the minimum required version to 11.0 for Apple Silicon

Fixes dotnet/runtime#48388 for the SDK installer


