### PR TITLE
[ArPow] Restore arcade patch that was inadvertently removed

### DIFF
--- a/src/SourceBuild/tarball/patches/arcade/0009-Disable-Workloads-WiX-dependency-in-source-build.patch
+++ b/src/SourceBuild/tarball/patches/arcade/0009-Disable-Workloads-WiX-dependency-in-source-build.patch
@@ -1,0 +1,124 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Davis Goodin <dagood@microsoft.com>
+Date: Fri, 8 Oct 2021 16:15:42 -0700
+Subject: [PATCH] Disable Workloads WiX dependency in source-build
+
+This removes the prebuilt WiX dependency: https://github.com/dotnet/arcade/issues/8014
+
+The patch is temporary, pending upstream fix and dependency flow.
+---
+ .../src/{FileRow.cs => FileRow.wix.cs}        |  0
+ ...ifestMsi.cs => GenerateManifestMsi.wix.cs} |  0
+ .../{GenerateMsi.cs => GenerateMsi.wix.cs}    |  0
+ ...erateMsiBase.cs => GenerateMsiBase.wix.cs} |  0
+ ...erateVisualStudioMsiPackageProject.wix.cs} |  0
+ ...cs => GenerateVisualStudioWorkload.wix.cs} |  0
+ ...oadMsis.cs => GenerateWorkloadMsis.wix.cs} |  0
+ ...rosoft.DotNet.Build.Tasks.Workloads.csproj | 23 ++++++++++++++++---
+ ...{MsiProperties.cs => MsiProperties.wix.cs} |  0
+ .../src/{MsiUtils.cs => MsiUtils.wix.cs}      |  0
+ ...elatedProduct.cs => RelatedProduct.wix.cs} |  0
+ 11 files changed, 20 insertions(+), 3 deletions(-)
+ rename src/Microsoft.DotNet.Build.Tasks.Workloads/src/{FileRow.cs => FileRow.wix.cs} (100%)
+ rename src/Microsoft.DotNet.Build.Tasks.Workloads/src/{GenerateManifestMsi.cs => GenerateManifestMsi.wix.cs} (100%)
+ rename src/Microsoft.DotNet.Build.Tasks.Workloads/src/{GenerateMsi.cs => GenerateMsi.wix.cs} (100%)
+ rename src/Microsoft.DotNet.Build.Tasks.Workloads/src/{GenerateMsiBase.cs => GenerateMsiBase.wix.cs} (100%)
+ rename src/Microsoft.DotNet.Build.Tasks.Workloads/src/{GenerateVisualStudioMsiPackageProject.cs => GenerateVisualStudioMsiPackageProject.wix.cs} (100%)
+ rename src/Microsoft.DotNet.Build.Tasks.Workloads/src/{GenerateVisualStudioWorkload.cs => GenerateVisualStudioWorkload.wix.cs} (100%)
+ rename src/Microsoft.DotNet.Build.Tasks.Workloads/src/{GenerateWorkloadMsis.cs => GenerateWorkloadMsis.wix.cs} (100%)
+ rename src/Microsoft.DotNet.Build.Tasks.Workloads/src/{MsiProperties.cs => MsiProperties.wix.cs} (100%)
+ rename src/Microsoft.DotNet.Build.Tasks.Workloads/src/{MsiUtils.cs => MsiUtils.wix.cs} (100%)
+ rename src/Microsoft.DotNet.Build.Tasks.Workloads/src/{RelatedProduct.cs => RelatedProduct.wix.cs} (100%)
+
+diff --git a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/FileRow.cs b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/FileRow.wix.cs
+similarity index 100%
+rename from src/Microsoft.DotNet.Build.Tasks.Workloads/src/FileRow.cs
+rename to src/Microsoft.DotNet.Build.Tasks.Workloads/src/FileRow.wix.cs
+diff --git a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.wix.cs
+similarity index 100%
+rename from src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.cs
+rename to src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateManifestMsi.wix.cs
+diff --git a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsi.cs b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsi.wix.cs
+similarity index 100%
+rename from src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsi.cs
+rename to src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsi.wix.cs
+diff --git a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.wix.cs
+similarity index 100%
+rename from src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.cs
+rename to src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateMsiBase.wix.cs
+diff --git a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateVisualStudioMsiPackageProject.cs b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateVisualStudioMsiPackageProject.wix.cs
+similarity index 100%
+rename from src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateVisualStudioMsiPackageProject.cs
+rename to src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateVisualStudioMsiPackageProject.wix.cs
+diff --git a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateVisualStudioWorkload.cs b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateVisualStudioWorkload.wix.cs
+similarity index 100%
+rename from src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateVisualStudioWorkload.cs
+rename to src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateVisualStudioWorkload.wix.cs
+diff --git a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateWorkloadMsis.cs b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateWorkloadMsis.wix.cs
+similarity index 100%
+rename from src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateWorkloadMsis.cs
+rename to src/Microsoft.DotNet.Build.Tasks.Workloads/src/GenerateWorkloadMsis.wix.cs
+diff --git a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Microsoft.DotNet.Build.Tasks.Workloads.csproj b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Microsoft.DotNet.Build.Tasks.Workloads.csproj
+index 19cf67b5..2d02b7f4 100644
+--- a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Microsoft.DotNet.Build.Tasks.Workloads.csproj
++++ b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Microsoft.DotNet.Build.Tasks.Workloads.csproj
+@@ -11,6 +11,16 @@
+     <NoWarn>$(NoWarn);NU5127</NoWarn>
+     <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
+     <RootNamespace>Microsoft.DotNet.Build.Tasks.Workloads</RootNamespace>
++
++    <!--
++      Only include WiX-powered features when running a non-from-source build. (For example, the
++      Microsoft build used to build .NET for Windows.)
++
++      This removes a dependency on prebuilt WiX binaries. The purpose of WiX is to produce Windows
++      installers, and source-build doesn't run on Windows, so excluding WiX while building in
++      source-build mode to remove the prebuilt dependency has no impact to available .NET features.
++    -->
++    <IncludeWiX Condition="'$(DotNetBuildFromSource)' != 'true'">true</IncludeWiX>
+   </PropertyGroup>
+ 
+   <ItemGroup>
+@@ -19,13 +29,16 @@
+     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
+     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />
+     <PackageReference Include="NuGet.Packaging" Version="$(NuGetVersion)" />
+-    <PackageReference Include="Wix" Version="3.11.2" />
+     <PackageReference Include="Microsoft.NET.Sdk.WorkloadManifestReader" Version="$(MicrosoftNetSdkWorkloadManifestReaderVersion)" />
+-    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" Condition="'$(TargetFramework)' == 'net472'"/>
++    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" Condition="'$(TargetFramework)' == 'net472'" />
+     <PackageReference Include="Microsoft.Deployment.DotNet.Releases" Version="$(MicrosoftDeploymentDotNetReleasesVersion)" />
+   </ItemGroup>
+ 
+-  <ItemGroup>
++  <ItemGroup Condition="'$(IncludeWiX)' == 'true'">
++    <PackageReference Include="Wix" Version="3.11.2" />
++  </ItemGroup>
++
++  <ItemGroup Condition="'$(IncludeWiX)' == 'true'">
+     <Reference Include="$(WixInstallPath)\Microsoft.Deployment.Resources.dll" />
+     <Reference Include="$(WixInstallPath)\Microsoft.Deployment.Compression.dll" />
+     <Reference Include="$(WixInstallPath)\Microsoft.Deployment.Compression.Cab.dll" />
+@@ -48,6 +61,10 @@
+     <EmbeddedResource Remove="obj\**" />
+   </ItemGroup>
+ 
++  <ItemGroup Condition="'$(IncludeWiX)' != 'true'">
++    <Compile Remove="**\*.wix.cs" />
++  </ItemGroup>
++
+   <ItemGroup>
+     <EmbeddedResource Include="Misc\*.*" />
+     <EmbeddedResource Include="MsiTemplate\*.wxs" />
+diff --git a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiProperties.cs b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiProperties.wix.cs
+similarity index 100%
+rename from src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiProperties.cs
+rename to src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiProperties.wix.cs
+diff --git a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiUtils.cs b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiUtils.wix.cs
+similarity index 100%
+rename from src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiUtils.cs
+rename to src/Microsoft.DotNet.Build.Tasks.Workloads/src/MsiUtils.wix.cs
+diff --git a/src/Microsoft.DotNet.Build.Tasks.Workloads/src/RelatedProduct.cs b/src/Microsoft.DotNet.Build.Tasks.Workloads/src/RelatedProduct.wix.cs
+similarity index 100%
+rename from src/Microsoft.DotNet.Build.Tasks.Workloads/src/RelatedProduct.cs
+rename to src/Microsoft.DotNet.Build.Tasks.Workloads/src/RelatedProduct.wix.cs


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/2411

This was an inadvertent removal during a dependency update where patch fixes were flowing in.
