### PR TITLE
Set SDK dependent value to include full semantic version

### DIFF
--- a/src/redist/targets/packaging/windows/clisdk/variables.wxi
+++ b/src/redist/targets/packaging/windows/clisdk/variables.wxi
@@ -46,5 +46,5 @@
   <?define DependencyKey   = "$(var.DependencyKeyName)_$(var.SDKBundleVersion)_$(var.Platform)"?>
   <?define DependencyKeyId = "$(var.DependencyKey)" ?>
   <!-- The dependent value associated with this SDK when creating reference counts for optional workloads. -->
-  <?define SdkDependent = "Microsoft.NET.SDK,$(var.SDKBundleVersion),$(var.Platform)"?>
+  <?define SdkDependent = "Microsoft.NET.SDK,$(var.NugetVersion),$(var.Platform)"?>
 </Include>


### PR DESCRIPTION
The dependent value used by the finalizer needs to match what the CLI will use and should be the full semantic version. Currently, the dependent will get set to a value such as ```Microsoft.NET.SDK,6.1.21.26005,x64```.

This change will ensure that the value will look something like ```Microsoft.NET.SDK,6.0.100-preview.5.21260.5,x64```
