### PR TITLE
[release/6.0.1xx-rc2] Migrate to 1ES hosted pools

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -54,11 +54,11 @@ stages:
       agentOs: Windows_NT
       pool:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: NetCorePublic-Pool
-          queue: buildpool.windows.10.amd64.vs2019.open
+          name: NetCore1ESPool-Svc-Public
+          demands: ImageOverride -equals build.windows.10.amd64.vs2019.open
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: NetCoreInternal-Pool
-          queue: buildpool.windows.10.amd64.vs2019
+          demands: ImageOverride -equals build.windows.10.amd64.vs2019
       timeoutInMinutes: 180
       strategy:
         matrix:
@@ -111,11 +111,11 @@ stages:
       agentOs: Windows_NT
       pool:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: NetCorePublic-Pool
-          queue: buildpool.windows.10.amd64.vs2019.open
+          name: NetCore1ESPool-Svc-Public
+          demands: ImageOverride -equals build.windows.10.amd64.vs2019.open
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: NetCoreInternal-Pool
-          queue: buildpool.windows.10.amd64.vs2019
+          name: NetCore1ESPool-Svc-Internal
+          demands: ImageOverride -equals build.windows.10.amd64.vs2019
       timeoutInMinutes: 180
       strategy:
         matrix:
@@ -140,11 +140,11 @@ stages:
       agentOs: Linux
       pool:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: NetCorePublic-Pool
-          queue: BuildPool.Ubuntu.1604.Amd64.Open
+          name: NetCore1ESPool-Svc-Public
+          demands: ImageOverride -equals Build.Ubuntu.1604.Amd64.Open
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: NetCoreInternal-Pool
-          queue: BuildPool.Ubuntu.1604.Amd64
+          name: NetCore1ESPool-Svc-Internal
+          demands: ImageOverride -equals Build.Ubuntu.1604.Amd64
       timeoutInMinutes: 180
       strategy:
         matrix:
@@ -312,11 +312,11 @@ stages:
       agentOs: Linux
       pool:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: NetCorePublic-Pool
-          queue: BuildPool.Ubuntu.1604.Amd64.Open
+          name: NetCore1ESPool-Svc-Public
+          demands: ImageOverride -equals Build.Ubuntu.1604.Amd64.Open
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: NetCoreInternal-Pool
-          queue: BuildPool.Ubuntu.1604.Amd64
+          name: NetCore1ESPool-Svc-Internal
+          demands: ImageOverride -equals Build.Ubuntu.1604.Amd64
       timeoutInMinutes: 180
       strategy:
         matrix:

--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-create-tarball.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-create-tarball.yml
@@ -6,11 +6,11 @@ jobs:
   displayName: Source-Build Create Tarball
   pool:
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
-      name: NetCorePublic-Pool
-      queue: BuildPool.Ubuntu.1604.Amd64.Open
+      name: NetCore1ESPool-Svc-Public
+      demands: ImageOverride -equals Build.Ubuntu.1604.Amd64.Open
     ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-      name: NetCoreInternal-Pool
-      queue: BuildPool.Ubuntu.1604.Amd64
+      name: NetCore1ESPool-Svc-Internal
+      demands: ImageOverride -equals Build.Ubuntu.1604.Amd64
   variables:
     _BuildConfig: Release
   workspace:

--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build.yml
@@ -17,11 +17,11 @@ jobs:
   dependsOn: ${{ parameters.dependsOn }}
   pool:
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
-      name: NetCorePublic-Pool
-      queue: BuildPool.Ubuntu.1604.Amd64.Open
+      name: NetCore1ESPool-Svc-Public
+      demands: ImageOverride -equals Build.Ubuntu.1604.Amd64.Open
     ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-      name: NetCoreInternal-Pool
-      queue: BuildPool.Ubuntu.1604.Amd64
+      name: NetCore1ESPool-Svc-Internal
+      demands: ImageOverride -equals Build.Ubuntu.1604.Amd64
   strategy:
     matrix:
       Fedora33-Online:


### PR DESCRIPTION
We need to migrate pools to 1ES hosted pools. Only the yamls have to be changed. The supported functionality stays the same.

Tracking issue: https://github.com/dotnet/core-eng/issues/14276