### PR TITLE
Remove ProdCon v1 version properties which cause incorrect versioning

### DIFF
--- a/src/SourceBuild/tarball/content/repos/Directory.Build.props
+++ b/src/SourceBuild/tarball/content/repos/Directory.Build.props
@@ -63,16 +63,6 @@
     <EnvironmentVariables Include="_InitializeToolset=$(ProjectDir)Tools/source-built/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj" Condition="'$(UseBootstrapArcade)' != 'true'" />
     <EnvironmentVariables Include="_OverrideArcadeInitializeBuildToolFramework=net6.0" />
 
-    <!--
-      With ProdCon v2, stabilization options are checked in, unlike ProdCon v1. These should be
-      deprecated but are left in to avoid potentially regressing edge-case versioning.
-    -->
-    <EnvironmentVariables Include="StabilizePackageVersion=$(IsStable)" Condition="'$(IsStable)' != '' and '$(IsToolingProject)' != 'true'" />
-    <EnvironmentVariables Include="PB_IsStable=$(IsStable)" Condition="'$(IsStable)' != '' and '$(IsToolingProject)' != 'true'" />
-    <EnvironmentVariables Include="IsStableBuild=$(IsStable)" Condition="'$(IsStable)' != '' and '$(IsToolingProject)' != 'true'" />
-    <EnvironmentVariables Include="DotNetFinalVersionKind=release" Condition="'$(IsStable)' == 'true' and '$(IsToolingProject)' != 'true'" />
-    <EnvironmentVariables Include="DropSuffix=true" Condition="'$(IsStable)' == 'true' and '$(IsToolingProject)' != 'true'" />
-
     <EnvironmentVariables Include="DotNetUseShippingVersions=true" />
 
     <EnvironmentVariables Include="PreReleaseVersionLabel=$(PreReleaseVersionLabel)" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/2433
Fixes https://github.com/dotnet/source-build/issues/2440

The incorrect versioning is caused by the presence of `DotNetFinalVersionKind=release`.  This prevents the `VersionSuffix` from being used.  I compared the output of all artifacts.  The only changes are to the sdk tarball as well as the System.CommandLine NuGet packages both of which were previously using 3 part version tags with no suffix.  I also verified the dotnet cli and .version file now reports the full version with the prerelease suffix.
