### PR TITLE
Update tag references to dotnet-buildtools/prereqs

### DIFF
--- a/eng/docker/alpine.3.6/Dockerfile
+++ b/eng/docker/alpine.3.6/Dockerfile
@@ -4,7 +4,7 @@
 #
 
 # Dockerfile that creates a container suitable to build dotnet-cli
-FROM microsoft/dotnet-buildtools-prereqs:alpine-3.6-3148f11-20171119021156
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.6-3148f11-20171119021156
 
 RUN apk update && apk upgrade && apk add --no-cache curl ncurses
 

--- a/eng/docker/centos/Dockerfile
+++ b/eng/docker/centos/Dockerfile
@@ -4,7 +4,7 @@
 #
 
 # Dockerfile that creates a container suitable to build dotnet-cli
-FROM microsoft/dotnet-buildtools-prereqs:centos-7-b46d863-20180719033416
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-b46d863-20180719033416
 
 RUN yum -q -y install sudo
 

--- a/eng/docker/fedora.29/Dockerfile
+++ b/eng/docker/fedora.29/Dockerfile
@@ -4,7 +4,7 @@
 #
 
 # Dockerfile that creates a container suitable to build dotnet-cli
-FROM microsoft/dotnet-buildtools-prereqs:fedora-29-2f0798a-20181105183801
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-29-2f0798a-20181105183801
 
 RUN dnf install -y nss
 

--- a/eng/docker/rhel/Dockerfile
+++ b/eng/docker/rhel/Dockerfile
@@ -4,7 +4,7 @@
 #
 
 # Dockerfile that creates a container suitable to build dotnet-cli
-FROM microsoft/dotnet-buildtools-prereqs:rhel-7-rpmpkg-e1b4a89-20175311035359
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:rhel-7-rpmpkg-e1b4a89-20175311035359
 
 # Setup User to match Host User, and give superuser permissions
 ARG USER_ID=0

--- a/eng/docker/ubuntu.18.04/Dockerfile
+++ b/eng/docker/ubuntu.18.04/Dockerfile
@@ -4,7 +4,7 @@
 #
 
 # Dockerfile that creates a container suitable to build dotnet-cli
-FROM microsoft/dotnet-buildtools-prereqs:ubuntu-18.04-f90bc20-20180320154721
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-f90bc20-20180320154721
 
 RUN apt-get update && \
     apt-get -qqy install \


### PR DESCRIPTION
Updating Docker image tag references that are obsolete and replaced by references to mcr.microsoft.com/dotnet-buildtools/prereqs.  See https://github.com/dotnet/dotnet-docker/issues/2848.