### PR TITLE
Bump to Xamarin ci.main workload manifests

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -149,11 +149,11 @@
   </PropertyGroup>
   <!-- Workload manifest package versions -->
   <PropertyGroup>
-    <XamarinAndroidWorkloadManifestVersion>11.0.200-preview.4.245</XamarinAndroidWorkloadManifestVersion>
-    <XamarinIOSWorkloadManifestVersion>14.5.100-preview.4.633</XamarinIOSWorkloadManifestVersion>
-    <XamarinMacCatalystWorkloadManifestVersion>14.5.100-preview.4.633</XamarinMacCatalystWorkloadManifestVersion>
-    <XamarinMacOSWorkloadManifestVersion>11.3.100-preview.4.633</XamarinMacOSWorkloadManifestVersion>
-    <XamarinTvOSWorkloadManifestVersion>14.5.100-preview.4.633</XamarinTvOSWorkloadManifestVersion>
+    <XamarinAndroidWorkloadManifestVersion>11.0.200-ci.main.256</XamarinAndroidWorkloadManifestVersion>
+    <XamarinIOSWorkloadManifestVersion>14.5.100-ci.main.723</XamarinIOSWorkloadManifestVersion>
+    <XamarinMacCatalystWorkloadManifestVersion>14.5.100-ci.main.723</XamarinMacCatalystWorkloadManifestVersion>
+    <XamarinMacOSWorkloadManifestVersion>11.3.100-ci.main.723</XamarinMacOSWorkloadManifestVersion>
+    <XamarinTvOSWorkloadManifestVersion>14.5.100-ci.main.723</XamarinTvOSWorkloadManifestVersion>
     <BlazorWorkloadManifestVersion>$(MicrosoftAspNetCoreAppRuntimePackageVersion)</BlazorWorkloadManifestVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/redist/targets/BundledManifests.targets
+++ b/src/redist/targets/BundledManifests.targets
@@ -1,11 +1,11 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <ItemGroup>
-    <BundledManifests Include="Microsoft.NET.Workload.Android" Version="$(XamarinAndroidWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Workload.Android" />
-    <BundledManifests Include="Microsoft.NET.Workload.iOS" Version="$(XamarinIOSWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Workload.iOS" />
-    <BundledManifests Include="Microsoft.NET.Workload.MacCatalyst" Version="$(XamarinMacCatalystWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Workload.MacCatalyst" />
-    <BundledManifests Include="Microsoft.NET.Workload.macOS" Version="$(XamarinMacOSWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Workload.macOS" />
-    <BundledManifests Include="Microsoft.NET.Workload.tvOS" Version="$(XamarinTvOSWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Workload.tvOS" />
+    <BundledManifests Include="Microsoft.NET.Sdk.Android.Manifest-6.0.100" Version="$(XamarinAndroidWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Sdk.Android" />
+    <BundledManifests Include="Microsoft.NET.Sdk.iOS.Manifest-6.0.100" Version="$(XamarinIOSWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Sdk.iOS" />
+    <BundledManifests Include="Microsoft.NET.Sdk.MacCatalyst.Manifest-6.0.100" Version="$(XamarinMacCatalystWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Sdk.MacCatalyst" />
+    <BundledManifests Include="Microsoft.NET.Sdk.macOS.Manifest-6.0.100" Version="$(XamarinMacOSWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Sdk.macOS" />
+    <BundledManifests Include="Microsoft.NET.Sdk.tvOS.Manifest-6.0.100" Version="$(XamarinTvOSWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Sdk.tvOS" />
     <BundledManifests Include="Microsoft.NET.Sdk.BlazorWebAssembly.AOT" Version="$(BlazorWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Workload.BlazorWebAssembly" />
   </ItemGroup>
 


### PR DESCRIPTION
Context: https://github.com/dotnet/designs/pull/188/files#diff-8fcaa29d8e6f00b34b3cb1830d93f33e75f04424780a66a3c658c7021048e74fR125
Context: https://github.com/xamarin/xamarin-android/pull/5898
Context: https://github.com/xamarin/xamarin-macios/pull/11436

The Xamarin workload manifest packages have been renamed to have a `$(PackageId)` of:

    Microsoft.NET.Sdk.[platform].Manifest-6.0.100

The `dotnet` directory on disk is expected to contain:

    dotnet\sdk-manifests\6.0.100\Microsoft.NET.Sdk.[platform]\
        WorkloadManifest.json
        WorkloadManifest.targets

I manually tested `.\build.cmd -pack -publish` which produced
`artifacts\**\dotnet-sdk-6.0.100-dev-win-x64.exe`. After installing
it, I can see the "advertising manifest" feature seems to be working:

    > dotnet workload install microsoft-android-sdk-full --configfile NuGet.config
    Updated advertising manifest microsoft.net.sdk.android.
    Updated advertising manifest microsoft.net.sdk.ios.
    Updated advertising manifest microsoft.net.sdk.maccatalyst.
    Updated advertising manifest microsoft.net.sdk.macos.
    Updated advertising manifest microsoft.net.sdk.tvos.
    Failed to update the advertising manifest microsoft.net.workload.blazorwebassembly: microsoft.net.workload.blazorwebassembly.manifest-6.0.100 is not found in NuGet feeds https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json, https://pkgs.dev.azure.com/azure-public/vside/_packaging/xamarin-impl/nuget/v3/index.json, https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json",
    Installing pack Microsoft.Android.Sdk version 11.0.200-ci.main.256...
    Writing workload pack installation record for Microsoft.Android.Sdk version 11.0.200-ci.main.256...
    Installing pack Microsoft.Android.Sdk.BundleTool version 11.0.200-ci.main.256...
    Writing workload pack installation record for Microsoft.Android.Sdk.BundleTool version 11.0.200-ci.main.256...
    Installing pack Microsoft.Android.Ref version 11.0.200-ci.main.256...
    Writing workload pack installation record for Microsoft.Android.Ref version 11.0.200-ci.main.256...
    Installing pack Microsoft.Android.Templates version 11.0.200-ci.main.256...
    Writing workload pack installation record for Microsoft.Android.Templates version 11.0.200-ci.main.256...
    Garbage collecting for SDK feature bands 6.0.100...
    Successfully installed workload(s) microsoft-android-sdk-full.

Then I'm able to build and run an Android application using the installed workload:

    > dotnet build HelloAndroid -t:Run
    ...
    Build succeeded.
        0 Warning(s)
        0 Error(s)
    Time Elapsed 00:00:21.76
