### PR TITLE
[ArPow] Update aspnetcore to use built versions of analyzers

### DIFF
--- a/src/SourceBuild/tarball/content/Directory.Build.props
+++ b/src/SourceBuild/tarball/content/Directory.Build.props
@@ -256,16 +256,6 @@
     <!-- if MicrosoftSourceLinkCommonPackageVersion is non-empty, then we've already built SourceLink, regardless of whether
          this is the production or offline build, so we should use that version.  -->
     <ExtraPackageVersionPropsPackageInfo Include="MicrosoftSourceLinkVersion" Version="%24(MicrosoftSourceLinkCommonPackageVersion)" />
-
-    <!--
-      From aspnetcore Versions.props:
-          Versions of Microsoft.CodeAnalysis packages referenced by analyzers shipped in the SDK.
-          This need to be pinned since they're used in 3.1 apps and need to be loadable in VS 2019.
-      In source-build these don't need to be pinned and can use the source-built versions since it doesn't
-      need to support VS 2019.
-    -->
-    <ExtraPackageVersionPropsPackageInfo Include="Analyzer_MicrosoftCodeAnalysisCSharpVersion" Version="%24(MicrosoftCodeAnalysisCSharpVersion)" />
-    <ExtraPackageVersionPropsPackageInfo Include="Analyzer_MicrosoftCodeAnalysisCSharpWorkspacesVersion" Version="%24(MicrosoftCodeAnalysisCSharpWorkspacesVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/SourceBuild/tarball/content/repos/aspnetcore.proj
+++ b/src/SourceBuild/tarball/content/repos/aspnetcore.proj
@@ -27,6 +27,18 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!--
+      From aspnetcore Versions.props:
+          Versions of Microsoft.CodeAnalysis packages referenced by analyzers shipped in the SDK.
+          This need to be pinned since they're used in 3.1 apps and need to be loadable in VS 2019.
+      In source-build these don't need to be pinned and can use the source-built versions since it doesn't
+      need to support VS 2019.
+    -->
+    <ExtraPackageVersionPropsPackageInfo Include="Analyzer_MicrosoftCodeAnalysisCSharpVersion" Version="%24(MicrosoftCodeAnalysisCSharpVersion)" />
+    <ExtraPackageVersionPropsPackageInfo Include="Analyzer_MicrosoftCodeAnalysisCSharpWorkspacesVersion" Version="%24(MicrosoftCodeAnalysisCSharpWorkspacesVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <RepositoryReference Include="arcade" />
     <RepositoryReference Include="source-build" />
     <RepositoryReference Include="runtime" />


### PR DESCRIPTION
Aspnetcore has pinned versions of CodeAnalysisCSharp* to support VS scenarios.  These can be changed to the built versions of these packages in source-build.