### PR TITLE
Rename the PackageVersions.props files used in source-build

### DIFF
--- a/src/SourceBuild/tarball/content/Directory.Build.props
+++ b/src/SourceBuild/tarball/content/Directory.Build.props
@@ -122,7 +122,7 @@
     <SourceBuiltAspNetCoreRuntime>$(LocalBlobStorageRoot)aspnetcore/Runtime/</SourceBuiltAspNetCoreRuntime>
     <RestoreSourcePropsPath>$(IntermediatePath)RestoreSources.props</RestoreSourcePropsPath>
     <PackageVersionPropsPath>$(IntermediatePath)PackageVersions.props</PackageVersionPropsPath>
-    <GennedPackageVersionPropsPath>$(IntermediatePath)GennedPackageVersions.props</GennedPackageVersionPropsPath>
+    <PreviouslySourceBuiltPackageVersionPropsPath>$(IntermediatePath)PreviouslySourceBuiltPackageVersions.props</PreviouslySourceBuiltPackageVersionPropsPath>
     <LoggingDir>$(BaseOutputPath)logs/</LoggingDir>
     <MSBuildDebugPathTargetDir>$(BaseOutputPath)msbuild-debug/</MSBuildDebugPathTargetDir>
     <RoslynDebugPathTargetDir>$(BaseOutputPath)roslyn-debug/</RoslynDebugPathTargetDir>

--- a/src/SourceBuild/tarball/content/Directory.Build.props
+++ b/src/SourceBuild/tarball/content/Directory.Build.props
@@ -122,7 +122,7 @@
     <SourceBuiltAspNetCoreRuntime>$(LocalBlobStorageRoot)aspnetcore/Runtime/</SourceBuiltAspNetCoreRuntime>
     <RestoreSourcePropsPath>$(IntermediatePath)RestoreSources.props</RestoreSourcePropsPath>
     <PackageVersionPropsPath>$(IntermediatePath)PackageVersions.props</PackageVersionPropsPath>
-    <PreviouslySourceBuiltPackageVersionPropsPath>$(IntermediatePath)PreviouslySourceBuiltPackageVersions.props</PreviouslySourceBuiltPackageVersionPropsPath>
+    <CurrentSourceBuiltPackageVersionPropsPath>$(IntermediatePath)CurrentSourceBuiltPackageVersions.props</CurrentSourceBuiltPackageVersionPropsPath>
     <LoggingDir>$(BaseOutputPath)logs/</LoggingDir>
     <MSBuildDebugPathTargetDir>$(BaseOutputPath)msbuild-debug/</MSBuildDebugPathTargetDir>
     <RoslynDebugPathTargetDir>$(BaseOutputPath)roslyn-debug/</RoslynDebugPathTargetDir>

--- a/src/SourceBuild/tarball/content/repos/Directory.Build.targets
+++ b/src/SourceBuild/tarball/content/repos/Directory.Build.targets
@@ -326,7 +326,7 @@
     <WriteBuildOutputProps NuGetPackages="@(PreviouslySourceBuiltPackages)"
                            ExtraProperties="@(ExtraPackageVersionPropsPackageInfo)"
                            AdditionalAssetDirs="@(_AdditionalAssetDirs)"
-                           OutputPath="$(PreviouslySourceBuiltPackageVersionPropsPath)" />
+                           OutputPath="$(CurrentSourceBuiltPackageVersionPropsPath)" />
 
     <WriteBuildOutputProps NuGetPackages="@(PreviouslySourceBuiltPackages)"
                            IncludeCreationTimeProperty="true"

--- a/src/SourceBuild/tarball/content/repos/Directory.Build.targets
+++ b/src/SourceBuild/tarball/content/repos/Directory.Build.targets
@@ -326,7 +326,7 @@
     <WriteBuildOutputProps NuGetPackages="@(PreviouslySourceBuiltPackages)"
                            ExtraProperties="@(ExtraPackageVersionPropsPackageInfo)"
                            AdditionalAssetDirs="@(_AdditionalAssetDirs)"
-                           OutputPath="$(GennedPackageVersionPropsPath)" />
+                           OutputPath="$(PreviouslySourceBuiltPackageVersionPropsPath)" />
 
     <WriteBuildOutputProps NuGetPackages="@(PreviouslySourceBuiltPackages)"
                            IncludeCreationTimeProperty="true"

--- a/src/SourceBuild/tarball/content/repos/package-source-build.proj
+++ b/src/SourceBuild/tarball/content/repos/package-source-build.proj
@@ -5,7 +5,7 @@
     <RepoApiImplemented>false</RepoApiImplemented>
     <ProjectDirectory>$(SubmoduleDirectory)$(RepositoryName)/</ProjectDirectory>
     <SkipEnsurePackagesCreated>true</SkipEnsurePackagesCreated>
-    <IncludedPackageVersionPropsFile>$(PreviouslySourceBuiltPackageVersionPropsPath)</IncludedPackageVersionPropsFile>
+    <IncludedPackageVersionPropsFile>$(CurrentSourceBuiltPackageVersionPropsPath)</IncludedPackageVersionPropsFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SourceBuild/tarball/content/repos/package-source-build.proj
+++ b/src/SourceBuild/tarball/content/repos/package-source-build.proj
@@ -5,7 +5,7 @@
     <RepoApiImplemented>false</RepoApiImplemented>
     <ProjectDirectory>$(SubmoduleDirectory)$(RepositoryName)/</ProjectDirectory>
     <SkipEnsurePackagesCreated>true</SkipEnsurePackagesCreated>
-    <IncludedPackageVersionPropsFile>$(GennedPackageVersionPropsPath)</IncludedPackageVersionPropsFile>
+    <IncludedPackageVersionPropsFile>$(PreviouslySourceBuiltPackageVersionPropsPath)</IncludedPackageVersionPropsFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SourceBuild/tarball/content/tools-local/init-build.proj
+++ b/src/SourceBuild/tarball/content/tools-local/init-build.proj
@@ -66,17 +66,17 @@
 
     <Delete Files="@(ReferencePackagesToOverride)" />
 
-    <!-- Setup the PackageVersions.props file to be a combination of SourceBuilt and GennedPackages -->
-    <Copy SourceFiles="$(PrebuiltSourceBuiltPackagesPath)PackageVersions.props" DestinationFiles="$(IntermediatePath)SourceBuiltPackageVersions.props" />
+    <!-- Setup the PackageVersions.props file to be a combination of source built and previously source built packages -->
+    <Copy SourceFiles="$(PrebuiltSourceBuiltPackagesPath)PackageVersions.props" DestinationFiles="$(IntermediatePath)CurrentSourceBuiltPackageVersions.props" />
 
     <PropertyGroup>
       <PackageVersionsPropsFile>$(IntermediatePath)PackageVersions.props</PackageVersionsPropsFile>
       <PackageVersionsPropsContents>
         <![CDATA[<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="SourceBuiltPackageVersions.props" Condition="Exists('SourceBuiltPackageVersions.props')" />
+  <Import Project="CurrentSourceBuiltPackageVersions.props" Condition="Exists('CurrentSourceBuiltPackageVersions.props')" />
   <Import Project="$(ProjectDir)TemporaryBootstrapPackageVersions.props" Condition="Exists('$(ProjectDir)TemporaryBootstrapPackageVersions.props')" />
-  <Import Project="GennedPackageVersions.props" Condition="Exists('GennedPackageVersions.props')" />
+  <Import Project="PreviouslySourceBuiltPackageVersions.props" Condition="Exists('PreviouslySourceBuiltPackageVersions.props')" />
 </Project>
 ]]>
       </PackageVersionsPropsContents>

--- a/src/SourceBuild/tarball/content/tools-local/init-build.proj
+++ b/src/SourceBuild/tarball/content/tools-local/init-build.proj
@@ -67,16 +67,16 @@
     <Delete Files="@(ReferencePackagesToOverride)" />
 
     <!-- Setup the PackageVersions.props file to be a combination of source built and previously source built packages -->
-    <Copy SourceFiles="$(PrebuiltSourceBuiltPackagesPath)PackageVersions.props" DestinationFiles="$(IntermediatePath)CurrentSourceBuiltPackageVersions.props" />
+    <Copy SourceFiles="$(PrebuiltSourceBuiltPackagesPath)PackageVersions.props" DestinationFiles="$(IntermediatePath)PreviouslySourceBuiltPackageVersions.props" />
 
     <PropertyGroup>
       <PackageVersionsPropsFile>$(IntermediatePath)PackageVersions.props</PackageVersionsPropsFile>
       <PackageVersionsPropsContents>
         <![CDATA[<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="CurrentSourceBuiltPackageVersions.props" Condition="Exists('CurrentSourceBuiltPackageVersions.props')" />
-  <Import Project="$(ProjectDir)TemporaryBootstrapPackageVersions.props" Condition="Exists('$(ProjectDir)TemporaryBootstrapPackageVersions.props')" />
   <Import Project="PreviouslySourceBuiltPackageVersions.props" Condition="Exists('PreviouslySourceBuiltPackageVersions.props')" />
+  <Import Project="$(ProjectDir)TemporaryBootstrapPackageVersions.props" Condition="Exists('$(ProjectDir)TemporaryBootstrapPackageVersions.props')" />
+  <Import Project="CurrentSourceBuiltPackageVersions.props" Condition="Exists('CurrentSourceBuiltPackageVersions.props')" />
 </Project>
 ]]>
       </PackageVersionsPropsContents>


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/2338

Renames two specialized PackageVersions.props files:

- `GennedPackageVersions.props` - renamed to `CurrentSourceBuiltPackageVersions.props`
    - Contains the package versions for the current source build
- `SourceBuiltPackageVersions.props` - renamed to `PreviouslySourceBuiltPackageVersions.props`
    - Contains the package versions from the previous source build