### PR TITLE
[ArPow] Refactor tarball creation to avoid retrieving all git history

### DIFF
--- a/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
+++ b/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
@@ -111,12 +111,23 @@
       Condition="$(IsRootRepo) == 'true'" />
 
     <Exec
-      Command="git clone $(CloneParam) $(RepoUri) $(SourceDir)"
-      WorkingDirectory="$(TarballSourceDir)"
+      Command="git init $(TarballRepoSourceDir)"
+      WorkingDirectory="$(RepoRoot)"
       Condition="$(IsRootRepo) != 'true'" />
 
     <Exec
-      Command="git checkout $(CloneParam) $(RepoSha)"
+      Command="git remote add origin $(RepoUri)"
+      WorkingDirectory="$(TarballRepoSourceDir)"
+      Condition="$(IsRootRepo) != 'true'" />
+
+    <!-- Fetching a sha requires git 2.5.0 or newer -->
+    <Exec
+      Command="git fetch origin $(RepoSha)"
+      WorkingDirectory="$(TarballRepoSourceDir)"
+      Condition="$(IsRootRepo) != 'true'" />
+
+    <Exec
+      Command="git reset --hard FETCH_HEAD"
       WorkingDirectory="$(TarballRepoSourceDir)"
       Condition="$(IsRootRepo) != 'true'" />
 


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/2260

This adds a requirement of git >= 2.5.0 on environments that will be used create the tarball.  While not ideal, I don't see that as an issue with the portable tarball.  We will produce this on one machine and will build/test the one tarball on all distros/versions we support.

This reduces the tarball from 954309136 to 818628526.  There is an opportunity to reduce this to 675411252 with the use of `--fetch=1` but our patching mechanism will not work in a shallow git environment.  I will make note of this in https://github.com/dotnet/source-build/issues/2260 for future consideration but wanted to get this first improvement in.