### PR TITLE
[ArPow] Add runtime patch to enable doc generation

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -161,7 +161,7 @@
     <MicrosoftBuildFrameworkVersion>15.7.179</MicrosoftBuildFrameworkVersion>
     <MicrosoftBuildUtilitiesCoreVersion>15.7.179</MicrosoftBuildUtilitiesCoreVersion>
     <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-6.0.100-bootstrap.19</PrivateSourceBuiltArtifactsPackageVersion>
-    <PrivateSourceBuiltPrebuiltsPackageVersion>0.1.0-6.0.100-24</PrivateSourceBuiltPrebuiltsPackageVersion>
+    <PrivateSourceBuiltPrebuiltsPackageVersion>0.1.0-6.0.100-25</PrivateSourceBuiltPrebuiltsPackageVersion>
   </PropertyGroup>
   <!-- Workload manifest package versions -->
   <PropertyGroup>

--- a/src/SourceBuild/tarball/content/eng/Versions.props
+++ b/src/SourceBuild/tarball/content/eng/Versions.props
@@ -23,6 +23,6 @@
   <PropertyGroup>
     <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-6.0.100-bootstrap.19</PrivateSourceBuiltArtifactsPackageVersion>
     <PrivateSourceBuiltPrebuiltsPackageVersionPrefix>0.1.0-6.0.100-</PrivateSourceBuiltPrebuiltsPackageVersionPrefix>
-    <PrivateSourceBuiltPrebuiltsPackageVersionSuffix>24</PrivateSourceBuiltPrebuiltsPackageVersionSuffix>
+    <PrivateSourceBuiltPrebuiltsPackageVersionSuffix>25</PrivateSourceBuiltPrebuiltsPackageVersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/SourceBuild/tarball/content/smoke-test.sh
+++ b/src/SourceBuild/tarball/content/smoke-test.sh
@@ -466,8 +466,8 @@ function runXmlDocTests() {
     )
 
     netcoreappIgnoreList=(
+        mscorlib.xml
         Microsoft.VisualBasic.xml
-        netstandard.xml
         System.AppContext.xml
         System.Buffers.xml
         System.ComponentModel.DataAnnotations.xml
@@ -482,12 +482,15 @@ function runXmlDocTests() {
         System.Globalization.Calendars.xml
         System.Globalization.Extensions.xml
         System.Globalization.xml
+        System.IO.Compression.Brotli.xml
         System.IO.Compression.FileSystem.xml
+        System.IO.FileSystem.xml
         System.IO.FileSystem.Primitives.xml
         System.IO.UnmanagedMemoryStream.xml
         System.IO.xml
         System.Net.xml
         System.Numerics.xml
+        System.Numerics.Vectors.xml
         System.Reflection.Extensions.xml
         System.Reflection.xml
         System.Resources.Reader.xml
@@ -501,6 +504,8 @@ function runXmlDocTests() {
         System.ServiceModel.Web.xml
         System.ServiceProcess.xml
         System.Text.Encoding.xml
+        System.Text.Json.SourceGeneration.resources.xml
+        System.Text.Json.SourceGeneration.xml
         System.Threading.Tasks.Extensions.xml
         System.Threading.Tasks.xml
         System.Threading.Timer.xml
@@ -513,124 +518,8 @@ function runXmlDocTests() {
         System.Xml.Serialization.xml
         System.Xml.xml
         System.Xml.XmlDocument.xml
-        Microsoft.CSharp.xml
-        # Added temporarily due to https://github.com/dotnet/source-build/issues/2404
-        Microsoft.VisualBasic.Core.xml
-        Microsoft.Win32.Primitives.xml
-        Microsoft.Win32.Registry.xml
-        System.Collections.Concurrent.xml
-        System.Collections.Immutable.xml
-        System.Collections.NonGeneric.xml
-        System.Collections.Specialized.xml
-        System.Collections.xml
-        System.ComponentModel.Annotations.xml
-        System.ComponentModel.EventBasedAsync.xml
-        System.ComponentModel.Primitives.xml
-        System.ComponentModel.TypeConverter.xml
-        System.ComponentModel.xml
-        System.Console.xml
-        System.Data.Common.xml
-        System.Diagnostics.Contracts.xml
-        System.Diagnostics.DiagnosticSource.xml
-        System.Diagnostics.FileVersionInfo.xml
-        System.Diagnostics.Process.xml
-        System.Diagnostics.StackTrace.xml
-        System.Diagnostics.TextWriterTraceListener.xml
-        System.Diagnostics.TraceSource.xml
-        System.Diagnostics.Tracing.xml
-        System.Drawing.Primitives.xml
-        System.Formats.Asn1.xml
-        System.IO.Compression.Brotli.xml
-        System.IO.Compression.ZipFile.xml
-        System.IO.Compression.xml
-        System.IO.FileSystem.AccessControl.xml
-        System.IO.FileSystem.DriveInfo.xml
-        System.IO.FileSystem.Watcher.xml
-        System.IO.FileSystem.xml
-        System.IO.IsolatedStorage.xml
-        System.IO.MemoryMappedFiles.xml
-        System.IO.Pipes.AccessControl.xml
-        System.IO.Pipes.xml
-        System.Linq.Expressions.xml
-        System.Linq.Parallel.xml
-        System.Linq.Queryable.xml
-        System.Linq.xml
-        System.Memory.xml
-        System.Net.Http.Json.xml
-        System.Net.Http.xml
-        System.Net.HttpListener.xml
-        System.Net.Mail.xml
-        System.Net.NameResolution.xml
-        System.Net.NetworkInformation.xml
-        System.Net.Ping.xml
-        System.Net.Primitives.xml
-        System.Net.Requests.xml
-        System.Net.Security.xml
-        System.Net.ServicePoint.xml
-        System.Net.Sockets.xml
-        System.Net.WebClient.xml
-        System.Net.WebHeaderCollection.xml
-        System.Net.WebProxy.xml
-        System.Net.WebSockets.Client.xml
-        System.Net.WebSockets.xml
-        System.Numerics.Vectors.xml
-        System.ObjectModel.xml
-        System.Reflection.DispatchProxy.xml
-        System.Reflection.Emit.ILGeneration.xml
-        System.Reflection.Emit.Lightweight.xml
-        System.Reflection.Emit.xml
-        System.Reflection.Metadata.xml
-        System.Reflection.Primitives.xml
-        System.Reflection.TypeExtensions.xml
-        System.Resources.Writer.xml
-        System.Runtime.CompilerServices.Unsafe.xml
-        System.Runtime.CompilerServices.VisualC.xml
-        System.Runtime.InteropServices.RuntimeInformation.xml
-        System.Runtime.InteropServices.xml
-        System.Runtime.Intrinsics.xml
-        System.Runtime.Loader.xml
-        System.Runtime.Numerics.xml
-        System.Runtime.Serialization.Formatters.xml
-        System.Runtime.Serialization.Json.xml
-        System.Runtime.Serialization.Primitives.xml
-        System.Runtime.Serialization.Xml.xml
-        System.Runtime.xml
-        System.Security.AccessControl.xml
-        System.Security.Claims.xml
-        System.Security.Cryptography.Algorithms.xml
-        System.Security.Cryptography.Cng.xml
-        System.Security.Cryptography.Csp.xml
-        System.Security.Cryptography.Encoding.xml
-        System.Security.Cryptography.OpenSsl.xml
-        System.Security.Cryptography.Primitives.xml
-        System.Security.Cryptography.X509Certificates.xml
-        System.Security.Principal.Windows.xml
-        System.Text.Encoding.CodePages.xml
-        System.Text.Encoding.Extensions.xml
-        System.Text.Encodings.Web.xml
-        System.Text.Json.xml
-        System.Text.Json.SourceGeneration.xml
-        System.Text.Json.SourceGeneration.resources.xml
-        System.Text.RegularExpressions.xml
-        System.Threading.Channels.xml
-        System.Threading.Overlapped.xml
-        System.Threading.Tasks.Dataflow.xml
-        System.Threading.Tasks.Parallel.xml
-        System.Threading.Thread.xml
-        System.Threading.ThreadPool.xml
-        System.Threading.xml
-        System.Transactions.Local.xml
-        System.Web.HttpUtility.xml
-        System.Xml.ReaderWriter.xml
-        System.Xml.XDocument.xml
-        System.Xml.XPath.XDocument.xml
-        System.Xml.XPath.xml
-        System.Xml.XmlSerializer.xml
-        WindowsBase.xml
-        mscorlib.xml
     )
 
-    # Added temporarily due to https://github.com/dotnet/source-build/issues/2404
     aspnetcoreappIgnoreList=(
         Microsoft.AspNetCore.App.Analyzers.xml
         Microsoft.AspNetCore.App.CodeFixes.xml
@@ -660,7 +549,6 @@ function runXmlDocTests() {
                 fi
             done
         fi
-        # Added temporarily due to https://github.com/dotnet/source-build/issues/2404
         if [[ "$xmlDocFile" == *"/packs/Microsoft.AspNetCore.App.Ref"* ]]; then
             xmlFileBasename=$(basename "$xmlDocFile")
             for ignoreItem in "${aspnetcoreappIgnoreList[@]}"; do
@@ -674,10 +562,16 @@ function runXmlDocTests() {
             error=1
             echo "error: missing $xmlDocFile"
         fi
+
+    if [[ $skip == 1 ]] && [[ -f "$xmlDocFile" ]]; then
+        error=1
+        echo "error: Ignored xml doc was found: $xmlDocFile"
+    fi
+
     done < <(find "$targetingPacksDir" -name '*.dll' -print0)
 
     if [[ $error != 0 ]]; then
-        echo "error: Missing xml documents"
+        echo "error: Missing or unexpected xml documents"
         exit 1
     else
         echo "All expected xml docs are present"

--- a/src/SourceBuild/tarball/patches/runtime/0001-Enable-doc-generation-in-source-build.patch
+++ b/src/SourceBuild/tarball/patches/runtime/0001-Enable-doc-generation-in-source-build.patch
@@ -1,0 +1,25 @@
+From 4ca12d74308dceface792dad959bd4a7eda0b1b4 Mon Sep 17 00:00:00 2001
+From: MichaelSimons <msimons@microsoft.com>
+Date: Thu, 30 Sep 2021 22:37:24 +0000
+Subject: [PATCH] Enable doc generation in source-build
+
+---
+ Build.proj | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Build.proj b/Build.proj
+index bff94b97a7a..5f47e869fb6 100644
+--- a/Build.proj
++++ b/Build.proj
+@@ -10,7 +10,7 @@
+   <Import Project="$(RepositoryEngineeringDir)SubsetValidation.targets" />
+ 
+   <!-- Upfront restore hooks -->
+-  <Import Project="$(RepositoryEngineeringDir)restore\docs.targets" Condition="'$(DotNetBuildFromSource)' != 'true'" />
++  <Import Project="$(RepositoryEngineeringDir)restore\docs.targets" />
+   <Import Project="$(RepositoryEngineeringDir)restore\optimizationData.targets" Condition="'$(DotNetBuildFromSource)' != 'true'" />
+ 
+   <Target Name="BuildLocalTasks"
+-- 
+2.29.2
+


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/2404.

I updated the smoke-tests to fail if there are unexpected xml files.  This surfaces a couple ignore entries that shouldn't exist.  The ignore list matches the msft build output.
