### PR TITLE
Remove writing InstallLocation from SDK, it will be handled by host

### DIFF
--- a/src/redist/targets/packaging/windows/clisdk/bundle.wxs
+++ b/src/redist/targets/packaging/windows/clisdk/bundle.wxs
@@ -209,9 +209,6 @@
       </MsiPackage>
       <MsiPackage SourceFile="$(var.CLISDKMsiSourcePath)">
         <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
-        <MsiProperty Name="DOTNETHOME_X86" Value="[DOTNETHOME_X86]" />
-        <MsiProperty Name="DOTNETHOME_X64" Value="[DOTNETHOME_X64]" />
-        <MsiProperty Name="DOTNETHOME_ARM64" Value="[DOTNETHOME_ARM64]" />
         <MsiProperty Name="EXEFULLPATH" Value="[WixBundleOriginalSource]" />
         <MsiProperty Name="ALLOWMSIINSTALL" Value="True" />
       </MsiPackage>

--- a/src/redist/targets/packaging/windows/clisdk/registrykeys.wxs
+++ b/src/redist/targets/packaging/windows/clisdk/registrykeys.wxs
@@ -15,66 +15,6 @@
           <RegistryValue Action="write" Name="WpfWinformsTemplates" Type="integer" Value="1" KeyPath="yes"/>
         </RegistryKey>
       </Component>
-      <Component Id="DotnetInstallLocation_arm64" Directory="TARGETDIR" Win64="no">
-        <Condition>VersionNT64 AND DOTNETHOME_ARM64</Condition>
-        <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\Setup\InstalledVersions\arm64">
-          <RegistryValue Action="write" Name="InstallLocation" Type="string" Value="[DOTNETHOME_ARM64]" KeyPath="yes"/>
-        </RegistryKey>
-      </Component>
-      <Component Id="DotnetInstallLocation_x64" Directory="TARGETDIR" Win64="no">
-        <Condition>VersionNT64 AND DOTNETHOME_X64</Condition>
-        <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\Setup\InstalledVersions\x64">
-          <RegistryValue Action="write" Name="InstallLocation" Type="string" Value="[DOTNETHOME_X64]" KeyPath="yes"/>
-        </RegistryKey>
-      </Component>
-      <Component Id="DotnetInstallLocation_x86" Directory="TARGETDIR" Win64="no">
-        <Condition>DOTNETHOME_X86</Condition>
-        <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\Setup\InstalledVersions\x86">
-          <RegistryValue Action="write" Name="InstallLocation" Type="string" Value="[DOTNETHOME_X86]" KeyPath="yes"/>
-        </RegistryKey>
-      </Component>
     </ComponentGroup>
-
-    <!-- Set values for DOTNETHOME if not passed in.  
-         These searches prefer the existing registry key and fallback to probing the default location if registry key isn't present -->
-    <Property Id="DOTNETHOME_X86_SEARCH">
-      <DirectorySearch Id="dirDOTNETHOME_X86_search" Path="[ProgramFilesFolder]dotnet" AssignToProperty="yes">
-        <FileSearch Id="fileDOTNETHOME_X86_search" Name="dotnet.exe" />
-      </DirectorySearch>
-      <RegistrySearch Id="regDOTNETHOME_X86_search" Root="HKLM"  Key="SOFTWARE\dotnet\Setup\InstalledVersions\x86" Name="InstallLocation" Win64="no" Type="raw" />
-    </Property>
-    <Property Id="DOTNETHOME_X64_SEARCH">
-      <DirectorySearch Id="dirDOTNETHOME_X64_search" Path="[ProgramFiles64Folder]dotnet" AssignToProperty="yes">
-        <FileSearch Id="fileDOTNETHOME_X64_search" Name="dotnet.exe" />
-      </DirectorySearch>
-      <RegistrySearch Id="regDOTNETHOME_X64_search" Root="HKLM"  Key="SOFTWARE\dotnet\Setup\InstalledVersions\x64" Name="InstallLocation" Win64="no" Type="raw" />
-    </Property>
-    <Property Id="DOTNETHOME_X64_ALT_SEARCH">
-      <DirectorySearch Id="dirDOTNETHOME_X64_ALT_search" Path="[ProgramFiles64Folder]dotnet\x64" AssignToProperty="yes">
-        <FileSearch Id="fileDOTNETHOME_X64_ALT_search" Name="dotnet.exe" />
-      </DirectorySearch>
-      <RegistrySearch Id="regDOTNETHOME_X64_ALT_search" Root="HKLM"  Key="SOFTWARE\dotnet\Setup\InstalledVersions\x64" Name="InstallLocation" Win64="no" Type="raw" />
-    </Property>
-    <Property Id="DOTNETHOME_ARM64_SEARCH">
-      <DirectorySearch Id="dirDOTNETHOME_ARM64_search" Path="[ProgramFiles64Folder]dotnet" AssignToProperty="yes">
-        <FileSearch Id="fileDOTNETHOME_ARM64_search" Name="dotnet.exe" />
-      </DirectorySearch>
-      <RegistrySearch Id="regDOTNETHOME_ARM64_search" Root="HKLM"  Key="SOFTWARE\dotnet\Setup\InstalledVersions\arm64" Name="InstallLocation" Win64="no" Type="raw" />
-    </Property>
-
-    <!-- Set the DOTNETHOME property if not passed in and we found a path -->
-    <SetProperty Id="DOTNETHOME_X86" Value="[DOTNETHOME_X86_SEARCH]" Before="CostFinalize">
-      NOT DOTNETHOME_X86 AND DOTNETHOME_X86_SEARCH
-    </SetProperty>
-    <SetProperty Id="DOTNETHOME_X64" Value="[DOTNETHOME_X64_SEARCH]" Before="CostFinalize">
-      NOT DOTNETHOME_X64 AND DOTNETHOME_X64_SEARCH AND %PROCESSOR_ARCHITECTURE="AMD64"
-    </SetProperty>
-    <SetProperty Action="Set_DOTNETHOME_X64_alt" Id="DOTNETHOME_X64" Value="[DOTNETHOME_X64_ALT_SEARCH]" Before="CostFinalize">
-      NOT DOTNETHOME_X64 AND DOTNETHOME_X64_ALT_SEARCH AND NOT %PROCESSOR_ARCHITECTURE="AMD64"
-    </SetProperty>
-    <SetProperty Id="DOTNETHOME_ARM64" Value="[DOTNETHOME_ARM64_SEARCH]" Before="CostFinalize">
-      NOT DOTNETHOME_ARM64 AND DOTNETHOME_ARM64_SEARCH
-    </SetProperty>
-
   </Fragment>
 </Wix>


### PR DESCRIPTION
Issue https://github.com/dotnet/installer/issues/11999

The host will be responsible for writing these from this point forward, and only when it is installed.
 
We should wait to merge this until [host changes](https://github.com/dotnet/runtime/pull/59537) flow to this branch, otherwise the keys will be missing completely.