### PR TITLE
Update Xamarin manifests for .NET 6 Preview 7

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -162,12 +162,12 @@
   </PropertyGroup>
   <!-- Workload manifest package versions -->
   <PropertyGroup>
-    <MauiWorkloadManifestVersion>6.0.100-ci.main.806</MauiWorkloadManifestVersion>
-    <XamarinAndroidWorkloadManifestVersion>11.0.200-ci.main.256</XamarinAndroidWorkloadManifestVersion>
-    <XamarinIOSWorkloadManifestVersion>14.5.100-ci.main.723</XamarinIOSWorkloadManifestVersion>
-    <XamarinMacCatalystWorkloadManifestVersion>14.5.100-ci.main.723</XamarinMacCatalystWorkloadManifestVersion>
-    <XamarinMacOSWorkloadManifestVersion>11.3.100-ci.main.723</XamarinMacOSWorkloadManifestVersion>
-    <XamarinTvOSWorkloadManifestVersion>14.5.100-ci.main.723</XamarinTvOSWorkloadManifestVersion>
+    <MauiWorkloadManifestVersion>6.0.100-preview.7.1063</MauiWorkloadManifestVersion>
+    <XamarinAndroidWorkloadManifestVersion>30.0.100-preview.7.93</XamarinAndroidWorkloadManifestVersion>
+    <XamarinIOSWorkloadManifestVersion>15.0.100-preview.7182</XamarinIOSWorkloadManifestVersion>
+    <XamarinMacCatalystWorkloadManifestVersion>15.0.100-preview.7182</XamarinMacCatalystWorkloadManifestVersion>
+    <XamarinMacOSWorkloadManifestVersion>12.0.100-preview.7182</XamarinMacOSWorkloadManifestVersion>
+    <XamarinTvOSWorkloadManifestVersion>15.0.100-preview.7182</XamarinTvOSWorkloadManifestVersion>
     <MonoWorkloadManifestVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MonoWorkloadManifestVersion>
     <MicrosoftNETWorkloadEmscriptenManifest60100Version>6.0.0-rc.1.21378.1</MicrosoftNETWorkloadEmscriptenManifest60100Version>
     <EmscriptenWorkloadManifestVersion>$(MicrosoftNETWorkloadEmscriptenManifest60100Version)</EmscriptenWorkloadManifestVersion>


### PR DESCRIPTION
Bringing this to main: https://github.com/dotnet/installer/pull/11203

Bump to: https://github.com/xamarin/xamarin-android/commit/8ca289588b6969a2cc878afa0813afec8cd63dd3
Bump to: https://github.com/xamarin/xamarin-macios/commit/ff24f9104cac801db8f11825ecb9537b2c5799e6
Bump to: https://github.com/dotnet/maui/commit/f5acc965e5f7d3bd1d2fd34a6e1f40fe4b87f319

After `.\build.cmd -pack -publish`, manually tested the new workload
names:

    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install android --skip-manifest-update
    Installing pack Microsoft.Android.Sdk.BundleTool version 30.0.100-preview.7.93...
    ...
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install ios --skip-manifest-update
    Installing pack Microsoft.iOS.Sdk version 15.0.100-preview.7182...
    ...
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install macos --skip-manifest-update
    Installing pack Microsoft.macOS.Sdk version 12.0.100-preview.7182...
    ...
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install maccatalyst --skip-manifest-update
    Installing pack Microsoft.MacCatalyst.Sdk version 15.0.100-preview.7182...
    ...
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install tvos --skip-manifest-update
    Installing pack Microsoft.tvOS.Sdk version 15.0.100-preview.7182...
    ...
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install maui --skip-manifest-update
    Installing pack Microsoft.Maui.Core.Ref.android version 6.0.100-preview.7.1063+sha.f5acc965e-azdo.5006556...