### PR TITLE
Make certificate for .otf files None

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -37,12 +37,13 @@
     <FileSignInfo Include="nunit3.dotnetnew.template.$(NUnit3Templates50PackageVersion).nupkg" CertificateName="None" />
 
     <FileExtensionSignInfo Include=".msi" CertificateName="$(InternalCertificateId)" />
-    <!-- .ttf and .js files come in from some older aspnetcore packages (e.g. 2.1).
+    <!-- .ttf, .otf, and .js files come in from some older aspnetcore packages (e.g. 2.1).
           These files in the 5.0 packages are NOT signed. When doing postbuild signing,
           SignTool will recognize that the files in the installer zips came from the 5.0 packages
           pulled in from aspnetcore, and aspnetcore said not to sign them. This info is not
           available for the 2.1 packages, so we need to avoid signing these in this repo. -->
     <FileExtensionSignInfo Include=".ttf" CertificateName="None" />
+    <FileExtensionSignInfo Include=".otf" CertificateName="None" />
     <FileExtensionSignInfo Remove=".js" />
     <FileExtensionSignInfo Include=".js" CertificateName="None" />
   </ItemGroup>


### PR DESCRIPTION
Like .ttf and .js files, .otf files come from aspnetcore and aren't signed there, so for post-build signing, we need to mark the certificate name as none

- Please add description for changes you are making.
- If there is an issue related to this PR, please add the reference.

Fixes https://github.com/dotnet/core-eng/issues/12276