### PR TITLE
Update CMAKE for Visual Studio 17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This project has adopted the code of conduct defined by the [Contributor Covenan
 # Building 
 
 The repository contains native code project required for the Windows installer. If you intend to build it locally on Windows, you will need to ensure that you have the following items installed.
-- Install CMAKE 3.2.0.1 or later
+- Install CMAKE 3.21.0 is required if you're building VS 17.0. Make sure to add CMAKE to your PATH (the installer will prompt you).
 - Install MSVC Build tools for x86/x64/arm64, v14.28-16.9
 
 - `build` for basic build

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -162,6 +162,11 @@
       <Sha>9b7027ba718462aa6410cef61a8be5a4283e7528</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.CMake.Sdk" Version="6.0.0-beta.21413.4">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>9b7027ba718462aa6410cef61a8be5a4283e7528</Sha>
+      <SourceBuild RepoName="arcade" ManagedOnly="true" />
+    </Dependency>
     <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="6.0.0-beta.21413.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>9b7027ba718462aa6410cef61a8be5a4283e7528</Sha>

--- a/global.json
+++ b/global.json
@@ -12,6 +12,6 @@
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21413.4",
-    "Microsoft.DotNet.CMake.Sdk": "6.0.0-beta.21253.2"
+    "Microsoft.DotNet.CMake.Sdk": "6.0.0-beta.21413.4"
   }
 }


### PR DESCRIPTION
Various updates for CMAKE to support building the repo when you have VS 17.0 installed. This also includes adding the Arcade CMake SDK to Version.details.xml to take automatic updates through DARC
