### PR TITLE
[ArPow] Fix source-build ci and build infra

### DIFF
--- a/src/SourceBuild/Arcade/eng/common/templates/steps/source-build-run-tarball-build.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/steps/source-build-run-tarball-build.yml
@@ -28,4 +28,4 @@ steps:
   parameters:
     sourceFolder: ${{ parameters.sourceFolder }}
     artifactQualifier: TarballBuild
-    condition: and(${{ parameters.condition }}, succeeded())
+    condition: and(${{ parameters.condition }}, succeededOrFailed())

--- a/src/SourceBuild/tarball/content/repos/Directory.Build.targets
+++ b/src/SourceBuild/tarball/content/repos/Directory.Build.targets
@@ -394,7 +394,7 @@
 
     <WriteLinesToFile
       Lines="&lt;Project /&gt;"
-      File="$([MSBuild]::NormalizePath('$(ClonedSubmoduleDirectory)', '%(DirectoryBuildFilename.Identity)'))"
+      File="$([MSBuild]::NormalizePath('$(SubmoduleDirectory)', '%(DirectoryBuildFilename.Identity)'))"
       Overwrite="True" />
 
     <WriteLinesToFile File="$(RepoCompletedSemaphorePath)PreventDirectoryBuildPropsTargetsEscape.complete" Overwrite="true" />
@@ -728,7 +728,7 @@
       ProjectAssetsJsonArchiveFile="$(ProjectAssetsJsonArchiveFile)" />
 
     <WriteLinesToFile File="$(RepoCompletedSemaphorePath)WritePrebuiltUsageData.complete" Overwrite="true" />
-</Target>
+  </Target>
 
   <Target Name="GetAllProjectDirectories">
     <ItemGroup>


### PR DESCRIPTION
This PR contains the following changes:

1. Modify the Tarball CI to capture the build logs on failure.
2. Modify the path the blank dir props and targets get written to in the tarball.  The path used was `<tarball>/artifacts/src` when it should be `<tarball>/src`.  This issue was causing the repo builds to load the existing dir props and targets which caused all sorts of badness.
