### PR TITLE
Add support for targeting Windows SDK 10.0.22000.0

### DIFF
--- a/eng/ManualVersions.props
+++ b/eng/ManualVersions.props
@@ -13,5 +13,6 @@
     <MicrosoftWindowsSDKNETRef10_0_18362PackageVersion>10.0.18362.21</MicrosoftWindowsSDKNETRef10_0_18362PackageVersion>
     <MicrosoftWindowsSDKNETRef10_0_19041PackageVersion>10.0.19041.21</MicrosoftWindowsSDKNETRef10_0_19041PackageVersion>
     <MicrosoftWindowsSDKNETRef10_0_20348PackageVersion>10.0.20348.21</MicrosoftWindowsSDKNETRef10_0_20348PackageVersion>
+    <MicrosoftWindowsSDKNETRef10_0_22000PackageVersion>10.0.22000.21</MicrosoftWindowsSDKNETRef10_0_22000PackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -486,6 +486,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <WindowsSdkSupportedTargetPlatformVersion Include="10.0.19041.0" WindowsSdkPackageVersion="$(MicrosoftWindowsSDKNETRef10_0_19041PackageVersion)" MinimumNETVersion="5.0" />
     <WindowsSdkSupportedTargetPlatformVersion Include="10.0.18362.0" WindowsSdkPackageVersion="$(MicrosoftWindowsSDKNETRef10_0_18362PackageVersion)" MinimumNETVersion="5.0" />
     <WindowsSdkSupportedTargetPlatformVersion Include="10.0.17763.0" WindowsSdkPackageVersion="$(MicrosoftWindowsSDKNETRef10_0_17763PackageVersion)" MinimumNETVersion="5.0" />
+    <WindowsSdkSupportedTargetPlatformVersion Include="10.0.22000.0" WindowsSdkPackageVersion="$(MicrosoftWindowsSDKNETRef10_0_22000PackageVersion)" MinimumNETVersion="5.0" />
     <WindowsSdkSupportedTargetPlatformVersion Include="8.0" />
     <WindowsSdkSupportedTargetPlatformVersion Include="7.0" />
     

--- a/test/EndToEnd/GivenWindows50App.cs
+++ b/test/EndToEnd/GivenWindows50App.cs
@@ -16,7 +16,8 @@ namespace EndToEnd
         [InlineData("10.0.17763.0")]
         [InlineData("10.0.18362.0")]
         [InlineData("10.0.19041.0")]
-        [InlineData("10.0.20348.0", Skip = "Package not published yet")]
+        [InlineData("10.0.20348.0")]
+        [InlineData("10.0.22000.0", Skip = "Package not published yet")]
         public void ItCanBuildAndRun(string targetPlatformVersion)
         {
             var testInstance = TestAssets.Get(TestAssetKinds.TestProjects, "UseCswinrt")


### PR DESCRIPTION
This PR provides the option to target Windows 11 via the TargetFramework `net5.0-windows.10.0.22000.0`. 

Related PRs:
.NET 6 - https://github.com/dotnet/installer/pull/12258