### PR TITLE
Add Mono workload baseline manifest

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -158,7 +158,7 @@
     <XamarinMacCatalystWorkloadManifestVersion>14.5.100-ci.main.723</XamarinMacCatalystWorkloadManifestVersion>
     <XamarinMacOSWorkloadManifestVersion>11.3.100-ci.main.723</XamarinMacOSWorkloadManifestVersion>
     <XamarinTvOSWorkloadManifestVersion>14.5.100-ci.main.723</XamarinTvOSWorkloadManifestVersion>
-    <MonoWorkloadManifestVersion>6.0.0-preview.5.21263.2</MonoWorkloadManifestVersion>
+    <MonoWorkloadManifestVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MonoWorkloadManifestVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- pinned dependency. This package is not being produced outside of the 2.0 branch of corefx and should not change. -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -158,7 +158,7 @@
     <XamarinMacCatalystWorkloadManifestVersion>14.5.100-ci.main.723</XamarinMacCatalystWorkloadManifestVersion>
     <XamarinMacOSWorkloadManifestVersion>11.3.100-ci.main.723</XamarinMacOSWorkloadManifestVersion>
     <XamarinTvOSWorkloadManifestVersion>14.5.100-ci.main.723</XamarinTvOSWorkloadManifestVersion>
-    <BlazorWorkloadManifestVersion>$(MicrosoftAspNetCoreAppRuntimePackageVersion)</BlazorWorkloadManifestVersion>
+    <MonoWorkloadManifestVersion>6.0.0-preview.5.21262.3</MonoWorkloadManifestVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- pinned dependency. This package is not being produced outside of the 2.0 branch of corefx and should not change. -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -158,7 +158,7 @@
     <XamarinMacCatalystWorkloadManifestVersion>14.5.100-ci.main.723</XamarinMacCatalystWorkloadManifestVersion>
     <XamarinMacOSWorkloadManifestVersion>11.3.100-ci.main.723</XamarinMacOSWorkloadManifestVersion>
     <XamarinTvOSWorkloadManifestVersion>14.5.100-ci.main.723</XamarinTvOSWorkloadManifestVersion>
-    <MonoWorkloadManifestVersion>6.0.0-preview.5.21262.3</MonoWorkloadManifestVersion>
+    <MonoWorkloadManifestVersion>6.0.0-preview.5.21263.2</MonoWorkloadManifestVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- pinned dependency. This package is not being produced outside of the 2.0 branch of corefx and should not change. -->

--- a/src/redist/targets/BundledManifests.targets
+++ b/src/redist/targets/BundledManifests.targets
@@ -6,7 +6,6 @@
     <BundledManifests Include="Microsoft.NET.Sdk.MacCatalyst.Manifest-6.0.100" Version="$(XamarinMacCatalystWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Sdk.MacCatalyst" />
     <BundledManifests Include="Microsoft.NET.Sdk.macOS.Manifest-6.0.100" Version="$(XamarinMacOSWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Sdk.macOS" />
     <BundledManifests Include="Microsoft.NET.Sdk.tvOS.Manifest-6.0.100" Version="$(XamarinTvOSWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Sdk.tvOS" />
-    <BundledManifests Include="Microsoft.NET.Sdk.tvOS.Manifest-6.0.100" Version="$(XamarinTvOSWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Sdk.tvOS" />
     <BundledManifests Include="Microsoft.NET.Workload.Mono.ToolChain.Manifest-6.0.100" Version="$(MonoWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Workload.Mono.ToolChain.Manifest" />
   </ItemGroup>
 

--- a/src/redist/targets/BundledManifests.targets
+++ b/src/redist/targets/BundledManifests.targets
@@ -6,7 +6,7 @@
     <BundledManifests Include="Microsoft.NET.Sdk.MacCatalyst.Manifest-6.0.100" Version="$(XamarinMacCatalystWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Sdk.MacCatalyst" />
     <BundledManifests Include="Microsoft.NET.Sdk.macOS.Manifest-6.0.100" Version="$(XamarinMacOSWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Sdk.macOS" />
     <BundledManifests Include="Microsoft.NET.Sdk.tvOS.Manifest-6.0.100" Version="$(XamarinTvOSWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Sdk.tvOS" />
-    <BundledManifests Include="Microsoft.NET.Workload.Mono.ToolChain.Manifest-6.0.100" Version="$(MonoWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Workload.Mono.ToolChain.Manifest" />
+    <BundledManifests Include="Microsoft.NET.Workload.Mono.ToolChain.Manifest-6.0.100" Version="$(MonoWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Workload.Mono.ToolChain" />
   </ItemGroup>
 
   <!-- Restore workload manifests via PackageReference -->

--- a/src/redist/targets/BundledManifests.targets
+++ b/src/redist/targets/BundledManifests.targets
@@ -6,7 +6,8 @@
     <BundledManifests Include="Microsoft.NET.Sdk.MacCatalyst.Manifest-6.0.100" Version="$(XamarinMacCatalystWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Sdk.MacCatalyst" />
     <BundledManifests Include="Microsoft.NET.Sdk.macOS.Manifest-6.0.100" Version="$(XamarinMacOSWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Sdk.macOS" />
     <BundledManifests Include="Microsoft.NET.Sdk.tvOS.Manifest-6.0.100" Version="$(XamarinTvOSWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Sdk.tvOS" />
-    <BundledManifests Include="Microsoft.NET.Sdk.BlazorWebAssembly.AOT" Version="$(BlazorWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Workload.BlazorWebAssembly" />
+    <BundledManifests Include="Microsoft.NET.Sdk.tvOS.Manifest-6.0.100" Version="$(XamarinTvOSWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Sdk.tvOS" />
+    <BundledManifests Include="Microsoft.NET.Workload.Mono.ToolChain.Manifest-6.0.100" Version="$(MonoWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Workload.Mono.ToolChain.Manifest" />
   </ItemGroup>
 
   <!-- Restore workload manifests via PackageReference -->


### PR DESCRIPTION
This also replaces the Microsoft.NET.Sdk.BlazorWebAssembly.AOT workload

