### PR TITLE
[release/6.0.1xx-rc2] Include dotnethome WIXOBJ files during light command package drop creation

### DIFF
--- a/src/redist/targets/GenerateMSIs.targets
+++ b/src/redist/targets/GenerateMSIs.targets
@@ -180,6 +180,7 @@
         <SdkMsiWixSrcFiles Include="$(WixRoot)\dotnet.wixobj" />
         <SdkMsiWixSrcFiles Include="$(WixRoot)\provider.wixobj" />
         <SdkMsiWixSrcFiles Include="$(WixRoot)\registrykeys.wixobj" />
+        <SdkMsiWixSrcFiles Include="$(WixRoot)\dotnethome_x64.wixobj" />
         <SdkMsiWixSrcFiles Include="$(WixRoot)\install-files.wixobj" />
     </ItemGroup>
     <CreateLightCommandPackageDrop
@@ -250,6 +251,7 @@
     <ItemGroup>
         <TemplatesMsiWixSrcFiles Include="$(WixRoot)\provider.wixobj" />
         <TemplatesMsiWixSrcFiles Include="$(WixRoot)\templates.wixobj" />
+        <TemplatesMsiWixSrcFiles Include="$(WixRoot)\dotnethome_x64.wixobj" />
         <TemplatesMsiWixSrcFiles Include="$(WixRoot)\template-install-files.wixobj" />
     </ItemGroup>
 
@@ -306,6 +308,7 @@
     <ItemGroup>
       <ManifestsMsiWixSrcFiles Include="$(WixRoot)\provider.wixobj" />
       <ManifestsMsiWixSrcFiles Include="$(WixRoot)\Manifests.wixobj" />
+      <ManifestsMsiWixSrcFiles Include="$(WixRoot)\dotnethome_x64.wixobj" />
       <ManifestsMsiWixSrcFiles Include="$(WixRoot)\Manifest-install-files.wixobj" />
     </ItemGroup>
 


### PR DESCRIPTION
After https://github.com/dotnet/installer/pull/11843, post build signing started failing, failing to find one of the input wixobj files. The wixobj was not included in the wixpack. This is because the installer repo uses custom scripts to generate MSIs, rather than the arcade tasks (which would handle adding this transparently), so the input files need to be added explicitly.
