### PR TITLE
[release/3.1.1xx] Hard-code 2.1 versions to 30

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -111,7 +111,7 @@
     <MicrosoftDotNetCommonItemTemplates21PackageVersion>1.0.2-beta3</MicrosoftDotNetCommonItemTemplates21PackageVersion>
     <MicrosoftDotNetCommonProjectTemplates21PackageVersion>$(MicrosoftDotNetCommonItemTemplates21PackageVersion)</MicrosoftDotNetCommonProjectTemplates21PackageVersion>
     <MicrosoftDotNetTestProjectTemplates21PackageVersion>1.0.2-beta4-20181009-2100240</MicrosoftDotNetTestProjectTemplates21PackageVersion>
-    <AspNetCorePackageVersionFor21Templates>2.1.29</AspNetCorePackageVersionFor21Templates>
+    <AspNetCorePackageVersionFor21Templates>2.1.30</AspNetCorePackageVersionFor21Templates>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->
   <PropertyGroup>

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-      <VersionPatch21>$([MSBuild]::Add($(VersionPatch), 11))</VersionPatch21>
+      <VersionPatch21>30</VersionPatch21>
   </PropertyGroup>
 
   <Target Name="GenerateBundledVersions"


### PR DESCRIPTION
Update template version for asp.net, and set `VersionPatch21` to `30` rather than calculating it