### PR TITLE
Add runtime patch to enable host.pkg subset to eliminate prebuilts

### DIFF
--- a/src/SourceBuild/tarball/patches/runtime/0003-Enable-host.pkg-subset-in-source-build.patch
+++ b/src/SourceBuild/tarball/patches/runtime/0003-Enable-host.pkg-subset-in-source-build.patch
@@ -1,0 +1,28 @@
+From 0e68346f6127a82cf54e910ddea9889a56ca9e21 Mon Sep 17 00:00:00 2001
+From: MichaelSimons <msimons@microsoft.com>
+Date: Wed, 6 Oct 2021 15:32:45 +0000
+Subject: [PATCH] Enable host.pkg subset in source-build
+
+Backported to runtime with https://github.com/dotnet/runtime/pull/60069
+---
+ eng/Subsets.props | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/eng/Subsets.props b/eng/Subsets.props
+index c935f7c3a81..a7c5fb0e96e 100644
+--- a/eng/Subsets.props
++++ b/eng/Subsets.props
+@@ -66,8 +66,8 @@
+     <DefaultLibrariesSubsets>$(DefaultLibrariesSubsets)libs.ref+libs.src</DefaultLibrariesSubsets>
+     <DefaultLibrariesSubsets Condition="'$(DotNetBuildFromSource)' != 'true'">$(DefaultLibrariesSubsets)+libs.pretest</DefaultLibrariesSubsets>
+ 
+-    <DefaultHostSubsets>host.native+host.tools</DefaultHostSubsets>
+-    <DefaultHostSubsets Condition="'$(DotNetBuildFromSource)' != 'true'">$(DefaultHostSubsets)+host.pkg+host.tests</DefaultHostSubsets>
++    <DefaultHostSubsets>host.native+host.tools+host.pkg</DefaultHostSubsets>
++    <DefaultHostSubsets Condition="'$(DotNetBuildFromSource)' != 'true'">$(DefaultHostSubsets)+host.tests</DefaultHostSubsets>
+     <DefaultHostSubsets Condition="'$(RuntimeFlavor)' != '$(PrimaryRuntimeFlavor)'"></DefaultHostSubsets>
+     <DefaultHostSubsets Condition="'$(RuntimeFlavor)' != '$(PrimaryRuntimeFlavor)' and '$(TargetsMobile)' != 'true'">host.native</DefaultHostSubsets>
+ 
+-- 
+2.29.2
+


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/2422.
