### PR TITLE
[main] Bump to latest preview 4 Xamarin workloads

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -146,11 +146,11 @@
   </PropertyGroup>
   <!-- Workload manifest package versions -->
   <PropertyGroup>
-    <XamarinAndroidWorkloadManifestVersion>11.0.200-preview.4.232</XamarinAndroidWorkloadManifestVersion>
-    <XamarinIOSWorkloadManifestVersion>14.5.100-preview.4.623</XamarinIOSWorkloadManifestVersion>
-    <XamarinMacCatalystWorkloadManifestVersion>14.5.100-preview.4.623</XamarinMacCatalystWorkloadManifestVersion>
-    <XamarinMacOSWorkloadManifestVersion>11.3.100-preview.4.623</XamarinMacOSWorkloadManifestVersion>
-    <XamarinTvOSWorkloadManifestVersion>14.5.100-preview.4.623</XamarinTvOSWorkloadManifestVersion>
+    <XamarinAndroidWorkloadManifestVersion>11.0.200-preview.4.245</XamarinAndroidWorkloadManifestVersion>
+    <XamarinIOSWorkloadManifestVersion>14.5.100-preview.4.633</XamarinIOSWorkloadManifestVersion>
+    <XamarinMacCatalystWorkloadManifestVersion>14.5.100-preview.4.633</XamarinMacCatalystWorkloadManifestVersion>
+    <XamarinMacOSWorkloadManifestVersion>11.3.100-preview.4.633</XamarinMacOSWorkloadManifestVersion>
+    <XamarinTvOSWorkloadManifestVersion>14.5.100-preview.4.633</XamarinTvOSWorkloadManifestVersion>
     <BlazorWorkloadManifestVersion>$(MicrosoftAspNetCoreAppRuntimePackageVersion)</BlazorWorkloadManifestVersion>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Ported to main from: https://github.com/dotnet/installer/pull/10479

* xamarin-android: https://github.com/xamarin/xamarin-android/commit/a09fa1e93a94c7ee9f759c840ed7a5829d0e9152
* xamarin-macios: https://github.com/xamarin/xamarin-macios/commit/422b620702d5ebfe7f5536e126d28f6b18d9fdc6

Manually tested this with:

    > .\build.cmd -pack -publish

Then `artifacts\packages\Debug\Shipping\dotnet-sdk-6.0.100-dev-win-x64.zip` seems to have the correct workload manifests.