### PR TITLE
Add source-build patch to fix Omnisharp

### DIFF
--- a/src/SourceBuild/tarball/content/patches/runtime/0001-Attempt1.patch
+++ b/src/SourceBuild/tarball/content/patches/runtime/0001-Attempt1.patch
@@ -1,0 +1,59 @@
+From 93de82c03ff71f897599db2824b959d020b877bd Mon Sep 17 00:00:00 2001
+From: Chris Rummel <crummel@microsoft.com>
+Date: Thu, 30 Sep 2021 16:08:28 -0500
+Subject: [PATCH 1/2] Attempt1
+
+---
+ src/libraries/Directory.Build.props                           | 2 +-
+ .../ref/System.Resources.Extensions.csproj                    | 4 ++--
+ .../src/System.Resources.Extensions.csproj                    | 2 +-
+ 3 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/libraries/Directory.Build.props b/src/libraries/Directory.Build.props
+index 4d39fad397e..649c669517e 100644
+--- a/src/libraries/Directory.Build.props
++++ b/src/libraries/Directory.Build.props
+@@ -27,7 +27,7 @@
+ 
+   <PropertyGroup>
+     <!-- Build all .NET Framework configurations when net48 is passed in. This is for convenience. -->
+-    <AdditionalBuildTargetFrameworks Condition="'$(BuildTargetFramework)' == 'net48'">net461;net462;net47;net471;net472</AdditionalBuildTargetFrameworks>
++    <AdditionalBuildTargetFrameworks Condition="'$(BuildTargetFramework)' == 'net48'">net46;net461;net462;net47;net471;net472</AdditionalBuildTargetFrameworks>
+   </PropertyGroup>
+ 
+   <!-- Define test projects and companions -->
+diff --git a/src/libraries/System.Resources.Extensions/ref/System.Resources.Extensions.csproj b/src/libraries/System.Resources.Extensions/ref/System.Resources.Extensions.csproj
+index 99037ae459c..848be41690c 100644
+--- a/src/libraries/System.Resources.Extensions/ref/System.Resources.Extensions.csproj
++++ b/src/libraries/System.Resources.Extensions/ref/System.Resources.Extensions.csproj
+@@ -1,6 +1,6 @@
+ <Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup>
+-    <TargetFrameworks>$(NetCoreAppCurrent);netstandard2.0;net461</TargetFrameworks>
++    <TargetFrameworks>$(NetCoreAppCurrent);netstandard2.0;net46;net461</TargetFrameworks>
+     <Nullable>enable</Nullable>
+   </PropertyGroup>
+ 
+@@ -11,4 +11,4 @@
+   <ItemGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">
+     <ProjectReference Include="$(LibrariesProjectRoot)System.Resources.Writer\ref\System.Resources.Writer.csproj" />
+   </ItemGroup>
+-</Project>
+\ No newline at end of file
++</Project>
+diff --git a/src/libraries/System.Resources.Extensions/src/System.Resources.Extensions.csproj b/src/libraries/System.Resources.Extensions/src/System.Resources.Extensions.csproj
+index adacc9b977e..38d4c145352 100644
+--- a/src/libraries/System.Resources.Extensions/src/System.Resources.Extensions.csproj
++++ b/src/libraries/System.Resources.Extensions/src/System.Resources.Extensions.csproj
+@@ -1,7 +1,7 @@
+ <Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup>
+     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+-    <TargetFrameworks>$(NetCoreAppCurrent);netstandard2.0;net461</TargetFrameworks>
++    <TargetFrameworks>$(NetCoreAppCurrent);netstandard2.0;net46;net461</TargetFrameworks>
+     <DefineConstants>$(DefineConstants);RESOURCES_EXTENSIONS</DefineConstants>
+     <Nullable>enable</Nullable>
+   </PropertyGroup>
+-- 
+2.17.1
+

--- a/src/SourceBuild/tarball/content/patches/runtime/0001-Fix-Omnisharp-add-needed-extra-TFMs.patch
+++ b/src/SourceBuild/tarball/content/patches/runtime/0001-Fix-Omnisharp-add-needed-extra-TFMs.patch
@@ -1,7 +1,9 @@
 From 93de82c03ff71f897599db2824b959d020b877bd Mon Sep 17 00:00:00 2001
 From: Chris Rummel <crummel@microsoft.com>
 Date: Thu, 30 Sep 2021 16:08:28 -0500
-Subject: [PATCH 1/2] Attempt1
+Subject: [PATCH 1/2] Fix Omnisharp: Add needed extra TFMs.
+
+Omnisharp requires the net46 TFMs of this files explictly and we don't build them by default.  This patch adds net46 to the relevant projects.  The original issue for this was https://github.com/OmniSharp/omnisharp-vscode/issues/4610 and the long-term fix of switching to net>4 TFM is tracked in https://github.com/OmniSharp/omnisharp-vscode/issues/4360.
 
 ---
  src/libraries/Directory.Build.props                           | 2 +-


### PR DESCRIPTION
Port of https://github.com/dotnet/installer/pull/12227.

Add net46 builds to DLLs needed by Omnisharp in source-build.  Fixes https://github.com/dotnet/source-build/issues/2478.