### PR TITLE
Update stage 0 SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "6.0.100-preview.6.21321.7",
+    "dotnet": "6.0.100-preview.6.21351.1",
     "runtimes": {
       "dotnet": [
         "$(VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion)"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "6.0.100-preview.5.21228.9",
+    "dotnet": "6.0.100-preview.6.21321.7",
     "runtimes": {
       "dotnet": [
         "$(VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion)"


### PR DESCRIPTION
I tested the precomputed cache change I made in MSBuild to make sure it worked, and it didn't because the version of the caches had changed in https://github.com/dotnet/msbuild/pull/6350.

This updates the stage 0 SDK again so they're aligned properly.

/cc: @wli3 @rainersigwald 