### PR TITLE
Add prebuilt acquisition and production build infra

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -159,6 +159,7 @@
     <MicrosoftBuildFrameworkVersion>15.7.179</MicrosoftBuildFrameworkVersion>
     <MicrosoftBuildUtilitiesCoreVersion>15.7.179</MicrosoftBuildUtilitiesCoreVersion>
     <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-6.0.100-bootstrap.11</PrivateSourceBuiltArtifactsPackageVersion>
+    <PrivateSourceBuiltPrebuiltsPackageVersion>0.1.0-6.0.100-1</PrivateSourceBuiltPrebuiltsPackageVersion>
   </PropertyGroup>
   <!-- Workload manifest package versions -->
   <PropertyGroup>

--- a/src/SourceBuild/Arcade/eng/common/templates/steps/source-build-run-tarball-build.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/steps/source-build-run-tarball-build.yml
@@ -31,6 +31,7 @@ steps:
     SourceFolder: '${{ parameters.sourceFolder }}'
     Contents: |
       artifacts/**/Private.SourceBuilt.Artifacts*.tar.gz
+      artifacts/prebuilt-report/Private.SourceBuilt.Prebuilts.*.tar.gz
     TargetFolder: '$(Build.StagingDirectory)/artifacts'
     CleanTargetFolder: true
   condition: and(${{ parameters.condition }}, succeeded())

--- a/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
+++ b/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
@@ -188,6 +188,7 @@
     <PropertyGroup>
       <ExternalTarballsDir>$(TarballRootDir)packages/archive/</ExternalTarballsDir>
       <SourceBuiltArtifactsTarballName>Private.SourceBuilt.Artifacts</SourceBuiltArtifactsTarballName>
+      <SourceBuiltPrebuiltsTarballName>Private.SourceBuilt.Prebuilts</SourceBuiltPrebuiltsTarballName>
       <SourceBuiltArtifactsTarballUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/</SourceBuiltArtifactsTarballUrl>
       <ArchiveArtifactsTextFileName>archiveArtifacts.txt</ArchiveArtifactsTextFileName>
       <ArchiveArtifactsTextFile>$(ExternalTarballsDir)$(ArchiveArtifactsTextFileName)</ArchiveArtifactsTextFile>
@@ -197,6 +198,7 @@
 
     <ItemGroup>
       <ArtifactUrls Include="$(SourceBuiltArtifactsTarballUrl)$(SourceBuiltArtifactsTarballName).$(PrivateSourceBuiltArtifactsPackageVersion).tar.gz" />
+      <ArtifactUrls Include="$(SourceBuiltArtifactsTarballUrl)$(SourceBuiltPrebuiltsTarballName).$(PrivateSourceBuiltPrebuiltsPackageVersion).tar.gz" />
     </ItemGroup>
 
     <WriteLinesToFile

--- a/src/SourceBuild/tarball/content/Directory.Build.props
+++ b/src/SourceBuild/tarball/content/Directory.Build.props
@@ -162,6 +162,7 @@
     <TextOnlyPackageBaseDir>$(ProjectDir)packages/text-only/</TextOnlyPackageBaseDir>
     <ReferencePackagesDir>$(ReferencePackagesBaseDir)packages/</ReferencePackagesDir>
     <SourceBuiltArtifactsTarballName>Private.SourceBuilt.Artifacts</SourceBuiltArtifactsTarballName>
+    <SourceBuiltPrebuiltsTarballName>Private.SourceBuilt.Prebuilts</SourceBuiltPrebuiltsTarballName>
     <SourceBuiltArtifactsTarballUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/</SourceBuiltArtifactsTarballUrl>
     <ArchiveArtifactsTextFileName>archiveArtifacts.txt</ArchiveArtifactsTextFileName>
     <ArchiveArtifactsTextFile>$(ExternalTarballsDir)$(ArchiveArtifactsTextFileName)</ArchiveArtifactsTextFile>

--- a/src/SourceBuild/tarball/content/build.proj
+++ b/src/SourceBuild/tarball/content/build.proj
@@ -138,4 +138,17 @@
                    Overwrite="true" />
   </Target>
 
+  <Target Name="CreatePrebuiltsTarball"
+          AfterTargets="Build" >
+
+    <PropertyGroup>
+      <TarballFileVersion>$(PrivateSourceBuiltPrebuiltsPackageVersionPrefix)$([MSBuild]::Add($(PrivateSourceBuiltPrebuiltsPackageVersionSuffix), 1))</TarballFileVersion>
+      <TarballFilePath>$(PackageReportDir)$(SourceBuiltPrebuiltsTarballName).$(TarballFileVersion).tar.gz</TarballFilePath>
+      <TarballWorkingDir>$(ResultingPrebuiltPackagesDir)</TarballWorkingDir>
+    </PropertyGroup>
+
+    <Exec Command="tar --numeric-owner -zcf $(TarballFilePath) -C $(TarballWorkingDir) ." />
+
+    <Message Text="Tarball '$(TarballFilePath)' was successfully created from '$(TarballWorkingDir)'" Importance="High" />
+  </Target>
 </Project>

--- a/src/SourceBuild/tarball/content/eng/Versions.props
+++ b/src/SourceBuild/tarball/content/eng/Versions.props
@@ -22,5 +22,7 @@
   <!-- Production Dependencies -->
   <PropertyGroup>
     <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-6.0.100-bootstrap.11</PrivateSourceBuiltArtifactsPackageVersion>
+    <PrivateSourceBuiltPrebuiltsPackageVersionPrefix>0.1.0-6.0.100-</PrivateSourceBuiltPrebuiltsPackageVersionPrefix>
+    <PrivateSourceBuiltPrebuiltsPackageVersionSuffix>1</PrivateSourceBuiltPrebuiltsPackageVersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/SourceBuild/tarball/content/prep.sh
+++ b/src/SourceBuild/tarball/content/prep.sh
@@ -38,6 +38,7 @@ if [ ! -f $SCRIPT_ROOT/packages/archive/archiveArtifacts.txt ]; then
 fi
 
 downloadArtifacts=true
+downloadPrebuilts=true
 installDotnet=true
 
 # Check to make sure curl exists to download the archive files
@@ -53,6 +54,12 @@ if [ -f $SCRIPT_ROOT/packages/archive/Private.SourceBuilt.Artifacts.*.tar.gz ]; 
     downloadArtifacts=false
 fi
 
+# Check if Private.SourceBuilt prebuilts archive exists
+if [ -f $SCRIPT_ROOT/packages/archive/Private.SourceBuilt.Prebuilts.*.tar.gz ]; then
+    echo "  Private.SourceBuilt.Prebuilts.*.tar.gz exists...it will not be downloaded"
+    downloadPrebuilts=false
+fi
+
 # Check if dotnet is installed
 if [ -d $SCRIPT_ROOT/.dotnet ]; then
     echo "  ./.dotnet SDK directory exists...it will not be installed"
@@ -64,6 +71,12 @@ while read -r line; do
     if [[ $line == *"Private.SourceBuilt.Artifacts"* ]]; then
         if [ "$downloadArtifacts" == "true" ]; then
             echo "  Downloading source-built artifacts..."
+            (cd $SCRIPT_ROOT/packages/archive/ && curl -O $line)
+        fi
+    fi
+    if [[ $line == *"Private.SourceBuilt.Prebuilts"* ]]; then
+        if [ "$downloadPrebuilts" == "true" ]; then
+            echo "  Downloading source-built prebuilts..."
             (cd $SCRIPT_ROOT/packages/archive/ && curl -O $line)
         fi
     fi

--- a/src/SourceBuild/tarball/content/tools-local/init-build.proj
+++ b/src/SourceBuild/tarball/content/tools-local/init-build.proj
@@ -46,6 +46,9 @@
           WorkingDirectory="$(PrebuiltSourceBuiltPackagesPath)"
           Condition="'$(CustomPrebuiltSourceBuiltPackagesPath)' == ''" />
 
+    <Exec Command="tar -xzf $(ExternalTarballsDir)$(SourceBuiltPrebuiltsTarballName).*.tar.gz"
+          WorkingDirectory="$(PrebuiltPackagesPath)" />
+
     <!-- Move SBRP packages to reference packages location -->
     <MakeDir Directories="$(ReferencePackagesDir)" />
     <ItemGroup>


### PR DESCRIPTION
Related to dotnet/source-build#2336

These are temporary changes that should be reverted once all prebuilts have been removed.

1. Added a step to prep.sh to download the prebuilts tarball.
2. Added a tools-init step to extract the prebuilts tarball.
3. Added a post build step to create a tarball of all prebuilts used during the build.  The version number in the tarball name is auto-incremented.
