### PR TITLE
Switch installer to use crossgen2 for ReadyToRun

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -217,7 +217,8 @@ stages:
               _LinuxPortable: ''
               _RuntimeIdentifier: '--runtime-id linux-musl-x64'
               _BuildArchitecture: 'x64'
-              _AdditionalBuildParameters: '/p:OSName="linux-musl"'
+              # Pass in HostOSName when running on alpine
+              _AdditionalBuildParameters: '/p:OSName="linux-musl" /p:HostOSName="linux-musl"'
               _TestArg: $(_NonWindowsTestArg)
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
             Build_Arm_Release:
@@ -261,7 +262,8 @@ stages:
               _LinuxPortable: ''
               _RuntimeIdentifier: '--runtime-id linux-musl-x64'
               _BuildArchitecture: 'x64'
-              _AdditionalBuildParameters: '/p:OSName="linux-musl"'
+              # Pass in HostOSName when running on alpine
+              _AdditionalBuildParameters: '/p:OSName="linux-musl" /p:HostOSName="linux-musl"'
             Build_Linux_Portable_Deb_Release_x64:
               _BuildConfig: Release
               _DockerParameter: '--docker ubuntu.16.04'

--- a/src/core-sdk-tasks/Crossgen.cs
+++ b/src/core-sdk-tasks/Crossgen.cs
@@ -41,8 +41,6 @@ namespace Microsoft.DotNet.Build.Tasks
 
         private string TempOutputPath { get; set; }
 
-        private bool _secondInvocationToCreateSymbols;
-
         protected override bool ValidateParameters()
         {
             base.ValidateParameters();
@@ -67,7 +65,15 @@ namespace Microsoft.DotNet.Build.Tasks
 
             if (toolResult)
             {
-                File.Copy(TempOutputPath, DestinationPath, overwrite: true);
+                var files = System.IO.Directory.GetFiles(Path.GetDirectoryName(TempOutputPath));
+                var dest = Path.GetDirectoryName(DestinationPath);
+                // Copy both dll and pdb files to the destination folder
+                foreach(var file in files)
+                {
+                    File.Copy(file, $"{dest}{Path.GetFileName(file)}", overwrite: true);
+                    // Delete file in temp
+                    File.Delete(file);
+                }
             }
 
             if (File.Exists(TempOutputPath))
@@ -76,18 +82,12 @@ namespace Microsoft.DotNet.Build.Tasks
             }
             Directory.Delete(tempDirPath);
 
-            if (toolResult && CreateSymbols)
-            {
-                _secondInvocationToCreateSymbols = true;
-                toolResult = base.Execute();
-            }
-
             return toolResult;
         }
 
         protected override string ToolName
         {
-            get { return "crossgen"; }
+            get { return "crossgen2"; }
         }
 
         protected override MessageImportance StandardOutputLoggingImportance
@@ -133,23 +133,18 @@ namespace Microsoft.DotNet.Build.Tasks
                 return CrossgenPath;
             }
 
-            return "crossgen";
+            return "crossgen2";
         }
 
         protected override string GenerateCommandLineCommands()
         {
-            if (_secondInvocationToCreateSymbols)
-            {
-                return $"{GetReadyToRun()} {GetPlatformAssemblyPaths()} {GetDiasymReaderPath()} {GetCreateSymbols()}";
-            }
-
-            return $"{GetReadyToRun()} {GetMissingDependenciesOk()} {GetInPath()} {GetOutPath()} {GetPlatformAssemblyPaths()} {GetJitPath()}";
+            return $"{GetInPath()} {GetOutPath()} {GetPlatformAssemblyPaths()} {GetCreateSymbols()}";
         }
 
         private string GetCreateSymbols()
         {
-            var option = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "-createpdb" : "-createperfmap";
-            return $"{option} \"{Path.GetDirectoryName(DestinationPath)}\" \"{DestinationPath}\"";
+            var option = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "--pdb" : "--perfmap";
+            return $"{option}";
         }
 
         private string GetDiasymReaderPath()
@@ -174,12 +169,12 @@ namespace Microsoft.DotNet.Build.Tasks
 
         private string GetInPath()
         {
-            return $"-in \"{SourceAssembly}\"";
+            return $" \"{SourceAssembly}\"";
         }
         
         private string GetOutPath()
         {
-            return $"-out \"{TempOutputPath}\"";
+            return $"-o \"{TempOutputPath}\"";
         }
 
         private string GetPlatformAssemblyPaths()
@@ -190,11 +185,11 @@ namespace Microsoft.DotNet.Build.Tasks
             {
                 foreach (var excludeTaskItem in PlatformAssemblyPaths)
                 {
-                    platformAssemblyPaths += $"{excludeTaskItem.ItemSpec}{Path.PathSeparator}";
+                    platformAssemblyPaths += $"-r {excludeTaskItem.ItemSpec}{Path.DirectorySeparatorChar}*.dll ";
                 }
             }
             
-            return $" -platform_assemblies_paths {platformAssemblyPaths.Trim(':')}";
+            return platformAssemblyPaths;
         }
         
         private string GetJitPath()

--- a/src/core-sdk-tasks/Crossgen.cs
+++ b/src/core-sdk-tasks/Crossgen.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.Build.Tasks
         public string DestinationPath { get; set; }
 
         [Required]
-        public string JITPath { get; set; }
+        public string Architecture { get; set; }
 
         public string CrossgenPath { get; set; }
 
@@ -138,7 +138,12 @@ namespace Microsoft.DotNet.Build.Tasks
 
         protected override string GenerateCommandLineCommands()
         {
-            return $"{GetInPath()} {GetOutPath()} {GetPlatformAssemblyPaths()} {GetCreateSymbols()}";
+            return $"{GetInPath()} {GetOutPath()} {GetArchitecture()} {GetPlatformAssemblyPaths()} {GetCreateSymbols()}";
+        }
+
+        private string GetArchitecture()
+        {
+            return $"--targetarch {Architecture}";
         }
 
         private string GetCreateSymbols()
@@ -192,11 +197,6 @@ namespace Microsoft.DotNet.Build.Tasks
             return platformAssemblyPaths;
         }
         
-        private string GetJitPath()
-        {
-            return $"-JITPath {JITPath}";
-        }
-
         private string GetMissingDependenciesOk()
         {
             return "-MissingDependenciesOK";

--- a/src/core-sdk-tasks/Crossgen.cs
+++ b/src/core-sdk-tasks/Crossgen.cs
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.Build.Tasks
                 // Copy both dll and pdb files to the destination folder
                 foreach(var file in files)
                 {
-                    File.Copy(file, $"{dest}{Path.DirectorySeparatorChar}{Path.GetFileName(file)}", overwrite: true);
+                    File.Copy(file, Path.Combine(dest, Path.GetFileName(file)), overwrite: true);
                     // Delete file in temp
                     File.Delete(file);
                 }
@@ -162,7 +162,7 @@ namespace Microsoft.DotNet.Build.Tasks
 
         private string GetInPath()
         {
-            return $" \"{SourceAssembly}\"";
+            return $"\"{SourceAssembly}\"";
         }
         
         private string GetOutPath()

--- a/src/core-sdk-tasks/Crossgen.cs
+++ b/src/core-sdk-tasks/Crossgen.cs
@@ -33,8 +33,6 @@ namespace Microsoft.DotNet.Build.Tasks
 
         public bool CreateSymbols { get; set; }
 
-        public string DiasymReaderPath { get; set; }
-
         public bool ReadyToRun { get; set; }
 
         public ITaskItem[] PlatformAssemblyPaths { get; set; }
@@ -150,16 +148,6 @@ namespace Microsoft.DotNet.Build.Tasks
         {
             var option = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "--pdb" : "--perfmap";
             return $"{option}";
-        }
-
-        private string GetDiasymReaderPath()
-        {
-            if (string.IsNullOrEmpty(DiasymReaderPath))
-            {
-                return null;
-            }
-
-            return $"-diasymreaderpath \"{DiasymReaderPath}\"";
         }
 
         private string GetReadyToRun()

--- a/src/core-sdk-tasks/Crossgen.cs
+++ b/src/core-sdk-tasks/Crossgen.cs
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.Build.Tasks
                 // Copy both dll and pdb files to the destination folder
                 foreach(var file in files)
                 {
-                    File.Copy(file, $"{dest}{Path.GetFileName(file)}", overwrite: true);
+                    File.Copy(file, $"{dest}{Path.DirectorySeparatorChar}{Path.GetFileName(file)}", overwrite: true);
                     // Delete file in temp
                     File.Delete(file);
                 }

--- a/src/redist/targets/Crossgen.targets
+++ b/src/redist/targets/Crossgen.targets
@@ -5,10 +5,11 @@
     
     <PropertyGroup>
       <RuntimeNETCoreAppPackageName>microsoft.netcore.app.runtime.$(SharedFrameworkRid)</RuntimeNETCoreAppPackageName>
+      <RuntimeNETCrossgenPackageName>Microsoft.NETCore.App.Crossgen2.$(SharedFrameworkRid)</RuntimeNETCrossgenPackageName>
       <_crossDir Condition="'$(Architecture)' == 'arm64' and '$(BuildArchitecture)' != 'arm64'">/x64_arm64</_crossDir>
       <_crossDir Condition="'$(Architecture)' == 'arm' And '$(OSName)' == 'win'">/x86_arm</_crossDir>
       <_crossDir Condition="'$(Architecture)' == 'arm' And '$(OSName)' != 'win'">/x64_arm</_crossDir>
-      <CrossgenPath>$(NuGetPackageRoot)/$(RuntimeNETCoreAppPackageName)/$(MicrosoftNETCoreAppRuntimePackageVersion)/tools$(_crossDir)/crossgen$(ExeExtension)</CrossgenPath>
+      <CrossgenPath>$(NuGetPackageRoot)/$(RuntimeNETCrossgenPackageName)/$(MicrosoftNETCoreAppRuntimePackageVersion)/tools/crossgen2$(ExeExtension)</CrossgenPath>
       <LibCLRJitRid Condition="'$(Architecture)' == 'arm64' and '$(BuildArchitecture)' == 'x64'">x64_arm64</LibCLRJitRid>
       <LibCLRJitRid Condition="'$(Architecture)' == 'arm' And '$(OSName)' == 'win'">x86_arm</LibCLRJitRid>
       <LibCLRJitRid Condition="'$(Architecture)' == 'arm' And '$(OSName)' != 'win'">x64_arm</LibCLRJitRid>
@@ -24,7 +25,7 @@
     <ItemGroup>
       <CrossGenDownloadPackageProject Include="$(MSBuildThisFileDirectory)DownloadPackage.csproj">
         <Properties>
-          PackageToRestore=$(RuntimeNETCoreAppPackageName);
+          PackageToRestore=$(RuntimeNETCrossgenPackageName);
           PackageVersionToRestore=$(MicrosoftNETCoreAppRuntimePackageVersion);
           TargetFramework=$(TargetFramework)
         </Properties>

--- a/src/redist/targets/Crossgen.targets
+++ b/src/redist/targets/Crossgen.targets
@@ -5,7 +5,7 @@
     
     <PropertyGroup>
       <RuntimeNETCoreAppPackageName>microsoft.netcore.app.runtime.$(SharedFrameworkRid)</RuntimeNETCoreAppPackageName>
-      <RuntimeNETCrossgenPackageName>microsoft.netcore.app.crossgen2.$(OSName)-$(BuildArchitecture)</RuntimeNETCrossgenPackageName>
+      <RuntimeNETCrossgenPackageName>microsoft.netcore.app.crossgen2.$(HostOSName)-$(BuildArchitecture)</RuntimeNETCrossgenPackageName>
       <CrossgenPath>$(NuGetPackageRoot)/$(RuntimeNETCrossgenPackageName)/$(MicrosoftNETCoreAppRuntimePackageVersion)/tools/crossgen2$(ExeExtension)</CrossgenPath>
       <SharedFrameworkNameVersionPath>$(RedistLayoutPath)shared/$(SharedFrameworkName)/$(MicrosoftNETCoreAppRuntimePackageVersion)</SharedFrameworkNameVersionPath>
     </PropertyGroup>

--- a/src/redist/targets/Crossgen.targets
+++ b/src/redist/targets/Crossgen.targets
@@ -123,7 +123,7 @@
     <Crossgen
         SourceAssembly="%(RoslynTargets.FullPath)"
         DestinationPath="%(RoslynTargets.FullPath)"
-        JITPath="$(LibCLRJitPath)"
+        Architecture="$(Architecture)"
         CrossgenPath="$(CrossgenPath)"
         ReadyToRun="True"
         CreateSymbols="$(CreateCrossgenSymbols)"
@@ -133,7 +133,7 @@
     <Crossgen
         SourceAssembly="%(FSharpTargets.FullPath)"
         DestinationPath="%(FSharpTargets.FullPath)"
-        JITPath="$(LibCLRJitPath)"
+        Architecture="$(Architecture)"
         CrossgenPath="$(CrossgenPath)"
         ReadyToRun="True"
         CreateSymbols="$(CreateCrossgenSymbols)"
@@ -143,7 +143,7 @@
     <Crossgen
         SourceAssembly="%(RemainingTargets.FullPath)"
         DestinationPath="%(RemainingTargets.FullPath)"
-        JITPath="$(LibCLRJitPath)"
+        Architecture="$(Architecture)"
         CrossgenPath="$(CrossgenPath)"
         ReadyToRun="True"
         CreateSymbols="$(CreateCrossgenSymbols)"

--- a/src/redist/targets/Crossgen.targets
+++ b/src/redist/targets/Crossgen.targets
@@ -5,7 +5,7 @@
     
     <PropertyGroup>
       <RuntimeNETCoreAppPackageName>microsoft.netcore.app.runtime.$(SharedFrameworkRid)</RuntimeNETCoreAppPackageName>
-      <RuntimeNETCrossgenPackageName>Microsoft.NETCore.App.Crossgen2.$(SharedFrameworkRid)</RuntimeNETCrossgenPackageName>
+      <RuntimeNETCrossgenPackageName>microsoft.netcore.app.crossgen2.$(SharedFrameworkRid)</RuntimeNETCrossgenPackageName>
       <_crossDir Condition="'$(Architecture)' == 'arm64' and '$(BuildArchitecture)' != 'arm64'">/x64_arm64</_crossDir>
       <_crossDir Condition="'$(Architecture)' == 'arm' And '$(OSName)' == 'win'">/x86_arm</_crossDir>
       <_crossDir Condition="'$(Architecture)' == 'arm' And '$(OSName)' != 'win'">/x64_arm</_crossDir>

--- a/src/redist/targets/Crossgen.targets
+++ b/src/redist/targets/Crossgen.targets
@@ -5,20 +5,9 @@
     
     <PropertyGroup>
       <RuntimeNETCoreAppPackageName>microsoft.netcore.app.runtime.$(SharedFrameworkRid)</RuntimeNETCoreAppPackageName>
-      <RuntimeNETCrossgenPackageName>microsoft.netcore.app.crossgen2.$(SharedFrameworkRid)</RuntimeNETCrossgenPackageName>
-      <_crossDir Condition="'$(Architecture)' == 'arm64' and '$(BuildArchitecture)' != 'arm64'">/x64_arm64</_crossDir>
-      <_crossDir Condition="'$(Architecture)' == 'arm' And '$(OSName)' == 'win'">/x86_arm</_crossDir>
-      <_crossDir Condition="'$(Architecture)' == 'arm' And '$(OSName)' != 'win'">/x64_arm</_crossDir>
+      <RuntimeNETCrossgenPackageName>microsoft.netcore.app.crossgen2.$(OSName)-$(BuildArchitecture)</RuntimeNETCrossgenPackageName>
       <CrossgenPath>$(NuGetPackageRoot)/$(RuntimeNETCrossgenPackageName)/$(MicrosoftNETCoreAppRuntimePackageVersion)/tools/crossgen2$(ExeExtension)</CrossgenPath>
-      <LibCLRJitRid Condition="'$(Architecture)' == 'arm64' and '$(BuildArchitecture)' == 'x64'">x64_arm64</LibCLRJitRid>
-      <LibCLRJitRid Condition="'$(Architecture)' == 'arm' And '$(OSName)' == 'win'">x86_arm</LibCLRJitRid>
-      <LibCLRJitRid Condition="'$(Architecture)' == 'arm' And '$(OSName)' != 'win'">x64_arm</LibCLRJitRid>
-      <LibCLRJitRid Condition="'$(LibCLRJitRid)' == ''">$(SharedFrameworkRid)</LibCLRJitRid>
-      <LibCLRJitPath>$(NuGetPackageRoot)/$(RuntimeNETCoreAppPackageName)/$(MicrosoftNETCoreAppRuntimePackageVersion)/runtimes/$(LibCLRJitRid)/native/$(DynamicLibPrefix)clrjit$(DynamicLibExtension)</LibCLRJitPath>
       <SharedFrameworkNameVersionPath>$(RedistLayoutPath)shared/$(SharedFrameworkName)/$(MicrosoftNETCoreAppRuntimePackageVersion)</SharedFrameworkNameVersionPath>
-      <DIASymReaderCrossgenFilter>*</DIASymReaderCrossgenFilter>
-      <DIASymReaderCrossgenFilter Condition="'$(Architecture)' == 'arm' And '$(OSName)' == 'win'">x86</DIASymReaderCrossgenFilter>
-      <DIASymReaderCrossgenFilter Condition="'$(Architecture)' == 'arm64' And '$(OSName)' == 'win'">amd64</DIASymReaderCrossgenFilter>
     </PropertyGroup>
 
     <!-- Download the runtime package with the crossgen executable in it -->
@@ -79,7 +68,6 @@
       <!-- Don't crossgen reference assemblies redisted with msbuild for RoslynCodeTaskFactory -->
       <RemainingFiles Remove="$(SdkOutputDirectory)**\ref\*.dll" />
 
-      <DiasymReaderPath Include="$(SharedFrameworkNameVersionPath)/Microsoft.DiaSymReader.Native.$(DIASymReaderCrossgenFilter).dll" />
     </ItemGroup>
 
     <AddMetadataIsPE Items="@(RoslynFiles)">
@@ -127,7 +115,6 @@
         CrossgenPath="$(CrossgenPath)"
         ReadyToRun="True"
         CreateSymbols="$(CreateCrossgenSymbols)"
-        DiasymReaderPath="@(DiasymReaderPath)"
         PlatformAssemblyPaths="@(RoslynFolders);$(SharedFrameworkNameVersionPath)" />
 
     <Crossgen
@@ -137,7 +124,6 @@
         CrossgenPath="$(CrossgenPath)"
         ReadyToRun="True"
         CreateSymbols="$(CreateCrossgenSymbols)"
-        DiasymReaderPath="@(DiasymReaderPath)"
         PlatformAssemblyPaths="@(FSharpFolders);$(SharedFrameworkNameVersionPath)" />
 
     <Crossgen
@@ -147,7 +133,6 @@
         CrossgenPath="$(CrossgenPath)"
         ReadyToRun="True"
         CreateSymbols="$(CreateCrossgenSymbols)"
-        DiasymReaderPath="@(DiasymReaderPath)"
         PlatformAssemblyPaths="@(RemainingFolders);$(SharedFrameworkNameVersionPath)" />
 
 

--- a/src/redist/targets/GetRuntimeInformation.targets
+++ b/src/redist/targets/GetRuntimeInformation.targets
@@ -10,6 +10,11 @@
       <OSName Condition=" '$(OSName)' == '' AND $([MSBuild]::IsOSPlatform('FREEBSD')) ">freebsd</OSName>
       <OSName Condition=" '$(OSName)' == '' AND '$(IsLinux)' == 'True' ">linux</OSName>
 
+      <HostOSName Condition=" '$(HostOSName)' == '' AND $([MSBuild]::IsOSPlatform('WINDOWS')) ">win</HostOSName>
+      <HostOSName Condition=" '$(HostOSName)' == '' AND $([MSBuild]::IsOSPlatform('OSX')) ">osx</HostOSName>
+      <HostOSName Condition=" '$(HostOSName)' == '' AND $([MSBuild]::IsOSPlatform('FREEBSD')) ">freebsd</HostOSName>
+      <HostOSName Condition=" '$(HostOSName)' == '' AND '$(IsLinux)' == 'True' ">linux</HostOSName>
+
       <Rid Condition=" '$(Rid)' == '' ">$(OSName)-$(Architecture)</Rid>
     </PropertyGroup>
 

--- a/src/redist/targets/GetRuntimeInformation.targets
+++ b/src/redist/targets/GetRuntimeInformation.targets
@@ -5,15 +5,12 @@
       <HostRid Condition="'$(HostRid)' == '' and '$(MSBuildRuntimeType)' != 'core'">win-$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant)</HostRid>
 
       <IsLinux Condition = " $([MSBuild]::IsOSPlatform('LINUX')) ">True</IsLinux>
-      <OSName Condition=" '$(OSName)' == '' AND $([MSBuild]::IsOSPlatform('WINDOWS')) ">win</OSName>
-      <OSName Condition=" '$(OSName)' == '' AND $([MSBuild]::IsOSPlatform('OSX')) ">osx</OSName>
-      <OSName Condition=" '$(OSName)' == '' AND $([MSBuild]::IsOSPlatform('FREEBSD')) ">freebsd</OSName>
-      <OSName Condition=" '$(OSName)' == '' AND '$(IsLinux)' == 'True' ">linux</OSName>
-
       <HostOSName Condition=" '$(HostOSName)' == '' AND $([MSBuild]::IsOSPlatform('WINDOWS')) ">win</HostOSName>
       <HostOSName Condition=" '$(HostOSName)' == '' AND $([MSBuild]::IsOSPlatform('OSX')) ">osx</HostOSName>
       <HostOSName Condition=" '$(HostOSName)' == '' AND $([MSBuild]::IsOSPlatform('FREEBSD')) ">freebsd</HostOSName>
       <HostOSName Condition=" '$(HostOSName)' == '' AND '$(IsLinux)' == 'True' ">linux</HostOSName>
+      
+      <OSName Condition=" '$(OSName)' == '' ">$(HostOSName)</OSName>
 
       <Rid Condition=" '$(Rid)' == '' ">$(OSName)-$(Architecture)</Rid>
     </PropertyGroup>


### PR DESCRIPTION
Use crossgen2 instead of crossgen since that has now been removed. This should unblock updating runtime dependencies. 