### PR TITLE
[ArPow] Reduce the size of the tarball.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -159,7 +159,7 @@
     <MicrosoftBuildFrameworkVersion>15.7.179</MicrosoftBuildFrameworkVersion>
     <MicrosoftBuildUtilitiesCoreVersion>15.7.179</MicrosoftBuildUtilitiesCoreVersion>
     <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-6.0.100-bootstrap.11</PrivateSourceBuiltArtifactsPackageVersion>
-    <PrivateSourceBuiltPrebuiltsPackageVersion>0.1.0-6.0.100-17</PrivateSourceBuiltPrebuiltsPackageVersion>
+    <PrivateSourceBuiltPrebuiltsPackageVersion>0.1.0-6.0.100-19</PrivateSourceBuiltPrebuiltsPackageVersion>
   </PropertyGroup>
   <!-- Workload manifest package versions -->
   <PropertyGroup>

--- a/src/SourceBuild/Arcade/src/Tarball_WriteSourceRepoProperties.cs
+++ b/src/SourceBuild/Arcade/src/Tarball_WriteSourceRepoProperties.cs
@@ -57,7 +57,8 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
                     SourceBuildRepoName = dep.GetMetadata("SourceBuildRepoName"),
                     Version = dep.GetMetadata("ExactVersion"),
                     Sha = dep.GetMetadata("Sha"),
-                    Uri = dep.GetMetadata("Uri")
+                    Uri = dep.GetMetadata("Uri"),
+                    GitCommitCount = dep.GetMetadata("GitCommitCount")
                 }))
             {
                 string repoName = dependency.SourceBuildRepoName;
@@ -72,6 +73,10 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
                     ["PreReleaseVersionLabel"] = derivedVersion.PreReleaseVersionLabel,
                     ["IsStable"] = string.IsNullOrWhiteSpace(derivedVersion.PreReleaseVersionLabel) ? "true" : "false",
                 };
+                if (!string.IsNullOrEmpty(dependency.GitCommitCount))
+                {
+                    repoProps.Add("GitCommitCount", dependency.GitCommitCount);
+                }                
                 WritePropsFile(propsPath, repoProps);
                 allRepoProps[$"{safeRepoName}GitCommitHash"] = dependency.Sha;
                 allRepoProps[$"{safeRepoName}OutputPackageVersion"] = dependency.Version;

--- a/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
+++ b/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
@@ -60,6 +60,14 @@
       <Output TaskParameter="ConsoleOutput" ItemName="RootRepoCommitSha" />
     </Exec>
 
+    <!-- Get commit count for installer repo only -->
+    <Exec
+      Command="cd $(RepoRoot);git rev-list --count HEAD"
+      ConsoleToMSBuild="true"
+      WorkingDirectory="$(RepoRoot)">
+      <Output TaskParameter="ConsoleOutput" ItemName="RootRepoCommitCount" />
+    </Exec>
+
     <!-- This is hardcoding version for the root repo (installer), since there
          isn't a Version.Details.xml file to read it from.
          See https://github.com/dotnet/source-build/issues/2250 -->
@@ -70,6 +78,7 @@
         <ExactVersion>1.0.0</ExactVersion>
         <Sha>@(RootRepoCommitSha)</Sha>
         <Uri>@(RootRepoUri)</Uri>
+        <GitCommitCount>@(RootRepoCommitCount)</GitCommitCount>
         <SourceBuildRepoName>$(GitHubRepositoryName)</SourceBuildRepoName>
         <IsRootRepo>true</IsRootRepo>
       </SourceBuildRepos>

--- a/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
+++ b/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
@@ -146,6 +146,11 @@
       Command="git submodule update --init --recursive"
       WorkingDirectory="$(TarballRepoSourceDir)" />
 
+    <!-- Remove the git objects folder to free up tarball space -->
+    <Exec
+      Command="rm -rf objects"
+      WorkingDirectory="$(TarballRepoSourceDir).git" />
+
     <Message Text="--> Done Cloning Repo $(SourceBuildRepoName)" Importance="High" />
 
     <!-- Override to use a temporary SourceBuild specific Version.Details.xml file in installer for Preview 6

--- a/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
+++ b/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
@@ -133,7 +133,7 @@
 
     <!-- Fetching a sha requires git 2.5.0 or newer -->
     <Exec
-      Command="git fetch origin $(RepoSha)"
+      Command="git fetch --depth 1 origin $(RepoSha)"
       WorkingDirectory="$(TarballRepoSourceDir)"
       Condition="$(IsRootRepo) != 'true'" />
 

--- a/src/SourceBuild/tarball/content/ArcadeOverrides/SourceBuildArcadeBuild.targets
+++ b/src/SourceBuild/tarball/content/ArcadeOverrides/SourceBuildArcadeBuild.targets
@@ -97,7 +97,17 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="CopySourceBuildRepoRoot" Condition=" '$(CopySrcInsteadOfClone)' == 'true' ">
+  <!--
+    PrepareInnerSourceBuildRepoRoot either clones the source to the inner repo
+    or copies the source to the inner repo depending on CopySrcInsteadOfClone.
+    Repos take a dependency on PrepareInnerSourceBuildRepoRoot, so this target
+    exists to wait until either the source is cloned or copied.
+  -->
+  <Target Name="PrepareInnerSourceBuildRepoRoot"
+          DependsOnTargets="CopyInnerSourceBuildRepoRoot;CloneInnerSourceBuildRepoRoot">
+  </Target>
+
+  <Target Name="CopyInnerSourceBuildRepoRoot" Condition=" '$(CopySrcInsteadOfClone)' == 'true' ">
     <ItemGroup>
       <SourceBuildFilesToCopy Include="$(RepoRoot)/**/*" />
       <SourceBuildFilesToCopy Include="$(RepoRoot)/**/.*" />
@@ -115,7 +125,7 @@
     access to the git data, this also makes it easy to see what changes the source-build infra has
     made, for diagnosis or exploratory purposes.
   -->
-  <Target Name="PrepareInnerSourceBuildRepoRoot" Condition=" '$(CopySrcInsteadOfClone)' != 'true' ">
+  <Target Name="CloneInnerSourceBuildRepoRoot" Condition=" '$(CopySrcInsteadOfClone)' != 'true' ">
     <PropertyGroup>
       <!--
         By default, copy WIP. WIP copy helps with local machine dev work. Don't copy WIP if this is
@@ -164,7 +174,7 @@
   </Target>
 
   <Target Name="RunInnerSourceBuildCommand"
-          DependsOnTargets="PrepareInnerSourceBuildRepoRoot;CopySourceBuildRepoRoot">
+          DependsOnTargets="PrepareInnerSourceBuildRepoRoot">
     <PropertyGroup>
       <!-- Prevent any projects from building in the outside build: they would use prebuilts. -->
       <PreventPrebuiltBuild>true</PreventPrebuiltBuild>

--- a/src/SourceBuild/tarball/content/ArcadeOverrides/SourceBuildArcadeBuild.targets
+++ b/src/SourceBuild/tarball/content/ArcadeOverrides/SourceBuildArcadeBuild.targets
@@ -111,8 +111,8 @@
     <ItemGroup>
       <SourceBuildFilesToCopy Include="$(RepoRoot)/**/*" />
       <SourceBuildFilesToCopy Include="$(RepoRoot)/**/.*" />
-      <SourceBuildFilesToCopy Include="$(RepoRoot)/artifacts/**/*" />
-      <SourceBuildFilesToCopy Include="$(RepoRoot)/artifacts/**/.*" />
+      <SourceBuildFilesToCopy Remove="$(RepoRoot)/artifacts/**/*" />
+      <SourceBuildFilesToCopy Remove="$(RepoRoot)/artifacts/**/.*" />
     </ItemGroup>
 
     <Copy

--- a/src/SourceBuild/tarball/content/ArcadeOverrides/SourceBuildArcadeBuild.targets
+++ b/src/SourceBuild/tarball/content/ArcadeOverrides/SourceBuildArcadeBuild.targets
@@ -111,6 +111,8 @@
     <ItemGroup>
       <SourceBuildFilesToCopy Include="$(RepoRoot)/**/*" />
       <SourceBuildFilesToCopy Include="$(RepoRoot)/**/.*" />
+      <SourceBuildFilesToCopy Include="$(RepoRoot)/artifacts/**/*" />
+      <SourceBuildFilesToCopy Include="$(RepoRoot)/artifacts/**/.*" />
     </ItemGroup>
 
     <Copy

--- a/src/SourceBuild/tarball/content/ArcadeOverrides/SourceBuildArcadeBuild.targets
+++ b/src/SourceBuild/tarball/content/ArcadeOverrides/SourceBuildArcadeBuild.targets
@@ -97,6 +97,17 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="CopySourceBuildRepoRoot" Condition=" '$(CopySrcInsteadOfClone)' == 'true' ">
+    <ItemGroup>
+      <SourceBuildFilesToCopy Include="$(RepoRoot)/**/*" />
+      <SourceBuildFilesToCopy Include="$(RepoRoot)/**/.*" />
+    </ItemGroup>
+
+    <Copy
+      SourceFiles="@(SourceBuildFilesToCopy)"
+      DestinationFolder="$(InnerSourceBuildRepoRoot)%(RecursiveDir)" />
+  </Target>
+
   <!--
     Clone the repo to a new location. Source-build targets will change the source dynamically.
     Creating a fresh clone avoids overwriting existing work or making subtle changes that might
@@ -104,7 +115,7 @@
     access to the git data, this also makes it easy to see what changes the source-build infra has
     made, for diagnosis or exploratory purposes.
   -->
-  <Target Name="PrepareInnerSourceBuildRepoRoot">
+  <Target Name="PrepareInnerSourceBuildRepoRoot" Condition=" '$(CopySrcInsteadOfClone)' != 'true' ">
     <PropertyGroup>
       <!--
         By default, copy WIP. WIP copy helps with local machine dev work. Don't copy WIP if this is
@@ -153,7 +164,7 @@
   </Target>
 
   <Target Name="RunInnerSourceBuildCommand"
-          DependsOnTargets="PrepareInnerSourceBuildRepoRoot">
+          DependsOnTargets="PrepareInnerSourceBuildRepoRoot;CopySourceBuildRepoRoot">
     <PropertyGroup>
       <!-- Prevent any projects from building in the outside build: they would use prebuilts. -->
       <PreventPrebuiltBuild>true</PreventPrebuiltBuild>

--- a/src/SourceBuild/tarball/content/eng/Versions.props
+++ b/src/SourceBuild/tarball/content/eng/Versions.props
@@ -23,6 +23,6 @@
   <PropertyGroup>
     <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-6.0.100-bootstrap.11</PrivateSourceBuiltArtifactsPackageVersion>
     <PrivateSourceBuiltPrebuiltsPackageVersionPrefix>0.1.0-6.0.100-</PrivateSourceBuiltPrebuiltsPackageVersionPrefix>
-    <PrivateSourceBuiltPrebuiltsPackageVersionSuffix>17</PrivateSourceBuiltPrebuiltsPackageVersionSuffix>
+    <PrivateSourceBuiltPrebuiltsPackageVersionSuffix>19</PrivateSourceBuiltPrebuiltsPackageVersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/SourceBuild/tarball/content/repos/Directory.Build.props
+++ b/src/SourceBuild/tarball/content/repos/Directory.Build.props
@@ -147,6 +147,7 @@
     <StandardSourceBuildArgs>$(StandardSourceBuildArgs) /p:ArcadeBuildFromSource=true</StandardSourceBuildArgs>
     <StandardSourceBuildArgs>$(StandardSourceBuildArgs) /p:CopyWipIntoInnerSourceBuildRepo=true</StandardSourceBuildArgs>
     <StandardSourceBuildArgs>$(StandardSourceBuildArgs) /p:DotNetBuildOffline=true</StandardSourceBuildArgs>
+    <StandardSourceBuildArgs>$(StandardSourceBuildArgs) /p:CopySrcInsteadOfClone=true</StandardSourceBuildArgs>
     <StandardSourceBuildArgs>$(StandardSourceBuildArgs) /p:DotNetPackageVersionPropsPath="$(PackageVersionPropsPath)"</StandardSourceBuildArgs>
     <StandardSourceBuildArgs>$(StandardSourceBuildArgs) /p:AdditionalSourceBuiltNupkgCacheDir="$(SourceBuiltPackagesPath)"</StandardSourceBuildArgs>
     <StandardSourceBuildArgs>$(StandardSourceBuildArgs) /p:ReferencePackageNupkgCacheDir="$(ReferencePackagesDir)"</StandardSourceBuildArgs>


### PR DESCRIPTION
2 main changes:
- Add copy of src instead of clone so the build doesn't rely on git.
- Remove .git/objects directories in repo src to reduce size of the tarball.

In local tests, tarball size changed from:
(packed) 3.42GB -> 597MB
(unpacked) 7.7GB -> 4.9GB
