### PR TITLE
Move to 5.0.400 SDK to unblock mac builds

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.100",
+    "dotnet": "5.0.400",
     "runtimes": {
       "dotnet": [
         "$(MicrosoftNETCoreAppInternalPackageVersion)"


### PR DESCRIPTION
- Please add description for changes you are making.
- If there is an issue related to this PR, please add the reference.
