### PR TITLE
Fix table for 6.0 rc2 bits

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,19 +120,19 @@ Reference notes:
 
 .NET Core SDK 2.x downloads can be found here: [.NET Core SDK 2.x Installers and Binaries](Downloads2.x.md)
 
-[win-x64-badge-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/win_x64_Release_version_badge.svg
-[win-x64-version-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/productCommit-win-x64.txt
-[win-x64-installer-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-win-x64.exe
-[win-x64-installer-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-win-x64.exe.sha
-[win-x64-zip-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-win-x64.zip
-[win-x64-zip-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-win-x64.zip.sha
+[win-x64-badge-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/win_x64_Release_version_badge.svg
+[win-x64-version-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/productCommit-win-x64.txt
+[win-x64-installer-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-win-x64.exe
+[win-x64-installer-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-win-x64.exe.sha
+[win-x64-zip-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-win-x64.zip
+[win-x64-zip-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-win-x64.zip.sha
 
-[win-x64-badge-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/win_x64_Release_version_badge.svg
-[win-x64-version-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/productCommit-win-x64.txt
-[win-x64-installer-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-win-x64.exe
-[win-x64-installer-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-win-x64.exe.sha
-[win-x64-zip-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-win-x64.zip
-[win-x64-zip-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-win-x64.zip.sha
+[win-x64-badge-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/win_x64_Release_version_badge.svg
+[win-x64-version-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/productCommit-win-x64.txt
+[win-x64-installer-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-win-x64.exe
+[win-x64-installer-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-win-x64.exe.sha
+[win-x64-zip-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-win-x64.zip
+[win-x64-zip-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-win-x64.zip.sha
 
 [win-x64-badge-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/win_x64_Release_version_badge.svg
 [win-x64-version-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/productCommit-win-x64.txt
@@ -162,19 +162,19 @@ Reference notes:
 [win-x64-zip-3.1.1XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/dotnet-sdk-latest-win-x64.zip
 [win-x64-zip-checksum-3.1.1XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/dotnet-sdk-latest-win-x64.zip.sha
 
-[win-x86-badge-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/win_x86_Release_version_badge.svg
-[win-x86-version-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/productCommit-win-x86.txt
-[win-x86-installer-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-win-x86.exe
-[win-x86-installer-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-win-x86.exe.sha
-[win-x86-zip-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-win-x86.zip
-[win-x86-zip-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-win-x86.zip.sha
+[win-x86-badge-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/win_x86_Release_version_badge.svg
+[win-x86-version-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/productCommit-win-x86.txt
+[win-x86-installer-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-win-x86.exe
+[win-x86-installer-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-win-x86.exe.sha
+[win-x86-zip-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-win-x86.zip
+[win-x86-zip-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-win-x86.zip.sha
 
-[win-x86-badge-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/win_x86_Release_version_badge.svg
-[win-x86-version-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/productCommit-win-x86.txt
-[win-x86-installer-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-win-x86.exe
-[win-x86-installer-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-win-x86.exe.sha
-[win-x86-zip-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-win-x86.zip
-[win-x86-zip-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-win-x86.zip.sha
+[win-x86-badge-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/win_x86_Release_version_badge.svg
+[win-x86-version-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/productCommit-win-x86.txt
+[win-x86-installer-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-win-x86.exe
+[win-x86-installer-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-win-x86.exe.sha
+[win-x86-zip-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-win-x86.zip
+[win-x86-zip-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-win-x86.zip.sha
 
 [win-x86-badge-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/win_x86_Release_version_badge.svg
 [win-x86-version-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/productCommit-win-x86.txt
@@ -204,19 +204,19 @@ Reference notes:
 [win-x86-zip-3.1.1XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/dotnet-sdk-latest-win-x86.zip
 [win-x86-zip-checksum-3.1.1XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/dotnet-sdk-latest-win-x86.zip.sha
 
-[osx-x64-badge-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/osx_x64_Release_version_badge.svg
-[osx-x64-version-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/productCommit-osx-x64.txt
-[osx-x64-installer-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-osx-x64.pkg
-[osx-x64-installer-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-osx-x64.pkg.sha
-[osx-x64-targz-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-osx-x64.tar.gz
-[osx-x64-targz-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-osx-x64.pkg.tar.gz.sha
+[osx-x64-badge-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/osx_x64_Release_version_badge.svg
+[osx-x64-version-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/productCommit-osx-x64.txt
+[osx-x64-installer-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-osx-x64.pkg
+[osx-x64-installer-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-osx-x64.pkg.sha
+[osx-x64-targz-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-osx-x64.tar.gz
+[osx-x64-targz-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-osx-x64.pkg.tar.gz.sha
 
-[osx-x64-badge-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/osx_x64_Release_version_badge.svg
-[osx-x64-version-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/productCommit-osx-x64.txt
-[osx-x64-installer-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-osx-x64.pkg
-[osx-x64-installer-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-osx-x64.pkg.sha
-[osx-x64-targz-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-osx-x64.tar.gz
-[osx-x64-targz-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-osx-x64.pkg.tar.gz.sha
+[osx-x64-badge-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/osx_x64_Release_version_badge.svg
+[osx-x64-version-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/productCommit-osx-x64.txt
+[osx-x64-installer-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-osx-x64.pkg
+[osx-x64-installer-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-osx-x64.pkg.sha
+[osx-x64-targz-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-osx-x64.tar.gz
+[osx-x64-targz-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-osx-x64.pkg.tar.gz.sha
 
 [osx-x64-badge-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/osx_x64_Release_version_badge.svg
 [osx-x64-version-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/productCommit-osx-x64.txt
@@ -246,37 +246,37 @@ Reference notes:
 [osx-x64-targz-3.1.1XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/dotnet-sdk-latest-osx-x64.tar.gz
 [osx-x64-targz-checksum-3.1.1XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/dotnet-sdk-latest-osx-x64.tar.gz.sha
 
-[osx-arm64-badge-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/osx_arm64_Release_version_badge.svg
-[osx-arm64-version-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/productCommit-osx-arm64.txt
-[osx-arm64-installer-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-osx-arm64.pkg
-[osx-arm64-installer-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-osx-arm64.pkg.sha
-[osx-arm64-targz-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-osx-arm64.tar.gz
-[osx-arm64-targz-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-osx-arm64.pkg.tar.gz.sha
+[osx-arm64-badge-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/osx_arm64_Release_version_badge.svg
+[osx-arm64-version-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/productCommit-osx-arm64.txt
+[osx-arm64-installer-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-osx-arm64.pkg
+[osx-arm64-installer-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-osx-arm64.pkg.sha
+[osx-arm64-targz-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-osx-arm64.tar.gz
+[osx-arm64-targz-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-osx-arm64.pkg.tar.gz.sha
 
-[osx-arm64-badge-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/osx_arm64_Release_version_badge.svg
-[osx-arm64-version-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/productCommit-osx-arm64.txt
-[osx-arm64-installer-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-osx-arm64.pkg
-[osx-arm64-installer-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-osx-arm64.pkg.sha
-[osx-arm64-targz-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-osx-arm64.tar.gz
-[osx-arm64-targz-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-osx-arm64.pkg.tar.gz.sha
+[osx-arm64-badge-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/osx_arm64_Release_version_badge.svg
+[osx-arm64-version-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/productCommit-osx-arm64.txt
+[osx-arm64-installer-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-osx-arm64.pkg
+[osx-arm64-installer-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-osx-arm64.pkg.sha
+[osx-arm64-targz-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-osx-arm64.tar.gz
+[osx-arm64-targz-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-osx-arm64.pkg.tar.gz.sha
 
-[linux-badge-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/linux_x64_Release_version_badge.svg
-[linux-version-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/productCommit-linux-x64.txt
-[linux-DEB-installer-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-x64.deb
-[linux-DEB-installer-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-x64.deb.sha
-[linux-RPM-installer-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-x64.rpm
-[linux-RPM-installer-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-x64.rpm.sha
-[linux-targz-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-linux-x64.tar.gz
-[linux-targz-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-linux-x64.tar.gz.sha
+[linux-badge-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/linux_x64_Release_version_badge.svg
+[linux-version-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/productCommit-linux-x64.txt
+[linux-DEB-installer-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-x64.deb
+[linux-DEB-installer-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-x64.deb.sha
+[linux-RPM-installer-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-x64.rpm
+[linux-RPM-installer-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-x64.rpm.sha
+[linux-targz-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-linux-x64.tar.gz
+[linux-targz-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-linux-x64.tar.gz.sha
 
-[linux-badge-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/linux_x64_Release_version_badge.svg
-[linux-version-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/productCommit-linux-x64.txt
-[linux-DEB-installer-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-x64.deb
-[linux-DEB-installer-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-x64.deb.sha
-[linux-RPM-installer-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-x64.rpm
-[linux-RPM-installer-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-x64.rpm.sha
-[linux-targz-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-linux-x64.tar.gz
-[linux-targz-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-linux-x64.tar.gz.sha
+[linux-badge-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/linux_x64_Release_version_badge.svg
+[linux-version-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/productCommit-linux-x64.txt
+[linux-DEB-installer-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-x64.deb
+[linux-DEB-installer-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-x64.deb.sha
+[linux-RPM-installer-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-x64.rpm
+[linux-RPM-installer-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-x64.rpm.sha
+[linux-targz-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-linux-x64.tar.gz
+[linux-targz-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-linux-x64.tar.gz.sha
 
 [linux-badge-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/linux_x64_Release_version_badge.svg
 [linux-version-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/productCommit-linux-x64.txt
@@ -314,15 +314,15 @@ Reference notes:
 [linux-targz-3.1.1XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/dotnet-sdk-latest-linux-x64.tar.gz
 [linux-targz-checksum-3.1.1XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/dotnet-sdk-latest-linux-x64.tar.gz.sha
 
-[linux-arm-badge-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/linux_arm_Release_version_badge.svg
-[linux-arm-version-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/productCommit-linux-arm.txt
-[linux-arm-targz-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-linux-arm.tar.gz
-[linux-arm-targz-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-linux-arm.tar.gz.sha
+[linux-arm-badge-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/linux_arm_Release_version_badge.svg
+[linux-arm-version-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/productCommit-linux-arm.txt
+[linux-arm-targz-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-linux-arm.tar.gz
+[linux-arm-targz-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-linux-arm.tar.gz.sha
 
-[linux-arm-badge-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/linux_arm_Release_version_badge.svg
-[linux-arm-version-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/productCommit-linux-arm.txt
-[linux-arm-targz-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-linux-arm.tar.gz
-[linux-arm-targz-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-linux-arm.tar.gz.sha
+[linux-arm-badge-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/linux_arm_Release_version_badge.svg
+[linux-arm-version-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/productCommit-linux-arm.txt
+[linux-arm-targz-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-linux-arm.tar.gz
+[linux-arm-targz-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-linux-arm.tar.gz.sha
 
 [linux-arm-badge-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/linux_arm_Release_version_badge.svg
 [linux-arm-version-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/productCommit-linux-arm.txt
@@ -344,15 +344,15 @@ Reference notes:
 [linux-arm-targz-3.1.1XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/dotnet-sdk-latest-linux-arm.tar.gz
 [linux-arm-targz-checksum-3.1.1XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/dotnet-sdk-latest-linux-arm.tar.gz.sha
 
-[linux-arm64-badge-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/linux_arm64_Release_version_badge.svg
-[linux-arm64-version-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/productCommit-linux-arm64.txt
-[linux-arm64-targz-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-linux-arm64.tar.gz
-[linux-arm64-targz-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-linux-arm64.tar.gz.sha
+[linux-arm64-badge-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/linux_arm64_Release_version_badge.svg
+[linux-arm64-version-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/productCommit-linux-arm64.txt
+[linux-arm64-targz-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-linux-arm64.tar.gz
+[linux-arm64-targz-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-linux-arm64.tar.gz.sha
 
-[linux-arm64-badge-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/linux_arm64_Release_version_badge.svg
-[linux-arm64-version-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/productCommit-linux-arm64.txt
-[linux-arm64-targz-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-linux-arm64.tar.gz
-[linux-arm64-targz-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-linux-arm64.tar.gz.sha
+[linux-arm64-badge-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/linux_arm64_Release_version_badge.svg
+[linux-arm64-version-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/productCommit-linux-arm64.txt
+[linux-arm64-targz-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-linux-arm64.tar.gz
+[linux-arm64-targz-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-linux-arm64.tar.gz.sha
 
 [linux-arm64-badge-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/linux_arm64_Release_version_badge.svg
 [linux-arm64-version-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/productCommit-linux-arm64.txt
@@ -374,15 +374,15 @@ Reference notes:
 [linux-arm64-targz-3.1.1XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/dotnet-sdk-latest-linux-arm64.tar.gz
 [linux-arm64-targz-checksum-3.1.1XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/dotnet-sdk-latest-linux-arm64.tar.gz.sha
 
-[rhel-6-badge-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/rhel.6_x64_Release_version_badge.svg
-[rhel-6-version-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/productCommit-rhel.6-x64.txt
-[rhel-6-targz-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-rhel.6-x64.tar.gz
-[rhel-6-targz-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-rhel.6-x64.tar.gz.sha
+[rhel-6-badge-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/rhel.6_x64_Release_version_badge.svg
+[rhel-6-version-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/productCommit-rhel.6-x64.txt
+[rhel-6-targz-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-rhel.6-x64.tar.gz
+[rhel-6-targz-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-rhel.6-x64.tar.gz.sha
 
-[rhel-6-badge-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/rhel.6_x64_Release_version_badge.svg
-[rhel-6-version-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/productCommit-rhel.6-x64.txt
-[rhel-6-targz-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-rhel.6-x64.tar.gz
-[rhel-6-targz-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-rhel.6-x64.tar.gz.sha
+[rhel-6-badge-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/rhel.6_x64_Release_version_badge.svg
+[rhel-6-version-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/productCommit-rhel.6-x64.txt
+[rhel-6-targz-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-rhel.6-x64.tar.gz
+[rhel-6-targz-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-rhel.6-x64.tar.gz.sha
 
 [rhel-6-badge-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/rhel.6_x64_Release_version_badge.svg
 [rhel-6-version-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/productCommit-rhel.6-x64.txt
@@ -404,15 +404,15 @@ Reference notes:
 [rhel-6-targz-3.1.1XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/dotnet-sdk-latest-rhel.6-x64.tar.gz
 [rhel-6-targz-checksum-3.1.1XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/dotnet-sdk-latest-rhel.6-x64.tar.gz.sha
 
-[linux-musl-x64-badge-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/linux_musl_x64_Release_version_badge.svg
-[linux-musl-x64-version-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/productCommit-linux-musl-x64.txt
-[linux-musl-x64-targz-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-linux-musl-x64.tar.gz
-[linux-musl-x64-targz-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-linux-musl-x64.tar.gz.sha
+[linux-musl-x64-badge-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/linux_musl_x64_Release_version_badge.svg
+[linux-musl-x64-version-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/productCommit-linux-musl-x64.txt
+[linux-musl-x64-targz-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-linux-musl-x64.tar.gz
+[linux-musl-x64-targz-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-linux-musl-x64.tar.gz.sha
 
-[linux-musl-x64-badge-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/linux_musl_x64_Release_version_badge.svg
-[linux-musl-x64-version-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/productCommit-linux-musl-x64.txt
-[linux-musl-x64-targz-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-linux-musl-x64.tar.gz
-[linux-musl-x64-targz-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-linux-musl-x64.tar.gz.sha
+[linux-musl-x64-badge-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/linux_musl_x64_Release_version_badge.svg
+[linux-musl-x64-version-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/productCommit-linux-musl-x64.txt
+[linux-musl-x64-targz-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-linux-musl-x64.tar.gz
+[linux-musl-x64-targz-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-linux-musl-x64.tar.gz.sha
 
 [linux-musl-x64-badge-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/linux_musl_x64_Release_version_badge.svg
 [linux-musl-x64-version-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/productCommit-linux-musl-x64.txt
@@ -434,15 +434,15 @@ Reference notes:
 [linux-musl-x64-targz-3.1.1XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/dotnet-sdk-latest-linux-musl-x64.tar.gz
 [linux-musl-x64-targz-checksum-3.1.1XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/dotnet-sdk-latest-linux-musl-x64.tar.gz.sha
 
-[linux-musl-arm-badge-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/linux_musl_arm_Release_version_badge.svg
-[linux-musl-arm-version-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/productCommit-linux-musl-arm.txt
-[linux-musl-arm-targz-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-linux-musl-arm.tar.gz
-[linux-musl-arm-targz-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-linux-musl-arm.tar.gz.sha
+[linux-musl-arm-badge-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/linux_musl_arm_Release_version_badge.svg
+[linux-musl-arm-version-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/productCommit-linux-musl-arm.txt
+[linux-musl-arm-targz-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-linux-musl-arm.tar.gz
+[linux-musl-arm-targz-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-linux-musl-arm.tar.gz.sha
 
-[linux-musl-arm-badge-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/linux_musl_arm_Release_version_badge.svg
-[linux-musl-arm-version-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/productCommit-linux-musl-arm.txt
-[linux-musl-arm-targz-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-linux-musl-arm.tar.gz
-[linux-musl-arm-targz-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-linux-musl-arm.tar.gz.sha
+[linux-musl-arm-badge-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/linux_musl_arm_Release_version_badge.svg
+[linux-musl-arm-version-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/productCommit-linux-musl-arm.txt
+[linux-musl-arm-targz-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-linux-musl-arm.tar.gz
+[linux-musl-arm-targz-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-linux-musl-arm.tar.gz.sha
 
 [linux-musl-arm-badge-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/linux_musl_arm_Release_version_badge.svg
 [linux-musl-arm-version-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/productCommit-linux-musl-arm.txt
@@ -454,15 +454,15 @@ Reference notes:
 [linux-musl-arm-targz-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-linux-musl-arm.tar.gz
 [linux-musl-arm-targz-checksum-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-linux-musl-arm.tar.gz.sha
 
-[linux-musl-arm64-badge-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/linux_musl_arm64_Release_version_badge.svg
-[linux-musl-arm64-version-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/productCommit-linux-musl-arm64.txt
-[linux-musl-arm64-targz-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-linux-musl-arm64.tar.gz
-[linux-musl-arm64-targz-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-linux-musl-arm64.tar.gz.sha
+[linux-musl-arm64-badge-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/linux_musl_arm64_Release_version_badge.svg
+[linux-musl-arm64-version-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/productCommit-linux-musl-arm64.txt
+[linux-musl-arm64-targz-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-linux-musl-arm64.tar.gz
+[linux-musl-arm64-targz-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-linux-musl-arm64.tar.gz.sha
 
-[linux-musl-arm64-badge-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/linux_musl_arm64_Release_version_badge.svg
-[linux-musl-arm64-version-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/productCommit-linux-musl-arm64.txt
-[linux-musl-arm64-targz-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-linux-musl-arm64.tar.gz
-[linux-musl-arm64-targz-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-linux-musl-arm64.tar.gz.sha
+[linux-musl-arm64-badge-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/linux_musl_arm64_Release_version_badge.svg
+[linux-musl-arm64-version-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/productCommit-linux-musl-arm64.txt
+[linux-musl-arm64-targz-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-linux-musl-arm64.tar.gz
+[linux-musl-arm64-targz-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-linux-musl-arm64.tar.gz.sha
 
 [linux-musl-arm64-badge-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/linux_musl_arm64_Release_version_badge.svg
 [linux-musl-arm64-version-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/productCommit-linux-musl-arm64.txt
@@ -474,15 +474,15 @@ Reference notes:
 [linux-musl-arm64-targz-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-linux-musl-arm64.tar.gz
 [linux-musl-arm64-targz-checksum-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-linux-musl-arm64.tar.gz.sha
 
-[win-arm-badge-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/win_arm_Release_version_badge.svg
-[win-arm-version-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/productCommit-win-arm.txt
-[win-arm-zip-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-win-arm.zip
-[win-arm-zip-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-win-arm.zip.sha
+[win-arm-badge-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/win_arm_Release_version_badge.svg
+[win-arm-version-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/productCommit-win-arm.txt
+[win-arm-zip-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-win-arm.zip
+[win-arm-zip-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-win-arm.zip.sha
 
-[win-arm-badge-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/win_arm_Release_version_badge.svg
-[win-arm-version-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/productCommit-win-arm.txt
-[win-arm-zip-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-win-arm.zip
-[win-arm-zip-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-win-arm.zip.sha
+[win-arm-badge-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/win_arm_Release_version_badge.svg
+[win-arm-version-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/productCommit-win-arm.txt
+[win-arm-zip-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-win-arm.zip
+[win-arm-zip-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-win-arm.zip.sha
 
 [win-arm-badge-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/win_arm_Release_version_badge.svg
 [win-arm-version-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/productCommit-win-arm.txt
@@ -504,19 +504,19 @@ Reference notes:
 [win-arm-zip-3.1.1XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/dotnet-sdk-latest-win-arm.zip
 [win-arm-zip-checksum-3.1.1XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.1xx/dotnet-sdk-latest-win-arm.zip.sha
 
-[win-arm64-badge-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/win_arm64_Release_version_badge.svg
-[win-arm64-version-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/productCommit-win-arm64.txt
-[win-arm64-installer-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-win-arm64.exe
-[win-arm64-installer-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-win-arm64.exe.sha
-[win-arm64-zip-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-win-arm64.zip
-[win-arm64-zip-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0/daily/dotnet-sdk-win-arm64.zip.sha
+[win-arm64-badge-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/win_arm64_Release_version_badge.svg
+[win-arm64-version-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/productCommit-win-arm64.txt
+[win-arm64-installer-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-win-arm64.exe
+[win-arm64-installer-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-win-arm64.exe.sha
+[win-arm64-zip-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-win-arm64.zip
+[win-arm64-zip-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-win-arm64.zip.sha
 
-[win-arm64-badge-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/win_arm64_Release_version_badge.svg
-[win-arm64-version-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/productCommit-win-arm64.txt
-[win-arm64-installer-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-win-arm64.exe
-[win-arm64-installer-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-win-arm64.exe.sha
-[win-arm64-zip-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-win-arm64.zip
-[win-arm64-zip-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1XX-rc1/daily/dotnet-sdk-win-arm64.zip.sha
+[win-arm64-badge-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/win_arm64_Release_version_badge.svg
+[win-arm64-version-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/productCommit-win-arm64.txt
+[win-arm64-installer-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-win-arm64.exe
+[win-arm64-installer-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-win-arm64.exe.sha
+[win-arm64-zip-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-win-arm64.zip
+[win-arm64-zip-checksum-6.0.1XX-rc1]: https://aka.ms/dotnet/6.0.1xx-rc1/daily/dotnet-sdk-win-arm64.zip.sha
 
 [win-arm64-badge-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/win_arm64_Release_version_badge.svg
 [win-arm64-version-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/productCommit-win-arm64.txt

--- a/tools/sdk-readme-table-generator/TableGenerator/Program.fs
+++ b/tools/sdk-readme-table-generator/TableGenerator/Program.fs
@@ -8,10 +8,10 @@ open TableGenerator.Table
 let inputBranches =
         [ { GitBranchName = "release/6.0.1xx"
             DisplayName = "Release/6.0.1XX<br>(6.0.x&nbsp;Runtime)"
-            AkaMsChannel = Some("6.0/daily") }
+            AkaMsChannel = Some("6.0.1xx/daily") }
           { GitBranchName = "release/6.0.1xx-rc1"
             DisplayName = "Release/6.0.1XX-rc1<br>(6.0 Runtime)"
-            AkaMsChannel = Some("6.0.1XX-rc1/daily") }
+            AkaMsChannel = Some("6.0.1xx-rc1/daily") }
           { GitBranchName = "release/5.0.4xx"
             DisplayName = "Release/5.0.4XX<br>(5.0 Runtime)"
             AkaMsChannel = Some("5.0.4xx/daily") }


### PR DESCRIPTION
- 6.0.1xx branches have different aka.ms linkes (6.0.1xx vs 6.0)
- Fix casing of the 'xx' part

- Please add description for changes you are making.
- If there is an issue related to this PR, please add the reference.
