### PR TITLE
Use arcade's conditional pattern for publishing

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -87,7 +87,8 @@
   </ItemGroup>
 
   <Target Name="PublishSdkAssetsAndChecksums"
-          BeforeTargets="Publish">
+          BeforeTargets="Publish"
+          Condition="$(DotNetPublishUsingPipelines)">
 
     <ReadLinesFromFile File="$(ArtifactsTmpDir)FullNugetVersion.version">
       <Output


### PR DESCRIPTION
Arcade runs CI/PR builds with --publish on. This does a general dry run of some parts of publishing. However, in this mode, packages are NOT published, as the azdo publishing target does not run if DotNetPublishUsingPipelines is false. This is false in non-official scenarios. installer is missing a check of this conditional for its custom installer publishing. Add it.

Note that we could probably remove the explicit use of PushToAzureDevOpsArtifacts in installer, by using `eng/Publishing.props` in a more typical workflow. See https://github.com/dotnet/aspnetcore/blob/main/eng/Publishing.props for an example of this. That would also avoid this bug.
