### PR TITLE
Update source-build commit shas

### DIFF
--- a/eng/SourceBuild.Version.Details.xml
+++ b/eng/SourceBuild.Version.Details.xml
@@ -1,11 +1,165 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="VS.Redist.Common.AspNetCore.SharedFramework.x64.6.0" Version="6.0.0-rc.2.21455.6" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.WindowsDesktop.App.Ref" Version="6.0.0-rc.2.21459.9" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Uri>https://github.com/dotnet/windowsdesktop</Uri>
+      <Sha>189cf3a060ffbae53057f3ab4d3be94dfbb61ea8</Sha>
+    </Dependency>
+    <Dependency Name="VS.Redist.Common.WindowsDesktop.SharedFramework.x64.6.0" Version="6.0.0-rc.2.21459.9" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Uri>https://github.com/dotnet/windowsdesktop</Uri>
+      <Sha>189cf3a060ffbae53057f3ab4d3be94dfbb61ea8</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.WindowsDesktop.App.Runtime.win-x64" Version="6.0.0-rc.2.21459.9" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Uri>https://github.com/dotnet/windowsdesktop</Uri>
+      <Sha>189cf3a060ffbae53057f3ab4d3be94dfbb61ea8</Sha>
+    </Dependency>
+    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.6.0" Version="6.0.0-rc.2.21459.6" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>06b23ba6edae9c1eeef4df5e84b33433617c22d1</Sha>
+      <SourceBuild RepoName="runtime" ManagedOnly="true" />
+    </Dependency>
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-rc.2.21459.6" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>06b23ba6edae9c1eeef4df5e84b33433617c22d1</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-rc.2.21459.6" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>06b23ba6edae9c1eeef4df5e84b33433617c22d1</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NETCore.App.Host.win-x64" Version="6.0.0-rc.2.21459.6" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>06b23ba6edae9c1eeef4df5e84b33433617c22d1</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="6.0.0-rc.2.21459.6" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>06b23ba6edae9c1eeef4df5e84b33433617c22d1</Sha>
+    </Dependency>
+    <!-- Change blob version in GenerateLayout.targets if this is unpinned to service targeting pack -->
+    <!-- No new netstandard.library planned for 3.1 timeframe at this time. -->
+    <Dependency Name="NETStandard.Library.Ref" Version="2.1.0" Pinned="true">
+      <Uri>https://github.com/dotnet/core-setup</Uri>
+      <Sha>7d57652f33493fa022125b7f63aad0d70c52d810</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="6.0.0-rc.2.21459.6" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>06b23ba6edae9c1eeef4df5e84b33433617c22d1</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="6.0.0-rc.2.21459.34" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>2f1f0072156f5029efc2bee047843aa82728af5c</Sha>
+      <Sha>e259201568807d84788ae0f6187e84361c18ece1</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="6.0.0-rc.2.21459.34" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>e259201568807d84788ae0f6187e84361c18ece1</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="6.0.0-rc.2.21459.34" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>e259201568807d84788ae0f6187e84361c18ece1</Sha>
+    </Dependency>
+    <Dependency Name="VS.Redist.Common.AspNetCore.SharedFramework.x64.6.0" Version="6.0.0-rc.2.21459.34" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>e259201568807d84788ae0f6187e84361c18ece1</Sha>
       <SourceBuild RepoName="aspnetcore" ManagedOnly="true" />
     </Dependency>
+    <Dependency Name="dotnet-dev-certs" Version="6.0.0-rc.2.21459.34" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>e259201568807d84788ae0f6187e84361c18ece1</Sha>
+    </Dependency>
+    <Dependency Name="dotnet-user-secrets" Version="6.0.0-rc.2.21459.34" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Uri>https://github.com/dotnet/aspnetcore</Uri>
+      <Sha>e259201568807d84788ae0f6187e84361c18ece1</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="1.0.2-beta4.21416.1">
+      <Uri>https://github.com/dotnet/test-templates</Uri>
+      <Sha>baf4b38e4f1dbc637efdb41624acbe05b2ff9f35</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.5.0" Version="1.0.2-beta4.21416.1">
+      <Uri>https://github.com/dotnet/test-templates</Uri>
+      <Sha>baf4b38e4f1dbc637efdb41624acbe05b2ff9f35</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.6.0" Version="1.0.2-beta4.21416.1">
+      <Uri>https://github.com/dotnet/test-templates</Uri>
+      <Sha>baf4b38e4f1dbc637efdb41624acbe05b2ff9f35</Sha>
+      <SourceBuild RepoName="test-templates" ManagedOnly="true" />
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="6.0.100-rc.2.21459.6" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Uri>https://github.com/dotnet/templating</Uri>
+      <Sha>79209eac8a27bcabf5a064a88abb95f32b91d863</Sha>
+      <SourceBuild RepoName="templating" ManagedOnly="true" />
+    </Dependency>
+    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-rc.2.21460.5">
+      <Uri>https://github.com/dotnet/sdk</Uri>
+      <Sha>34151f8401ef08249f6a55f6565eb72895482fdf</Sha>
+      <SourceBuild RepoName="sdk" ManagedOnly="true" />
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.MSBuildSdkResolver" Version="6.0.100-rc.2.21460.5">
+      <Uri>https://github.com/dotnet/sdk</Uri>
+      <Sha>34151f8401ef08249f6a55f6565eb72895482fdf</Sha>
+    </Dependency>
+    <!-- For coherency purposes, these versions should be gated by the versions of winforms and wpf routed via windowsdesktop -->
+    <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="6.0.0-rc.2.21459.9" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/winforms</Uri>
+      <Sha>cd98a8c4d79bef1cb02de7890cd3f7d020ac713c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.Wpf.ProjectTemplates" Version="6.0.0-rc.2.21459.8" CoherentParentDependency="Microsoft.WindowsDesktop.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/wpf</Uri>
+      <Sha>0e9cf5b6c744fc5b02db738dfc66a43fb3f79b77</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.FSharp.Compiler" Version="12.0.0-beta.21457.3" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Uri>https://github.com/dotnet/fsharp</Uri>
+      <Sha>b0a54707064024f8959e54027e9e5d8fe49e82c7</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.fsharp" Version="6.0.0-beta.21457.3" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Uri>https://github.com/dotnet/fsharp</Uri>
+      <Sha>b0a54707064024f8959e54027e9e5d8fe49e82c7</Sha>
+      <SourceBuild RepoName="fsharp" ManagedOnly="true" />
+    </Dependency>
+    <Dependency Name="Microsoft.NET.Test.Sdk" Version="17.0.0-release-20210908-02" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Uri>https://github.com/microsoft/vstest</Uri>
+      <Sha>d6f64b37c2cfee76c8b1269d688384ced30ecd21</Sha>
+      <SourceBuild RepoName="vstest" ManagedOnly="true" />
+    </Dependency>
+    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.100-1.21459.1" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Uri>https://github.com/mono/linker</Uri>
+      <Sha>c8499798a2a09639174e2f5c694d6652794cc73d</Sha>
+      <SourceBuild RepoName="linker" ManagedOnly="true" />
+      <RepoName>linker</RepoName>
+    </Dependency>
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.0.0-5.21457.19" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Uri>https://github.com/dotnet/roslyn</Uri>
+      <Sha>dae39045cd460ba44053ff2af2217da126c25dbf</Sha>
+      <SourceBuild RepoName="roslyn" ManagedOnly="true" />
+    </Dependency>
+    <Dependency Name="Microsoft.Build" Version="17.0.0-preview-21459-02" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Uri>https://github.com/dotnet/msbuild</Uri>
+      <Sha>a9594b978ca1157af28ffffa79b9ce1ad39c5874</Sha>
+      <SourceBuild RepoName="msbuild" ManagedOnly="true" />
+    </Dependency>
+    <Dependency Name="NuGet.Build.Tasks" Version="6.0.0-preview.4.243" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Uri>https://github.com/nuget/nuget.client</Uri>
+      <Sha>f82431ecc38a28f396d527446834c7de679a6722</Sha>
+      <SourceBuild RepoName="nuget-client" ManagedOnly="true" />
+    </Dependency>
+    <Dependency Name="Microsoft.ApplicationInsights" Version="2.0.0">
+      <Uri>https://github.com/Microsoft/ApplicationInsights-dotnet</Uri>
+      <Sha>53b80940842204f78708a538628288ff5d741a1d</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Web.Xdt" Version="5.0.0-preview.21401.1">
+      <Uri>https://github.com/dotnet/xdt</Uri>
+      <Sha>37469b9f38e7a56be04621f77b12a51ef49c1074</Sha>
+      <SourceBuild RepoName="xdt" ManagedOnly="true" />
+    </Dependency>
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-6.0.100" Version="6.0.0-rc.2.21451.1" CoherentParentDependency="VS.Redist.Common.NetCore.SharedFramework.x64.6.0">
+      <Uri>https://github.com/dotnet/emsdk</Uri>
+      <Sha>9838ec0843442f761488cfec9cf34612c9f675e6</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build" Version="0.1.0-alpha.1.21460.1" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Uri>https://github.com/dotnet/source-build</Uri>
+      <Sha>ca07d8763334fa66011ed496d444d68355fb9511</Sha>
+      <SourceBuild RepoName="source-build" ManagedOnly="true" />
+    </Dependency>
+
+    <!-- Dependencies missing from installers Version.Details.xml graph which are explicitly added for source-build. -->
     <Dependency Name="Microsoft.DotNet.Cli.CommandLine" Version="1.0.0-preview.21310.2">
       <Uri>https://github.com/dotnet/clicommandlineparser</Uri>
       <Sha>3198bf5660cad3dab85f5475bf1fda9688146e3f</Sha>
@@ -21,71 +175,15 @@
       <Sha>e0189ea53737fbb0cc110dab56c260ef2a6f5b74</Sha>
       <SourceBuild RepoName="diagnostics" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.fsharp" Version="6.0.0-beta.21456.1" CoherentParentDependency="Microsoft.NET.Sdk">
-      <Uri>https://github.com/dotnet/fsharp</Uri>
-      <Sha>29a1afe4e1c61e92cfaf63a8bfa56c464a83efc4</Sha>
-      <SourceBuild RepoName="fsharp" ManagedOnly="true" />
-    </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="6.0.100-preview.6.21452.4" CoherentParentDependency="Microsoft.NET.Sdk">
-      <Uri>https://github.com/mono/linker</Uri>
-      <Sha>8a5c446a84922bddccfcfc6d3cb5c117dc3babd4</Sha>
-      <SourceBuild RepoName="linker" ManagedOnly="true" />
-      <RepoName>linker</RepoName>
-    </Dependency>
-    <Dependency Name="Microsoft.Build" Version="17.0.0-preview-21453-03" CoherentParentDependency="Microsoft.NET.Sdk">
-      <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>74e9935a4a2e0108343533b3445516ad111e87ea</Sha>
-      <SourceBuild RepoName="msbuild" ManagedOnly="true" />
-    </Dependency>
-    <Dependency Name="NuGet.Build.Tasks" Version="6.0.0-preview.4.230" CoherentParentDependency="Microsoft.NET.Sdk">
-      <Uri>https://github.com/nuget/nuget.client</Uri>
-      <Sha>fcb4b9a7fb52777ed3e740cda029f78813a988d9</Sha>
-      <SourceBuild RepoName="nuget-client" ManagedOnly="true" />
-    </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.0.0-5.21453.15" CoherentParentDependency="Microsoft.NET.Sdk">
-      <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>2bbf85baa30a90f9d491699734e814050356da32</Sha>
-      <SourceBuild RepoName="roslyn" ManagedOnly="true" />
-    </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0-rc2.21452.5">
-      <Uri>https://github.com/dotnet/roslyn-analyzers</Uri>
-      <Sha>4c168e06ba2e4ba872a00f4d94acbb2090bd00b7</Sha>
-      <SourceBuild RepoName="roslyn-analyzers" ManagedOnly="true" />
-    </Dependency>
-    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.6.0" Version="6.0.0-rc.2.21457.6" CoherentParentDependency="Microsoft.NET.Sdk">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>c300b096419523024f2b807ec9db3c2d91df0298</Sha>
-      <SourceBuild RepoName="runtime" ManagedOnly="true" />
-    </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="6.0.100-rc.2.21457.13">
-      <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>53638077fcb5b1a49246489c28b338a0fee104c7</Sha>
-      <SourceBuild RepoName="sdk" ManagedOnly="true" />
-    </Dependency>
     <Dependency Name="Microsoft.DiaSymReader" Version="1.4.0-beta2-21410-02">
       <Uri>https://github.com/dotnet/symreader</Uri>
       <Sha>dd6b71744be8cdbfd69117e96f5b9e64a7b38b6e</Sha>
       <SourceBuild RepoName="symreader" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="6.0.100-rc.2.21456.2" CoherentParentDependency="Microsoft.NET.Sdk">
-      <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>b9bde7c2d1dc5eeb7f40d9bae864ebc3b0c3ed35</Sha>
-      <SourceBuild RepoName="templating" ManagedOnly="true" />
-    </Dependency>
-    <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.6.0" Version="1.0.2-beta4.21416.1">
-      <Uri>https://github.com/dotnet/test-templates</Uri>
-      <Sha>baf4b38e4f1dbc637efdb41624acbe05b2ff9f35</Sha>
-      <SourceBuild RepoName="test-templates" ManagedOnly="true" />
-    </Dependency>
-    <Dependency Name="Microsoft.Web.Xdt" Version="5.0.0-preview.21401.1">
-      <Uri>https://github.com/dotnet/xdt</Uri>
-      <Sha>37469b9f38e7a56be04621f77b12a51ef49c1074</Sha>
-      <SourceBuild RepoName="xdt" ManagedOnly="true" />
-    </Dependency>
-    <Dependency Name="Microsoft.NET.Test.Sdk" Version="17.0.0-preview-20210817-02" CoherentParentDependency="Microsoft.NET.Sdk">
-      <Uri>https://github.com/microsoft/vstest</Uri>
-      <Sha>e79909063ddfc9d8fd4959e072b2dcf5e8d9d3c1</Sha>
-      <SourceBuild RepoName="vstest" ManagedOnly="true" />
+    <Dependency Name="Microsoft.Deployment.DotNet.Releases" Version="1.0.245102" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Uri>https://github.com/dotnet/deployment-tools</Uri>
+      <Sha>01f1b60fc5405dbb5579fa9b01702e29b0ed4ddf</Sha>
+      <SourceBuild RepoName="deployment-tools" ManagedOnly="true" />
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
@@ -94,30 +192,29 @@
       <Sha>474307e526160c813c9fd58060eb8356ccca6099</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.CMake.Sdk" Version="6.0.0-beta.21427.6">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>474307e526160c813c9fd58060eb8356ccca6099</Sha>
+      <SourceBuild RepoName="arcade" ManagedOnly="true" />
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="6.0.0-beta.21427.6">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>474307e526160c813c9fd58060eb8356ccca6099</Sha>
+    </Dependency>
+    <Dependency Name="Private.SourceBuild.ReferencePackages" Version="6.0.0-alpha.1.21459.1">
+      <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
+      <Sha>2c258045e880397264adf5e954fa9c8f5d74b101</Sha>
+      <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
+    </Dependency>
     <Dependency Name="Microsoft.SourceLink.GitHub" Version="1.1.0-beta-21423-02" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
       <Uri>https://github.com/dotnet/sourcelink</Uri>
       <Sha>6dcc7d005e38829efb6714d2ecfc4c0cb383e7d9</Sha>
       <SourceBuild RepoName="sourcelink" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build" Version="0.1.0-alpha.1.21460.1" CoherentParentDependency="Microsoft.NET.Sdk">
-      <Uri>https://github.com/dotnet/source-build</Uri>
-      <Sha>ca07d8763334fa66011ed496d444d68355fb9511</Sha>
-      <SourceBuild RepoName="source-build" ManagedOnly="true" />
-    </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="6.0.0-alpha.1.21457.1">
-      <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>203ced7252f5104d13b83bf446a6c6dea827b673</Sha>
-      <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
-    </Dependency>
     <Dependency Name="Microsoft.DotNet.XliffTasks" Version="1.0.0-beta.21426.1" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
       <Uri>https://github.com/dotnet/xliff-tasks</Uri>
       <Sha>22d8cfd8807ba8e4f2e32eeb9f207010ca5e6f6d</Sha>
       <SourceBuild RepoName="xliff-tasks" ManagedOnly="true" />
-    </Dependency>
-    <Dependency Name="Microsoft.Deployment.DotNet.Releases" Version="1.0.0-preview1.1.21112.1" CoherentParentDependency="Microsoft.NET.Sdk">
-      <Uri>https://github.com/dotnet/deployment-tools</Uri>
-      <Sha>74f718b714755057d2a146e195afd259b45fa48d</Sha>
-      <SourceBuild RepoName="deployment-tools" ManagedOnly="true" />
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/SourceBuild.Version.Details.xml
+++ b/eng/SourceBuild.Version.Details.xml
@@ -99,9 +99,9 @@
       <Sha>6dcc7d005e38829efb6714d2ecfc4c0cb383e7d9</Sha>
       <SourceBuild RepoName="sourcelink" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build" Version="0.1.0-alpha.1.21318.1" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build" Version="0.1.0-alpha.1.21460.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/source-build</Uri>
-      <Sha>3fb25b8db3bec654e37e71a5b2b7fde14444bc2f</Sha>
+      <Sha>ca07d8763334fa66011ed496d444d68355fb9511</Sha>
       <SourceBuild RepoName="source-build" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="6.0.0-alpha.1.21457.1">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -150,9 +150,9 @@
       <Uri>https://github.com/dotnet/emsdk</Uri>
       <Sha>9838ec0843442f761488cfec9cf34612c9f675e6</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build" Version="0.1.0-alpha.1.21318.1" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build" Version="0.1.0-alpha.1.21460.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/source-build</Uri>
-      <Sha>3fb25b8db3bec654e37e71a5b2b7fde14444bc2f</Sha>
+      <Sha>ca07d8763334fa66011ed496d444d68355fb9511</Sha>
       <SourceBuild RepoName="source-build" ManagedOnly="true" />
     </Dependency>
   </ProductDependencies>

--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-create-tarball.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-create-tarball.yml
@@ -52,7 +52,7 @@ jobs:
     # This prevents allocation of additional agents if the tarball build legs should be skipped.
     # Only build the tarball if the PR touches source-build source.
     - script: |
-        if curl "https://api.github.com/repos/dotnet/installer/pulls/$(System.PullRequest.PullRequestNumber)/files" | grep '"filename": "src/SourceBuild/*'
+        if curl "https://api.github.com/repos/dotnet/installer/pulls/$(System.PullRequest.PullRequestNumber)/files" | grep '"filename": "src/SourceBuild/*\|"filename": "eng/SourceBuild.Version.Details.xml"'
         then
           echo "##vso[task.setvariable variable=_includeTarballBuild;isoutput=true]true"
         fi


### PR DESCRIPTION
This PR updates the source-build commit shas to latest.  As stated in https://github.com/dotnet/source-build/issues/2399, I am now copying the installer's Version.Details.xml verbatim and then making a few custom edits for the missing graph pieces as stated in https://github.com/dotnet/source-build/issues/2431.

This PR is based on the changes made in https://github.com/dotnet/installer/pull/11965
