### PR TITLE
[ArPow] Resolve Microsoft.DotNet prebuilts for dotnet/roslyn

### DIFF
--- a/src/SourceBuild/tarball/patches/roslyn/0003-remove-Microsoft.DotNet-prebuilts.patch
+++ b/src/SourceBuild/tarball/patches/roslyn/0003-remove-Microsoft.DotNet-prebuilts.patch
@@ -1,0 +1,24 @@
+From 7260c572b1ce424f7ff3a64aa3227417c6a7a676 Mon Sep 17 00:00:00 2001
+From: Logan Bussell <36081148+lbussell@users.noreply.github.com>
+Date: Fri, 8 Oct 2021 00:56:41 +0000
+Subject: [PATCH 1/1] remove Microsoft.DotNet prebuilts
+
+---
+ eng/Tools.props | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/eng/Tools.props b/eng/Tools.props
+index 1579b510558..944448855ee 100644
+--- a/eng/Tools.props
++++ b/eng/Tools.props
+@@ -1,6 +1,6 @@
+ <Project>
+ 
+-  <ItemGroup>
++  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
+     <!--
+       This package would normally be restored by the Arcade SDK, but it is not included during restore operations
+       if the -package flag is not also provided during the build. Roslyn separates the restore operation from the
+-- 
+2.30.2
+

--- a/src/SourceBuild/tarball/patches/roslyn/0003-remove-Microsoft.DotNet-prebuilts.patch
+++ b/src/SourceBuild/tarball/patches/roslyn/0003-remove-Microsoft.DotNet-prebuilts.patch
@@ -1,8 +1,9 @@
 From 7260c572b1ce424f7ff3a64aa3227417c6a7a676 Mon Sep 17 00:00:00 2001
 From: Logan Bussell <36081148+lbussell@users.noreply.github.com>
 Date: Fri, 8 Oct 2021 00:56:41 +0000
-Subject: [PATCH 1/1] remove Microsoft.DotNet prebuilts
+Subject: [PATCH] remove Microsoft.DotNet prebuilts
 
+Pull request for applying this patch: https://github.com/dotnet/roslyn/pull/57159
 ---
  eng/Tools.props | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)


### PR DESCRIPTION
Removes a couple of prebuilts from the roslyn repo:
```
Microsoft.DotNet.Build.Tasks.Feed.6.0.0-beta.21473.5
Microsoft.DotNet.NuGetRepack.Tasks.6.0.0-beta.21473.5
```