### PR TITLE
[release/6.0] x64 on ARM64 fixes

### DIFF
--- a/src/redist/targets/packaging/windows/clisdk/bundle.wxs
+++ b/src/redist/targets/packaging/windows/clisdk/bundle.wxs
@@ -11,11 +11,16 @@
           Compressed="yes">
 
     <bal:Condition Message="The installation path for x64 SDK installations: &quot;[DOTNETHOME_X64]&quot; cannot be the same as for x86 SDK installations: &quot;[DOTNETHOME_X86]&quot;">
-        WixBundleInstalled OR ((NOT (DOTNETHOME_X64 ~= DOTNETHOME_X86)) OR DOTNETHOMESIMILARITYCHECKOVERRIDE)
+        WixBundleInstalled OR (NOT DOTNETHOME_X64 ~= DOTNETHOME_X86) OR DOTNETHOMESIMILARITYCHECKOVERRIDE
     </bal:Condition>
 
     <bal:Condition Message="The installation path for ARM64 SDK installations: &quot;[DOTNETHOME_ARM64]&quot; cannot be the same as for x86 SDK installations: &quot;[DOTNETHOME_X86]&quot;">
-        WixBundleInstalled OR ((NOT (DOTNETHOME_ARM64 ~= DOTNETHOME_X86)) OR DOTNETHOMESIMILARITYCHECKOVERRIDE)
+        WixBundleInstalled OR (NOT DOTNETHOME_ARM64 ~= DOTNETHOME_X86) OR DOTNETHOMESIMILARITYCHECKOVERRIDE
+    </bal:Condition>
+
+    <!-- Permit same path on non-ARM64 machines since past SDKs always wrote this value -->
+    <bal:Condition Message="The installation path for ARM64 SDK installations: &quot;[DOTNETHOME_ARM64]&quot; cannot be the same as for x64 SDK installations: &quot;[DOTNETHOME_X64]&quot;">
+        WixBundleInstalled OR (NOT DOTNETHOME_ARM64 ~= DOTNETHOME_X64) OR (NOT NativeProcessorArchitecture=&quot;ARM64&quot;) OR DOTNETHOMESIMILARITYCHECKOVERRIDE
     </bal:Condition>
 
     <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.Foundation">
@@ -27,7 +32,7 @@
       <PayloadGroupRef Id="DotnetCoreBAPayloads" />
     </BootstrapperApplicationRef>
 
-    <swid:Tag Regid="microsoft.com" InstallPath="[DOTNETHOME]" />
+    <swid:Tag Regid="microsoft.com" InstallPath="[$(var.Program_Files)]dotnet" />
 
     <util:RegistrySearch Id="CheckDotnetInstallLocation_x86"
               Variable="DotnetInstallLocationExists_x86"
@@ -56,7 +61,7 @@
               Variable="DOTNETHOME_X86"
               Path="[ProgramFilesFolder]dotnet"/>
 
-    <?if $(var.Platform)=x64?>
+    <?if $(var.Platform)!=x86?>
     <util:RegistrySearch Id="CheckDotnetInstallLocation_x64"
               Variable="DotnetInstallLocationExists_x64"
               Result="exists"
@@ -71,11 +76,21 @@
               Root="HKLM"
               Key="SOFTWARE\dotnet\Setup\InstalledVersions\x64"
               Value="InstallLocation" />
-
-    <util:FileSearch Id="DotnetExeSearch_x64"
+    
+    <!-- Determine native OS architecture -->
+    <util:RegistrySearch Id="CheckProcessorArchitecture_x64"
               After="DotnetInstallLocation_x64"
+              Variable="NativeProcessorArchitecture"
+              Result="value"
+              Root="HKLM"
+              Key="SYSTEM\CurrentControlSet\Control\Session Manager\Environment"
+              Value="PROCESSOR_ARCHITECTURE" />
+
+    <!-- Check default location when on x64 OS-->
+    <util:FileSearch Id="DotnetExeSearch_x64"
+              After="CheckProcessorArchitecture_x64"
               Variable="DotnetExeExists_x64"
-              Condition="NOT DotnetInstallLocationExists_x64"
+              Condition="NOT DotnetInstallLocationExists_x64 AND NativeProcessorArchitecture=&quot;AMD64&quot;"
               Result="exists"
               Path="[ProgramFiles64Folder]dotnet\dotnet.exe"/>
     <util:DirectorySearch Id="DotnetExeLocation_x64"
@@ -84,7 +99,20 @@
               Variable="DOTNETHOME_X64"
               Path="[ProgramFiles64Folder]dotnet"/>
 
-    <?elseif $(var.Platform)=arm64?>
+    <!-- Check alternate location on non-x64 OS -->
+    <util:FileSearch Id="DotnetExeSearch_alt_x64"
+              After="CheckProcessorArchitecture_x64"
+              Variable="DotnetExeExists_alt_x64"
+              Condition="NOT DotnetInstallLocationExists_x64 AND NOT NativeProcessorArchitecture=&quot;AMD64&quot;"
+              Result="exists"
+              Path="[ProgramFiles64Folder]dotnet\x64\dotnet.exe"/>
+    <util:DirectorySearch Id="DotnetExeLocation_alt_x64"
+              After="DotnetExeSearch_alt_x64"
+              Condition="DotnetExeExists_alt_x64"
+              Variable="DOTNETHOME_X64"
+              Path="[ProgramFiles64Folder]dotnet\x64"/>
+    <?endif?>
+    <?if $(var.Platform)=arm64?>
     <util:RegistrySearch Id="CheckDotnetInstallLocation_arm64"
               Variable="DotnetInstallLocationExists_arm64"
               Result="exists"
@@ -121,9 +149,9 @@
         Example:
             dotnet-sdk-3.0.100-alpha1-009719-win-x64.exe /install DOTNETHOME_X64="D:\dotnet\x64" DOTNETHOME_X86="D:\dotnet\x86" /log "installation.log" /quiet /norestart
     -->
-    <Variable Name="DOTNETHOME_X86" Type="string" Value="[ProgramFilesFolder]dotnet" bal:Overridable="yes" />
-    <Variable Name="DOTNETHOME_X64" Type="string" Value="[ProgramFiles64Folder]dotnet" bal:Overridable="yes" />
-    <Variable Name="DOTNETHOME_ARM64" Type="string" Value="[ProgramFiles64Folder]dotnet" bal:Overridable="yes" />
+    <Variable Name="DOTNETHOME_X86" bal:Overridable="yes" />
+    <Variable Name="DOTNETHOME_X64" bal:Overridable="yes" />
+    <Variable Name="DOTNETHOME_ARM64" bal:Overridable="yes" />
     <Variable Name="DOTNETHOME" Type="string" Value="[DOTNETHOME_$(var.PlatformToken)]" bal:Overridable="no" />
     <Variable Name="BUNDLEMONIKER" Type="string" Value="$(var.ProductMoniker)" bal:Overridable="no" />
     <Variable Name="DOTNETSDKVERSION" Type="string" Value="$(var.NugetVersion)" bal:Overridable="no" />

--- a/src/redist/targets/packaging/windows/clisdk/dotnet.wxs
+++ b/src/redist/targets/packaging/windows/clisdk/dotnet.wxs
@@ -30,12 +30,6 @@
     <Property Id="NUGETVERSION" Value="$(var.NugetVersion)" />
     <WixVariable Id="WixUILicenseRtf" Value="$(var.MicrosoftEula)" />
 
-    <Property Id="DOTNETEXE">
-      <DirectorySearch Id="DOTNETPATH" Path="[#DOTNETHOME]">
-        <FileSearch Id="DOTNETEXESEARCH" Name="dotnet.exe" />
-      </DirectorySearch>
-    </Property>
-
     <CustomActionRef Id="WixBroadcastEnvironmentChange" />
 
     <CustomAction Id="PropertyAssignPrimeCacheAndTelemetry"
@@ -68,6 +62,10 @@
         </Directory>
       </Directory>
     </Directory>
+    
+    <?if $(var.Platform)~=x64?>
+    <CustomActionRef Id="Set_DOTNETHOME_NON_NATIVE_ARCHITECTURE" />
+    <?endif?>
   </Fragment>
   <Fragment>
     <ComponentGroup Id="DotnetToolSetup">

--- a/src/redist/targets/packaging/windows/clisdk/dotnethome_x64.wxs
+++ b/src/redist/targets/packaging/windows/clisdk/dotnethome_x64.wxs
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <?ifndef Platform?>
+    <?define Platform = "$(sys.BUILDARCH)"?>
+  <?endif?>
+
+  <!-- InstallerArchitecture matches the expected values for PROCESSOR_ARCHITECTURE 
+       https://docs.microsoft.com/en-us/windows/win32/winprog64/wow64-implementation-details  -->
+  <?if $(var.Platform)~=x86?>
+    <?define InstallerArchitecture="X86"?>
+  <?elseif $(var.Platform)~=x64?>
+    <?define InstallerArchitecture="AMD64"?>
+  <?elseif $(var.Platform)~=arm64?>
+    <?define InstallerArchitecture="ARM64"?>
+  <?else?>
+    <?error Unknown platform, $(var.Platform) ?>?
+  <?endif?>
+
+  <Fragment>
+    <!-- Identify when installing in emulation as when PROCESSOR_ARCHITECTURE does not match the installer architecture
+          https://docs.microsoft.com/en-us/windows/win32/winprog64/wow64-implementation-details -->
+    <SetProperty Action="Set_NON_NATIVE_ARCHITECTURE" Id="NON_NATIVE_ARCHITECTURE" Value="true" Before="CostFinalize">
+      NOT %PROCESSOR_ARCHITECTURE="$(var.InstallerArchitecture)"
+    </SetProperty>
+  </Fragment>
+
+  <?if $(var.Platform)~=x64?>
+  <Fragment>
+    <!-- When running in a non-native architecture and user hasn't specified install directory,
+         install to an x64 subdirectory.
+         This is only define for x64, since x86 has redirection and no other native architecture can install ARM64 today -->
+    <SetProperty Action="Set_DOTNETHOME_NON_NATIVE_ARCHITECTURE" Id="DOTNETHOME" Value="[ProgramFiles64Folder]dotnet\x64\" After="Set_NON_NATIVE_ARCHITECTURE">
+      NON_NATIVE_ARCHITECTURE AND NOT DOTNETHOME
+    </SetProperty>
+  </Fragment>
+  <?endif?>
+</Wix>

--- a/src/redist/targets/packaging/windows/clisdk/generatemanifestsmsi.ps1
+++ b/src/redist/targets/packaging/windows/clisdk/generatemanifestsmsi.ps1
@@ -65,6 +65,7 @@ function RunCandle
         -ext WixDependencyExtension.dll `
         "$PSScriptRoot\manifests.wxs" `
         "$PSScriptRoot\provider.wxs" `
+        "$PSScriptRoot\dotnethome_x64.wxs" `
         $InstallFileswsx
 
     Write-Information "Candle output: $candleOutput"
@@ -91,6 +92,7 @@ function RunLight
         -cultures:en-us `
         manifests.wixobj `
         provider.wixobj `
+        dotnethome_x64.wixobj `
         $InstallFilesWixobj `
         -b "$inputDir" `
         -b "$PSScriptRoot" `

--- a/src/redist/targets/packaging/windows/clisdk/generatemsi.ps1
+++ b/src/redist/targets/packaging/windows/clisdk/generatemsi.ps1
@@ -73,6 +73,7 @@ function RunCandle
         -arch "$Architecture" `
         -ext WixDependencyExtension.dll `
         "$PSScriptRoot\dotnet.wxs" `
+        "$PSScriptRoot\dotnethome_x64.wxs" `
         "$PSScriptRoot\provider.wxs" `
         "$PSScriptRoot\registrykeys.wxs" `
         $InstallFileswsx
@@ -100,6 +101,7 @@ function RunLight
     $lightOutput = .\light.exe -nologo -ext WixUIExtension -ext WixDependencyExtension -ext WixUtilExtension `
         -cultures:en-us `
         dotnet.wixobj `
+        dotnethome_x64.wixobj `
         provider.wixobj `
         registrykeys.wixobj `
         $InstallFilesWixobj `

--- a/src/redist/targets/packaging/windows/clisdk/generatetemplatesmsi.ps1
+++ b/src/redist/targets/packaging/windows/clisdk/generatetemplatesmsi.ps1
@@ -63,6 +63,7 @@ function RunCandle
         -dDependencyKeyName="$DependencyKeyName" `
         -arch "$Architecture" `
         -ext WixDependencyExtension.dll `
+        "$PSScriptRoot\dotnethome_x64.wxs" `
         "$PSScriptRoot\templates.wxs" `
         "$PSScriptRoot\provider.wxs" `
         $InstallFileswsx
@@ -89,6 +90,7 @@ function RunLight
 
     $lightOutput = .\light.exe -nologo -ext WixUIExtension -ext WixDependencyExtension -ext WixUtilExtension `
         -cultures:en-us `
+        dotnethome_x64.wixobj `
         templates.wixobj `
         provider.wixobj `
         $InstallFilesWixobj `

--- a/src/redist/targets/packaging/windows/clisdk/manifests.wxs
+++ b/src/redist/targets/packaging/windows/clisdk/manifests.wxs
@@ -32,5 +32,9 @@
         <Directory Id="DOTNETHOME" Name="dotnet"/>
       </Directory>
     </Directory>
+    
+    <?if $(var.Platform)~=x64?>
+    <CustomActionRef Id="Set_DOTNETHOME_NON_NATIVE_ARCHITECTURE" />
+    <?endif?>
   </Fragment>
 </Wix>

--- a/src/redist/targets/packaging/windows/clisdk/registrykeys.wxs
+++ b/src/redist/targets/packaging/windows/clisdk/registrykeys.wxs
@@ -34,5 +34,47 @@
         </RegistryKey>
       </Component>
     </ComponentGroup>
+
+    <!-- Set values for DOTNETHOME if not passed in.  
+         These searches prefer the existing registry key and fallback to probing the default location if registry key isn't present -->
+    <Property Id="DOTNETHOME_X86_SEARCH">
+      <DirectorySearch Id="dirDOTNETHOME_X86_search" Path="[ProgramFilesFolder]dotnet" AssignToProperty="yes">
+        <FileSearch Id="fileDOTNETHOME_X86_search" Name="dotnet.exe" />
+      </DirectorySearch>
+      <RegistrySearch Id="regDOTNETHOME_X86_search" Root="HKLM"  Key="SOFTWARE\dotnet\Setup\InstalledVersions\x86" Name="InstallLocation" Win64="no" Type="raw" />
+    </Property>
+    <Property Id="DOTNETHOME_X64_SEARCH">
+      <DirectorySearch Id="dirDOTNETHOME_X64_search" Path="[ProgramFiles64Folder]dotnet" AssignToProperty="yes">
+        <FileSearch Id="fileDOTNETHOME_X64_search" Name="dotnet.exe" />
+      </DirectorySearch>
+      <RegistrySearch Id="regDOTNETHOME_X64_search" Root="HKLM"  Key="SOFTWARE\dotnet\Setup\InstalledVersions\x64" Name="InstallLocation" Win64="no" Type="raw" />
+    </Property>
+    <Property Id="DOTNETHOME_X64_ALT_SEARCH">
+      <DirectorySearch Id="dirDOTNETHOME_X64_ALT_search" Path="[ProgramFiles64Folder]dotnet\x64" AssignToProperty="yes">
+        <FileSearch Id="fileDOTNETHOME_X64_ALT_search" Name="dotnet.exe" />
+      </DirectorySearch>
+      <RegistrySearch Id="regDOTNETHOME_X64_ALT_search" Root="HKLM"  Key="SOFTWARE\dotnet\Setup\InstalledVersions\x64" Name="InstallLocation" Win64="no" Type="raw" />
+    </Property>
+    <Property Id="DOTNETHOME_ARM64_SEARCH">
+      <DirectorySearch Id="dirDOTNETHOME_ARM64_search" Path="[ProgramFiles64Folder]dotnet" AssignToProperty="yes">
+        <FileSearch Id="fileDOTNETHOME_ARM64_search" Name="dotnet.exe" />
+      </DirectorySearch>
+      <RegistrySearch Id="regDOTNETHOME_ARM64_search" Root="HKLM"  Key="SOFTWARE\dotnet\Setup\InstalledVersions\arm64" Name="InstallLocation" Win64="no" Type="raw" />
+    </Property>
+
+    <!-- Set the DOTNETHOME property if not passed in and we found a path -->
+    <SetProperty Id="DOTNETHOME_X86" Value="[DOTNETHOME_X86_SEARCH]" Before="CostFinalize">
+      NOT DOTNETHOME_X86 AND DOTNETHOME_X86_SEARCH
+    </SetProperty>
+    <SetProperty Id="DOTNETHOME_X64" Value="[DOTNETHOME_X64_SEARCH]" Before="CostFinalize">
+      NOT DOTNETHOME_X64 AND DOTNETHOME_X64_SEARCH AND %PROCESSOR_ARCHITECTURE="AMD64"
+    </SetProperty>
+    <SetProperty Action="Set_DOTNETHOME_X64_alt" Id="DOTNETHOME_X64" Value="[DOTNETHOME_X64_ALT_SEARCH]" Before="CostFinalize">
+      NOT DOTNETHOME_X64 AND DOTNETHOME_X64_ALT_SEARCH AND NOT %PROCESSOR_ARCHITECTURE="AMD64"
+    </SetProperty>
+    <SetProperty Id="DOTNETHOME_ARM64" Value="[DOTNETHOME_ARM64_SEARCH]" Before="CostFinalize">
+      NOT DOTNETHOME_ARM64 AND DOTNETHOME_ARM64_SEARCH
+    </SetProperty>
+
   </Fragment>
 </Wix>

--- a/src/redist/targets/packaging/windows/clisdk/templates.wxs
+++ b/src/redist/targets/packaging/windows/clisdk/templates.wxs
@@ -32,5 +32,9 @@
         <Directory Id="DOTNETHOME" Name="dotnet"/>
       </Directory>
     </Directory>
+    
+    <?if $(var.Platform)~=x64?>
+    <CustomActionRef Id="Set_DOTNETHOME_NON_NATIVE_ARCHITECTURE" />
+    <?endif?>
   </Fragment>
 </Wix>


### PR DESCRIPTION
Retarget DOTNETHOME when installing x64 on ARM64

**Customer Impact**
Customers want to install our x64 product on arm64 machines in order to run x64 targeted applications.

**Testing**
We have tested the Windows - runtime consumption of these in main and confirmed it produces installers which behave as we expect. We have tested the changes in isolation as well. It is difficult to test the full end-to-end due to 7.0 not having coherent builds and these changes spanning many repos to realize full end-to-end.

**Risk**
Low - as designed these changes should not impact existing working scenarios. The risk here is that we have a bug that accidentally impacts those scenarios. We've tried to mitigate that through testing consumption in main. We'll also mitigate by testing bits out of RC2 branches as soon as these changes flow.