### PR TITLE
[release/6.0.1xx] Repoint source-build dependencies for runtime and aspnet

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -63,7 +63,7 @@
     <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="6.0.0" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>20de863bd37ad521b7a3bd6056186da5e8a7a2ef</Sha>
-      <SourceBuild RepoName="aspnetcore" ManagedOnly="true" />
+      <SourceBuildTarball RepoName="aspnetcore" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="VS.Redist.Common.AspNetCore.SharedFramework.x64.6.0" Version="6.0.0-rtm.21521.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>

--- a/src/SourceBuild/README.md
+++ b/src/SourceBuild/README.md
@@ -6,7 +6,7 @@ to build .NET from source.
 For more information, see
 [dotnet/source-build](https://github.com/dotnet/source-build).
 
-## Local development workflow 
+## Local development workflow
 
 These are the steps used by some members of the .NET source-build team to create
 a tarball and build it on a local machine as part of the development cycle:


### PR DESCRIPTION
These should point to versions that will stabilize like the runtime packages are supposed to.