### PR TITLE
Reclassify source-build dependency

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -150,6 +150,11 @@
       <Uri>https://github.com/dotnet/emsdk</Uri>
       <Sha>a4b73e3e43d8a23a467016f1ffb22ab4821da774</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build" Version="0.1.0-alpha.1.21318.1" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Uri>https://github.com/dotnet/source-build</Uri>
+      <Sha>3fb25b8db3bec654e37e71a5b2b7fde14444bc2f</Sha>
+      <SourceBuild RepoName="source-build" ManagedOnly="true" />
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.21373.11">
@@ -164,11 +169,6 @@
     <Dependency Name="Private.SourceBuild.ReferencePackages" Version="1.0.0-beta.20217.1">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
       <Sha>639aeb4d76c8b1a6226bf7c4edb34fbdae30e6e1</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build" Version="0.1.0-alpha.1.21318.1">
-      <Uri>https://github.com/dotnet/source-build</Uri>
-      <Sha>3fb25b8db3bec654e37e71a5b2b7fde14444bc2f</Sha>
-      <SourceBuild RepoName="source-build" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceLink.GitHub" Version="1.1.0-beta-21309-01" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
       <Uri>https://github.com/dotnet/sourcelink</Uri>


### PR DESCRIPTION
After speaking with the source build team, this should be a product dependency (lining up with other repos).
- It's important for coherency
- It contains source build outputs of product dependencies of these repos

Also tie this to SDK's version, rather than letting it float on its own

- Please add description for changes you are making.
- If there is an issue related to this PR, please add the reference.
