### PR TITLE
[ArPow] Add ArcadeSharedFrameworkSdkOverride

### DIFF
--- a/src/SourceBuild/tarball/content/repos/Directory.Build.props
+++ b/src/SourceBuild/tarball/content/repos/Directory.Build.props
@@ -151,6 +151,7 @@
     <ArcadeBootstrapSdkOverride Include="Microsoft.DotNet.Arcade.Sdk" Group="ARCADE" Version="$(ArcadeBootstrapVersion)" Location="$(ArcadeBootstrapDir)microsoft.dotnet.arcade.sdk/$(ArcadeBootstrapVersion)" />
     <ArcadePackagingOverride Include="Microsoft.DotNet.Build.Tasks.Packaging" Group="ARCADE_PACKAGING" Version="$(arcadeOutputPackageVersion)"/>
     <ArcadeTargetFrameworkSdkOverride Include="Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk" Group="ARCADE_TGT_FX_SDK" Version="$(arcadeOutputPackageVersion)"/>
+    <ArcadeSharedFrameworkSdkOverride Include="Microsoft.DotNet.SharedFramework.Sdk" Group="ARCADE_SHARED_FX_SDK" Version="$(arcadeOutputPackageVersion)"/>
     <ILSdkOverride Include="Microsoft.NET.Sdk.IL" Group="IL" />
     <MsBuildTraversalSdkOverride Include="Microsoft.Build.Traversal" Group="MSBUILD_TRAVERSAL" Version="2.0.2"/>
   </ItemGroup>

--- a/src/SourceBuild/tarball/content/repos/arcade.proj
+++ b/src/SourceBuild/tarball/content/repos/arcade.proj
@@ -25,6 +25,7 @@
     <BuiltSdkPackageOverride Include="@(ArcadeCoreFxTestingOverride)" />
     <BuiltSdkPackageOverride Include="@(ArcadePackagingOverride)" />
     <BuiltSdkPackageOverride Include="@(ArcadeTargetFrameworkSdkOverride)" />
+    <BuiltSdkPackageOverride Include="@(ArcadeSharedFrameworkSdkOverride)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SourceBuild/tarball/content/repos/runtime.common.props
+++ b/src/SourceBuild/tarball/content/repos/runtime.common.props
@@ -32,6 +32,7 @@
     <UseSourceBuiltSdkOverride Include="@(ArcadeCoreFxTestingOverride)" />
     <UseSourceBuiltSdkOverride Include="@(ArcadePackagingOverride)" />
     <UseSourceBuiltSdkOverride Include="@(ArcadeTargetFrameworkSdkOverride)" />
+    <UseSourceBuiltSdkOverride Include="@(ArcadeSharedFrameworkSdkOverride)" />
   </ItemGroup>
 
   <!-- Environment Variables -->


### PR DESCRIPTION
Setup override to allow runtime to use source-built version of Microsoft.DotNet.SharedFramework.Sdk.
