### PR TITLE
Update xlifftasks dependency name

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -175,9 +175,9 @@
       <Sha>4b584dbc392bb1aad49c2eb1ab84d8b489b6dccc</Sha>
       <SourceBuild RepoName="sourcelink" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="XliffTasks" Version="1.0.0-beta.21371.1" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
+    <Dependency Name="Microsoft.DotNet.XliffTasks" Version="1.0.0-beta.21378.1" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
       <Uri>https://github.com/dotnet/xliff-tasks</Uri>
-      <Sha>31d2b6c3aa2f874e9e93a005e773101468b8612a</Sha>
+      <Sha>85cac0820fcb9c066bdae0cb9886dcbc7748914e</Sha>
       <SourceBuild RepoName="xliff-tasks" ManagedOnly="true" />
     </Dependency>
   </ToolsetDependencies>


### PR DESCRIPTION
The package name changed, which is causing issues with coherency updates. 