### PR TITLE
Modify GenerateLayout to work with runtime configs that contain more than one runtime

### DIFF
--- a/src/core-sdk-tasks/UpdateRuntimeConfig.cs
+++ b/src/core-sdk-tasks/UpdateRuntimeConfig.cs
@@ -1,0 +1,70 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public sealed class UpdateRuntimeConfig : Task
+    {
+        [Required]
+        public ITaskItem[] RuntimeConfigPaths { get; set; }
+
+        [Required]
+        public string MicrosoftNetCoreAppVersion { get; set; }
+
+        [Required]
+        public string MicrosoftAspNetCoreAppVersion { get; set; }
+
+        public override bool Execute()
+        {
+            foreach (var file in RuntimeConfigPaths)
+            {
+                UpdateFile(file.ItemSpec);
+            }
+
+            return true;
+        }
+
+        private void UpdateFile(string file)
+        {
+            var text = File.ReadAllText(file);
+            JObject config = JObject.Parse(text);
+            var frameworks = config["runtimeOptions"]?["frameworks"];
+            var framework = config["runtimeOptions"]?["framework"];
+            if (frameworks != null)
+            {
+                foreach (var item in frameworks)
+                {
+                    UpdateFramework(item);
+                }
+            }
+            else if (framework != null)
+            {
+                UpdateFramework(framework);
+            }
+
+            File.WriteAllText(file, config.ToString());
+        }
+
+        private void UpdateFramework(JToken item)
+        {
+            var framework = (JObject)item;
+            var name = framework["name"].Value<string>();
+            if (name == "Microsoft.NETCore.App")
+            {
+                framework["version"] = MicrosoftNetCoreAppVersion;
+            }
+            else if (name == "Microsoft.AspNetCore.App")
+            {
+                framework["version"] = MicrosoftAspNetCoreAppVersion;
+            }
+        }
+    }
+}

--- a/src/redist/targets/BuildCoreSdkTasks.targets
+++ b/src/redist/targets/BuildCoreSdkTasks.targets
@@ -3,7 +3,7 @@
     <!-- Tasks are multitargeted to support building in VS and with desktop MSBuild -->
     <TaskTargetFramework>$(CoreSdkTargetFramework)</TaskTargetFramework>
     <TaskTargetFramework Condition="'$(MSBuildRuntimeType)' != 'Core'">net472</TaskTargetFramework>
-    
+
     <CoreSdkTaskDll>$(ArtifactsDir)tasks\bin\core-sdk-tasks\$(Configuration)\$(TaskTargetFramework)\core-sdk-tasks.dll</CoreSdkTaskDll>
     <CoreSdkTaskProject>$(RepoRoot)src\core-sdk-tasks\core-sdk-tasks.csproj</CoreSdkTaskProject>
   </PropertyGroup>
@@ -27,6 +27,7 @@
   <UsingTask TaskName="TarGzFileCreateFromDirectory" AssemblyFile="$(CoreSdkTaskDll)" />
   <UsingTask TaskName="GenerateMsiVersionFromFullVersion" AssemblyFile="$(CoreSdkTaskDll)" />
   <UsingTask TaskName="ReplaceFileContents" AssemblyFile="$(CoreSdkTaskDll)" />
+  <UsingTask TaskName="UpdateRuntimeConfig" AssemblyFile="$(CoreSdkTaskDll)" />
   <UsingTask TaskName="Chmod" AssemblyFile="$(CoreSdkTaskDll)" />
   <UsingTask TaskName="DotNetDebTool" AssemblyFile="$(CoreSdkTaskDll)" />
   <UsingTask TaskName="BuildFPMToolPreReqs" AssemblyFile="$(CoreSdkTaskDll)"/>

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -403,30 +403,15 @@
   </Target>
 
   <Target Name="RetargetTools">
-    <PropertyGroup>
-      <ReplacementPattern>"version": ".*"</ReplacementPattern>
-      <ReplacementString>"version": "$(MicrosoftNETCoreAppRuntimePackageVersion)"</ReplacementString>
-      <AspNetCoreRuntimeReplacementString>"version": "$(MicrosoftAspNetCoreAppRuntimePackageVersion)"</AspNetCoreRuntimeReplacementString>
-    </PropertyGroup>
     <ItemGroup>
       <ToolRuntimeConfigPath Include="$(RedistLayoutPath)sdk/$(Version)/**/*.runtimeconfig.json" />
     </ItemGroup>
 
-    <!-- Update runtimeconfig files that target Microsoft.NETCore.App -->
-    <ReplaceFileContents
-      InputFiles="@(ToolRuntimeConfigPath)"
-      DestinationFiles="@(ToolRuntimeConfigPath)"
-      ReplacementPatterns="$(ReplacementPattern)"
-      ReplacementStrings="$(ReplacementString)"
-      FileMustContainText="Microsoft.NETCore.App" />
-
-    <!-- Update runtimeconfig files that target Microsoft.AspNetCore.App -->
-    <ReplaceFileContents
-      InputFiles="@(ToolRuntimeConfigPath)"
-      DestinationFiles="@(ToolRuntimeConfigPath)"
-      ReplacementPatterns="$(ReplacementPattern)"
-      ReplacementStrings="$(AspNetCoreRuntimeReplacementString)"
-      FileMustContainText="Microsoft.AspNetCore.App" />
+    <!-- Update runtimeconfig files for tools in the SDK to pin the shared frameworks to the one carried by this installer. -->
+    <UpdateRuntimeConfig
+      RuntimeConfigPaths="@(ToolRuntimeConfigPath)"
+      MicrosoftNetCoreAppVersion="$(MicrosoftNETCoreAppRuntimePackageVersion)"
+      MicrosoftAspNetCoreAppVersion="$(MicrosoftAspNetCoreAppRuntimePackageVersion)" />
   </Target>
 
   <Target Name="GenerateVersionFile"


### PR DESCRIPTION
Recent builds of dotnet-watch contain more than one runtime in the runtimconfig.json. This trips up the way RetargetTools currently works. Changing this to a bespoke task rather than one that finds-and-replaces text.