### PR TITLE
Change BuildInParallel to solve race condition

### DIFF
--- a/src/SourceBuild/tarball/content/ArcadeOverrides/AfterSourceBuild.proj
+++ b/src/SourceBuild/tarball/content/ArcadeOverrides/AfterSourceBuild.proj
@@ -150,7 +150,7 @@
         SourceBuildArcadeTargetsFile=$(MSBuildThisFileDirectory)SourceBuildArcade.targets;
         SourceBuildIntermediateNupkgLicenseFile=$(SourceBuildIntermediateNupkgLicenseFile);
         "
-      BuildInParallel="true"/>
+      BuildInParallel="false"/>
   </Target>
 
   <Import Project="SourceBuildArcade.targets" />


### PR DESCRIPTION
The intermediate packages are being built in parallel, which in some cases causes a race condition where 2 projects try to create teh same file and one fails because the file already exists.
