### PR TITLE
Extend the list of RIDs supported by Crossgen2

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -157,7 +157,21 @@
         " />
 
       <Net50Crossgen2SupportedRids Include="linux-musl-x64;linux-x64;win-x64" />
-      <Crossgen2SupportedRids Include="@(Net50Crossgen2SupportedRids);osx-x64;osx-arm64" />
+
+      <Net60Crossgen2SupportedRids Include="
+          @(Net50Crossgen2SupportedRids);
+          linux-arm;
+          linux-arm64;
+          linux-musl-arm;
+          linux-musl-arm64;
+          osx-arm64;
+          osx-x64;
+          win-arm;
+          win-arm64;
+          win-x86;
+          " />
+
+      <Crossgen2SupportedRids Include="@(Net60Crossgen2SupportedRids)" />
 
       <AspNetCore31RuntimePackRids Include="@(AspNetCore30RuntimePackRids)" />
       <AspNetCore50RuntimePackRids Include="@(AspNetCore31RuntimePackRids);linux-musl-arm;win-arm64" />


### PR DESCRIPTION
We produce Crossgen2 packages for 12 RIDs now (see dotnet/runtime#50514). Extend the list accordingly.