### PR TITLE
Fix CODEOWNERS path

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,4 @@
 # Snaps
 
 /src/snaps/ @rbhanda
-/src/sourceBuild/ @dotnet/source-build-internal
+/src/SourceBuild/ @dotnet/source-build-internal


### PR DESCRIPTION
Fix incorrect path in the CODEOWNERS file.

@sfoslund, Can you grant `dotnet/source-build-internal` write access to the repo?  According to the [code owners documentation](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners), write access is required.
