### PR TITLE
Update source-build-reference-packages reference to reference intermediate package

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -211,9 +211,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>e58cb829bf6d9c340b4a0c100956e2995d792aa2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="6.0.0-alpha.1.21508.1">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="6.0.0-alpha.1.21511.3">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>5334f439e93c93244c5e2ef97b953491a0dbcf09</Sha>
+      <Sha>feb7e7676aeba776ad906396db4cee4eeeb0454d</Sha>
       <SourceBuildTarball RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceLink.GitHub" Version="1.1.0-beta-21423-02" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">


### PR DESCRIPTION
The reference to source-build-reference-packages was referencing a package that is no longer created when building SBRP.  Update to use the intermediate package instead to enable auto-PRs for this repo.
