### PR TITLE
Do not create .zip files on Linux/Mac

### DIFF
--- a/src/redist/targets/GenerateArchives.targets
+++ b/src/redist/targets/GenerateArchives.targets
@@ -10,12 +10,15 @@
       <IgnoreTarExitCode Condition="'$(DOTNET_CORESDK_IGNORE_TAR_EXIT_CODE)' == '1'">true</IgnoreTarExitCode>
     </PropertyGroup>
 
+    <!-- Create .tar.gz files on Linux/MacOS, and .zip files on Windows -->
     <ZipFileCreateFromDirectory
+        Condition=" '$(OSName)' == 'win' "
         SourceDirectory="$(RedistLayoutPath)"
         DestinationArchive="$(ArtifactsShippingPackagesDir)$(ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk).zip"
         OverwriteDestination="true" />
 
     <ZipFileCreateFromDirectory
+        Condition=" '$(OSName)' == 'win' "
         SourceDirectory="$(SdkInternalLayoutPath)"
         DestinationArchive="$(ArtifactsNonShippingPackagesDir)$(ArtifactNameWithVersionSdk).zip"
         OverwriteDestination="true" />

--- a/src/redist/targets/GenerateArchives.targets
+++ b/src/redist/targets/GenerateArchives.targets
@@ -10,6 +10,9 @@
       <IgnoreTarExitCode Condition="'$(DOTNET_CORESDK_IGNORE_TAR_EXIT_CODE)' == '1'">true</IgnoreTarExitCode>
     </PropertyGroup>
 
+    <!-- Ensure output directories are created -->
+    <MakeDir Directories="$(ArtifactsShippingPackagesDir);$(ArtifactsNonShippingPackagesDir)" />
+
     <!-- Create .tar.gz files on Linux/MacOS, and .zip files on Windows -->
     <ZipFileCreateFromDirectory
         Condition=" '$(OSName)' == 'win' "


### PR DESCRIPTION
Avoid creating the .zip files on Linux/Mac, as they are not distributed or used in any scenario.
This saves > 20% of the total artifact size for this build (2.7 GB). Yay!
