### PR TITLE
[ArPow] Update clicommandlineparser to build offline

### DIFF
--- a/src/SourceBuild/tarball/content/patches/clicommandlineparser/0001-Remove-installation-of-runtime-2.1.0-from-build.sh.patch
+++ b/src/SourceBuild/tarball/content/patches/clicommandlineparser/0001-Remove-installation-of-runtime-2.1.0-from-build.sh.patch
@@ -1,0 +1,44 @@
+From 3110caf93828aad2ecfe9929e03dc4dd6dd85c5d Mon Sep 17 00:00:00 2001
+From: dseefeld <dseefeld@microsoft.com>
+Date: Wed, 28 Jul 2021 15:56:35 +0000
+Subject: [PATCH] Remove installation of runtime 2.1.0 from build.sh
+
+Installation of another runtime in build.sh doesn't work for source-build
+when building offline.  
+---
+ build.sh    | 3 ---
+ global.json | 7 ++++++-
+ 2 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/build.sh b/build.sh
+index d511e95..acc0e31 100755
+--- a/build.sh
++++ b/build.sh
+@@ -8,7 +8,4 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
+ done
+ ScriptRoot="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+ 
+-# install the 2.1.0 runtime for running tests
+-"$ScriptRoot/eng/common/dotnet-install.sh"  -runtime dotnet -version 2.1.0
+-
+ . "$ScriptRoot/eng/common/build.sh" --build --restore $@
+diff --git a/global.json b/global.json
+index e276e30..347e455 100644
+--- a/global.json
++++ b/global.json
+@@ -1,6 +1,11 @@
+ {
+   "tools": {
+-    "dotnet": "5.0.201"
++    "dotnet": "5.0.201",
++    "runtimes": {
++      "dotnet": [
++        "2.1.0"
++      ]
++    }
+   },
+   "msbuild-sdks": {
+     "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21256.3"
+-- 
+2.31.1
+


### PR DESCRIPTION
The clicommandline parser build installs another version of the runtime in `build.sh`.  This prohibits source-build from building offline.