### PR TITLE
[release/5.0.4xx] Backport x64 on ARM64 installer changes 

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -94,6 +94,9 @@
     <SharedHostVersion>$(MicrosoftNETCoreAppRuntimePackageVersion)</SharedHostVersion>
   </PropertyGroup>
   <PropertyGroup>
+    <WixPackageVersion>1.0.0-v3.14.0.5722</WixPackageVersion>
+  </PropertyGroup>
+  <PropertyGroup>
     <!-- 5.0 Template versions -->
     <MicrosoftDotnetWinFormsProjectTemplates50PackageVersion>$(MicrosoftDotnetWinFormsProjectTemplatesPackageVersion)</MicrosoftDotnetWinFormsProjectTemplates50PackageVersion>
     <MicrosoftDotNetWpfProjectTemplates50PackageVersion>$(MicrosoftDotNetWpfProjectTemplatesPackageVersion)</MicrosoftDotNetWpfProjectTemplates50PackageVersion>

--- a/src/redist/targets/GenerateMSIs.targets
+++ b/src/redist/targets/GenerateMSIs.targets
@@ -14,8 +14,8 @@
   <Target Name="SetupWixProperties" DependsOnTargets="GetCurrentRuntimeInformation">
     <!-- AcquireWix Properties -->
     <PropertyGroup>
-      <WixVersion>3.14.0.4118</WixVersion>
-      <WixDownloadUrl>https://dotnetcli.azureedge.net/build/wix/wix.$(WixVersion).zip</WixDownloadUrl>
+      <WixVersion>1.0.0-v3.14.0.4118</WixVersion>
+      <WixDownloadUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/wix/Microsoft.Signed.Wix-$(WixVersion).zip</WixDownloadUrl>
       <WixRoot>$(ArtifactsDir)Tools/WixTools/$(WixVersion)</WixRoot>
       <WixDestinationPath>$(WixRoot)/WixTools.$(WixVersion).zip</WixDestinationPath>
       <WixDownloadSentinel>$(WixRoot)/WixDownload.$(WixVersion).sentinel</WixDownloadSentinel>

--- a/src/redist/targets/GenerateMSIs.targets
+++ b/src/redist/targets/GenerateMSIs.targets
@@ -14,7 +14,7 @@
   <Target Name="SetupWixProperties" DependsOnTargets="GetCurrentRuntimeInformation">
     <!-- AcquireWix Properties -->
     <PropertyGroup>
-      <WixVersion>1.0.0-v3.14.0.4118</WixVersion>
+      <WixVersion>$(WixPackageVersion)</WixVersion>
       <WixDownloadUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/wix/Microsoft.Signed.Wix-$(WixVersion).zip</WixDownloadUrl>
       <WixRoot>$(ArtifactsDir)Tools/WixTools/$(WixVersion)</WixRoot>
       <WixDestinationPath>$(WixRoot)/WixTools.$(WixVersion).zip</WixDestinationPath>

--- a/src/redist/targets/packaging/osx/clisdk/Distribution-Template
+++ b/src/redist/targets/packaging/osx/clisdk/Distribution-Template
@@ -10,6 +10,7 @@
             <os-version min="10.13" />
         </allowed-os-versions>
     </volume-check>
+    <installation-check script="CheckInstallX64()" />
     <choices-outline>
         <line choice="{NetCoreAppTargetingPackComponentId}.pkg" />
         <line choice="{NetStandardTargetingPackComponentId}.pkg" />
@@ -47,4 +48,37 @@
     <pkg-ref id="{HostFxrComponentId}.pkg">{HostFxrComponentId}.pkg</pkg-ref>
     <pkg-ref id="{SharedHostComponentId}.pkg">{SharedHostComponentId}.pkg</pkg-ref>
     <pkg-ref id="{CLISdkComponentId}.pkg">{CLISdkComponentId}.pkg</pkg-ref>
+        <script>
+<![CDATA[
+function IsX64Machine() {
+    var machine = system.sysctl("hw.machine");
+    var cputype = system.sysctl("hw.cputype");
+    var cpu64 = system.sysctl("hw.cpu64bit_capable");
+    var translated = system.sysctl("sysctl.proc_translated");
+    system.log("Machine type: " + machine);
+    system.log("Cpu type: " + cputype);
+    system.log("64-bit: " + cpu64);
+    system.log("Translated: " + translated);
+    
+    // From machine.h
+    // CPU_TYPE_X86_64 = CPU_TYPE_X86 | CPU_ARCH_ABI64 = 0x010000007 = 16777223
+    // CPU_TYPE_X86 = 7
+    var result = machine == "amd64" || machine == "x86_64" || cputype == "16777223" || (cputype == "7" && cpu64 == "1");
+    // We may be running under translation (Rosetta) that makes it seem like system is x64, if so assume machine is not actually x64
+    result = result && (translated != "1");
+    system.log("IsX64Machine: " + result);
+    return result;
+}
+function CheckInstallX64() {
+    var result = IsX64Machine() ;
+    if (!result)
+    {
+        my.result.message = "This package may only be installed on an x64 machine.";
+        my.result.type = 'Fatal';
+    }
+
+    return result;
+}
+]]>
+    </script>
 </installer-gui-script>

--- a/src/redist/targets/packaging/windows/clisdk/bundle.wxs
+++ b/src/redist/targets/packaging/windows/clisdk/bundle.wxs
@@ -11,11 +11,15 @@
           Compressed="yes">
 
     <bal:Condition Message="The installation path for x64 SDK installations: &quot;[DOTNETHOME_X64]&quot; cannot be the same as for x86 SDK installations: &quot;[DOTNETHOME_X86]&quot;">
-        WixBundleInstalled OR ((NOT (DOTNETHOME_X64 ~= DOTNETHOME_X86)) OR DOTNETHOMESIMILARITYCHECKOVERRIDE)
+        WixBundleInstalled OR (NOT DOTNETHOME_X64 ~= DOTNETHOME_X86) OR DOTNETHOMESIMILARITYCHECKOVERRIDE
     </bal:Condition>
 
     <bal:Condition Message="The installation path for ARM64 SDK installations: &quot;[DOTNETHOME_ARM64]&quot; cannot be the same as for x86 SDK installations: &quot;[DOTNETHOME_X86]&quot;">
-        WixBundleInstalled OR ((NOT (DOTNETHOME_ARM64 ~= DOTNETHOME_X86)) OR DOTNETHOMESIMILARITYCHECKOVERRIDE)
+        WixBundleInstalled OR (NOT DOTNETHOME_ARM64 ~= DOTNETHOME_X86) OR DOTNETHOMESIMILARITYCHECKOVERRIDE
+    </bal:Condition>
+
+    <bal:Condition Message="This product is not supported on ARM64.">
+        WixBundleInstalled OR (NOT NativeMachine = $(var.NativeMachine_arm64)) OR DOTNETALLOWINSTALLONARM64
     </bal:Condition>
 
     <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.Foundation">

--- a/src/redist/targets/packaging/windows/clisdk/bundle.wxs
+++ b/src/redist/targets/packaging/windows/clisdk/bundle.wxs
@@ -177,9 +177,6 @@
       </MsiPackage>
       <MsiPackage SourceFile="$(var.CLISDKMsiSourcePath)">
         <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
-        <MsiProperty Name="DOTNETHOME_X86" Value="[DOTNETHOME_X86]" />
-        <MsiProperty Name="DOTNETHOME_X64" Value="[DOTNETHOME_X64]" />
-        <MsiProperty Name="DOTNETHOME_ARM64" Value="[DOTNETHOME_ARM64]" />
         <MsiProperty Name="EXEFULLPATH" Value="[WixBundleOriginalSource]" />
         <MsiProperty Name="ALLOWMSIINSTALL" Value="True" />
       </MsiPackage>

--- a/src/redist/targets/packaging/windows/clisdk/registrykeys.wxs
+++ b/src/redist/targets/packaging/windows/clisdk/registrykeys.wxs
@@ -15,24 +15,6 @@
           <RegistryValue Action="write" Name="WpfWinformsTemplates" Type="integer" Value="1" KeyPath="yes"/>
         </RegistryKey>
       </Component>
-      <Component Id="DotnetInstallLocation_arm64" Directory="TARGETDIR" Win64="no">
-        <Condition>VersionNT64 AND DOTNETHOME_ARM64</Condition>
-        <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\Setup\InstalledVersions\arm64">
-          <RegistryValue Action="write" Name="InstallLocation" Type="string" Value="[DOTNETHOME_ARM64]" KeyPath="yes"/>
-        </RegistryKey>
-      </Component>
-      <Component Id="DotnetInstallLocation_x64" Directory="TARGETDIR" Win64="no">
-        <Condition>VersionNT64 AND DOTNETHOME_X64</Condition>
-        <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\Setup\InstalledVersions\x64">
-          <RegistryValue Action="write" Name="InstallLocation" Type="string" Value="[DOTNETHOME_X64]" KeyPath="yes"/>
-        </RegistryKey>
-      </Component>
-      <Component Id="DotnetInstallLocation_x86" Directory="TARGETDIR" Win64="no">
-        <Condition>DOTNETHOME_X86</Condition>
-        <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\Setup\InstalledVersions\x86">
-          <RegistryValue Action="write" Name="InstallLocation" Type="string" Value="[DOTNETHOME_X86]" KeyPath="yes"/>
-        </RegistryKey>
-      </Component>
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/src/redist/targets/packaging/windows/clisdk/variables.wxi
+++ b/src/redist/targets/packaging/windows/clisdk/variables.wxi
@@ -15,6 +15,12 @@
   <?define LCID  = "$(var.ProductLanguage)"?>
   <?define DowngradeErrorMessage  = "A newer version is already installed; please uninstall it and re-run setup."?>
 
+  <!-- NativeMachine values match the expected values for image file machine constants
+       https://docs.microsoft.com/en-us/windows/win32/sysinfo/image-file-machine-constants -->
+  <?define NativeMachine_x86=332?>
+  <?define NativeMachine_x64=34404?>
+  <?define NativeMachine_arm64=43620?>
+  
   <?define Platform   =   "$(sys.BUILDARCH)" ?>
   <?if $(var.Platform)=x86?>
   <?define PlatformToken="X86"?>


### PR DESCRIPTION
This is a cherry-pick of the following 6.0 changes to support blocking installation on ARM64, and moving product detection keys to the host installer.
- https://github.com/dotnet/installer/commit/a6385f7be2edfb8654b592c28349d3b25480adad
- https://github.com/dotnet/installer/commit/912bf7a61bd09ec6dc11c1bdd7b05508c77e8114
- https://github.com/dotnet/installer/commit/46fa4c306e37f233c3244bf84897856980e64f98

This also adds installation blocks to both the MacOs and Windows installers.