### PR TITLE
Update Xamarin manifests for .NET 6 rc 1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -163,12 +163,12 @@
   </PropertyGroup>
   <!-- Workload manifest package versions -->
   <PropertyGroup>
-    <MauiWorkloadManifestVersion>6.0.100-preview.7.1063</MauiWorkloadManifestVersion>
-    <XamarinAndroidWorkloadManifestVersion>30.0.100-preview.7.93</XamarinAndroidWorkloadManifestVersion>
-    <XamarinIOSWorkloadManifestVersion>15.0.100-preview.7182</XamarinIOSWorkloadManifestVersion>
-    <XamarinMacCatalystWorkloadManifestVersion>15.0.100-preview.7182</XamarinMacCatalystWorkloadManifestVersion>
-    <XamarinMacOSWorkloadManifestVersion>12.0.100-preview.7182</XamarinMacOSWorkloadManifestVersion>
-    <XamarinTvOSWorkloadManifestVersion>15.0.100-preview.7182</XamarinTvOSWorkloadManifestVersion>
+    <MauiWorkloadManifestVersion>6.0.100-rc.1.1351</MauiWorkloadManifestVersion>
+    <XamarinAndroidWorkloadManifestVersion>30.0.100-rc.1.137</XamarinAndroidWorkloadManifestVersion>
+    <XamarinIOSWorkloadManifestVersion>15.0.100-rc.1.496</XamarinIOSWorkloadManifestVersion>
+    <XamarinMacCatalystWorkloadManifestVersion>15.0.100-rc.1.496</XamarinMacCatalystWorkloadManifestVersion>
+    <XamarinMacOSWorkloadManifestVersion>12.0.100-rc.1.496</XamarinMacOSWorkloadManifestVersion>
+    <XamarinTvOSWorkloadManifestVersion>15.0.100-rc.1.496</XamarinTvOSWorkloadManifestVersion>
     <MonoWorkloadManifestVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MonoWorkloadManifestVersion>
     <MicrosoftNETWorkloadEmscriptenManifest60100Version>6.0.0-rc.1.21416.1</MicrosoftNETWorkloadEmscriptenManifest60100Version>
     <EmscriptenWorkloadManifestVersion>$(MicrosoftNETWorkloadEmscriptenManifest60100Version)</EmscriptenWorkloadManifestVersion>


### PR DESCRIPTION
Bump to: xamarin/xamarin-android/main@f7d3210
Bump to: xamarin/xamarin-macios/main@7f5fcfc
Bump to: dotnet/maui/main@3fbb791

After `.\build.cmd -pack -publish`, manually tested the workloads:

    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install android --skip-manifest-update --verbosity diag
    Installing pack Microsoft.Android.Sdk.BundleTool version 30.0.100-rc.1.137...
    ...
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install ios --skip-manifest-update
    Installing pack Microsoft.iOS.Sdk version 15.0.100-rc.1.496...
    ...
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install macos --skip-manifest-update
    ...
    Installing pack Microsoft.macOS.Sdk version 12.0.100-rc.1.496...
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install maccatalyst --skip-manifest-update
    ...
    Installing pack Microsoft.MacCatalyst.Sdk version 15.0.100-rc.1.496...
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install tvos --skip-manifest-update
    Installing pack Microsoft.tvOS.Sdk version 15.0.100-rc.1.496...
    ...
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install maui --skip-manifest-update
    Installing pack Microsoft.Maui.Core.Ref.android version 6.0.100-rc.1.1351...
    ...
