### PR TITLE
Update .NET 6 Preview 5 Xamarin workload manifests

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -153,11 +153,11 @@
   </PropertyGroup>
   <!-- Workload manifest package versions -->
   <PropertyGroup>
-    <XamarinAndroidWorkloadManifestVersion>11.0.200-ci.main.256</XamarinAndroidWorkloadManifestVersion>
-    <XamarinIOSWorkloadManifestVersion>14.5.100-ci.main.723</XamarinIOSWorkloadManifestVersion>
-    <XamarinMacCatalystWorkloadManifestVersion>14.5.100-ci.main.723</XamarinMacCatalystWorkloadManifestVersion>
-    <XamarinMacOSWorkloadManifestVersion>11.3.100-ci.main.723</XamarinMacOSWorkloadManifestVersion>
-    <XamarinTvOSWorkloadManifestVersion>14.5.100-ci.main.723</XamarinTvOSWorkloadManifestVersion>
+    <XamarinAndroidWorkloadManifestVersion>30.0.100-preview.5.18</XamarinAndroidWorkloadManifestVersion>
+    <XamarinIOSWorkloadManifestVersion>14.5.100-preview.5.881</XamarinIOSWorkloadManifestVersion>
+    <XamarinMacCatalystWorkloadManifestVersion>14.5.100-preview.5.881</XamarinMacCatalystWorkloadManifestVersion>
+    <XamarinMacOSWorkloadManifestVersion>11.3.100-preview.5.881</XamarinMacOSWorkloadManifestVersion>
+    <XamarinTvOSWorkloadManifestVersion>14.5.100-preview.5.881</XamarinTvOSWorkloadManifestVersion>
     <MonoWorkloadManifestVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MonoWorkloadManifestVersion>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
* Bump to xamarin/xamarin-android/release/6.0.1xx-preview5@198eeff
* Bump to xamarin/xamarin-macios/release/6.0.1xx-preview5@be26b02

Since we have the packages named appropriately with
`.Manifest-6.0.100`, I don't think we will need to bump this again for
Preview 5:

    > dotnet workload install microsoft-android-sdk-full
    Updated advertising manifest microsoft.net.sdk.android.
    Updated advertising manifest microsoft.net.sdk.ios.
    Updated advertising manifest microsoft.net.sdk.maccatalyst.
    Updated advertising manifest microsoft.net.sdk.macos.
    Updated advertising manifest microsoft.net.sdk.tvos.