### PR TITLE
Add .NET MAUI workload manifest

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -153,6 +153,7 @@
   </PropertyGroup>
   <!-- Workload manifest package versions -->
   <PropertyGroup>
+    <MauiWorkloadManifestVersion>6.0.100-ci.main.806</MauiWorkloadManifestVersion>
     <XamarinAndroidWorkloadManifestVersion>11.0.200-ci.main.256</XamarinAndroidWorkloadManifestVersion>
     <XamarinIOSWorkloadManifestVersion>14.5.100-ci.main.723</XamarinIOSWorkloadManifestVersion>
     <XamarinMacCatalystWorkloadManifestVersion>14.5.100-ci.main.723</XamarinMacCatalystWorkloadManifestVersion>

--- a/src/redist/targets/BundledManifests.targets
+++ b/src/redist/targets/BundledManifests.targets
@@ -5,6 +5,7 @@
     <BundledManifests Include="Microsoft.NET.Sdk.iOS.Manifest-6.0.100" Version="$(XamarinIOSWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Sdk.iOS" />
     <BundledManifests Include="Microsoft.NET.Sdk.MacCatalyst.Manifest-6.0.100" Version="$(XamarinMacCatalystWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Sdk.MacCatalyst" />
     <BundledManifests Include="Microsoft.NET.Sdk.macOS.Manifest-6.0.100" Version="$(XamarinMacOSWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Sdk.macOS" />
+    <BundledManifests Include="Microsoft.NET.Sdk.Maui.Manifest-6.0.100" Version="$(MauiWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Sdk.Maui" />
     <BundledManifests Include="Microsoft.NET.Sdk.tvOS.Manifest-6.0.100" Version="$(XamarinTvOSWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Sdk.tvOS" />
     <BundledManifests Include="Microsoft.NET.Workload.Mono.ToolChain.Manifest-6.0.100" Version="$(MonoWorkloadManifestVersion)" WorkloadManifestId="Microsoft.NET.Workload.Mono.ToolChain" />
   </ItemGroup>


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/pull/603

After building with `.\build.cmd -pack -publish`, I could install the
workload:

    .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install maui --verbosity diag
    ...
    Successfully installed workload(s) maui.

Next, I setup a `global.json` with `6.0.100-dev` and tried:

    .\artifacts\bin\redist\Debug\dotnet\dotnet.exe new maui

I was able to build and run the app, after some minor tweaks to the
template.
