### PR TITLE
Fix condition to execute finalizer

### DIFF
--- a/src/finalizer/finalizer.cpp
+++ b/src/finalizer/finalizer.cpp
@@ -317,7 +317,7 @@ int wmain(int argc, wchar_t* argv[])
     hr = ::DetectSdk(sczFeatureBandVersion, argv[3], &bSdkFeatureBandInstalled);
     ExitOnFailure(hr, "Failed to detect installed SDKs.");
 
-    if (bSdkFeatureBandInstalled)
+    if (!bSdkFeatureBandInstalled)
     {
         goto LExit;
     }


### PR DESCRIPTION
The finalizer will run, but it will skip doing anything when it detects the SDK, instead of skipping when it does not detect the SDK
