### PR TITLE
Cleanup disabled ExtractLinkerPackageToCache linker target

### DIFF
--- a/src/SourceBuild/tarball/content/repos/linker.proj
+++ b/src/SourceBuild/tarball/content/repos/linker.proj
@@ -18,26 +18,6 @@
     <UseSourceBuiltSdkOverride Include="@(ArcadeSdkOverride)" />
   </ItemGroup>
 
-  <!-- Extract this package into packages dir, because repos assume it's restored as a tool. -->
-  <!-- TODO: Determine if this is still required.  See https://github.com/dotnet/source-build/issues/2291 -->
-  <!-- <Target Name="ExtractLinkerPackageToCache"
-          AfterTargets="Package"
-          Inputs="$(MSBuildProjectFullPath)"
-          Outputs="$(RepoCompletedSemaphorePath)ExtractLinkerPackageToCache.complete">
-    <PropertyGroup>
-      <ILLinkTasksPackageFile>$(PackagesOutput)/$(ILLinkTasksPackageId).$(OutputPackageVersion).nupkg</ILLinkTasksPackageFile>
-      <ILLinkTasksPackageIdToLower>$(ILLinkTasksPackageId.ToLowerInvariant())</ILLinkTasksPackageIdToLower>
-    </PropertyGroup>
-
-    <Message Importance="high" Text="Extracting $(ILLinkTasksPackageFile) to package cache..." />
-
-    <ZipFileExtractToDirectory SourceArchive="$(ILLinkTasksPackageFile)"
-                               DestinationDirectory="$(PackagesDir)$(ILLinkTasksPackageIdToLower)/$(OutputPackageVersion)/"
-                               OverwriteDestination="true" />
-
-    <WriteLinesToFile File="$(RepoCompletedSemaphorePath)ExtractLinkerPackageToCache.complete" Overwrite="true" />
-  </Target> -->
-
   <!-- Replace file includes in nuspec as recommended in the linker repo's ./corebuild/README.md -->
   <Target Name="ReplaceNuspecDllIncludeLines" BeforeTargets="Build" Condition="'$(TargetOS)' != 'Windows_NT'">
     <PropertyGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/2291.

This target was originally added to remove ILLink.Tasks prebuilts.  It is currently disabled and we have no ILLink prebuilts therefore I am removing the disabled target.
