### PR TITLE
[ArPow] Re-enable building Microsoft.CodeAnalysis.Features* in roslyn source-build

### DIFF
--- a/src/SourceBuild/tarball/patches/roslyn/0004-Build-more-projects-during-source-build.patch
+++ b/src/SourceBuild/tarball/patches/roslyn/0004-Build-more-projects-during-source-build.patch
@@ -13,20 +13,14 @@ See https://github.com/dotnet/roslyn/pull/57165
 ---
  eng/SourceBuild.props                                       | 2 +-
  .../Core/Tests}/Directory.Build.props                       | 0
- src/Features/CSharp/Portable/Directory.Build.props          | 6 ++++++
- src/Features/Core/Portable/Directory.Build.props            | 6 ++++++
  src/Features/LanguageServer/Directory.Build.props           | 6 ++++++
  src/Features/Lsif/Directory.Build.props                     | 6 ++++++
- src/Features/VisualBasic/Portable/Directory.Build.props     | 6 ++++++
  src/NuGet/VisualStudio/Directory.Build.props                | 6 ++++++
  .../Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj        | 2 --
- 9 files changed, 37 insertions(+), 3 deletions(-)
+ 6 files changed, 19 insertions(+), 3 deletions(-)
  rename src/{Features => CodeStyle/Core/Tests}/Directory.Build.props (100%)
- create mode 100644 src/Features/CSharp/Portable/Directory.Build.props
- create mode 100644 src/Features/Core/Portable/Directory.Build.props
  create mode 100644 src/Features/LanguageServer/Directory.Build.props
  create mode 100644 src/Features/Lsif/Directory.Build.props
- create mode 100644 src/Features/VisualBasic/Portable/Directory.Build.props
  create mode 100644 src/NuGet/VisualStudio/Directory.Build.props
 
 diff --git a/eng/SourceBuild.props b/eng/SourceBuild.props
@@ -46,30 +40,6 @@ diff --git a/src/Features/Directory.Build.props b/src/CodeStyle/Core/Tests/Direc
 similarity index 100%
 rename from src/Features/Directory.Build.props
 rename to src/CodeStyle/Core/Tests/Directory.Build.props
-diff --git a/src/Features/CSharp/Portable/Directory.Build.props b/src/Features/CSharp/Portable/Directory.Build.props
-new file mode 100644
-index 00000000000..6eef643958f
---- /dev/null
-+++ b/src/Features/CSharp/Portable/Directory.Build.props
-@@ -0,0 +1,6 @@
-+<Project>
-+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-+  <PropertyGroup>
-+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
-+  </PropertyGroup>
-+</Project>
-diff --git a/src/Features/Core/Portable/Directory.Build.props b/src/Features/Core/Portable/Directory.Build.props
-new file mode 100644
-index 00000000000..6eef643958f
---- /dev/null
-+++ b/src/Features/Core/Portable/Directory.Build.props
-@@ -0,0 +1,6 @@
-+<Project>
-+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-+  <PropertyGroup>
-+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
-+  </PropertyGroup>
-+</Project>
 diff --git a/src/Features/LanguageServer/Directory.Build.props b/src/Features/LanguageServer/Directory.Build.props
 new file mode 100644
 index 00000000000..6eef643958f
@@ -94,18 +64,6 @@ index 00000000000..6eef643958f
 +    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
 +  </PropertyGroup>
 +</Project>
-diff --git a/src/Features/VisualBasic/Portable/Directory.Build.props b/src/Features/VisualBasic/Portable/Directory.Build.props
-new file mode 100644
-index 00000000000..6eef643958f
---- /dev/null
-+++ b/src/Features/VisualBasic/Portable/Directory.Build.props
-@@ -0,0 +1,6 @@
-+<Project>
-+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-+  <PropertyGroup>
-+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
-+  </PropertyGroup>
-+</Project>
 diff --git a/src/NuGet/VisualStudio/Directory.Build.props b/src/NuGet/VisualStudio/Directory.Build.props
 new file mode 100644
 index 00000000000..6eef643958f
@@ -119,7 +77,7 @@ index 00000000000..6eef643958f
 +  </PropertyGroup>
 +</Project>
 diff --git a/src/Workspaces/Core/MSBuild/Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj b/src/Workspaces/Core/MSBuild/Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj
-index 76d0dc36da1..a65fc35f1c3 100644
+index 3bd6d6398e3..2edf2da6d1a 100644
 --- a/src/Workspaces/Core/MSBuild/Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj
 +++ b/src/Workspaces/Core/MSBuild/Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj
 @@ -7,8 +7,6 @@


### PR DESCRIPTION
See https://github.com/dotnet/roslyn/issues/57270

Original PR that disabled these projects: https://github.com/dotnet/installer/pull/12397