### PR TITLE
WindowsDesktop NET5 ARM64: Include WindowsDesktop ARM64 in the Installer

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -127,7 +127,7 @@
 
       <WindowsDesktop30RuntimePackRids Include="win-x64;win-x86" />
       <WindowsDesktop31RuntimePackRids Include="@(WindowsDesktop30RuntimePackRids)" />
-      <WindowsDesktopRuntimePackRids Include="@(WindowsDesktop31RuntimePackRids)" />
+      <WindowsDesktopRuntimePackRids Include="@(WindowsDesktop31RuntimePackRids);win-arm64" />
     </ItemGroup>
 
     <!--

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -224,7 +224,7 @@
       </BundledInstallerComponent>
 
       <BundledInstallerComponent Include="DownloadedWindowsDesktopTargetingPackInstallerFile"
-                                 Condition="'$(InstallerExtension)' == '.msi' And '$(SkipBuildingInstallers)' != 'true' And !$(Architecture.StartsWith('arm'))">
+                                 Condition="'$(InstallerExtension)' == '.msi' And '$(SkipBuildingInstallers)' != 'true' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64')">
         <BaseUrl>$(WinFormsAndWpfSharedFxRootUrl)$(WindowsDesktopTargetingPackBlobVersion)</BaseUrl>
         <DownloadFileName>$(DownloadedWindowsDesktopTargetingPackInstallerFileName)</DownloadFileName>
       </BundledInstallerComponent>
@@ -285,7 +285,7 @@
 
     <PropertyGroup>
       <IncludeWpfAndWinForms Condition=" '$(IncludeWpfAndWinForms)' == '' AND '$(Architecture)' == 'arm'">false</IncludeWpfAndWinForms>
-      <IncludeWpfAndWinForms Condition=" '$(IncludeWpfAndWinForms)' == '' AND '$(OS)' == 'Windows_NT' AND '$(Architecture)' != 'arm64' ">true</IncludeWpfAndWinForms>
+      <IncludeWpfAndWinForms Condition=" '$(IncludeWpfAndWinForms)' == '' AND '$(OS)' == 'Windows_NT'">true</IncludeWpfAndWinForms>
       <IncludeWpfAndWinForms Condition=" '$(IncludeWpfAndWinForms)' == '' ">false</IncludeWpfAndWinForms>
     </PropertyGroup>
 
@@ -303,7 +303,7 @@
       </BundledLayoutComponent>
 
       <BundledInstallerComponent Include="DownloadedWinFormsAndWpfSharedFrameworkInstallerFile"
-                                 Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And !$(Architecture.StartsWith('arm'))">
+                                 Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64')">
         <BaseUrl>$(WinFormsAndWpfSharedFxRootUrl)$(WindowsDesktopBlobVersion)</BaseUrl>
         <DownloadFileName>$(DownloadedWinFormsAndWpfSharedFrameworkInstallerFileName)</DownloadFileName>
       </BundledInstallerComponent>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1028/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1028/bundle.wxl
@@ -63,21 +63,6 @@
     • 如需 SDK 文件，請前往 https://aka.ms/dotnet-sdk-docs
     • 如需版本資訊，請前往 https://aka.ms/dotnet5-release-notes
     • 如需教學課程，請前往 https://aka.ms/dotnet-tutorials</String>
-<String Id="FirstTimeWelcomeMessageArm64">安裝成功。
-
-下列項目已安裝在: '[DOTNETHOME]'
-    • .NET SDK [DOTNETSDKVERSION]
-    • .NET Runtime [DOTNETRUNTIMEVERSION]
-    • ASP.NET Core Runtime [ASPNETCOREVERSION]
-
-此產品會收集使用方式資料
-    • 如需詳細資訊並退出，請前往 https://aka.ms/dotnet-cli-telemetry
-
-資源
-    • 如需 .NET 文件，請前往 https://aka.ms/dotnet-docs
-    • 如需 SDK 文件，請前往 https://aka.ms/dotnet-sdk-docs
-    • 如需版本資訊，請前往 https://aka.ms/dotnet5-release-notes
-    • 如需教學課程，請前往 https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">.NET SDK</String>
   <String Id="WelcomeDescription">
     .NET SDK 可用於建置、執行及測試 .NET 應用程式。您可以選擇多種語言、編輯器以及開發人員工具，並可利用程式庫的大型生態系統，來建置 Web、行動裝置、桌面、遊戲及 IoT 的應用程式。希望您會喜歡!</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1029/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1029/bundle.wxl
@@ -63,21 +63,6 @@ Zdroje informací
     • Dokumentace k sadě SDK: https://aka.ms/dotnet-sdk-docs
     • Zpráva k vydání verze: https://aka.ms/dotnet5-release-notes
     • Kurzy: https://aka.ms/dotnet-tutorials</String>
-  <String Id="FirstTimeWelcomeMessageArm64">Instalace proběhla úspěšně.
-
-Do [DOTNETHOME] byly nainstalovány tyto součásti:
-    • Sada .NET SDK [DOTNETSDKVERSION]
-    • Modul runtime .NET [DOTNETRUNTIMEVERSION]
-    • Modul runtime ASP.NET Core [ASPNETCOREVERSION]
-
-Tento produkt shromažďuje data o využití.
-    • Další informace a vyjádření výslovného nesouhlasu: https://aka.ms/dotnet-cli-telemetry
-
-Zdroje informací
-    • Dokumentace k .NET : https://aka.ms/dotnet-docs
-    • Dokumentace k sadě SDK: https://aka.ms/dotnet-sdk-docs
-    • Zpráva k vydání verze: https://aka.ms/dotnet5-release-notes
-    • Kurzy: https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">Sada .NET SDK</String>
   <String Id="WelcomeDescription">
     Sada .NET SDK se používá k vytváření, spouštění a testování aplikací .NET. Můžete si vybrat z několika jazyků, editorů a vývojářských nástrojů. K dispozici jsou výhody rozsáhlého ekosystému knihoven, se kterými můžete vytvářet aplikace pro web, mobilní zařízení, desktop, herní zařízení a IoT. Doufáme, že se vám bude líbit!</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1031/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1031/bundle.wxl
@@ -63,21 +63,6 @@ Ressourcen
     • SDK-Dokumentation: https://aka.ms/dotnet-sdk-docs
     • Versionshinweise: https://aka.ms/dotnet5-release-notes
     • Tutorials: https://aka.ms/dotnet-tutorials</String>
-<String Id="FirstTimeWelcomeMessageArm64">Die Installation war erfolgreich.
-
-Folgende Komponenten wurden unter [DOTNETHOME] installiert:
-    • .NET SDK [DOTNETSDKVERSION]
-    • .NET-Runtime [DOTNETRUNTIMEVERSION]
-    • ASP.NET Core-Runtime [ASPNETCOREVERSION]
-
-Dieses Produkt erfasst Nutzungsdaten.
-    • Weitere Informationen und Deaktivieren der Erfassung: https://aka.ms/dotnet-cli-telemetry
-
-Ressourcen
-    • .NET-Dokumentation: https://aka.ms/dotnet-docs
-    • SDK-Dokumentation: https://aka.ms/dotnet-sdk-docs
-    • Versionshinweise: https://aka.ms/dotnet5-release-notes
-    • Tutorials: https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">.NET SDK</String>
   <String Id="WelcomeDescription">
     Das .NET SDK wird zum Erstellen, Ausführen und Testen von .NET-Anwendungen verwendet. Sie können aus mehreren Sprachen, Editoren und Entwicklertools auswählen und ein großes Bibliotheksnetzwerk nutzen, um Apps für das Web, mobile Geräte, Desktops, Gaming und IoT zu entwickeln. Wir wünschen Ihnen viel Spaß damit!</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1033/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1033/bundle.wxl
@@ -63,21 +63,6 @@ Resources
     • SDK Documentation https://aka.ms/dotnet-sdk-docs
     • Release Notes https://aka.ms/dotnet5-release-notes
     • Tutorials https://aka.ms/dotnet-tutorials</String>
-<String Id="FirstTimeWelcomeMessageArm64">The installation was successful.
-
-The following were installed at: '[DOTNETHOME]'
-    • .NET SDK [DOTNETSDKVERSION]
-    • .NET Runtime [DOTNETRUNTIMEVERSION]
-    • ASP.NET Core Runtime [ASPNETCOREVERSION]
-
-This product collects usage data
-    • More information and opt-out https://aka.ms/dotnet-cli-telemetry
-
-Resources
-    • .NET Documentation https://aka.ms/dotnet-docs
-    • SDK Documentation https://aka.ms/dotnet-sdk-docs
-    • Release Notes https://aka.ms/dotnet5-release-notes
-    • Tutorials https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">.NET SDK</String>
   <String Id="WelcomeDescription">
     The .NET SDK is used to build, run and test .NET applications. You can choose from multiple languages, editors, and developer tools, and take advantage of a large ecosystem of libraries to build apps for web, mobile, desktop, gaming and IoT. We hope you enjoy it!</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1036/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1036/bundle.wxl
@@ -63,21 +63,6 @@ Ressources
     • Documentation de kit SDK sur https://aka.ms/dotnet-sdk-docs
     • Notes de publication sur https://aka.ms/dotnet5-release-notes
     • Tutoriels sur https://aka.ms/dotnet-tutorials</String>
-  <String Id="FirstTimeWelcomeMessageArm64">L'installation a réussi.
-
-Les éléments suivants ont été installés sur : '[DOTNETHOME]'
-    • Kit SDK .NET [DOTNETSDKVERSION]
-    • Runtime .NET [DOTNETRUNTIMEVERSION]
-    • Runtime ASP.NET Core [ASPNETCOREVERSION]
-
-Ce produit collecte des données d'utilisation
-    • Plus informations et refus d'adhésion sur https://aka.ms/dotnet-cli-telemetry
-
-Ressources
-    • Documentation .NET sur https://aka.ms/dotnet-docs
-    • Documentation de kit SDK sur https://aka.ms/dotnet-sdk-docs
-    • Notes de publication sur https://aka.ms/dotnet5-release-notes
-    • Tutoriels sur https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">SDK .NET</String>
   <String Id="WelcomeDescription">
     Le kit SDK .NET permet de générer, d'exécuter et de tester des applications .NET. Vous pouvez choisir parmi plusieurs langages, éditeurs et outils de développement. De plus, vous pouvez bénéficier d'un vaste écosystème de bibliothèques afin de générer des applications pour le web, les appareils mobiles, les ordinateurs de bureau, les jeux et l'IoT. Nous espérons que vous l'apprécierez !</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1040/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1040/bundle.wxl
@@ -63,21 +63,6 @@ Risorse
     • Documentazione dell'SDK https://aka.ms/dotnet-sdk-docs
     • Note sulla versione https://aka.ms/dotnet5-release-notes
     • Esercitazioni https://aka.ms/dotnet-tutorials</String>
-  <String Id="FirstTimeWelcomeMessageArm64">L'installazione è riuscita.
-
-I componenti seguenti sono stati installati in '[DOTNETHOME]'
-    • .NET SDK [DOTNETSDKVERSION]
-    • Runtime di .NET [DOTNETRUNTIMEVERSION]
-    • Runtime di ASP.NET Core [ASPNETCOREVERSION]
-
-Questo prodotto consente di raccogliere i dati sull'utilizzo
-    • Altre informazioni e annullamento sottoscrizione https://aka.ms/dotnet-cli-telemetry
-
-Risorse
-    • Documentazione di .NET https://aka.ms/dotnet-docs
-    • Documentazione dell'SDK https://aka.ms/dotnet-sdk-docs
-    • Note sulla versione https://aka.ms/dotnet5-release-notes
-    • Esercitazioni https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">.NET SDK</String>
   <String Id="WelcomeDescription">
     .NET SDK consente di creare, eseguire e testare applicazioni NET. È possibile scegliere tra più linguaggi, editor e strumenti di sviluppo e sfruttare un vasto ecosistema di librerie per creare app per Web, dispositivi mobili, desktop, giochi e IoT.</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1041/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1041/bundle.wxl
@@ -63,21 +63,6 @@
     • SDK ドキュメント https://aka.ms/dotnet-sdk-docs
     • リリース ノート https://aka.ms/dotnet5-release-notes
     • チュートリアル https://aka.ms/dotnet-tutorials</String>
-  <String Id="FirstTimeWelcomeMessageArm64">インストールが成功しました。
-
-'[DOTNETHOME]' に以下がインストールされました
-    • .NET SDK [DOTNETSDKVERSION]
-    • .NET Runtime [DOTNETRUNTIMEVERSION]
-    • ASP.NET Core Runtime [ASPNETCOREVERSION]
-
-この製品は使用状況データを収集します
-    • 詳細およびオプトアウト https://aka.ms/dotnet-cli-telemetry
-
-リソース
-    • .NET ドキュメント https://aka.ms/dotnet-docs
-    • SDK ドキュメント https://aka.ms/dotnet-sdk-docs
-    • リリース ノート https://aka.ms/dotnet5-release-notes
-    • チュートリアル https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">.NET SDK</String>
   <String Id="WelcomeDescription">
     .Net SDK は、.NET アプリケーションをビルド、実行、テストするために使用されます。複数の言語、エディター、開発者ツールから選択し、ライブラリの大規模なエコシステムを利用して、Web、モバイル、デスクトップ、ゲーム、IoT 用のアプリを作成できます。ぜひご利用ください。</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1042/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1042/bundle.wxl
@@ -63,21 +63,6 @@
     • SDK 설명서 https://aka.ms/dotnet-sdk-docs
     • 릴리스 정보 https://aka.ms/dotnet5-release-notes
     • 자습서 https://aka.ms/dotnet-tutorials</String>
-  <String Id="FirstTimeWelcomeMessageArm64">설치가 완료되었습니다.
-
-다음이 '[DOTNETHOME]'에 설치되었습니다.
-    • .NET SDK [DOTNETSDKVERSION]
-    • .NET 런타임 [DOTNETRUNTIMEVERSION]
-    • ASP.NET Core 런타임 [ASPNETCOREVERSION]
-
-이 제품은 사용량 현황 데이터를 수집합니다.
-    • 추가 정보 및 옵트아웃 https://aka.ms/dotnet-cli-telemetry
-
-리소스
-    • .NET 설명서 https://aka.ms/dotnet-docs
-    • SDK 설명서 https://aka.ms/dotnet-sdk-docs
-    • 릴리스 정보 https://aka.ms/dotnet5-release-notes
-    • 자습서 https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">.NET SDK</String>
   <String Id="WelcomeDescription">
     .NET SDK는 .NET 애플리케이션을 빌드, 실행 및 테스트하는 데 사용됩니다. 여러 언어, 편집기 및 개발자 도구 중에서 선택하고 대규모 라이브러리 에코시스템을 활용하여 웹, 모바일, 데스크톱, 게임 및 IoT용 앱을 빌드할 수 있습니다. .NET SDK를 유용하게 사용하시길 바랍니다.</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1045/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1045/bundle.wxl
@@ -63,21 +63,6 @@ Zasoby
     • Dokumentacja zestawu SDK: https://aka.ms/dotnet-sdk-docs
     • Informacje o wersji: https://aka.ms/dotnet5-release-notes
     • Samouczki: https://aka.ms/dotnet-tutorials</String>
-  <String Id="FirstTimeWelcomeMessageArm64">Instalacja zakończyła się pomyślnie.
-
-Następujące elementy zostały zainstalowane w: „[DOTNETHOME]”
-    • Zestaw .NET SDK [DOTNETSDKVERSION]
-    • Środowisko uruchomieniowe platformy .NET [DOTNETRUNTIMEVERSION]
-    • Środowisko uruchomieniowe platformy ASP.NET Core [ASPNETCOREVERSION]
-
-Ten produkt gromadzi dane dotyczące użycia
-    • Więcej informacji i rezygnacja: https://aka.ms/dotnet-cli-telemetry
-
-Zasoby
-    • Dokumentacja platformy .NET: https://aka.ms/dotnet-docs
-    • Dokumentacja zestawu SDK: https://aka.ms/dotnet-sdk-docs
-    • Informacje o wersji: https://aka.ms/dotnet5-release-notes
-    • Samouczki: https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">.NET SDK</String>
   <String Id="WelcomeDescription">
     Zestaw SDK platformy .NET służy do tworzenia, uruchamiania i testowania aplikacji platformy .NET. Możesz wybierać spośród wielu języków, edytorów i narzędzi deweloperskich oraz korzystać z dużego ekosystemu bibliotek do tworzenia aplikacji dla sieci Web, urządzeń przenośnych, komputerów, środowisk gier i technologii IoT. Mamy nadzieję, że Ci się podoba!</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1046/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1046/bundle.wxl
@@ -63,21 +63,6 @@ Recursos
     • Documentação do SDK: https://aka.ms/dotnet-sdk-docs
     • Notas sobre a Versão: https://aka.ms/netcore3releasenotes
     • Tutoriais: https://aka.ms/dotnet-tutorials</String>
-  <String Id="FirstTimeWelcomeMessageArm64">A instalação foi bem-sucedida.
-
-O seguinte foi instalado em: '[DOTNETHOME]'
-    • SDK do .NET [DOTNETSDKVERSION]
-    • Runtime do .NET [DOTNETRUNTIMEVERSION]
-    • Runtime do ASP.NET Core [ASPNETCOREVERSION]
-
-Este produto coleta dados de uso
-    • Para obter mais informações ou recusá-lo, acesse https://aka.ms/dotnet-cli-telemetry
-
-Recursos
-    • Documentação do .NET: https://aka.ms/dotnet-docs
-    • Documentação do SDK: https://aka.ms/dotnet-sdk-docs
-    • Notas sobre a Versão: https://aka.ms/netcore3releasenotes
-    • Tutoriais: https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">SDK do .NET</String>
   <String Id="WelcomeDescription">
     O SDK do .NET é usado para compilar, executar e testar aplicativos .NET. Você pode escolher entre vários idiomas, editores e ferramentas de desenvolvedor e aproveitar um grande ecossistema de bibliotecas para criar aplicativos para Web, móveis, área de trabalho, jogos e IoT. Esperamos que você goste!</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1049/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1049/bundle.wxl
@@ -63,21 +63,6 @@
     • Документация по SDK: https://aka.ms/dotnet-sdk-docs
     • Заметки о выпуске: https://aka.ms/dotnet5-release-notes
     • Учебники: https://aka.ms/dotnet-tutorials</String>
-  <String Id="FirstTimeWelcomeMessageArm64">Установка выполнена.
-
-В "[DOTNETHOME]" установлены следующие компоненты:
-    • Пакет SDK для .NET [DOTNETSDKVERSION]
-    • Среда выполнения .NET [DOTNETRUNTIMEVERSION]
-    • Среда выполнения ASP.NET Core [ASPNETCOREVERSION]
-
-Этот продукт собирает данные об использовании.
-    • Чтобы получить дополнительные сведения или отказаться от использования продукта, перейдите на страницу https://aka.ms/dotnet-cli-telemetry
-
-Ресурсы
-    • Документация по .NET: https://aka.ms/dotnet-docs
-    • Документация по SDK: https://aka.ms/dotnet-sdk-docs
-    • Заметки о выпуске: https://aka.ms/dotnet5-release-notes
-    • Учебники: https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">Пакет SDK для .NET</String>
   <String Id="WelcomeDescription">
     Пакет SDK для .NET используется для сборки, запуска и тестирования приложений .NET. Вы можете выбрать один из нескольких языков, использовать различные редакторы и инструменты для разработчиков, а также воспользоваться преимуществами большой экосистемы библиотек для создания веб-приложений, мобильных и классических приложений, игр и приложений Интернета вещей. Надеемся, вам понравится!</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1055/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1055/bundle.wxl
@@ -63,21 +63,6 @@ Kaynaklar
     • SDK Belgeleri https://aka.ms/dotnet-sdk-docs
     • Sürüm Notları https://aka.ms/dotnet5-release-notes
     • Öğreticiler https://aka.ms/dotnet-tutorials</String>
-  <String Id="FirstTimeWelcomeMessageArm64">Yükleme başarılı oldu.
-
-Aşağıdakiler şu konumda yüklü: '[DOTNETHOME]'
-    • .NET SDK [DOTNETSDKVERSION]
-    • .NET Çalışma Zamanı [DOTNETRUNTIMEVERSION]
-    • ASP.NET Core Çalışma Zamanı [ASPNETCOREVERSION]
-
-Bu ürün, kullanım verilerini toplar
-    • Daha fazla bilgi ve katılmamayı seçmek için bkz. https://aka.ms/dotnet-cli-telemetry
-
-Kaynaklar
-    • .NET Belgeleri https://aka.ms/dotnet-docs
-    • SDK Belgeleri https://aka.ms/dotnet-sdk-docs
-    • Sürüm Notları https://aka.ms/dotnet5-release-notes
-    • Öğreticiler https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">.NET SDK'sı</String>
   <String Id="WelcomeDescription">
     .NET SDK, .NET uygulamalarını derlemek, çalıştırmak ve test etmek için kullanılır. Birden çok dil, düzenleyici ve geliştirici aracı arasından seçim yapabilirsiniz ve web, mobil, masaüstü, oyun ve IoT uygulamaları oluşturmak için büyük bir kitaplık ekosisteminden yararlanabilirsiniz. Beğeneceğinizi umuyoruz!</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/2052/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/2052/bundle.wxl
@@ -63,21 +63,6 @@
     • SDK 文档: https://aka.ms/dotnet-sdk-docs
     • 发行说明: https://aka.ms/dotnet5-release-notes
     • 教程: https://aka.ms/dotnet-tutorials</String>
-<String Id="FirstTimeWelcomeMessageArm64">已成功安装。
-
-下列项安装于: "[DOTNETHOME]"
-    • .NET SDK [DOTNETSDKVERSION]
-    • .NET 运行时 [DOTNETRUNTIMEVERSION]
-    • ASP.NET Core 运行时 [ASPNETCOREVERSION]
-
-此产品会收集用法数据
-    • 详细信息和选择退出选项: https://aka.ms/dotnet-cli-telemetry
-
-资源
-    • .NET 文档: https://aka.ms/dotnet-docs
-    • SDK 文档: https://aka.ms/dotnet-sdk-docs
-    • 发行说明: https://aka.ms/dotnet5-release-notes
-    • 教程: https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">.NET SDK</String>
   <String Id="WelcomeDescription">
     .NET SDK 用于生成、运行和测试 .NET 应用程序。有多种语言、编辑器和开发人员工具可供选择，你也可使用由库构成的大型生态系统来构建面向 Web、移动设备、桌面、游戏和 IoT 的应用。希望你喜欢它!</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/3082/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/3082/bundle.wxl
@@ -63,21 +63,6 @@ Recursos
     • Documentación del SDK https://aka.ms/dotnet-sdk-docs
     • Notas de la versión https://aka.ms/dotnet5-release-notes
     • Tutoriales https://aka.ms/dotnet-tutorials</String>
-  <String Id="FirstTimeWelcomeMessageArm64">La instalación se realizó correctamente.
-
-Se instaló lo siguiente en: "[DOTNETHOME]"
-    • SDK de .NET [DOTNETSDKVERSION]
-    • .NET Runtime [DOTNETRUNTIMEVERSION]
-    • ASP.NET Core Runtime [ASPNETCOREVERSION]
-
-Este producto recopila datos de uso
-    • Para obtener más información y declinar la participación, visite https://aka.ms/dotnet-cli-telemetry
-
-Recursos
-    • Documentación de .NET https://aka.ms/dotnet-docs
-    • Documentación del SDK https://aka.ms/dotnet-sdk-docs
-    • Notas de la versión https://aka.ms/dotnet5-release-notes
-    • Tutoriales https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">SDK de .NET</String>
   <String Id="WelcomeDescription">
     El SDK de .NET se usa para compilar, ejecutar y probar las aplicaciones .NET. Puede elegir entre varios lenguajes, editores y herramientas de desarrollo y aprovechar las ventajas de un amplio ecosistema de bibliotecas para compilar aplicaciones web, móviles, de escritorio, juegos e IoT. Esperamos que lo disfrute.</String>

--- a/src/redist/targets/packaging/windows/clisdk/bundle.wxs
+++ b/src/redist/targets/packaging/windows/clisdk/bundle.wxs
@@ -161,13 +161,13 @@
       <MsiPackage SourceFile="$(var.NetStandardTargetingPackMsiSourcePath)">
         <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
       </MsiPackage>
+      <?endif?>
       <MsiPackage SourceFile="$(var.WinFormsAndWpfMsiSourcePath)">
           <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
       </MsiPackage>
       <MsiPackage SourceFile="$(var.WindowsDesktopTargetingPackMsiSourcePath)">
         <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
       </MsiPackage>
-      <?endif?>
       <MsiPackage SourceFile="$(var.AspNetTargetingPackMsiSourcePath)">
         <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
       </MsiPackage>
@@ -195,15 +195,7 @@
 
   <Fragment>
     <PayloadGroup Id="DotnetCoreBAPayloads">
-      <!-- This theme is dupped with a slight change: It uses a modified version of FirstTimeWelcomeMessageArm64
-      for SuccessInstallHeader to account for ARM64's lack of support for WPF/WinForms. Once they converge, remove
-      this and remove FirstTimeWelcomeMessageArm64 from the wxl files. -->
-      <?if $(var.Platform)=arm64?>
-      <Payload Name="thm.xml" Compressed="yes" SourceFile="bundleArm64.thm" />
-      <?else?>
       <Payload Name="thm.xml" Compressed="yes" SourceFile="bundle.thm" />
-      <?endif?>
-
       <!-- Default/Neutral localized content is US English -->
       <Payload Name="thm.wxl" Compressed="yes" SourceFile="LCID\1033\bundle.wxl" />
       <Payload Name="bg.png" Compressed="yes" SourceFile="..\..\osx\clisdk\resources\dotnetbackground.png" />

--- a/test/EndToEnd/ProjectBuildTests.cs
+++ b/test/EndToEnd/ProjectBuildTests.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Linq;
 using System.Xml.Linq;
 using Microsoft.DotNet.TestFramework;
 using Microsoft.DotNet.Tools.Test.Utilities;
@@ -80,6 +81,58 @@ namespace EndToEnd.Tests
                 .WithWorkingDirectory(projectDirectory)
                 .ExecuteWithCapturedOutput()
                 .Should().Pass().And.HaveStdOutContaining("Hello World!");
+        }
+
+        [WindowsOnlyFact]
+        public void ItCanPublishArm64Winforms()
+        {
+            DirectoryInfo directory = TestAssets.CreateTestDirectory();
+            string projectDirectory = directory.FullName;
+
+            string newArgs = "winforms --no-restore";
+            new NewCommandShim()
+                .WithWorkingDirectory(projectDirectory)
+                .Execute(newArgs)
+                .Should().Pass();
+
+            string publishArgs="-r win-arm64";
+            new PublishCommand()
+                .WithWorkingDirectory(projectDirectory)
+                .Execute(publishArgs)
+                .Should().Pass();
+            var selfContainedPublishDir = new DirectoryInfo(projectDirectory)
+                .Sub("bin").Sub("Debug").GetDirectories().FirstOrDefault()
+                .Sub("win-arm64").Sub("publish");
+
+            selfContainedPublishDir.Should().HaveFilesMatching("System.Windows.Forms.dll", SearchOption.TopDirectoryOnly);
+            selfContainedPublishDir.Should().HaveFilesMatching($"{directory.Name}.dll", SearchOption.TopDirectoryOnly);
+        }
+        
+        [WindowsOnlyFact]
+        public void ItCanPublishArm64Wpf()
+        {
+            DirectoryInfo directory = TestAssets.CreateTestDirectory();
+            string projectDirectory = directory.FullName;
+
+            string newArgs = "wpf --no-restore";
+            new NewCommandShim()
+                .WithWorkingDirectory(projectDirectory)
+                .Execute(newArgs)
+                .Should().Pass();
+
+            string publishArgs="-r win-arm64";
+            new PublishCommand()
+                .WithWorkingDirectory(projectDirectory)
+                .Execute(publishArgs)
+                .Should().Pass();
+
+            var selfContainedPublishDir = new DirectoryInfo(projectDirectory)
+                .Sub("bin").Sub("Debug").GetDirectories().FirstOrDefault()
+                .Sub("win-arm64").Sub("publish");
+
+            selfContainedPublishDir.Should().HaveFilesMatching("PresentationCore.dll", SearchOption.TopDirectoryOnly);
+            selfContainedPublishDir.Should().HaveFilesMatching("PresentationNative_*.dll", SearchOption.TopDirectoryOnly);
+            selfContainedPublishDir.Should().HaveFilesMatching($"{directory.Name}.dll", SearchOption.TopDirectoryOnly);
         }
 
         [Theory]


### PR DESCRIPTION
**Description**

Backport NET6 WPF ARM64 and enable WinForms ARM64 support on NET5.  

* Add NET5 WPF ARM64 support.

* Unblock WinForms on NET5 ARM64, working but disabled on NET5 due to lack of WPF ARM64 support.

**Public PRs**

WPF public (these PRs need to go in separately due to WPF internal relying on the WPF Arcade SDK package): 
https://github.com/dotnet/wpf/pull/4522
https://github.com/dotnet/wpf/pull/4523

WindowsDesktop:
https://github.com/dotnet/windowsdesktop/pull/1629

SDK:
No changes are required in main. 

Installer: 
WindowsDesktop NET5 ARM64: Include WindowsDesktop ARM64 in the Installer by ryalanms · Pull Request #10699 · dotnet/installer (github.com)


**Customer Impact**

These changes allow existing NET5 customers to build WPF and WinForms applications for ARM64


**Regression?**

No.  This is a new feature.  

WinForms was available in NET5 preview, then disabled, due to lack of WPF ARM64 support.  This unblocks WinForms.  


**Risk**

Low.   

There are no existing ARM64 WPF or WinForms application on NET5 to break, and these changes have been in NET 6 Preview since Preview 1.  

Some files that have conditionally compiled sections shared with x86/x64.  There is a small risk of a regression due these modifications.

The addition of new packages and changes to the Installer pose some risk, but we have built and tested all PRs end-to-end (locally and through Azure) and tested the Installer on arm64 and x64/x86.  


**Is there a packaging impact?**

Yes.  This requires new runtime and targeting packs.  


**Testing**

Manual and automated testing was performed on a local test Installer build, created with the E2E changes from all five repos.  An E2E build on Azure using the PRs (with required feed and version updates) was also created to verify that we will not introduce build issues. 

WPF has ported 49% of the netcore test automation to ARM64.  There are parts of the test infrastructure (touch driver, printer driver, and others) that do not have ARM64 versions available and must be rewritten.  Manual tests were run to fill in the test gaps.  

For the manual tests, 202 test applications from WPF’s samples repo were built and run.  The sample application behavior was compared against the same applications running on NET5 x64 and net6 ARM64.  There were no differences observed between NET6 ARM64 and NET5 ARM64.

All ported test automation was run against the current NET5 x86 and NET5 x64 builds (without any changes), and results were compared against NET5 ARM64.  There are five failures that are being investigated, but we do not consider these blocking. 

For regression testing, a full test pass was run against x86 and x64 NET5 Installer builds containing the WPF ARM64 changes.  This covered all OS versions: Windows 7 SP1, Windows Blue, Windows Server 2012 R2 SP1, Win10 RS1, RS3, RS4, Server 2019, 21H1, Server 2016, 19H1, 19H2, 20H1, 20H2.  No new issues were found (introduced due to these changes) with x86 or x64.

Non-functioning bitmap effects were discovered, Blur and DropShadow, which work on non-ARM64 plaforms, but are considered non-blocking.  No blocking issues were found in automation or manual testing.
