### PR TITLE
Bump to xamarin/xamarin-macios/release/6.0.1xx-preview4@48982224

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -147,10 +147,10 @@
   <!-- Workload manifest package versions -->
   <PropertyGroup>
     <XamarinAndroidWorkloadManifestVersion>11.0.200-preview.4.245</XamarinAndroidWorkloadManifestVersion>
-    <XamarinIOSWorkloadManifestVersion>14.5.100-preview.4.633</XamarinIOSWorkloadManifestVersion>
-    <XamarinMacCatalystWorkloadManifestVersion>14.5.100-preview.4.633</XamarinMacCatalystWorkloadManifestVersion>
-    <XamarinMacOSWorkloadManifestVersion>11.3.100-preview.4.633</XamarinMacOSWorkloadManifestVersion>
-    <XamarinTvOSWorkloadManifestVersion>14.5.100-preview.4.633</XamarinTvOSWorkloadManifestVersion>
+    <XamarinIOSWorkloadManifestVersion>14.5.100-preview.4.635</XamarinIOSWorkloadManifestVersion>
+    <XamarinMacCatalystWorkloadManifestVersion>14.5.100-preview.4.635</XamarinMacCatalystWorkloadManifestVersion>
+    <XamarinMacOSWorkloadManifestVersion>11.3.100-preview.4.635</XamarinMacOSWorkloadManifestVersion>
+    <XamarinTvOSWorkloadManifestVersion>14.5.100-preview.4.635</XamarinTvOSWorkloadManifestVersion>
     <BlazorWorkloadManifestVersion>$(MicrosoftAspNetCoreAppRuntimePackageVersion)</BlazorWorkloadManifestVersion>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Changes: https://github.com/xamarin/xamarin-macios/compare/422b6207...48982224

This includes a bug fix, where the Apple workloads (unintentionally)
required legacy Xamarin to be installed for builds to succeed.