### PR TITLE
[release/3.1.1xx] Remove dotnet-core feed

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -16,7 +16,6 @@
     <!--  Begin: Package sources from dotnet-templating -->
     <!--  End: Package sources from dotnet-templating -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
-    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet3" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3/nuget/v3/index.json" />


### PR DESCRIPTION
Required to re-enable the nuget scanning by default.

- Please add description for changes you are making.
- If there is an issue related to this PR, please add the reference.
