### PR TITLE
Remove IsTrimmable from Mono KnownRuntimePack

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -295,7 +295,6 @@ Copyright (c) .NET Foundation. All rights reserved.
                       RuntimePackNamePatterns="Microsoft.NETCore.App.Runtime.Mono.**RID**"
                       RuntimePackRuntimeIdentifiers="@(MonoRuntimePackRids, '%3B')"
                       RuntimePackLabels="Mono"
-                      IsTrimmable="true"
                       />
 
     <KnownFrameworkReference Include="Microsoft.WindowsDesktop.App"


### PR DESCRIPTION
The assemblies themselves embed the trimmability information now, see https://github.com/dotnet/installer/commit/6c2b85564fb7854a50f47223c6eb34c515ebc82b
