### PR TITLE
Remove duplicate telemetry events

### DIFF
--- a/src/redist/targets/packaging/windows/clisdk/dotnet.wxs
+++ b/src/redist/targets/packaging/windows/clisdk/dotnet.wxs
@@ -44,8 +44,8 @@
                   Impersonate="no"/>
 
     <InstallExecuteSequence>
-      <Custom Action="PropertyAssignPrimeCacheAndTelemetry" Before="QtExecPrimeCacheAndTelemetryTarget" />
-      <Custom Action="QtExecPrimeCacheAndTelemetryTarget" Before="InstallFinalize" />
+      <Custom Action="PropertyAssignPrimeCacheAndTelemetry" Before="QtExecPrimeCacheAndTelemetryTarget">NOT Installed</Custom>
+      <Custom Action="QtExecPrimeCacheAndTelemetryTarget" Before="InstallFinalize">NOT Installed</Custom>
     </InstallExecuteSequence>
   </Product>
   <Fragment>


### PR DESCRIPTION
.NET registers a setup telemetry event to track successful operations for install, uninstall, and repair. The captured event doesn't describe the operation type and we end up discarding the data. This change avoids sending unnecessary events.
