### PR TITLE
[release/5.0.4xx] Add sign check exclusions for non-shipping files

### DIFF
--- a/eng/SignCheckExclusionsFile.txt
+++ b/eng/SignCheckExclusionsFile.txt
@@ -6,3 +6,6 @@
 *singlefilehost.exe;;Template, DO-NOT-SIGN, https://github.com/dotnet/core-setup/pull/7549
 *comhost.dll;;Template, DO-NOT-SIGN, https://github.com/dotnet/core-setup/pull/7549
 *apphosttemplateapphostexe.exe;;Template, DO-NOT-SIGN, https://github.com/dotnet/core-setup/pull/7549
+VS.Redist.*;; Non-shipping packages are not signed
+VS.Tools.*;; Non-shipping packages are not signed
+Microsoft.Dotnet.Sdk.Internal.*;; Non-shipping packages are not signed

--- a/eng/SignCheckExclusionsFile.txt
+++ b/eng/SignCheckExclusionsFile.txt
@@ -8,4 +8,3 @@
 *apphosttemplateapphostexe.exe;;Template, DO-NOT-SIGN, https://github.com/dotnet/core-setup/pull/7549
 VS.Redist.*;; Non-shipping packages are not signed
 VS.Tools.*;; Non-shipping packages are not signed
-Microsoft.Dotnet.Sdk.Internal.*;; Non-shipping packages are not signed


### PR DESCRIPTION
The VS.Redist.* and VS.Tools.* nupkgs are excluded from signing in 5.0.xxx, but their contents should be signed. This change adds these files to the sign check exclusions list, while still allowing us to verify the contents. Example output:

```
[File] VS.Tools.Net.Core.SDK.x86.5.0.401-servicing.21431.21.nupkg, Signed: False, Excluded
  [File] eb89bcc3aea344187afd792c5e60a4a5.nupkg, Signed: True, Virtual path: VS.Tools.Net.Core.SDK.x86.5.0.401-servicing.21431.21.nupkg/templates/5.0.9/microsoft.dotnet.common.itemtemplates.5.0.400-preview.21302.2.nupkg, Full Name: templates/5.0.9/microsoft.dotnet.common.itemtemplates.5.0.400-preview.21302.2.nupkg
  [File] 040f6820f3587f307bb08f33b8771cf1.nupkg, Signed: True, Virtual path: VS.Tools.Net.Core.SDK.x86.5.0.401-servicing.21431.21.nupkg/templates/5.0.9/microsoft.dotnet.common.projecttemplates.5.0.5.0.400-preview.21302.2.nupkg, Full Name: templates/5.0.9/microsoft.dotnet.common.projecttemplates.5.0.5.0.400-preview.21302.2.nupkg
  [File] cda406fd702a13238f18b16b6d34f174.nupkg, Signed: True, Virtual path: VS.Tools.Net.Core.SDK.x86.5.0.401-servicing.21431.21.nupkg/templates/5.0.9/microsoft.dotnet.test.projecttemplates.5.0.1.0.2-beta4.21268.1.nupkg, Full Name: templates/5.0.9/microsoft.dotnet.test.projecttemplates.5.0.1.0.2-beta4.21268.1.nupkg
  [File] 9bc88363ed048626d7a9c7a9d5b5e923.nupkg, Signed: True, Virtual path: VS.Tools.Net.Core.SDK.x86.5.0.401-servicing.21431.21.nupkg/templates/5.0.9/microsoft.dotnet.web.itemtemplates.5.0.9.nupkg, Full Name: templates/5.0.9/microsoft.dotnet.web.itemtemplates.5.0.9.nupkg
  [File] 3ca71879e6a5127638a9221a4ee79417.nupkg, Signed: True, Virtual path: VS.Tools.Net.Core.SDK.x86.5.0.401-servicing.21431.21.nupkg/templates/5.0.9/microsoft.dotnet.web.projecttemplates.5.0.5.0.9.nupkg, Full Name: templates/5.0.9/microsoft.dotnet.web.projecttemplates.5.0.5.0.9.nupkg
  [File] 3f19f233eb6b399d54149f03bfee7939.nupkg, Signed: True, Virtual path: VS.Tools.Net.Core.SDK.x86.5.0.401-servicing.21431.21.nupkg/templates/5.0.9/microsoft.dotnet.web.spa.projecttemplates.5.0.5.0.9.nupkg, Full Name: templates/5.0.9/microsoft.dotnet.web.spa.projecttemplates.5.0.5.0.9.nupkg
  [File] 8c16ee1bdd94e8fc42c9bdb2ebbd06e3.nupkg, Signed: True, Virtual path: VS.Tools.Net.Core.SDK.x86.5.0.401-servicing.21431.21.nupkg/templates/5.0.9/microsoft.dotnet.winforms.projecttemplates.5.0.9-servicing.21363.2.nupkg, Full Name: templates/5.0.9/microsoft.dotnet.winforms.projecttemplates.5.0.9-servicing.21363.2.nupkg
  [File] b0d729b3afcc64d8479cfad4b04da975.nupkg, Signed: True, Virtual path: VS.Tools.Net.Core.SDK.x86.5.0.401-servicing.21431.21.nupkg/templates/5.0.9/microsoft.dotnet.wpf.projecttemplates.5.0.9-servicing.21365.4.nupkg, Full Name: templates/5.0.9/microsoft.dotnet.wpf.projecttemplates.5.0.9-servicing.21365.4.nupkg
  [File] b4b2083647d4cb94d165add68f4b61df.nupkg, Signed: True, Virtual path: VS.Tools.Net.Core.SDK.x86.5.0.401-servicing.21431.21.nupkg/templates/5.0.9/nunit3.dotnetnew.template.1.8.1.nupkg, Full Name: templates/5.0.9/nunit3.dotnetnew.template.1.8.1.nupkg
```

- Please add description for changes you are making.
- If there is an issue related to this PR, please add the reference.
