### PR TITLE
Ensure copy latest runs on dotnet engine and not msbuild

### DIFF
--- a/eng/CopyToLatest.cmd
+++ b/eng/CopyToLatest.cmd
@@ -3,5 +3,5 @@
 REM Copyright (c) .NET Foundation and contributors. All rights reserved.
 REM Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-powershell -ExecutionPolicy Bypass -NoProfile -NoLogo -Command "& \"%~dp0common\build.ps1\" -restore -build /p:Projects=\"%~dp0..\src\CopyToLatest\CopyToLatest.csproj\" %*; exit $LastExitCode;"
+powershell -ExecutionPolicy Bypass -NoProfile -NoLogo -Command "& \"%~dp0common\build.ps1\" -restore -build -msbuildEngine dotnet /p:Projects=\"%~dp0..\src\CopyToLatest\CopyToLatest.csproj\" %*; exit $LastExitCode;"
 if %errorlevel% neq 0 exit /b %errorlevel%


### PR DESCRIPTION
This is needed because Arcade picks msbuild by default when global,json references the VS toolset and copylatest needs to run on dotnet, otherwise the SDK is not resolved
