### PR TITLE
Update WiX to signed build

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -106,7 +106,7 @@
     <SharedHostVersion>$(MicrosoftNETCoreAppRuntimePackageVersion)</SharedHostVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <WixPackageVersion>3.14.0-dotnet</WixPackageVersion>
+    <WixPackageVersion>1.0.0-v3.14.0.4118</WixPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- 6.0 Template versions -->

--- a/src/finalizer_shim/finalizer_shim.csproj
+++ b/src/finalizer_shim/finalizer_shim.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="WiX" Version="$(WixPackageVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Signed.Wix" Version="$(WixPackageVersion)" GeneratePathProperty="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/redist/targets/GenerateMSIs.targets
+++ b/src/redist/targets/GenerateMSIs.targets
@@ -13,8 +13,8 @@
   <Target Name="SetupWixProperties" DependsOnTargets="GetCurrentRuntimeInformation">
     <!-- AcquireWix Properties -->
     <PropertyGroup>
-      <WixVersion>3.14.0.4118</WixVersion>
-      <WixDownloadUrl>https://dotnetcli.azureedge.net/build/wix/wix.$(WixVersion).zip</WixDownloadUrl>
+      <WixVersion>1.0.0-v3.14.0.4118</WixVersion>
+      <WixDownloadUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/wix/Microsoft.Signed.Wix-$(WixVersion).zip</WixDownloadUrl>
       <WixRoot>$(ArtifactsDir)Tools/WixTools/$(WixVersion)</WixRoot>
       <WixDestinationPath>$(WixRoot)/WixTools.$(WixVersion).zip</WixDestinationPath>
       <WixDownloadSentinel>$(WixRoot)/WixDownload.$(WixVersion).sentinel</WixDownloadSentinel>


### PR DESCRIPTION
Updated internal package that contains binaries signed with MS 3rd party app cert in addition to .NET Foundation certs.

This is to address issues where customers have deployed strict CI policies through Device Guard and neither wants to add exclusions nor install additional root certificates.
