### PR TITLE
ArPow: Add package-source-build project

### DIFF
--- a/src/SourceBuild/tarball/content/repos/known-good.proj
+++ b/src/SourceBuild/tarball/content/repos/known-good.proj
@@ -31,6 +31,10 @@
         <RepositoryReference Include="arcade" />
         <RepositoryReference Include="linker" />
 
+        <!-- Package source-build artifacts -->
+
+        <RepositoryReference Include="package-source-build" />
+        
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/src/SourceBuild/tarball/content/repos/package-source-build.proj
+++ b/src/SourceBuild/tarball/content/repos/package-source-build.proj
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <RepositoryReference Include="arcade" />
-    <!-- <RepositoryReference Include="sdk" /> -->
   </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />

--- a/src/SourceBuild/tarball/content/repos/package-source-build.proj
+++ b/src/SourceBuild/tarball/content/repos/package-source-build.proj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <RepositoryReference Include="arcade" />
-    <RepositoryReference Include="sdk" />
+    <!-- <RepositoryReference Include="sdk" /> -->
   </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
@@ -20,17 +20,11 @@
     <!-- Copy PVP to packages dir in order to package them together -->
     <Copy SourceFiles="$(IncludedPackageVersionPropsFile)" DestinationFiles="$(SourceBuiltPackagesPath)PackageVersions.props" />
 
-    <!-- Copy coreclr tools to packages dir to include it in the source-built tarball as well -->
-    <ItemGroup>
-      <CoreClrToolsFiles Include="$(ToolPackageExtractDir)coreclr-tools/*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(CoreClrToolsFiles)" DestinationFolder="$(SourceBuiltPackagesPath)coreclr-tools" />
-
     <PropertyGroup>
       <SourceBuiltTarballName>$(OutputPath)$(SourceBuiltArtifactsTarballName).$(VersionPrefix)-$(VersionSuffix).tar.gz</SourceBuiltTarballName>
     </PropertyGroup>
 
-    <Exec Command="tar --numeric-owner -czf $(SourceBuiltTarballName) *.nupkg *.props coreclr-tools/*" WorkingDirectory="$(SourceBuiltPackagesPath)" />
+    <Exec Command="tar --numeric-owner -czf $(SourceBuiltTarballName) *.nupkg *.props" WorkingDirectory="$(SourceBuiltPackagesPath)" />
 
     <Message Importance="High" Text="Packaged source-built artifacts to $(SourceBuiltTarballName)" />
   </Target>


### PR DESCRIPTION
Add package-source-build.proj to package up previously source-built packages after building the tarball.   Remove coreclr-tools from this package, since that was previously used to build SBRP but is no longer needed.

This is the first step in https://github.com/dotnet/source-build/issues/2285