### PR TITLE
Update .vsts-ci.yml

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -70,12 +70,6 @@ stages:
               _DOTNET_CLI_UI_LANGUAGE: ''
               _AdditionalBuildParameters: ''
               _TestArg: $(_WindowsTestArg)
-            Build_ES_Debug_x64:
-              _BuildConfig: Debug
-              _BuildArchitecture: x64
-              _DOTNET_CLI_UI_LANGUAGE: es
-              _AdditionalBuildParameters: ''
-              _TestArg: $(_WindowsTestArg)
           # Internal-only builds
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
             Build_Release_x86:


### PR DESCRIPTION
There are a bunch of tests that don't work with the new localization handback and we'd have to put a lot of effort into fixing those. Since the ES leg hasn't found a real issue before, removing it to safe resources.
