### PR TITLE
Handle workload manifests as text-only packages in source-build

### DIFF
--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build.yml
@@ -90,12 +90,11 @@ jobs:
       artifact: $(Agent.JobName)_Artifacts_Attempt$(System.JobAttempt)
       displayName: Publish Source Build Artifacts
 
-  # TODO: Re-enable once https://github.com/dotnet/source-build/issues/2489 is fixed.
-  # - script: |
-  #     set -x
+  - script: |
+      set -x
 
-  #     docker run --rm -v $(_TarballDir):/tarball -w /tarball $(_Container) ./build.sh --run-smoke-test
-  #   displayName: Run Tests
+      docker run --rm -v $(_TarballDir):/tarball -w /tarball $(_Container) ./build.sh --run-smoke-test
+    displayName: Run Tests
 
   - template: /src/SourceBuild/Arcade/eng/common/templates/steps/source-build-publish-logs.yml
     parameters:

--- a/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
+++ b/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
@@ -325,6 +325,20 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <BinaryExtension Include="
+        .dll;
+        .Dll;
+        .exe;
+        .pdb;
+        .mdb;
+        .zip" />
+
+      <BinaryPackageContent Include="$(TextOnlyDirectory)/**/*%(BinaryExtension.Identity)" />
+    </ItemGroup>
+
+    <Error Text="Binary content found in text-only packages: @(BinaryPackageContent)" Condition=" '@(BinaryPackageContent)' != '' " />
+
+    <ItemGroup>
       <TextOnlyPackageContent 
         Include="$(TextOnlyDirectory)/**/*"
         Exclude="

--- a/src/SourceBuild/Arcade/tools/TextOnlyPackages.csproj
+++ b/src/SourceBuild/Arcade/tools/TextOnlyPackages.csproj
@@ -43,6 +43,12 @@
     <PackageDownload Include="Microsoft.DotNet.Web.Spa.ProjectTemplates.5.0" Version="[$(AspNetCorePackageVersionFor50Templates)]" />
     <PackageDownload Include="Microsoft.DotNet.Web.Spa.ProjectTemplates.6.0" Version="[$(AspNetCorePackageVersionFor60Templates)]" />
 
+    <PackageDownload Include="Microsoft.NET.Sdk.Android.Manifest-6.0.100" Version="[$(XamarinAndroidWorkloadManifestVersion)]" />
+    <PackageDownload Include="Microsoft.NET.Sdk.iOS.Manifest-6.0.100" Version="[$(XamarinIOSWorkloadManifestVersion)]" />
+    <PackageDownload Include="Microsoft.NET.Sdk.MacCatalyst.Manifest-6.0.100" Version="[$(XamarinMacCatalystWorkloadManifestVersion)]" />
+    <PackageDownload Include="Microsoft.NET.Sdk.macOS.Manifest-6.0.100" Version="[$(XamarinMacOSWorkloadManifestVersion)]" />
+    <PackageDownload Include="Microsoft.NET.Sdk.Maui.Manifest-6.0.100" Version="[$(MauiWorkloadManifestVersion)]" />
+    <PackageDownload Include="Microsoft.NET.Sdk.tvOS.Manifest-6.0.100" Version="[$(XamarinTvOSWorkloadManifestVersion)]" />
     <PackageDownload Include="Microsoft.NET.Workload.Emscripten.Manifest-6.0.100" Version="[$(EmscriptenWorkloadManifestVersion)]" />
     <PackageDownload Include="Microsoft.NET.Workload.Mono.ToolChain.Manifest-6.0.100" Version="[$(MonoWorkloadManifestVersion)]" />
   </ItemGroup>

--- a/src/redist/targets/BundledManifests.targets
+++ b/src/redist/targets/BundledManifests.targets
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <!-- Restore workload manifests via PackageReference -->
-  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
+  <ItemGroup>
     <BundledManifestsForPackageDownload Include="@(BundledManifests)" >
       <Version>[%(Version)]</Version>
     </BundledManifestsForPackageDownload>
@@ -26,8 +26,7 @@
   </ItemGroup>
 
   <Target Name="LayoutManifests"
-        DependsOnTargets="LayoutManifestsForSDK;LayoutManifestsForMSI" 
-        Condition="'$(DotNetBuildFromSource)' != 'true'"/>
+        DependsOnTargets="LayoutManifestsForSDK;LayoutManifestsForMSI"/>
 
   <Target Name="LayoutManifestsForSDK"
           DependsOnTargets="SetupBundledComponents;GenerateManifestVersions">


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/2489
