### PR TITLE
Update Maui/Xamarin manifests for .NET 6 RC 2

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -165,12 +165,12 @@
   </PropertyGroup>
   <!-- Workload manifest package versions -->
   <PropertyGroup>
-    <MauiWorkloadManifestVersion>6.0.100-rc.1.1351</MauiWorkloadManifestVersion>
-    <XamarinAndroidWorkloadManifestVersion>30.0.100-rc.1.137</XamarinAndroidWorkloadManifestVersion>
-    <XamarinIOSWorkloadManifestVersion>15.0.100-rc.1.496</XamarinIOSWorkloadManifestVersion>
-    <XamarinMacCatalystWorkloadManifestVersion>15.0.100-rc.1.496</XamarinMacCatalystWorkloadManifestVersion>
-    <XamarinMacOSWorkloadManifestVersion>12.0.100-rc.1.496</XamarinMacOSWorkloadManifestVersion>
-    <XamarinTvOSWorkloadManifestVersion>15.0.100-rc.1.496</XamarinTvOSWorkloadManifestVersion>
+    <MauiWorkloadManifestVersion>6.0.101-preview.9.1805</MauiWorkloadManifestVersion>
+    <XamarinAndroidWorkloadManifestVersion>31.0.101-preview.9.16</XamarinAndroidWorkloadManifestVersion>
+    <XamarinIOSWorkloadManifestVersion>15.0.101-preview.9.31</XamarinIOSWorkloadManifestVersion>
+    <XamarinMacCatalystWorkloadManifestVersion>15.0.101-preview.9.31</XamarinMacCatalystWorkloadManifestVersion>
+    <XamarinMacOSWorkloadManifestVersion>12.0.101-preview.9.31</XamarinMacOSWorkloadManifestVersion>
+    <XamarinTvOSWorkloadManifestVersion>15.0.101-preview.9.31</XamarinTvOSWorkloadManifestVersion>
     <MonoWorkloadManifestVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MonoWorkloadManifestVersion>
     <MicrosoftNETWorkloadEmscriptenManifest60100Version>6.0.0-rc.2.21464.1</MicrosoftNETWorkloadEmscriptenManifest60100Version>
     <EmscriptenWorkloadManifestVersion>$(MicrosoftNETWorkloadEmscriptenManifest60100Version)</EmscriptenWorkloadManifestVersion>


### PR DESCRIPTION
Bump to: xamarin/xamarin-android/release/6.0.1xx-preview9@2c2302a
Bump to: xamarin/xamarin-macios/release/6.0.1xx-preview9@233cef2
Bump to: dotnet/maui/release/6.0.1xx-preview9@f3f8f5f

Our version numbers have switched from `rc.2` to `preview.9`, and we
incremented `*.100` to `*.101`.

After `.\build.cmd -pack -publish`, manually tested the workloads:

    > $env:DOTNET_MULTILEVEL_LOOKUP=0
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install android --skip-manifest-update
    Installing pack Microsoft.Android.Sdk version 31.0.101-preview.9.16...
    ...
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install ios --skip-manifest-update
    Installing pack Microsoft.iOS.Sdk version 15.0.101-preview.9.31...
    ...
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install maccatalyst --skip-manifest-update
    Installing pack Microsoft.MacCatalyst.Sdk version 15.0.101-preview.9.31...
    ...
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install macos --skip-manifest-update
    Installing pack Microsoft.macOS.Sdk version 12.0.101-preview.9.31...
    ...
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install tvos --skip-manifest-update
    Installing pack Microsoft.tvOS.Sdk version 15.0.101-preview.9.31...
    ...
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install maui --skip-manifest-update
    Installing pack Microsoft.Maui.Core.Ref.ios version 6.0.101-preview.9.1805...