### PR TITLE
Configure xunit to report long running tests

### DIFF
--- a/test/EndToEnd/EndToEnd.Tests.csproj
+++ b/test/EndToEnd/EndToEnd.Tests.csproj
@@ -16,4 +16,10 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DotNet.Tools.Tests.Utilities\Microsoft.DotNet.Tools.Tests.Utilities.csproj" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>   
 </Project>

--- a/test/EndToEnd/xunit.runner.json
+++ b/test/EndToEnd/xunit.runner.json
@@ -1,0 +1,6 @@
+{
+  "shadowCopy": false,
+  "methodDisplay": "method",
+  "diagnosticMessages": true,
+  "longRunningTestSeconds": 120
+}


### PR DESCRIPTION
Finding out which tests hang-up is very hard now.

One of the good practices is to configure it in xunit.runner.json as stated here: https://xunit.net/docs/configuration-files#longRunningTestSeconds.

I have also put there 'best-practice-values' since we now have it.