### PR TITLE
Remove install location from Windows conclusion

### DIFF
--- a/src/redist/targets/packaging/windows/clisdk/LCID/1028/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1028/bundle.wxl
@@ -49,7 +49,7 @@
   <String Id="FilesInUseCancelButton">取消(&amp;C)</String>
   <String Id="FirstTimeWelcomeMessage">安裝成功。
 
-下列項目已安裝在: '[DOTNETHOME]'
+下列項目已安裝:
     • .NET SDK [DOTNETSDKVERSION]
     • .NET Runtime [DOTNETRUNTIMEVERSION]
     • ASP.NET Core Runtime [ASPNETCOREVERSION]

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1029/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1029/bundle.wxl
@@ -49,7 +49,7 @@
   <String Id="FilesInUseCancelButton">&amp;Zrušit</String>
   <String Id="FirstTimeWelcomeMessage">Instalace proběhla úspěšně.
 
-Do [DOTNETHOME] byly nainstalovány tyto součásti:
+Byly nainstalovány tyto součásti:
     • Sada .NET SDK [DOTNETSDKVERSION]
     • Modul runtime .NET [DOTNETRUNTIMEVERSION]
     • Modul runtime ASP.NET Core [ASPNETCOREVERSION]

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1031/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1031/bundle.wxl
@@ -49,7 +49,7 @@
   <String Id="FilesInUseCancelButton">&amp;Abbrechen</String>
   <String Id="FirstTimeWelcomeMessage">Die Installation war erfolgreich.
 
-Folgende Komponenten wurden unter [DOTNETHOME] installiert:
+Folgende Komponenten wurden installiert:
     • .NET SDK [DOTNETSDKVERSION]
     • .NET Runtime [DOTNETRUNTIMEVERSION]
     • ASP.NET Core Runtime [ASPNETCOREVERSION]

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1033/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1033/bundle.wxl
@@ -49,7 +49,7 @@
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
   <String Id="FirstTimeWelcomeMessage">The installation was successful.
 
-The following products were installed at: '[DOTNETHOME]'
+The following products were installed:
     • .NET SDK [DOTNETSDKVERSION]
     • .NET Runtime [DOTNETRUNTIMEVERSION]
     • ASP.NET Core Runtime [ASPNETCOREVERSION]

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1036/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1036/bundle.wxl
@@ -49,7 +49,7 @@
   <String Id="FilesInUseCancelButton">&amp;Annuler</String>
   <String Id="FirstTimeWelcomeMessage">L'installation a réussi.
 
-Les éléments suivants ont été installés sur : '[DOTNETHOME]'
+Les éléments suivants ont été installés:
     • Kit SDK .NET [DOTNETSDKVERSION]
     • Runtime .NET [DOTNETRUNTIMEVERSION]
     • Runtime ASP.NET Core [ASPNETCOREVERSION]

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1040/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1040/bundle.wxl
@@ -49,7 +49,7 @@
   <String Id="FilesInUseCancelButton">Ann&amp;ulla</String>
   <String Id="FirstTimeWelcomeMessage">L'installazione è riuscita.
 
-I componenti seguenti sono stati installati in '[DOTNETHOME]'
+I componenti seguenti sono stati installati
     • .NET SDK [DOTNETSDKVERSION]
     • Runtime di .NET [DOTNETRUNTIMEVERSION]
     • Runtime di ASP.NET Core [ASPNETCOREVERSION]

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1041/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1041/bundle.wxl
@@ -49,7 +49,7 @@
   <String Id="FilesInUseCancelButton">キャンセル(&amp;C)</String>
   <String Id="FirstTimeWelcomeMessage">インストールが成功しました。
 
-'[DOTNETHOME]' に以下がインストールされました
+以下がインストールされました
     • .NET SDK [DOTNETSDKVERSION]
     • .NET Runtime [DOTNETRUNTIMEVERSION]
     • ASP.NET Core Runtime [ASPNETCOREVERSION]

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1042/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1042/bundle.wxl
@@ -49,7 +49,7 @@
   <String Id="FilesInUseCancelButton">취소(&amp;C)</String>
   <String Id="FirstTimeWelcomeMessage">설치가 완료되었습니다.
 
-다음이 '[DOTNETHOME]'에 설치되었습니다.
+다음이 설치되었습니다.
     • .NET SDK [DOTNETSDKVERSION]
     • .NET 런타임 [DOTNETRUNTIMEVERSION]
     • ASP.NET Core 런타임 [ASPNETCOREVERSION]

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1045/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1045/bundle.wxl
@@ -49,7 +49,7 @@
   <String Id="FilesInUseCancelButton">&amp;Anuluj</String>
   <String Id="FirstTimeWelcomeMessage">Instalacja zakończyła się pomyślnie.
 
-Następujące elementy zostały zainstalowane w: „[DOTNETHOME]”
+Następujące elementy zostały zainstalowane:
     • Zestaw .NET SDK [DOTNETSDKVERSION]
     • Środowisko uruchomieniowe platformy .NET [DOTNETRUNTIMEVERSION]
     • Środowisko uruchomieniowe platformy ASP.NET Core [ASPNETCOREVERSION]

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1046/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1046/bundle.wxl
@@ -49,7 +49,7 @@
   <String Id="FilesInUseCancelButton">&amp;Cancelar</String>
   <String Id="FirstTimeWelcomeMessage">A instalação foi bem-sucedida.
 
-O seguinte foi instalado em: '[DOTNETHOME]'
+O seguinte foi instalado:
     • SDK do .NET [DOTNETSDKVERSION]
     • Runtime do .NET [DOTNETRUNTIMEVERSION]
     • Runtime do ASP.NET Core [ASPNETCOREVERSION]

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1046/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1046/bundle.wxl
@@ -49,7 +49,7 @@
   <String Id="FilesInUseCancelButton">&amp;Cancelar</String>
   <String Id="FirstTimeWelcomeMessage">A instalação foi bem-sucedida.
 
-O seguinte foi instalado:
+Os seguintes produtos foram instalados:
     • SDK do .NET [DOTNETSDKVERSION]
     • Runtime do .NET [DOTNETRUNTIMEVERSION]
     • Runtime do ASP.NET Core [ASPNETCOREVERSION]

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1049/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1049/bundle.wxl
@@ -49,7 +49,7 @@
   <String Id="FilesInUseCancelButton">От&amp;мена</String>
   <String Id="FirstTimeWelcomeMessage">Установка выполнена.
 
-В "[DOTNETHOME]" установлены следующие компоненты:
+Установлены следующие компоненты:
     • Пакет SDK для .NET [DOTNETSDKVERSION]
     • Среда выполнения .NET [DOTNETRUNTIMEVERSION]
     • Среда выполнения ASP.NET Core [ASPNETCOREVERSION]

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1055/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1055/bundle.wxl
@@ -49,7 +49,7 @@
   <String Id="FilesInUseCancelButton">&amp;İptal</String>
   <String Id="FirstTimeWelcomeMessage">Yükleme başarılı oldu.
 
-Aşağıdakiler şu konumda yüklü: '[DOTNETHOME]'
+Aşağıdakiler şu yüklü:
     • .NET SDK [DOTNETSDKVERSION]
     • .NET Çalışma Zamanı [DOTNETRUNTIMEVERSION]
     • ASP.NET Core Çalışma Zamanı [ASPNETCOREVERSION]

--- a/src/redist/targets/packaging/windows/clisdk/LCID/2052/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/2052/bundle.wxl
@@ -49,7 +49,7 @@
   <String Id="FilesInUseCancelButton">取消(&amp;C)</String>
   <String Id="FirstTimeWelcomeMessage">已成功安装。
 
-下列项安装于: "[DOTNETHOME]"
+下列项安装:
     • .NET SDK [DOTNETSDKVERSION]
     • .NET Runtime [DOTNETRUNTIMEVERSION]
     • ASP.NET Core Runtime [ASPNETCOREVERSION]

--- a/src/redist/targets/packaging/windows/clisdk/LCID/3082/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/3082/bundle.wxl
@@ -49,7 +49,7 @@
   <String Id="FilesInUseCancelButton">&amp;Cancelar</String>
   <String Id="FirstTimeWelcomeMessage">La instalación se realizó correctamente.
 
-Se instaló lo siguiente:
+Los siguientes productos han sido instalados:
     • SDK de .NET [DOTNETSDKVERSION]
     • .NET Runtime [DOTNETRUNTIMEVERSION]
     • ASP.NET Core Runtime [ASPNETCOREVERSION]

--- a/src/redist/targets/packaging/windows/clisdk/LCID/3082/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/3082/bundle.wxl
@@ -49,7 +49,7 @@
   <String Id="FilesInUseCancelButton">&amp;Cancelar</String>
   <String Id="FirstTimeWelcomeMessage">La instalación se realizó correctamente.
 
-Se instaló lo siguiente en: "[DOTNETHOME]"
+Se instaló lo siguiente:
     • SDK de .NET [DOTNETSDKVERSION]
     • .NET Runtime [DOTNETRUNTIMEVERSION]
     • ASP.NET Core Runtime [ASPNETCOREVERSION]


### PR DESCRIPTION
DOTNETHOME will not always be set in the bundle.
It's only set when an existing installation was present and the bundle is run.

As a result this string is sometimes empty.  Remove it to avoid confusion.

I did my best at trying to get the translations correct.  I'm not sure though, we might want those to be reviewed by native speakers.

Fixes: #12283
