### PR TITLE
Exclude externals project in vstest when building from source

### DIFF
--- a/src/SourceBuild/tarball/content/patches/vstest/0002-Exclude-externals-when-building-from-source.patch
+++ b/src/SourceBuild/tarball/content/patches/vstest/0002-Exclude-externals-when-building-from-source.patch
@@ -1,0 +1,25 @@
+From 9cf491ea8b913b0ec615778e5597584e675f4205 Mon Sep 17 00:00:00 2001
+From: dseefeld <dseefeld@microsoft.com>
+Date: Mon, 13 Sep 2021 21:01:44 +0000
+Subject: [PATCH] Exclude externals when building from source
+
+---
+ src/package/external/external.csproj | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/package/external/external.csproj b/src/package/external/external.csproj
+index 036f92ce..9b0e87ad 100644
+--- a/src/package/external/external.csproj
++++ b/src/package/external/external.csproj
+@@ -29,7 +29,7 @@
+     <Reference Include="Microsoft.CSharp" />
+   </ItemGroup>
+ 
+-  <ItemGroup>
++  <ItemGroup  Condition=" '$(DotNetBuildFromSource)' != 'true' ">
+     <!-- This csproj restore external tools required for build process -->
+     <PackageReference Include="NuGet.CommandLine" Version="5.8.1" PrivateAssets="All" />
+     <PackageReference Include="fmdev.xlftool" Version="0.1.3" PrivateAssets="All" />
+-- 
+2.31.1
+


### PR DESCRIPTION

Related to https://github.com/dotnet/source-build/issues/2427