### PR TITLE
[release/6.0.1xx] Remove writing InstallLocation from SDK, it will be handled by host

### DIFF
--- a/src/redist/targets/packaging/windows/clisdk/bundle.wxs
+++ b/src/redist/targets/packaging/windows/clisdk/bundle.wxs
@@ -181,9 +181,6 @@
       </MsiPackage>
       <MsiPackage SourceFile="$(var.CLISDKMsiSourcePath)">
         <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
-        <MsiProperty Name="DOTNETHOME_X86" Value="[DOTNETHOME_X86]" />
-        <MsiProperty Name="DOTNETHOME_X64" Value="[DOTNETHOME_X64]" />
-        <MsiProperty Name="DOTNETHOME_ARM64" Value="[DOTNETHOME_ARM64]" />
         <MsiProperty Name="EXEFULLPATH" Value="[WixBundleOriginalSource]" />
         <MsiProperty Name="ALLOWMSIINSTALL" Value="True" />
       </MsiPackage>

--- a/src/redist/targets/packaging/windows/clisdk/registrykeys.wxs
+++ b/src/redist/targets/packaging/windows/clisdk/registrykeys.wxs
@@ -15,24 +15,6 @@
           <RegistryValue Action="write" Name="WpfWinformsTemplates" Type="integer" Value="1" KeyPath="yes"/>
         </RegistryKey>
       </Component>
-      <Component Id="DotnetInstallLocation_arm64" Directory="TARGETDIR" Win64="no">
-        <Condition>VersionNT64 AND DOTNETHOME_ARM64</Condition>
-        <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\Setup\InstalledVersions\arm64">
-          <RegistryValue Action="write" Name="InstallLocation" Type="string" Value="[DOTNETHOME_ARM64]" KeyPath="yes"/>
-        </RegistryKey>
-      </Component>
-      <Component Id="DotnetInstallLocation_x64" Directory="TARGETDIR" Win64="no">
-        <Condition>VersionNT64 AND DOTNETHOME_X64</Condition>
-        <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\Setup\InstalledVersions\x64">
-          <RegistryValue Action="write" Name="InstallLocation" Type="string" Value="[DOTNETHOME_X64]" KeyPath="yes"/>
-        </RegistryKey>
-      </Component>
-      <Component Id="DotnetInstallLocation_x86" Directory="TARGETDIR" Win64="no">
-        <Condition>DOTNETHOME_X86</Condition>
-        <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\Setup\InstalledVersions\x86">
-          <RegistryValue Action="write" Name="InstallLocation" Type="string" Value="[DOTNETHOME_X86]" KeyPath="yes"/>
-        </RegistryKey>
-      </Component>
     </ComponentGroup>
   </Fragment>
 </Wix>


### PR DESCRIPTION
Issue https://github.com/dotnet/installer/issues/11999

The host will be responsible for writing these from this point forward, and only when it is installed.
 
Host changes in 6.0 are https://github.com/dotnet/runtime/pull/59654