### PR TITLE
Ensure CopyLatest runs on VS2019 agent

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -411,7 +411,7 @@ stages:
     jobs:
     - job: Copy_SDK_To_Latest
       pool:
-        name: Hosted VS2017
+        image: windows-2019
       condition: succeeded()
       variables:
         - group: DotNet-DotNetCli-Storage

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -411,7 +411,7 @@ stages:
     jobs:
     - job: Copy_SDK_To_Latest
       pool:
-        image: windows-2019
+        vmimage: windows-2019
       condition: succeeded()
       variables:
         - group: DotNet-DotNetCli-Storage


### PR DESCRIPTION
CopyLatest requires an agent with VS2019 since global.json references 16.8
