### PR TITLE
Update xdt dependency to latest

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -154,9 +154,9 @@
       <Sha>53b80940842204f78708a538628288ff5d741a1d</Sha>
     </Dependency>
     <!-- Temporarily pinning Microsoft.Web.Xdt until strict coherency is enabled by default -->
-    <Dependency Name="Microsoft.Web.Xdt" Version="3.1.0" CoherentParentDependency="Microsoft.NET.Sdk" Pinned="true">
-      <Uri>https://github.com/aspnet/xdt</Uri>
-      <Sha>c01a538851a8ab1a1fbeb2e6243f391fff7587b4</Sha>
+    <Dependency Name="Microsoft.Web.Xdt" Version="5.0.0-preview.21431.1" CoherentParentDependency="Microsoft.NET.Sdk" Pinned="true">
+      <Uri>https://github.com/dotnet/xdt</Uri>
+      <Sha>698fdad58fa64a55f16cd9562c90224cc498ed02</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-6.0.100" Version="6.0.0-rc.2.21464.1" CoherentParentDependency="VS.Redist.Common.NetCore.SharedFramework.x64.6.0">
       <Uri>https://github.com/dotnet/emsdk</Uri>


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/2431.

This PR updates the xdt dependency to the latest version.  This is needed to get the source-build infra changes that were checked in during 6.0.  These changes are needed for building the source-build tarball.