### PR TITLE
Add format repo to source-build tarball

### DIFF
--- a/src/SourceBuild/tarball/content/repos/format.proj
+++ b/src/SourceBuild/tarball/content/repos/format.proj
@@ -1,0 +1,22 @@
+<Project>
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
+  <PropertyGroup>
+    <BuildCommand>$(ProjectDirectory)eng\common\build$(ShellExtension) $(StandardSourceBuildArgs)</BuildCommand>
+
+    <GlobalJsonFile>$(ProjectDirectory)global.json</GlobalJsonFile>
+    <NuGetConfigFile>$(ProjectDirectory)NuGet.config</NuGetConfigFile>
+    <OutputPlacementRepoApiImplemented>false</OutputPlacementRepoApiImplemented>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <RepositoryReference Include="source-build" />
+    <RepositoryReference Include="roslyn" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <UseSourceBuiltSdkOverride Include="@(ArcadeSdkOverride)" />
+  </ItemGroup>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+</Project>

--- a/src/SourceBuild/tarball/content/repos/known-good.proj
+++ b/src/SourceBuild/tarball/content/repos/known-good.proj
@@ -54,6 +54,7 @@
         <!-- Tier 4 -->
         <RepositoryReference Include="aspnetcore" />
         <RepositoryReference Include="deployment-tools" />
+        <RepositoryReference Include="format" />
         <RepositoryReference Include="nuget-client" />
 
         <!-- Tier 5 -->

--- a/src/SourceBuild/tarball/content/repos/sdk.proj
+++ b/src/SourceBuild/tarball/content/repos/sdk.proj
@@ -42,6 +42,7 @@
     <RepositoryReference Include="roslyn-analyzers" />
     <RepositoryReference Include="vstest" />
     <RepositoryReference Include="fsharp" />
+    <RepositoryReference Include="format" />
     <RepositoryReference Include="deployment-tools" />
   </ItemGroup>
 

--- a/src/SourceBuild/tarball/patches/format/0001-Exclude-unit-and-performance-test-from-source-build.patch
+++ b/src/SourceBuild/tarball/patches/format/0001-Exclude-unit-and-performance-test-from-source-build.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MichaelSimons <msimons@microsoft.com>
+Date: Thu, 14 Oct 2021 01:15:37 +0000
+Subject: [PATCH] Exclude unit and performance test from source-build
+
+---
+ perf/dotnet-format.Performance.csproj | 1 +
+ tests/dotnet-format.UnitTests.csproj  | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/perf/dotnet-format.Performance.csproj b/perf/dotnet-format.Performance.csproj
+index dd4c95e..c96e8b8 100644
+--- a/perf/dotnet-format.Performance.csproj
++++ b/perf/dotnet-format.Performance.csproj
+@@ -14,6 +14,7 @@
+ 
+     <!-- Always run on the latest runtime installed. -->
+     <RollForward>LatestMajor</RollForward>
++    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+   </PropertyGroup>
+   <ItemGroup>
+     <PackageReference Include="BenchmarkDotNet" />
+diff --git a/tests/dotnet-format.UnitTests.csproj b/tests/dotnet-format.UnitTests.csproj
+index 06dbbb4..f566d6a 100644
+--- a/tests/dotnet-format.UnitTests.csproj
++++ b/tests/dotnet-format.UnitTests.csproj
+@@ -12,6 +12,7 @@
+     <!-- Always run on the latest runtime installed. -->
+     <RuntimeFrameworkVersion>6.0.0-preview.7.21317.1</RuntimeFrameworkVersion>
+     <RollForward>LatestMajor</RollForward>
++    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+   </PropertyGroup>
+ 
+   <ItemGroup>

--- a/src/SourceBuild/tarball/patches/format/0002-Package-version-changes-to-support-source-build.patch
+++ b/src/SourceBuild/tarball/patches/format/0002-Package-version-changes-to-support-source-build.patch
@@ -1,0 +1,44 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michael Simons <msimons@microsoft.com>
+Date: Thu, 14 Oct 2021 10:35:52 +0000
+Subject: [PATCH] Package version changes to support source-build
+
+---
+ Directory.Packages.props | 3 +--
+ eng/Versions.props       | 2 ++
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/Directory.Packages.props b/Directory.Packages.props
+index 57c2735..6b628c2 100644
+--- a/Directory.Packages.props
++++ b/Directory.Packages.props
+@@ -2,7 +2,6 @@
+   <!-- <Import Project="eng\Versions.props" /> -->
+ 
+   <PropertyGroup>
+-    <MicrosoftBuildVersion>16.11.0</MicrosoftBuildVersion>
+     <MicrosoftExtensionsVersion>5.0.0</MicrosoftExtensionsVersion>
+     <!-- In order tests against the same version of NuGet as the SDK. We have to set this to match. -->
+     <NuGetVersion>6.0.0-preview.4.221</NuGetVersion>
+@@ -15,7 +14,7 @@
+     <PackageVersion Include="Microsoft.Build.Locator" Version="1.4.1" />
+     <PackageVersion Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)"/>
+     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzer.Testing" Version="1.1.1-beta1.21413.1" />
+-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" />
++    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" />
+     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Features" Version="$(MicrosoftNETCoreCompilersPackageVersion)" />
+     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftNETCoreCompilersPackageVersion)" />
+     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftNETCoreCompilersPackageVersion)" />
+diff --git a/eng/Versions.props b/eng/Versions.props
+index 7a39a9c..5270ea4 100644
+--- a/eng/Versions.props
++++ b/eng/Versions.props
+@@ -13,6 +13,8 @@
+     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
+   </PropertyGroup>
+   <PropertyGroup>
++    <MicrosoftBuildVersion>16.11.0</MicrosoftBuildVersion>
++    <MicrosoftCodeAnalysisAnalyzersVersion>3.3.2</MicrosoftCodeAnalysisAnalyzersVersion>
+     <!-- Dependencies from https://github.com/dotnet/roslyn -->
+     <MicrosoftNETCoreCompilersPackageVersion>4.0.0-6.21515.3</MicrosoftNETCoreCompilersPackageVersion>
+     <!-- Dependencies from https://github.com/dotnet/command-line-api -->

--- a/src/SourceBuild/tarball/patches/format/0003-Project-changes-to-eliminate-prebuilts.patch
+++ b/src/SourceBuild/tarball/patches/format/0003-Project-changes-to-eliminate-prebuilts.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "msimons@microsoft.com" <MichaelSimons>
+Date: Tue, 19 Oct 2021 14:32:25 +0000
+Subject: [PATCH] Project changes to eliminate prebuilts
+
+---
+ src/dotnet-format.csproj | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/src/dotnet-format.csproj b/src/dotnet-format.csproj
+index dbc94b8..994e539 100644
+--- a/src/dotnet-format.csproj
++++ b/src/dotnet-format.csproj
+@@ -19,7 +19,6 @@
+     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+ 
+     <!-- Always run on the latest runtime installed. -->
+-    <RuntimeFrameworkVersion>6.0.0-preview.7.21317.1</RuntimeFrameworkVersion>
+     <RollForward>LatestMajor</RollForward>
+ 
+     <IsPackable>true</IsPackable>
+@@ -29,7 +28,7 @@
+       These identifiers are for generating the shim'd core executables for signing. Not all options
+       from $(RoslynPortableRuntimeIdentifiers) work or make sense in this context.
+     -->
+-    <PackAsToolShimRuntimeIdentifiers>win-x64;win-x86;osx-x64</PackAsToolShimRuntimeIdentifiers>
++    <PackAsToolShimRuntimeIdentifiers Condition=" '$(DotnetBuildFromSource)' != 'true' ">win-x64;win-x86;osx-x64</PackAsToolShimRuntimeIdentifiers>
+   </PropertyGroup>
+ 
+   <ItemGroup>

--- a/src/SourceBuild/tarball/patches/source-build/0001-Fix-humanizer-assembly-version.patch
+++ b/src/SourceBuild/tarball/patches/source-build/0001-Fix-humanizer-assembly-version.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "msimons@microsoft.com" <MichaelSimons>
+Date: Tue, 19 Oct 2021 18:59:23 +0000
+Subject: [PATCH] Fix humanizer assembly version
+
+Patch for https://github.com/dotnet/source-build/pull/2539
+---
+ .../humanizer/0001-Fix-building-in-a-source-build-context.patch | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/patches/humanizer/0001-Fix-building-in-a-source-build-context.patch b/patches/humanizer/0001-Fix-building-in-a-source-build-context.patch
+index 8d31028..7a5e5f3 100644
+--- a/patches/humanizer/0001-Fix-building-in-a-source-build-context.patch
++++ b/patches/humanizer/0001-Fix-building-in-a-source-build-context.patch
+@@ -24,7 +24,7 @@ index 842a373..e018285 100644
+      <TargetFramework>netstandard1.0</TargetFramework>    
+      <Authors>Mehdi Khalili, Oren Novotny</Authors>
+      <PackageLicenseUrl>https://raw.githubusercontent.com/Humanizr/Humanizer/master/LICENSE</PackageLicenseUrl>
+-+    <PackageVersion>2.2.0</PackageVersion>
+++    <Version>2.2.0</Version>
+      <PackageProjectUrl>https://github.com/Humanizr/Humanizer</PackageProjectUrl>
+      <MinClientVersion>2.12</MinClientVersion>
+      <Description>A micro-framework that turns your normal strings, type names, enum fields, date fields ETC into a human friendly format</Description>    


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/2509

This adds the following prebuilt which are being addressed by https://github.com/dotnet/installer/pull/12397.

Microsoft.CodeAnalysis.AnalyzerUtilities 3.3.0
Microsoft.CodeAnalysis.Features 4.0.0-6.21515.3 (direct)
Microsoft.CodeAnalysis.VisualBasic.Features 4.0.0-6.21515.3 (direct)

The PR to backport the dotnet-format patches is https://github.com/dotnet/format/pull/1392