### PR TITLE
[ArPow] Check in the empty src/Directory.Build.props and targets instead of generating them

### DIFF
--- a/src/SourceBuild/tarball/content/repos/Directory.Build.targets
+++ b/src/SourceBuild/tarball/content/repos/Directory.Build.targets
@@ -402,28 +402,6 @@
     <WriteLinesToFile File="$(RepoCompletedSemaphorePath)CreateCombinedRestoreSourceAndVersionProps.complete" Overwrite="true" />
   </Target>
 
-  <!--
-    Generate blank directory build files above the repos, so they won't
-    automatically find the source-build directory build files ("escaping" their
-    directories and causing differences vs. ordinary build).
-  -->
-  <Target Name="PreventDirectoryBuildPropsTargetsEscape"
-          BeforeTargets="Build"
-          Inputs="$(MSBuildProjectFullPath)"
-          Outputs="$(RepoCompletedSemaphorePath)PreventDirectoryBuildPropsTargetsEscape.complete">
-    <ItemGroup>
-      <DirectoryBuildFilename Include="Directory.Build.targets" />
-      <DirectoryBuildFilename Include="Directory.Build.props" />
-    </ItemGroup>
-
-    <WriteLinesToFile
-      Lines="&lt;Project /&gt;"
-      File="$([MSBuild]::NormalizePath('$(SubmoduleDirectory)', '%(DirectoryBuildFilename.Identity)'))"
-      Overwrite="True" />
-
-    <WriteLinesToFile File="$(RepoCompletedSemaphorePath)PreventDirectoryBuildPropsTargetsEscape.complete" Overwrite="true" />
-  </Target>
-
   <Target Name="Build"
           DependsOnTargets="BuildRepoReferences"
           Inputs="$(MSBuildProjectFullPath)"

--- a/src/SourceBuild/tarball/content/src/Directory.Build.props
+++ b/src/SourceBuild/tarball/content/src/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+
+  <!--
+    Prevent automatic Directory.Build imports from finding source-build infra. Note: used for
+    tarball build too, as the cloned repos are merged into this directory.
+  -->
+
+</Project>

--- a/src/SourceBuild/tarball/content/src/Directory.Build.props
+++ b/src/SourceBuild/tarball/content/src/Directory.Build.props
@@ -1,8 +1,7 @@
 <Project>
 
   <!--
-    Prevent automatic Directory.Build imports from finding source-build infra. Note: used for
-    tarball build too, as the cloned repos are merged into this directory.
+    Prevent repo src automatic Directory.Build imports from finding source-build infra.
   -->
 
 </Project>

--- a/src/SourceBuild/tarball/content/src/Directory.Build.targets
+++ b/src/SourceBuild/tarball/content/src/Directory.Build.targets
@@ -1,0 +1,8 @@
+<Project>
+
+  <!--
+    Prevent automatic Directory.Build imports from finding source-build infra. Note: used for
+    tarball build too, as the cloned repos are merged into this directory.
+  -->
+
+</Project>

--- a/src/SourceBuild/tarball/content/src/Directory.Build.targets
+++ b/src/SourceBuild/tarball/content/src/Directory.Build.targets
@@ -1,8 +1,7 @@
 <Project>
 
   <!--
-    Prevent automatic Directory.Build imports from finding source-build infra. Note: used for
-    tarball build too, as the cloned repos are merged into this directory.
+    Prevent repo src automatic Directory.Build imports from finding source-build infra.
   -->
 
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/2326

Currently we generate empty `Directory.Build.props` and `Directory.Build.targets` files at the root of the `src` directory in the tarball. It is simpler for these to be checked in instead of generating them every time we build the tarball.