### PR TITLE
Switch to 16.8

### DIFF
--- a/global.json
+++ b/global.json
@@ -12,7 +12,7 @@
       ]
     },
     "vs": {
-      "version": "16.9"
+      "version": "16.8"
     }
   },
   "native-tools": {


### PR DESCRIPTION
The CI pipeline contains logic that tries to match the global.json vs version to the xcopy msbuild package. Right now, there are no 16.9 versions of this package, so the CI pipeline fails to publish artifacts.
