### PR TITLE
Update source-build prebuilts and previous source-build

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -159,8 +159,8 @@
          removed.  See https://github.com/dotnet/source-build/issues/2295 -->
     <MicrosoftBuildFrameworkVersion>15.7.179</MicrosoftBuildFrameworkVersion>
     <MicrosoftBuildUtilitiesCoreVersion>15.7.179</MicrosoftBuildUtilitiesCoreVersion>
-    <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-6.0.100-bootstrap.22</PrivateSourceBuiltArtifactsPackageVersion>
-    <PrivateSourceBuiltPrebuiltsPackageVersion>0.1.0-6.0.100-29</PrivateSourceBuiltPrebuiltsPackageVersion>
+    <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-6.0.100-bootstrap.23</PrivateSourceBuiltArtifactsPackageVersion>
+    <PrivateSourceBuiltPrebuiltsPackageVersion>0.1.0-6.0.100-30</PrivateSourceBuiltPrebuiltsPackageVersion>
   </PropertyGroup>
   <!-- Workload manifest package versions -->
   <PropertyGroup>

--- a/src/SourceBuild/tarball/content/eng/Versions.props
+++ b/src/SourceBuild/tarball/content/eng/Versions.props
@@ -22,6 +22,6 @@
   <!-- Production Dependencies -->
   <PropertyGroup>
     <PrivateSourceBuiltPrebuiltsPackageVersionPrefix>0.1.0-6.0.100-</PrivateSourceBuiltPrebuiltsPackageVersionPrefix>
-    <PrivateSourceBuiltPrebuiltsPackageVersionSuffix>29</PrivateSourceBuiltPrebuiltsPackageVersionSuffix>
+    <PrivateSourceBuiltPrebuiltsPackageVersionSuffix>30</PrivateSourceBuiltPrebuiltsPackageVersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This change picks up Microsoft.DotNet.Compatibility in the previous source-built binaries eliminate the prebuilt in the runtime repo.

Fixes https://github.com/dotnet/source-build/issues/2421
Fixes https://github.com/dotnet/source-build/issues/2498
