### PR TITLE
Update to latest Microsoft.SourceBuild.Intermediate.source-build

### DIFF
--- a/eng/SourceBuild.Version.Details.xml
+++ b/eng/SourceBuild.Version.Details.xml
@@ -99,9 +99,9 @@
       <Sha>6dcc7d005e38829efb6714d2ecfc4c0cb383e7d9</Sha>
       <SourceBuild RepoName="sourcelink" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build" Version="0.1.0-alpha.1.21318.1" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build" Version="0.1.0-alpha.1.21460.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/source-build</Uri>
-      <Sha>3fb25b8db3bec654e37e71a5b2b7fde14444bc2f</Sha>
+      <Sha>ca07d8763334fa66011ed496d444d68355fb9511</Sha>
       <SourceBuild RepoName="source-build" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="6.0.0-alpha.1.21457.1">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -150,9 +150,9 @@
       <Uri>https://github.com/dotnet/emsdk</Uri>
       <Sha>9838ec0843442f761488cfec9cf34612c9f675e6</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build" Version="0.1.0-alpha.1.21318.1" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build" Version="0.1.0-alpha.1.21460.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/source-build</Uri>
-      <Sha>3fb25b8db3bec654e37e71a5b2b7fde14444bc2f</Sha>
+      <Sha>ca07d8763334fa66011ed496d444d68355fb9511</Sha>
       <SourceBuild RepoName="source-build" ManagedOnly="true" />
     </Dependency>
   </ProductDependencies>


### PR DESCRIPTION
This upgrades the version of Newtonsoft used in source-build from 12.0.2 to 13.0.1.

Related to https://github.com/dotnet/source-build/issues/2415