### PR TITLE
Update Xamarin manifests for .NET 6 rc 1: part 2

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -15,8 +15,6 @@
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="dotnet6-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6-transport/nuget/v3/index.json" />
     <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
-    <!-- Temporary feed for Xamarin workload manifest -->
-    <add key="xamarin" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/xamarin-impl/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources />
 </configuration>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -163,12 +163,12 @@
   </PropertyGroup>
   <!-- Workload manifest package versions -->
   <PropertyGroup>
-    <MauiWorkloadManifestVersion>6.0.100-rc.1.1351</MauiWorkloadManifestVersion>
-    <XamarinAndroidWorkloadManifestVersion>30.0.100-rc.1.137</XamarinAndroidWorkloadManifestVersion>
-    <XamarinIOSWorkloadManifestVersion>15.0.100-rc.1.496</XamarinIOSWorkloadManifestVersion>
-    <XamarinMacCatalystWorkloadManifestVersion>15.0.100-rc.1.496</XamarinMacCatalystWorkloadManifestVersion>
-    <XamarinMacOSWorkloadManifestVersion>12.0.100-rc.1.496</XamarinMacOSWorkloadManifestVersion>
-    <XamarinTvOSWorkloadManifestVersion>15.0.100-rc.1.496</XamarinTvOSWorkloadManifestVersion>
+    <MauiWorkloadManifestVersion>6.0.100-rc.1.1528</MauiWorkloadManifestVersion>
+    <XamarinAndroidWorkloadManifestVersion>31.0.100-rc.1.12</XamarinAndroidWorkloadManifestVersion>
+    <XamarinIOSWorkloadManifestVersion>15.0.100-rc.1.1531</XamarinIOSWorkloadManifestVersion>
+    <XamarinMacCatalystWorkloadManifestVersion>15.0.100-rc.1.1531</XamarinMacCatalystWorkloadManifestVersion>
+    <XamarinMacOSWorkloadManifestVersion>12.0.100-rc.1.1531</XamarinMacOSWorkloadManifestVersion>
+    <XamarinTvOSWorkloadManifestVersion>15.0.100-rc.1.1531</XamarinTvOSWorkloadManifestVersion>
     <MonoWorkloadManifestVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MonoWorkloadManifestVersion>
     <MicrosoftNETWorkloadEmscriptenManifest60100Version>6.0.0-rc.1.21419.1</MicrosoftNETWorkloadEmscriptenManifest60100Version>
     <EmscriptenWorkloadManifestVersion>$(MicrosoftNETWorkloadEmscriptenManifest60100Version)</EmscriptenWorkloadManifestVersion>


### PR DESCRIPTION
Bump to: xamarin/xamarin-android/release/6.0.1xx-rc1@eadb58fc
Bump to: xamarin/xamarin-macios/release/6.0.1xx-rc.1@a0ad4988
Bump to: dotnet/maui/release/6.0.1xx-rc1@2b44438f

A couple changes here:

1. We don't need the `xamarin-impl` feed, as all of our packages are
   on the `dotnet6` feed now.

2. We now have `.Msi` packs for elevated workload installs on Windows.
   Let's update the baseline manifests to make sure these packs are
   present for these versions.

I manually tested the workloads with:

    > $env:DOTNET_MULTILEVEL_LOOKUP=0
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install android --skip-manifest-update
    Installing pack Microsoft.Android.Sdk version 31.0.100-rc.1.12...
    ...
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install ios --skip-manifest-update
    Installing pack Microsoft.iOS.Sdk version 15.0.100-rc.1.1531...
    ...
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install macos --skip-manifest-update
    Installing pack Microsoft.macOS.Sdk version 12.0.100-rc.1.1531...
    ...
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install maccatalyst --skip-manifest-update
    Installing pack Microsoft.MacCatalyst.Sdk version 15.0.100-rc.1.1531...
    ...
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install tvos --skip-manifest-update
    Installing pack Microsoft.tvOS.Sdk version 15.0.100-rc.1.1531...
    ...
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install maui --skip-manifest-update
    Installing pack Microsoft.Maui.Core.Ref.android version 6.0.100-rc.1.1528...

I'll open a different PR for `rc.2` builds later on.