### PR TITLE
Update Xamarin manifests for .NET 6 Preview 6

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -154,11 +154,11 @@
   <!-- Workload manifest package versions -->
   <PropertyGroup>
     <MauiWorkloadManifestVersion>6.0.100-preview.6.882</MauiWorkloadManifestVersion>
-    <XamarinAndroidWorkloadManifestVersion>11.0.200-ci.main.256</XamarinAndroidWorkloadManifestVersion>
-    <XamarinIOSWorkloadManifestVersion>14.5.100-ci.main.723</XamarinIOSWorkloadManifestVersion>
-    <XamarinMacCatalystWorkloadManifestVersion>14.5.100-ci.main.723</XamarinMacCatalystWorkloadManifestVersion>
-    <XamarinMacOSWorkloadManifestVersion>11.3.100-ci.main.723</XamarinMacOSWorkloadManifestVersion>
-    <XamarinTvOSWorkloadManifestVersion>14.5.100-ci.main.723</XamarinTvOSWorkloadManifestVersion>
+    <XamarinAndroidWorkloadManifestVersion>30.0.100-preview.6.53</XamarinAndroidWorkloadManifestVersion>
+    <XamarinIOSWorkloadManifestVersion>15.0.100-preview.6.58</XamarinIOSWorkloadManifestVersion>
+    <XamarinMacCatalystWorkloadManifestVersion>15.0.100-preview.6.58</XamarinMacCatalystWorkloadManifestVersion>
+    <XamarinMacOSWorkloadManifestVersion>12.0.100-preview.6.58</XamarinMacOSWorkloadManifestVersion>
+    <XamarinTvOSWorkloadManifestVersion>15.0.100-preview.6.58</XamarinTvOSWorkloadManifestVersion>
     <MonoWorkloadManifestVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MonoWorkloadManifestVersion>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Bump to: https://github.com/xamarin/xamarin-android/commit/03b91941bf31a562b3243d3ac76846f0bac71636
Bump to: https://github.com/xamarin/xamarin-macios/commit/56acca3a0c42a69f42c04a8ac618c50f8335d979

After `.\build.cmd -pack -publish`, manually tested:

    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install microsoft-android-sdk-full --skip-manifest-update
    Installing pack Microsoft.Android.Sdk.BundleTool version 30.0.100-preview.6.53...
    ...
    Successfully installed workload(s) microsoft-android-sdk-full.
    
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install microsoft-ios-sdk-full --skip-manifest-update
    Installing pack Microsoft.iOS.Sdk version 15.0.100-preview.6.58...
    ...
    Successfully installed workload(s) microsoft-ios-sdk-full
    
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install microsoft-macos-sdk-full --skip-manifest-update
    Installing pack Microsoft.macOS.Sdk version 12.0.100-preview.6.58...
    ...
    Successfully installed workload(s) microsoft-macos-sdk-full.
    
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install microsoft-maccatalyst-sdk-full --skip-manifest-update
    Installing pack Microsoft.MacCatalyst.Sdk version 15.0.100-preview.6.58...
    ...
    Successfully installed workload(s) microsoft-maccatalyst-sdk-full.
    
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install microsoft-tvos-sdk-full --skip-manifest-update
    Installing pack Microsoft.tvOS.Sdk version 15.0.100-preview.6.58...
    ...
    Successfully installed workload(s) microsoft-tvos-sdk-full.