### PR TITLE
Update instructions for installing nightly DEB

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Please do not directly edit the table below. Use https://github.com/dotnet/insta
 
 Reference notes:
 > **1**: Our Debian packages are put together slightly differently than the other OS specific installers. Instead of combining everything, we have separate component packages that depend on each other. If you're installing the SDK from the .deb file (via dpkg or similar), then you'll need to install the corresponding dependencies first:
-> * [Host, Host FX Resolver, and Shared Framework](https://github.com/dotnet/runtime#daily-builds)
+> * [Host, Host FX Resolver, and Shared Framework](https://github.com/dotnet/runtime/blob/main/docs/project/dogfooding.md#nightly-builds-table)
 > * [ASP.NET Core Shared Framework](https://github.com/aspnet/AspNetCore/blob/main/docs/DailyBuilds.md)
 
 .NET Core SDK 2.x downloads can be found here: [.NET Core SDK 2.x Installers and Binaries](Downloads2.x.md)


### PR DESCRIPTION
Correcting link to the nightly DEB packages from dotnet/runtime. I'm trying to use these to install the latest RC1 SDK on Ubuntu.

Questions
* Where are the nightly DEB packages for ASP.NET? Even though I don't need them, they're a dependency of the dotnet-sdk-x64.deb so I'm blocked without them. The page [linked here](https://github.com/dotnet/aspnetcore/blob/main/docs/DailyBuilds.md) just gives instructions to use nuget. @wtgodbe ?

* Has anyone created a script to collect and install all these? There's ~9 different DEB files, each one you have to `curl -Lo ...` and then `sudo dpkg -i ...`. If we had a script it would presumably also have some smarts to find them.
