### PR TITLE
[ArPow Tarball] Handle SBRP packages in previously source-built artifacts

### DIFF
--- a/eng/SourceBuild.Version.Details.xml
+++ b/eng/SourceBuild.Version.Details.xml
@@ -49,9 +49,9 @@
       <Sha>a3377cccde8639089f99107e2ba5df2c8cbe6394</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="5.0.0-alpha.1.20473.1">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="6.0.0-alpha.1.21357.1">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>def2e2c6dc5064319250e2868a041a3dc07f9579</Sha>
+      <Sha>36fb56afdf0ee2fb2e0833bdef98dfde12a0837b</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build" Version="0.1.0-alpha.1.21318.1">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -158,7 +158,7 @@
          removed.  See https://github.com/dotnet/source-build/issues/2295 -->
     <MicrosoftBuildFrameworkVersion>15.7.179</MicrosoftBuildFrameworkVersion>
     <MicrosoftBuildUtilitiesCoreVersion>15.7.179</MicrosoftBuildUtilitiesCoreVersion>
-    <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-6.0.100-bootstrap.5</PrivateSourceBuiltArtifactsPackageVersion>
+    <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-6.0.100-bootstrap.6</PrivateSourceBuiltArtifactsPackageVersion>
   </PropertyGroup>
   <!-- Workload manifest package versions -->
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -158,7 +158,7 @@
          removed.  See https://github.com/dotnet/source-build/issues/2295 -->
     <MicrosoftBuildFrameworkVersion>15.7.179</MicrosoftBuildFrameworkVersion>
     <MicrosoftBuildUtilitiesCoreVersion>15.7.179</MicrosoftBuildUtilitiesCoreVersion>
-    <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-6.0.100-bootstrap.4</PrivateSourceBuiltArtifactsPackageVersion>
+    <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-6.0.100-bootstrap.5</PrivateSourceBuiltArtifactsPackageVersion>
   </PropertyGroup>
   <!-- Workload manifest package versions -->
   <PropertyGroup>

--- a/src/SourceBuild/tarball/content/eng/Versions.props
+++ b/src/SourceBuild/tarball/content/eng/Versions.props
@@ -21,6 +21,6 @@
   </PropertyGroup>
   <!-- Production Dependencies -->
   <PropertyGroup>
-    <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-6.0.100-bootstrap.5</PrivateSourceBuiltArtifactsPackageVersion>
+    <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-6.0.100-bootstrap.6</PrivateSourceBuiltArtifactsPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/SourceBuild/tarball/content/eng/Versions.props
+++ b/src/SourceBuild/tarball/content/eng/Versions.props
@@ -21,6 +21,6 @@
   </PropertyGroup>
   <!-- Production Dependencies -->
   <PropertyGroup>
-    <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-6.0.100-bootstrap.4</PrivateSourceBuiltArtifactsPackageVersion>
+    <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-6.0.100-bootstrap.5</PrivateSourceBuiltArtifactsPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/SourceBuild/tarball/content/repos/package-source-build.proj
+++ b/src/SourceBuild/tarball/content/repos/package-source-build.proj
@@ -19,11 +19,39 @@
     <!-- Copy PVP to packages dir in order to package them together -->
     <Copy SourceFiles="$(IncludedPackageVersionPropsFile)" DestinationFiles="$(SourceBuiltPackagesPath)PackageVersions.props" />
 
+    <!-- Expand SBRP intermediate package into separate folder and remove intermediate package -->
+    <PropertyGroup>
+      <SourceBuildReferencePackagesDestination>$(SourceBuiltPackagesPath)SourceBuildReferencePackages/</SourceBuildReferencePackagesDestination>
+      <SBRPIntermediateWildcard>Microsoft.SourceBuild.Intermediate.source-build-reference-packages*.nupkg</SBRPIntermediateWildcard>
+    </PropertyGroup>
+    <ItemGroup>
+      <SourceBuildReferencePackagesIntermediatePackage Include="$(SourceBuiltPackagesPath)$(SBRPIntermediateWildcard)"/>
+    </ItemGroup>
+
+    <MakeDir Directories="$(SourceBuildReferencePackagesDestination)" />
+    <ZipFileExtractToDirectory Condition="'@(SourceBuildReferencePackagesIntermediatePackage)' != ''"
+                            SourceArchive="%(SourceBuildReferencePackagesIntermediatePackage.Identity)"
+                            DestinationDirectory="$(SourceBuildReferencePackagesDestination)extractArtifacts/"
+                            OverwriteDestination="true" />
+
+    <ItemGroup>
+      <SourceBuildReferencePackagesNupkgFiles Include="$(SourceBuildReferencePackagesDestination)extractArtifacts/**/*.nupkg" />
+    </ItemGroup>
+
+    <Copy
+      Condition="'@(SourceBuildReferencePackagesNupkgFiles)' != ''"
+      SourceFiles="@(SourceBuildReferencePackagesNupkgFiles)"
+      DestinationFiles="@(SourceBuildReferencePackagesNupkgFiles -> '$(SourceBuildReferencePackagesDestination)%(Filename)%(Extension)')" />
+
+    <RemoveDir
+      Condition="Exists('$(SourceBuildReferencePackagesDestination)extractArtifacts/')"
+      Directories="$(SourceBuildReferencePackagesDestination)extractArtifacts/" />
+
     <PropertyGroup>
       <SourceBuiltTarballName>$(OutputPath)$(SourceBuiltArtifactsTarballName).$(VersionPrefix)-$(VersionSuffix).tar.gz</SourceBuiltTarballName>
     </PropertyGroup>
 
-    <Exec Command="tar --numeric-owner -czf $(SourceBuiltTarballName) *.nupkg *.props" WorkingDirectory="$(SourceBuiltPackagesPath)" />
+    <Exec Command="tar --numeric-owner --exclude='$(SBRPIntermediateWildcard)' -czf $(SourceBuiltTarballName) *.nupkg *.props SourceBuildReferencePackages/" WorkingDirectory="$(SourceBuiltPackagesPath)" />
 
     <Message Importance="High" Text="Packaged source-built artifacts to $(SourceBuiltTarballName)" />
   </Target>

--- a/src/SourceBuild/tarball/content/repos/source-build-reference-packages.proj
+++ b/src/SourceBuild/tarball/content/repos/source-build-reference-packages.proj
@@ -17,5 +17,17 @@
     <UseSourceBuiltSdkOverride Include="@(ArcadeBootstrapSdkOverride)" />
   </ItemGroup>
 
+  <!-- Remove reference packages that were restored from the previously source-built
+       archive.  These packages were used when building tasks, but now will be rebuilt
+       from the SBRP repo. -->
+  <Target Name="CleanReferencePackageFolder"
+          BeforeTargets="Build">
+    <ItemGroup>
+      <ReferencePackagesToDelete Include="$(ReferencePackagesDir)**/*" />
+    </ItemGroup>
+
+    <Delete Files="@(ReferencePackagesToDelete)" />
+  </Target>
+
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/SourceBuild/tarball/content/repos/source-build-reference-packages.proj
+++ b/src/SourceBuild/tarball/content/repos/source-build-reference-packages.proj
@@ -17,17 +17,5 @@
     <UseSourceBuiltSdkOverride Include="@(ArcadeBootstrapSdkOverride)" />
   </ItemGroup>
 
-  <!-- Remove reference packages that were restored from the previously source-built
-       archive.  These packages were used when building tasks, but now will be rebuilt
-       from the SBRP repo. -->
-  <Target Name="CleanReferencePackageFolder"
-          BeforeTargets="Build">
-    <ItemGroup>
-      <ReferencePackagesToDelete Include="$(ReferencePackagesDir)**/*" />
-    </ItemGroup>
-
-    <Delete Files="@(ReferencePackagesToDelete)" />
-  </Target>
-
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/SourceBuild/tarball/content/tools-local/init-build.proj
+++ b/src/SourceBuild/tarball/content/tools-local/init-build.proj
@@ -46,20 +46,22 @@
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(CompletedSemaphorePath)UnpackTarballs.complete" >
 
-    <!-- Make this directory here even though we're no
-        longer unpacking into it because some restore sources are looking
-        for it.  Keeping this because once source-build-reference-packages
-        is built, the resulting packages will be put here. -->
-    <MakeDir Directories="$(ReferencePackagesDir)" />
-
     <MakeDir Directories="$(PrebuiltSourceBuiltPackagesPath)" Condition="'$(CustomPrebuiltSourceBuiltPackagesPath)' == ''" />
     <Exec Command="tar -xzf $(ExternalTarballsDir)$(SourceBuiltArtifactsTarballName).*.tar.gz"
           WorkingDirectory="$(PrebuiltSourceBuiltPackagesPath)"
           Condition="'$(CustomPrebuiltSourceBuiltPackagesPath)' == ''" />
 
-    <Copy SourceFiles="$(PrebuiltSourceBuiltPackagesPath)PackageVersions.props" DestinationFiles="$(IntermediatePath)SourceBuiltPackageVersions.props" />
+    <!-- Move SBRP packages to reference packages location -->
+    <MakeDir Directories="$(ReferencePackagesDir)" />
+    <ItemGroup>
+      <UnpackedSourceBuildReferencePackages Include="$(PrebuiltSourceBuiltPackagesPath)SourceBuildReferencePackages/*"/>
+    </ItemGroup>
+
+    <Move SourceFiles="@(UnpackedSourceBuildReferencePackages)" DestinationFiles="$(ReferencePackagesDir)%(Filename)%(Extension)" />
 
     <!-- Setup the PackageVersions.props file to be a combination of SourceBuilt and GennedPackages -->
+    <Copy SourceFiles="$(PrebuiltSourceBuiltPackagesPath)PackageVersions.props" DestinationFiles="$(IntermediatePath)SourceBuiltPackageVersions.props" />
+
     <PropertyGroup>
       <PackageVersionsPropsFile>$(IntermediatePath)PackageVersions.props</PackageVersionsPropsFile>
       <PackageVersionsPropsContents>


### PR DESCRIPTION
Expand the SBRP packages into a folder and add the folder to the previously source-build artifacts archive.  On restore of previously source-build artifacts, copy the SBRP packages to the reference-packages directory so they can be used by the tasks that are built in `tools-local/`.

Fixes: https://github.com/dotnet/source-build/issues/2257
