### PR TITLE
Fix Bash shebang for scripts to run under FreeBSD

### DIFF
--- a/run-build.sh
+++ b/run-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) .NET Foundation and contributors. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.


### PR DESCRIPTION
Not on all OS'es `bash` is placed under `/bin` (ex. FreeBSD). This small PR fixes those issues when running those scripts on such systems.