### PR TITLE
[6.0.1xx] dotnet/arcade: Disable Workloads WiX dependency in source-build to remove prebuilt

### DIFF
--- a/src/SourceBuild/tarball/patches/arcade/0009-Disable-Workloads-WiX-dependency-in-source-build.patch
+++ b/src/SourceBuild/tarball/patches/arcade/0009-Disable-Workloads-WiX-dependency-in-source-build.patch
@@ -3,6 +3,9 @@ From: Davis Goodin <dagood@microsoft.com>
 Date: Fri, 8 Oct 2021 16:15:42 -0700
 Subject: [PATCH] Disable Workloads WiX dependency in source-build
 
+This removes the prebuilt WiX dependency: https://github.com/dotnet/arcade/issues/8014
+
+The patch is temporary, pending upstream fix and dependency flow.
 ---
  .../src/{FileRow.cs => FileRow.wix.cs}        |  0
  ...ifestMsi.cs => GenerateManifestMsi.wix.cs} |  0


### PR DESCRIPTION
Apply https://github.com/dotnet/arcade/pull/8016 as a patch:

> For dotnet/arcade#8014 (see issue for details/caveats)
> 
> After setting up the csproj, my process was to run a build with `IncludeWiX=false`, see which `.cs` files caused failures, change the extension to `.wix.cs`, and repeat. It seems to ended up pretty reasonably--at least, the files all _seem_ to have to do with MSIs and not anything that could be useful for Linux. 😄
> 
> I'm running a 6.0 source-build with this change as a patch file to make sure it doesn't cause a downstream build error.
> 
> The intent is that this change doesn't affect "normal" builds at all.

Formatted with `git format-patch --zero-commit --no-signature -1` for low diff on changes. (I found a few new flags while working on patches elsewhere: commit is now zeroed out, and the Git version is no longer at the end of the file.)

Local build is still running, but it did remove the prebuilt in dotnet/arcade and the dotnet/runtime portable build passed, so far.