### PR TITLE
added tests to check if the templates shipped with SDK have net6.0 set as default framework

### DIFF
--- a/test/EndToEnd/ProjectBuildTests.cs
+++ b/test/EndToEnd/ProjectBuildTests.cs
@@ -351,6 +351,22 @@ namespace EndToEnd.Tests
                 .Execute(newArgs)
                 .Should().Pass();
 
+            if (!string.IsNullOrWhiteSpace(framework))
+            {
+                //check if MSBuild TargetFramework property for *proj is set to expected framework
+                string expectedExtension = language switch
+                {
+                    "C#" => "*.csproj",
+                    "F#" => "*.fsproj",
+                    "VB" => "*.vbproj",
+                    _ => "*.csproj"
+                };
+                string projectFile = Directory.GetFiles(projectDirectory, expectedExtension).Single();
+                XDocument projectXml = XDocument.Load(projectFile);
+                XNamespace ns = projectXml.Root.Name.Namespace;
+                Assert.Equal(framework, projectXml.Root.Element(ns + "PropertyGroup").Element(ns + "TargetFramework").Value);
+            }
+
             if (build)
             {
                 string buildArgs = selfContained ? "" : $"-r {RuntimeInformation.RuntimeIdentifier}";
@@ -364,15 +380,6 @@ namespace EndToEnd.Tests
                      .WithWorkingDirectory(projectDirectory)
                      .Execute(buildArgs)
                      .Should().Pass();
-            }
-
-            if (!build && !string.IsNullOrWhiteSpace(framework))
-            {
-                //check if MSBuild TargetFramework property for csproj is set to expected framework
-                string projectFile = Directory.GetFiles(projectDirectory, "*.csproj").Single();
-                XDocument projectXml = XDocument.Load(projectFile);
-                XNamespace ns = projectXml.Root.Name.Namespace;
-                Assert.Equal(framework, projectXml.Root.Element(ns + "PropertyGroup").Element(ns + "TargetFramework").Value);
             }
         }
     }

--- a/test/EndToEnd/ProjectBuildTests.cs
+++ b/test/EndToEnd/ProjectBuildTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -324,15 +325,14 @@ namespace EndToEnd.Tests
         private static string DetectExpectedDefaultFramework()
         {
             string dotnetFolder = Path.GetDirectoryName(RepoDirectoriesProvider.DotnetUnderTest);
-            string[] sdkFolders = Directory.GetDirectories(Path.Combine(dotnetFolder, "sdk"));
-            sdkFolders.Length.Should().Be(1, "Only one SDK folder is expected in the layout");
-            string expectedSdkVersion = Path.GetFileName(sdkFolders.Single());
+            string[] runtimeFolders = Directory.GetDirectories(Path.Combine(dotnetFolder, "shared", "Microsoft.NETCore.App"));
 
-            if (expectedSdkVersion.StartsWith("6."))
+            int latestMajorVersion = runtimeFolders.Select(folder => int.Parse(Path.GetFileName(folder).Split('.').First())).Max();
+            if (latestMajorVersion == 6)
             {
                 return "net6.0";
             }
-            throw new System.Exception("Unsupported version of SDK");
+            throw new Exception("Unsupported version of SDK");
         }
 
         private static void TestTemplateCreateAndBuild(string templateName, bool build = true, bool selfContained = false, string language = "", string framework = "")


### PR DESCRIPTION
fixes dotnet/templating#3054 fixes dotnet/templating#2797 
Added tests to check if the templates shipped with SDK have net6.0 set as default framework for .NET 6 SDK

Also, added new data sets for templating managed templates and added basic tests on item templates as they were missing
Console templates are targeting net6.0 already so fixes dotnet/installer#8974