### PR TITLE
[ArPow] Add Microsoft.Deployment.DotNet.Releases to tarball

### DIFF
--- a/eng/SourceBuild.Version.Details.xml
+++ b/eng/SourceBuild.Version.Details.xml
@@ -115,8 +115,8 @@
       <SourceBuild RepoName="xliff-tasks" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.Deployment.DotNet.Releases" Version="1.0.0-preview1.1.21112.1" CoherentParentDependency="Microsoft.NET.Sdk">
-      <Uri>https://github.com/lbussell/deployment-tools</Uri>
-      <Sha>610d9922acec06419b8d0eec985866a0b1befdc8</Sha>
+      <Uri>https://github.com/dotnet/deployment-tools</Uri>
+      <Sha>428d5b3878bf14eb2c497ffb00863bf396699896</Sha>
       <SourceBuild RepoName="deployment-tools" ManagedOnly="true" />
     </Dependency>
   </ToolsetDependencies>

--- a/eng/SourceBuild.Version.Details.xml
+++ b/eng/SourceBuild.Version.Details.xml
@@ -116,7 +116,7 @@
     </Dependency>
     <Dependency Name="Microsoft.Deployment.DotNet.Releases" Version="1.0.0-preview1.1.21112.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/deployment-tools</Uri>
-      <Sha>428d5b3878bf14eb2c497ffb00863bf396699896</Sha>
+      <Sha>74f718b714755057d2a146e195afd259b45fa48d</Sha>
       <SourceBuild RepoName="deployment-tools" ManagedOnly="true" />
     </Dependency>
   </ToolsetDependencies>

--- a/eng/SourceBuild.Version.Details.xml
+++ b/eng/SourceBuild.Version.Details.xml
@@ -114,5 +114,10 @@
       <Sha>71c811561ad4dcf46825a5077fbcc668ab74754f</Sha>
       <SourceBuild RepoName="xliff-tasks" ManagedOnly="true" />
     </Dependency>
+    <Dependency Name="Microsoft.Deployment.DotNet.Releases" Version="1.0.0-preview1.1.21112.1" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Uri>https://github.com/lbussell/deployment-tools</Uri>
+      <Sha>610d9922acec06419b8d0eec985866a0b1befdc8</Sha>
+      <SourceBuild RepoName="deployment-tools" ManagedOnly="true" />
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -159,7 +159,7 @@
     <MicrosoftBuildFrameworkVersion>15.7.179</MicrosoftBuildFrameworkVersion>
     <MicrosoftBuildUtilitiesCoreVersion>15.7.179</MicrosoftBuildUtilitiesCoreVersion>
     <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-6.0.100-bootstrap.11</PrivateSourceBuiltArtifactsPackageVersion>
-    <PrivateSourceBuiltPrebuiltsPackageVersion>0.1.0-6.0.100-17</PrivateSourceBuiltPrebuiltsPackageVersion>
+    <PrivateSourceBuiltPrebuiltsPackageVersion>0.1.0-6.0.100-18</PrivateSourceBuiltPrebuiltsPackageVersion>
   </PropertyGroup>
   <!-- Workload manifest package versions -->
   <PropertyGroup>

--- a/src/SourceBuild/tarball/content/eng/Versions.props
+++ b/src/SourceBuild/tarball/content/eng/Versions.props
@@ -23,6 +23,6 @@
   <PropertyGroup>
     <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-6.0.100-bootstrap.11</PrivateSourceBuiltArtifactsPackageVersion>
     <PrivateSourceBuiltPrebuiltsPackageVersionPrefix>0.1.0-6.0.100-</PrivateSourceBuiltPrebuiltsPackageVersionPrefix>
-    <PrivateSourceBuiltPrebuiltsPackageVersionSuffix>17</PrivateSourceBuiltPrebuiltsPackageVersionSuffix>
+    <PrivateSourceBuiltPrebuiltsPackageVersionSuffix>18</PrivateSourceBuiltPrebuiltsPackageVersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/SourceBuild/tarball/content/patches/deployment-tools/0001-remove-unnecessary-pvp-import.patch
+++ b/src/SourceBuild/tarball/content/patches/deployment-tools/0001-remove-unnecessary-pvp-import.patch
@@ -1,0 +1,23 @@
+From 44e69209ab5f641104815da7fcad063e923115af Mon Sep 17 00:00:00 2001
+From: Logan Bussell <36081148+lbussell@users.noreply.github.com>
+Date: Thu, 19 Aug 2021 22:37:59 +0000
+Subject: [PATCH] remove unnecessary pvp import
+
+---
+ eng/Versions.props | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/eng/Versions.props b/eng/Versions.props
+index aa896af..2a62eb2 100644
+--- a/eng/Versions.props
++++ b/eng/Versions.props
+@@ -142,6 +142,4 @@
+     <MicrosoftNETCoreTargetsPackage>Microsoft.NETCore.Targets</MicrosoftNETCoreTargetsPackage>
+     <MicrosoftNETCoreRuntimeCoreCLRPackage>Microsoft.NETCore.Runtime.CoreCLR</MicrosoftNETCoreRuntimeCoreCLRPackage>
+   </PropertyGroup>
+-  <!-- Override isolated build dependency versions with versions from Repo API. -->
+-  <Import Project="$(DotNetPackageVersionPropsPath)" Condition="'$(DotNetPackageVersionPropsPath)' != ''" />
+ </Project>
+-- 
+2.30.2
+

--- a/src/SourceBuild/tarball/content/patches/deployment-tools/0002-https-github.com-dotnet-arcade-issues-7778-Ignore-cu.patch
+++ b/src/SourceBuild/tarball/content/patches/deployment-tools/0002-https-github.com-dotnet-arcade-issues-7778-Ignore-cu.patch
@@ -1,0 +1,26 @@
+From 4c6179851c1e4ff7f6835707d11f0d9a411aefbc Mon Sep 17 00:00:00 2001
+From: Matt Galbraith <mattgal@microsoft.com>
+Date: Mon, 23 Aug 2021 08:52:35 -0700
+Subject: [PATCH] https://github.com/dotnet/arcade/issues/7778 - Ignore curl
+ failures for no-network build scenario
+
+---
+ eng/common/tools.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/eng/common/tools.sh b/eng/common/tools.sh
+index 3c5f3a12..41e32310 100755
+--- a/eng/common/tools.sh
++++ b/eng/common/tools.sh
+@@ -402,7 +402,7 @@ function StopProcesses {
+ function TryLogClientIpAddress () {
+   echo 'Attempting to log this client''s IP for Azure Package feed telemetry purposes'
+   if command -v curl > /dev/null; then
+-    curl -s 'http://co1.msedge.net/fdv2/diagnostics.aspx' | grep ' IP: '
++    curl -s 'http://co1.msedge.net/fdv2/diagnostics.aspx' | grep ' IP: ' || true
+   fi
+ }
+ 
+-- 
+2.30.2
+

--- a/src/SourceBuild/tarball/content/repos/deployment-tools.proj
+++ b/src/SourceBuild/tarball/content/repos/deployment-tools.proj
@@ -1,0 +1,21 @@
+<Project>
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
+  <PropertyGroup>
+    <BuildCommand>$(ProjectDirectory)eng\common\build$(ShellExtension) $(StandardSourceBuildArgs)</BuildCommand>
+
+    <GlobalJsonFile>$(ProjectDirectory)global.json</GlobalJsonFile>
+    <NuGetConfigFile>$(ProjectDirectory)NuGet.config</NuGetConfigFile>
+    <OutputPlacementRepoApiImplemented>false</OutputPlacementRepoApiImplemented>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <RepositoryReference Include="runtime" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <UseSourceBuiltSdkOverride Include="@(ArcadeSdkOverride)" />
+  </ItemGroup>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+</Project>

--- a/src/SourceBuild/tarball/content/repos/known-good.proj
+++ b/src/SourceBuild/tarball/content/repos/known-good.proj
@@ -42,6 +42,7 @@
         <RepositoryReference Include="xliff-tasks" />
 
         <!-- Tier 2 -->
+        <RepositoryReference Include="deployment-tools" />
         <RepositoryReference Include="linker" />
         <RepositoryReference Include="msbuild" />
         <RepositoryReference Include="runtime-portable" />

--- a/src/SourceBuild/tarball/content/repos/known-good.proj
+++ b/src/SourceBuild/tarball/content/repos/known-good.proj
@@ -42,7 +42,6 @@
         <RepositoryReference Include="xliff-tasks" />
 
         <!-- Tier 2 -->
-        <RepositoryReference Include="deployment-tools" />
         <RepositoryReference Include="linker" />
         <RepositoryReference Include="msbuild" />
         <RepositoryReference Include="runtime-portable" />
@@ -54,6 +53,7 @@
 
         <!-- Tier 4 -->
         <RepositoryReference Include="aspnetcore" />
+        <RepositoryReference Include="deployment-tools" />
         <RepositoryReference Include="nuget-client" />
 
         <!-- Tier 5 -->

--- a/src/SourceBuild/tarball/content/repos/sdk.proj
+++ b/src/SourceBuild/tarball/content/repos/sdk.proj
@@ -42,6 +42,7 @@
     <RepositoryReference Include="roslyn-analyzers" />
     <RepositoryReference Include="vstest" />
     <RepositoryReference Include="fsharp" />
+    <RepositoryReference Include="deployment-tools" />
   </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />


### PR DESCRIPTION
Part of https://github.com/dotnet/source-build/issues/2365

One patch is needed because deployment-tools uses an outdated version of arcade.