### PR TITLE
[release/6.0.1xx] Update dotnet/diagnostics version

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -181,9 +181,9 @@
       <Sha>7431bf2f3c204cbbc326c8d55ce4ac5cad7661d6</Sha>
       <SourceBuildTarball RepoName="deployment-tools" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.diagnostics" Version="5.0.0-preview.21477.1">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.diagnostics" Version="5.0.0-preview.21506.1">
       <Uri>https://github.com/dotnet/diagnostics</Uri>
-      <Sha>f758ec93e1098e5bcbc4550f8a36c6cd1ce04918</Sha>
+      <Sha>ab3eb7a525e31dc6fb4d9cc0b7154fa2be58dac1</Sha>
       <SourceBuildTarball RepoName="diagnostics" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.symreader" Version="1.4.0-beta2-21475-02">


### PR DESCRIPTION
Update the dotnet diagnostics version to a slightly newer version that incorporates a re-categorization of some dependencies there. This removes a cycle in the product.

Diff: https://github.com/dotnet/diagnostics/compare/f758ec93e1098e5bcbc4550f8a36c6cd1ce04918...ab3eb7a525e31dc6fb4d9cc0b7154fa2be58dac1