### PR TITLE
Do not generate checksums for wixpdb files

### DIFF
--- a/src/redist/targets/Checksum.targets
+++ b/src/redist/targets/Checksum.targets
@@ -11,6 +11,7 @@
   <Target Name="InitializeChecksumItemGroup">
     <ItemGroup>
       <FilesToExcludeForChecksum Include="$(ArtifactsShippingPackagesDir)*.svg" />
+      <FilesToExcludeForChecksum Include="$(ArtifactsShippingPackagesDir)*.wixpdb" />
       <FilesToExcludeForChecksum Include="$(ArtifactsShippingPackagesDir)*.nupkg" />
       <FilesToExcludeForChecksum Include="$(ArtifactsShippingPackagesDir)*.sha" />
       <FilesToExcludeForChecksum Include="$(ArtifactsShippingPackagesDir)*.cab" />


### PR DESCRIPTION
The corresponding wixpdbs aren't published