### PR TITLE
Add support for s390x architecture, part 2

### DIFF
--- a/src/SourceBuild/tarball/content/smoke-test.sh
+++ b/src/SourceBuild/tarball/content/smoke-test.sh
@@ -33,6 +33,9 @@ case $cpuName in
   i686)
     buildArch=x86
     ;;
+  s390x)
+    buildArch=s390x
+    ;;
   *)
     echo "Unknown CPU $cpuName detected, treating it as x64"
     buildArch=x64

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -187,7 +187,7 @@
 
       <AspNetCore31RuntimePackRids Include="@(AspNetCore30RuntimePackRids)" />
       <AspNetCore50RuntimePackRids Include="@(AspNetCore31RuntimePackRids);linux-musl-arm;win-arm64" />
-      <AspNetCoreRuntimePackRids Include="@(AspNetCore50RuntimePackRids);osx-arm64" />
+      <AspNetCoreRuntimePackRids Include="@(AspNetCore50RuntimePackRids);osx-arm64;linux-s390x" />
 
       <WindowsDesktop30RuntimePackRids Include="win-x64;win-x86" />
       <WindowsDesktop31RuntimePackRids Include="@(WindowsDesktop30RuntimePackRids)" />


### PR DESCRIPTION
This is a follow-on to https://github.com/dotnet/installer/pull/12018 adding s390x to a couple of places I had unfortunately overlooked.  This was discovered by running the ArPow source-build smoke tests.

* Add linux-s390x RID for aspnetcore net6.0 to GenerateBundledVersions

* Add s390x build architecture in ArPow smoke-test.sh

CC @marcpopMSFT @crummel 
