### PR TITLE
Add smoke-test-prereqs to NuGet.config.

### DIFF
--- a/src/SourceBuild/tarball/content/smoke-testNuGet.Config
+++ b/src/SourceBuild/tarball/content/smoke-testNuGet.Config
@@ -14,6 +14,7 @@
     <!--  End: Package sources from dotnet-templating -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="source-built-packages" value="SOURCE_BUILT_PACKAGES" />
+    <add key="smoke-test-prereqs" value="SMOKE_TEST_PACKAGE_FEED" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public%40Local/nuget/v3/index.json" />
     <add key="dotnet6" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet6/nuget/v3/index.json" />
   </packageSources>


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/2448

