### PR TITLE
[ArPow] Reconcile prebuilt checks between inner and outer builds

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -158,7 +158,7 @@
          removed.  See https://github.com/dotnet/source-build/issues/2295 -->
     <MicrosoftBuildFrameworkVersion>15.7.179</MicrosoftBuildFrameworkVersion>
     <MicrosoftBuildUtilitiesCoreVersion>15.7.179</MicrosoftBuildUtilitiesCoreVersion>
-    <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-6.0.100-bootstrap.3</PrivateSourceBuiltArtifactsPackageVersion>
+    <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-6.0.100-bootstrap.4</PrivateSourceBuiltArtifactsPackageVersion>
   </PropertyGroup>
   <!-- Workload manifest package versions -->
   <PropertyGroup>

--- a/src/SourceBuild/tarball/content/ArcadeOverrides/AfterSourceBuild.proj
+++ b/src/SourceBuild/tarball/content/ArcadeOverrides/AfterSourceBuild.proj
@@ -1,0 +1,158 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+<Project DefaultTargets="AfterSourceBuild">
+
+  <Import Project="..\BuildStep.props" />
+
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GetLicenseFilePath" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
+
+  <PropertyGroup>
+    <MicrosoftDotNetSourceBuildTasksBuildDir>$(NuGetPackageRoot)microsoft.dotnet.sourcebuild.tasks\$(MicrosoftDotNetSourceBuildTasksVersion)\build\</MicrosoftDotNetSourceBuildTasksBuildDir>
+  </PropertyGroup>
+
+  <Import Project="$(MicrosoftDotNetSourceBuildTasksBuildDir)Microsoft.DotNet.SourceBuild.Tasks.props" />
+
+  <Target Name="AfterSourceBuild"
+          Condition="'$(ArcadeInnerBuildFromSource)' != 'true'"
+          DependsOnTargets="
+            ReportPrebuiltUsage;
+            PackSourceBuildIntermediateNupkgs" />
+
+  <Target Name="WritePrebuiltUsageData">
+    <ItemGroup>
+      <AllRestoredPackageFiles Include="$(CurrentRepoSourceBuildPackageCache)**/*.nupkg" />
+      <SourceBuiltPackageFiles Include="$(CurrentRepoSourceBuiltNupkgCacheDir)**/*.nupkg" />
+      <SourceBuiltPackageFiles Include="$(AdditionalSourceBuiltNupkgCacheDir)**/*.nupkg" Condition=" '$(AdditionalSourceBuiltNupkgCacheDir)' != '' " />
+      <SourceBuiltPackageFiles Include="$(ReferencePackageNupkgCacheDir)**/*.nupkg" Condition=" '$(ReferencePackageNupkgCacheDir)' != '' " />
+      <SourceBuiltPackageFiles Include="$(PreviouslySourceBuiltNupkgCacheDir)**/*.nupkg" Condition=" '$(PreviouslySourceBuiltNupkgCacheDir)' != '' " />
+
+      <!-- Add some other potential top-level project directories for a more specific report. -->
+      <ProjectDirectories Include="$(CurrentRepoSourceBuildSourceDir)" />
+      <!-- Finally, scan entire source-build, in case project.assets.json ends up in an unexpected place. -->
+      <ProjectDirectories Include="$(SourceBuildSelfDir)" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <PackageReportDataFile Condition="'$(PackageReportDataFile)' == ''">$([MSBuild]::NormalizePath('$(SourceBuildSelfPrebuiltReportDir)prebuilt-usage.xml'))</PackageReportDataFile>
+    </PropertyGroup>
+
+    <WritePackageUsageData
+      RestoredPackageFiles="@(AllRestoredPackageFiles)"
+      TarballPrebuiltPackageFiles="@(TarballPrebuiltPackageFiles)"
+      SourceBuiltPackageFiles="@(SourceBuiltPackageFiles)"
+      ReferencePackageFiles="@(ReferencePackageFiles)"
+      PlatformsRuntimeJsonFiles="@(PlatformsRuntimeJsonFiles)"
+      TargetRid="$(TargetRid)"
+      ProjectDirectories="@(ProjectDirectories)"
+      RootDir="$(SourceBuildSelfDir)"
+      IgnoredProjectAssetsJsonFiles="@(IgnoredProjectAssetsJsonFiles)"
+      DataFile="$(PackageReportDataFile)"
+      ProjectAssetsJsonArchiveFile="$(ProjectAssetsJsonArchiveFile)" />
+  </Target>
+
+  <Target Name="ReportPrebuiltUsage"
+          DependsOnTargets="WritePrebuiltUsageData">
+    <PropertyGroup>
+      <FailOnPrebuiltBaselineError Condition="'$(FailOnPrebuiltBaselineError)' == ''">false</FailOnPrebuiltBaselineError>
+    </PropertyGroup>
+
+    <WriteUsageReports
+      DataFile="$(PackageReportDataFile)"
+      PoisonedReportFile="$(PoisonedReportFile)"
+      OutputDirectory="$(SourceBuildSelfPrebuiltReportDir)" />
+
+    <PropertyGroup Condition="'$(ContinueOnPrebuiltBaselineError)' == ''">
+      <ContinueOnPrebuiltBaselineError>false</ContinueOnPrebuiltBaselineError>
+      <ContinueOnPrebuiltBaselineError Condition="'$(FailOnPrebuiltBaselineError)' != 'true'">true</ContinueOnPrebuiltBaselineError>
+    </PropertyGroup>
+
+    <ValidateUsageAgainstBaseline
+      DataFile="$(PackageReportDataFile)"
+      BaselineDataFile="$(PrebuiltBaselineDataFile)"
+      BaselineDataUpdateHintFile="$(PrebuiltBaselineDataFileDefault)"
+      OutputBaselineFile="$(SourceBuildSelfPrebuiltReportDir)generated-new-baseline.xml"
+      OutputReportFile="$(SourceBuildSelfPrebuiltReportDir)baseline-comparison.xml"
+      AllowTestProjectUsage="$(AllowTestProjectUsage)"
+      ContinueOnError="$(ContinueOnPrebuiltBaselineError)" />
+  </Target>
+
+  <!--
+    Copies the intermediate nupkg project to 'artifacts/' so the repo's global.json is in an
+    ancestor dir. This helps ensure the same version of Arcade is used throughout the build.
+  -->
+  <Target Name="CopyIntermediateNupkgProjToProjectDirectory">
+    <PropertyGroup>
+      <SourceBuildIntermediateProjFile>$(MSBuildThisFileDirectory)SourceBuildIntermediate.proj</SourceBuildIntermediateProjFile>
+      <SourceBuildIntermediateProjTargetFile>$(ArtifactsObjDir)ArcadeGeneratedProjects\SourceBuildIntermediate\SourceBuildIntermediate.proj</SourceBuildIntermediateProjTargetFile>
+    </PropertyGroup>
+
+    <Copy
+      SourceFiles="$(SourceBuildIntermediateProjFile)"
+      DestinationFiles="$(SourceBuildIntermediateProjTargetFile)" />
+
+    <!-- Run a restore so the SDK doesn't complain. Nothing should actually get restored. -->
+    <MSBuild
+      Projects="$(SourceBuildIntermediateProjTargetFile)"
+      Targets="Restore"
+      Properties="
+        SourceBuildArcadeTargetsFile=$(MSBuildThisFileDirectory)SourceBuildArcade.targets;
+        " />
+  </Target>
+
+  <Target Name="GetLicenseFileForIntermediateNupkgPack"
+          Condition="'$(DetectSourceBuildIntermediateNupkgLicense)' == 'true'">
+    <!-- Find the repository's global LICENSE file to apply. -->
+    <Microsoft.DotNet.Arcade.Sdk.GetLicenseFilePath Directory="$(RepoRoot)">
+      <Output TaskParameter="Path" PropertyName="DetectedLicenseFile"/>
+    </Microsoft.DotNet.Arcade.Sdk.GetLicenseFilePath>
+
+    <!-- Copy it to a file with '.txt' extension to avoid running into this NuGet problem: https://github.com/NuGet/Home/issues/7601 -->
+    <PropertyGroup>
+      <SourceBuildIntermediateNupkgLicenseFile>$(ArtifactsObjDir)ArcadeGeneratedProjects\SourceBuildIntermediate\LICENSE.txt</SourceBuildIntermediateNupkgLicenseFile>
+    </PropertyGroup>
+
+    <Copy
+      SourceFiles="$(DetectedLicenseFile)"
+      DestinationFiles="$(SourceBuildIntermediateNupkgLicenseFile)" />
+  </Target>
+
+  <!--
+    Create source-build intermediate NuGet package and supplemental intermediate NuGet packages (if
+    necessary) for dependency transport to downstream repos.
+  -->
+  <Target Name="PackSourceBuildIntermediateNupkgs"
+          DependsOnTargets="
+            CopyIntermediateNupkgProjToProjectDirectory;
+            GetLicenseFileForIntermediateNupkgPack;
+            GetCategorizedIntermediateNupkgContents;
+            GetSourceBuildIntermediateNupkgNameConvention">
+    <ItemGroup>
+      <IntermediateNupkgProject Include="$(SourceBuildIntermediateProjTargetFile)" />
+
+      <IntermediateNupkgProject
+        Include="$(SourceBuildIntermediateProjTargetFile)"
+        Condition=" '%(SupplementalIntermediateNupkgCategory.Identity)' != '' "
+        AdditionalProperties="
+          SupplementalIntermediateNupkgCategory=%(SupplementalIntermediateNupkgCategory.Identity)" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <IntermediateNupkgBuildMessage>Building intermediate nupkg</IntermediateNupkgBuildMessage>
+      <IntermediateNupkgBuildMessage Condition=" '@(SupplementalIntermediateNupkgCategory)' != '' ">$(IntermediateNupkgBuildMessage), and supplemental nupkgs for @(SupplementalIntermediateNupkgCategory, ', ')</IntermediateNupkgBuildMessage>
+    </PropertyGroup>
+
+    <Message Importance="High" Text="$(IntermediateNupkgBuildMessage)..." />
+
+    <MSBuild
+      Projects="@(IntermediateNupkgProject)"
+      Targets="Pack"
+      Properties="
+        CurrentRepoSourceBuildArtifactsPackagesDir=$(CurrentRepoSourceBuildArtifactsPackagesDir);
+        SourceBuildArcadeTargetsFile=$(MSBuildThisFileDirectory)SourceBuildArcade.targets;
+        SourceBuildIntermediateNupkgLicenseFile=$(SourceBuildIntermediateNupkgLicenseFile);
+        "
+      BuildInParallel="true"/>
+  </Target>
+
+  <Import Project="SourceBuildArcade.targets" />
+
+</Project>

--- a/src/SourceBuild/tarball/content/eng/Versions.props
+++ b/src/SourceBuild/tarball/content/eng/Versions.props
@@ -21,6 +21,6 @@
   </PropertyGroup>
   <!-- Production Dependencies -->
   <PropertyGroup>
-    <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-6.0.100-bootstrap.3</PrivateSourceBuiltArtifactsPackageVersion>
+    <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-6.0.100-bootstrap.4</PrivateSourceBuiltArtifactsPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/SourceBuild/tarball/content/repos/Directory.Build.props
+++ b/src/SourceBuild/tarball/content/repos/Directory.Build.props
@@ -152,6 +152,9 @@
     <StandardSourceBuildArgs>$(StandardSourceBuildArgs) /p:CopyWipIntoInnerSourceBuildRepo=true</StandardSourceBuildArgs>
     <StandardSourceBuildArgs>$(StandardSourceBuildArgs) /p:DotNetBuildOffline=true</StandardSourceBuildArgs>
     <StandardSourceBuildArgs>$(StandardSourceBuildArgs) /p:DotNetPackageVersionPropsPath="$(PackageVersionPropsPath)"</StandardSourceBuildArgs>
+    <StandardSourceBuildArgs>$(StandardSourceBuildArgs) /p:AdditionalSourceBuiltNupkgCacheDir="$(SourceBuiltPackagesPath)"</StandardSourceBuildArgs>
+    <StandardSourceBuildArgs>$(StandardSourceBuildArgs) /p:ReferencePackageNupkgCacheDir="$(ReferencePackagesDir)"</StandardSourceBuildArgs>
+    <StandardSourceBuildArgs>$(StandardSourceBuildArgs) /p:PreviouslySourceBuiltNupkgCacheDir="$(PrebuiltSourceBuiltPackagesPath)"</StandardSourceBuildArgs>
 
     <StandardSourceBuildCommand>$(ProjectDirectory)\build$(ShellExtension)</StandardSourceBuildCommand>
   </PropertyGroup>

--- a/src/SourceBuild/tarball/content/repos/Directory.Build.targets
+++ b/src/SourceBuild/tarball/content/repos/Directory.Build.targets
@@ -500,6 +500,19 @@
 
   </Target>
 
+  <!-- Copy restored packages from inner build to ensure they're included in the 
+       main build prebuilt check -->
+  <Target Name="CopyInnerBuildRestoredPackages"
+          AfterTargets="Package">
+    <ItemGroup>
+      <_InnerPackageCacheFiles Include="$(ProjectDirectory)artifacts/source-build/self/package-cache/**/*" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(_InnerPackageCacheFiles)"
+          DestinationFiles="$(PackagesDir)%(RecursiveDir)%(Filename)%(Extension)"
+          Condition=" '@(_InnerPackageCacheFiles)' != '' " />
+  </Target>
+
   <Target Name="CopyPackage"
           AfterTargets="Package"
           Condition="'$(OutputPlacementRepoApiImplemented)' != 'true' AND ('$(PackagesOutput)' != '' OR '@(PackagesOutputList)' != '')"

--- a/src/SourceBuild/tarball/content/repos/Directory.Build.targets
+++ b/src/SourceBuild/tarball/content/repos/Directory.Build.targets
@@ -585,13 +585,18 @@
 
     <!-- Allow overriding of Arcade targets for SourceBuild to enable quicker 
          dev turnaround for Preview 6 -->
+    <PropertyGroup>
+      <ArcadeSDKToolPackagePath></ArcadeSDKToolPackagePath>
+      <ArcadeSDKToolPackagePath Condition=" '%(_ToolPackage.Id)' == 'Microsoft.DotNet.Arcade.Sdk' ">$(ToolPackageExtractDir)%(_ToolPackage.Id)/</ArcadeSDKToolPackagePath>
+    </PropertyGroup>
     <ItemGroup>
       <OverrideArcadeFiles Include="$(ProjectDir)ArcadeOverrides/**/*" />
     </ItemGroup>
 
     <Copy
+      Condition=" '$(ArcadeSDKToolPackagePath))' != '' "
       SourceFiles="@(OverrideArcadeFiles)"
-      DestinationFiles="$(ToolPackageExtractDir)%(_ToolPackage.Id)/tools/SourceBuild/%(RecursiveDir)%(Filename)%(Extension)" />
+      DestinationFiles="$(ArcadeSDKToolPackagePath)tools/SourceBuild/%(RecursiveDir)%(Filename)%(Extension)" />
       
     <WriteLinesToFile File="$(RepoCompletedSemaphorePath)ExtractToolPackage.complete" Overwrite="true" />
   </Target>

--- a/src/SourceBuild/tarball/content/repos/source-build-reference-packages.proj
+++ b/src/SourceBuild/tarball/content/repos/source-build-reference-packages.proj
@@ -5,6 +5,8 @@
 
     <BuildCommand>$(StandardSourceBuildCommand) $(StandardSourceBuildArgs)</BuildCommand>
 
+    <NuGetConfigFile>$(ProjectDirectory)/NuGet.config</NuGetConfigFile>
+    <GlobalJsonFile>$(ProjectDirectory)global.json</GlobalJsonFile>
     <OutputPlacementRepoApiImplemented>false</OutputPlacementRepoApiImplemented>
 
     <!-- SBRP builds before Arcade so it also needs the bootstrap Arcade version -->

--- a/src/SourceBuild/tarball/content/repos/source-build-reference-packages.proj
+++ b/src/SourceBuild/tarball/content/repos/source-build-reference-packages.proj
@@ -5,7 +5,7 @@
 
     <BuildCommand>$(StandardSourceBuildCommand) $(StandardSourceBuildArgs)</BuildCommand>
 
-    <NuGetConfigFile>$(ProjectDirectory)/NuGet.config</NuGetConfigFile>
+    <NuGetConfigFile>$(ProjectDirectory)NuGet.config</NuGetConfigFile>
     <GlobalJsonFile>$(ProjectDirectory)global.json</GlobalJsonFile>
     <OutputPlacementRepoApiImplemented>false</OutputPlacementRepoApiImplemented>
 


### PR DESCRIPTION
Changes to improve prebuilt reporting:
1. Pass 3 additional caches from outer built to inner builds to improve accuracy of inner build prebuilt reports (built-packages, reference-packages and previously source-built packages)
2. Update previously source-built packages to a version built from a tarball after https://github.com/dotnet/installer/pull/10998 was merged.
3. Copy inner build package cache to outer build cache after build so restored packages can participate in outer build prebuilt checks.
4. A fix to overriding arcade targets.
5. Update to SBRP project to allow it to get it's NuGet.config file updated to use build package caches.
