### PR TITLE
Fix roslyn to build with boostrapped build

### DIFF
--- a/src/SourceBuild/tarball/patches/roslyn/0005-Build-a-subset-of-roslyn-projects.patch
+++ b/src/SourceBuild/tarball/patches/roslyn/0005-Build-a-subset-of-roslyn-projects.patch
@@ -1,0 +1,146 @@
+From 110fc28ea7c17d57bbd5ce8ed3fc4e2b0274c5b3 Mon Sep 17 00:00:00 2001
+From: dseefeld <dseefeld@microsoft.com>
+Date: Fri, 22 Oct 2021 22:17:37 +0000
+Subject: [PATCH] Build a subset of roslyn projects
+
+Some projects use Microsoft.NET.Sdk.WindowsDesktop sdk
+which cannot be built using a boostrapped source-build
+sdk, since WindowsDesktop is not supported.  These cannot
+be ignored using ExcludeFromSourceBuild because the project
+still needs to be loaded and the sdk cannot be found.
+
+See https://github.com/dotnet/roslyn/issues/57342
+---
+ Roslyn.SourceBuild.slnf | 105 ++++++++++++++++++++++++++++++++++++++++
+ eng/SourceBuild.props   |   2 +-
+ 2 files changed, 106 insertions(+), 1 deletion(-)
+ create mode 100644 Roslyn.SourceBuild.slnf
+
+diff --git a/Roslyn.SourceBuild.slnf b/Roslyn.SourceBuild.slnf
+new file mode 100644
+index 00000000000..e6f8eb315bf
+--- /dev/null
++++ b/Roslyn.SourceBuild.slnf
+@@ -0,0 +1,105 @@
++{
++  "solution": {
++    "path": "Roslyn.sln",
++    "projects": [
++      "src\\Deployment\\RoslynDeployment.csproj",
++      "src\\Compilers\\Core\\Portable\\Microsoft.CodeAnalysis.csproj",
++      "src\\Compilers\\Server\\VBCSCompiler\\VBCSCompiler.csproj",
++      "src\\Compilers\\CSharp\\csc\\csc.csproj",
++      "src\\Compilers\\CSharp\\Portable\\Microsoft.CodeAnalysis.CSharp.csproj",
++      "src\\Compilers\\VisualBasic\\Portable\\Microsoft.CodeAnalysis.VisualBasic.vbproj",
++      "src\\Workspaces\\Core\\Portable\\Microsoft.CodeAnalysis.Workspaces.csproj",
++      "src\\Tools\\Source\\CompilerGeneratorTools\\Source\\BoundTreeGenerator\\CompilersBoundTreeGenerator.csproj",
++      "src\\Tools\\Source\\CompilerGeneratorTools\\Source\\CSharpErrorFactsGenerator\\CSharpErrorFactsGenerator.csproj",
++      "src\\Tools\\Source\\CompilerGeneratorTools\\Source\\CSharpSyntaxGenerator\\CSharpSyntaxGenerator.csproj",
++      "src\\Tools\\Source\\CompilerGeneratorTools\\Source\\VisualBasicSyntaxGenerator\\VisualBasicSyntaxGenerator.vbproj",
++      "src\\Tools\\Source\\CompilerGeneratorTools\\Source\\VisualBasicErrorFactsGenerator\\VisualBasicErrorFactsGenerator.vbproj",
++      "src\\Workspaces\\Core\\Desktop\\Microsoft.CodeAnalysis.Workspaces.Desktop.csproj",
++      "src\\Workspaces\\Core\\MSBuild\\Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj",
++      "src\\Workspaces\\CSharp\\Portable\\Microsoft.CodeAnalysis.CSharp.Workspaces.csproj",
++      "src\\Workspaces\\VisualBasic\\Portable\\Microsoft.CodeAnalysis.VisualBasic.Workspaces.vbproj",
++      "src\\Features\\VisualBasic\\Portable\\Microsoft.CodeAnalysis.VisualBasic.Features.vbproj",
++      "src\\Features\\CSharp\\Portable\\Microsoft.CodeAnalysis.CSharp.Features.csproj",
++      "src\\Features\\Core\\Portable\\Microsoft.CodeAnalysis.Features.csproj",
++      "src\\Scripting\\VisualBasic\\Microsoft.CodeAnalysis.VisualBasic.Scripting.vbproj",
++      "src\\Scripting\\Core\\Microsoft.CodeAnalysis.Scripting.csproj",
++      "src\\Scripting\\CSharp\\Microsoft.CodeAnalysis.CSharp.Scripting.csproj",
++      "src\\ExpressionEvaluator\\Package\\ExpressionEvaluatorPackage.csproj",
++      "src\\ExpressionEvaluator\\CSharp\\Source\\ExpressionCompiler\\Microsoft.CodeAnalysis.CSharp.ExpressionCompiler.csproj",
++      "src\\ExpressionEvaluator\\VisualBasic\\Source\\ExpressionCompiler\\Microsoft.CodeAnalysis.VisualBasic.ExpressionCompiler.vbproj",
++      "src\\ExpressionEvaluator\\Core\\Source\\ExpressionCompiler\\Microsoft.CodeAnalysis.ExpressionCompiler.csproj",
++      "src\\Compilers\\Core\\AnalyzerDriver\\AnalyzerDriver.shproj",
++      "src\\ExpressionEvaluator\\VisualBasic\\Source\\ResultProvider\\BasicResultProvider.shproj",
++      "src\\ExpressionEvaluator\\VisualBasic\\Source\\ResultProvider\\NetFX20\\BasicResultProvider.NetFX20.vbproj",
++      "src\\ExpressionEvaluator\\VisualBasic\\Source\\ResultProvider\\Portable\\Microsoft.CodeAnalysis.VisualBasic.ResultProvider.vbproj",
++      "src\\ExpressionEvaluator\\CSharp\\Source\\ResultProvider\\CSharpResultProvider.shproj",
++      "src\\ExpressionEvaluator\\CSharp\\Source\\ResultProvider\\NetFX20\\CSharpResultProvider.NetFX20.csproj",
++      "src\\ExpressionEvaluator\\CSharp\\Source\\ResultProvider\\Portable\\Microsoft.CodeAnalysis.CSharp.ResultProvider.csproj",
++      "src\\ExpressionEvaluator\\Core\\Source\\ResultProvider\\ResultProvider.shproj",
++      "src\\ExpressionEvaluator\\Core\\Source\\ResultProvider\\NetFX20\\ResultProvider.NetFX20.csproj",
++      "src\\ExpressionEvaluator\\Core\\Source\\ResultProvider\\Portable\\Microsoft.CodeAnalysis.ResultProvider.csproj",
++      "src\\Compilers\\VisualBasic\\vbc\\vbc.csproj",
++      "src\\Compilers\\VisualBasic\\BasicAnalyzerDriver\\BasicAnalyzerDriver.shproj",
++      "src\\Compilers\\CSharp\\CSharpAnalyzerDriver\\CSharpAnalyzerDriver.shproj",
++      "src\\Compilers\\Core\\CommandLine\\CommandLine.shproj",
++      "src\\Compilers\\Extension\\Roslyn.Compilers.Extension.csproj",
++      "src\\Dependencies\\CodeAnalysis.Debugging\\Microsoft.CodeAnalysis.Debugging.shproj",
++      "src\\Dependencies\\PooledObjects\\Microsoft.CodeAnalysis.PooledObjects.shproj",
++      "src\\Workspaces\\Remote\\Core\\Microsoft.CodeAnalysis.Remote.Workspaces.csproj",
++      "src\\Workspaces\\Remote\\ServiceHub\\Microsoft.CodeAnalysis.Remote.ServiceHub.csproj",
++      "src\\Compilers\\Core\\MSBuildTask\\Microsoft.Build.Tasks.CodeAnalysis.csproj",
++      "src\\Tools\\BuildBoss\\BuildBoss.csproj",
++      "src\\ExpressionEvaluator\\Core\\Source\\FunctionResolver\\Microsoft.CodeAnalysis.FunctionResolver.csproj",
++      "src\\CodeStyle\\Core\\Analyzers\\Microsoft.CodeAnalysis.CodeStyle.csproj",
++      "src\\CodeStyle\\Core\\CodeFixes\\Microsoft.CodeAnalysis.CodeStyle.Fixes.csproj",
++      "src\\CodeStyle\\CSharp\\Analyzers\\Microsoft.CodeAnalysis.CSharp.CodeStyle.csproj",
++      "src\\CodeStyle\\CSharp\\CodeFixes\\Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.csproj",
++      "src\\CodeStyle\\VisualBasic\\Analyzers\\Microsoft.CodeAnalysis.VisualBasic.CodeStyle.vbproj",
++      "src\\CodeStyle\\VisualBasic\\CodeFixes\\Microsoft.CodeAnalysis.VisualBasic.CodeStyle.Fixes.vbproj",
++      "src\\Tools\\AnalyzerRunner\\AnalyzerRunner.csproj",
++      "src\\Dependencies\\CodeAnalysis.Debugging\\Microsoft.CodeAnalysis.Debugging.Package.csproj",
++      "src\\Dependencies\\PooledObjects\\Microsoft.CodeAnalysis.PooledObjects.Package.csproj",
++      "src\\NuGet\\Microsoft.Net.Compilers\\Microsoft.Net.Compilers.Package.csproj",
++      "src\\NuGet\\Microsoft.NETCore.Compilers\\Microsoft.NETCore.Compilers.Package.csproj",
++      "src\\NuGet\\Microsoft.CodeAnalysis.Compilers.Package.csproj",
++      "src\\NuGet\\Microsoft.CodeAnalysis.Scripting.Package.csproj",
++      "src\\NuGet\\Microsoft.CodeAnalysis.EditorFeatures.Package.csproj",
++      "src\\NuGet\\Microsoft.CodeAnalysis.Package.csproj",
++      "src\\Setup\\DevDivVsix\\CompilersPackage\\Microsoft.CodeAnalysis.Compilers.Setup.csproj",
++      "src\\Setup\\Installer\\Installer.Package.csproj",
++      "src\\Setup\\DevDivInsertionFiles\\DevDivInsertionFiles.csproj",
++      "src\\Tools\\ExternalAccess\\FSharp\\Microsoft.CodeAnalysis.ExternalAccess.FSharp.csproj",
++      "src\\Tools\\ExternalAccess\\Razor\\Microsoft.CodeAnalysis.ExternalAccess.Razor.csproj",
++      "src\\NuGet\\Microsoft.Net.Compilers.Toolset\\Microsoft.Net.Compilers.Toolset.Package.csproj",
++      "src\\Features\\LanguageServer\\Protocol\\Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj",
++      "src\\Tools\\ExternalAccess\\Debugger\\Microsoft.CodeAnalysis.ExternalAccess.Debugger.csproj",
++      "src\\Tools\\ExternalAccess\\Xamarin.Remote\\Microsoft.CodeAnalysis.ExternalAccess.Xamarin.Remote.csproj",
++      "src\\Tools\\ExternalAccess\\Apex\\Microsoft.CodeAnalysis.ExternalAccess.Apex.csproj",
++      "src\\Tools\\IdeBenchmarks\\IdeBenchmarks.csproj",
++      "src\\Tools\\Source\\CompilerGeneratorTools\\Source\\IOperationGenerator\\CompilersIOperationGenerator.csproj",
++      "src\\Features\\Lsif\\Generator\\Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.csproj",
++      "src\\Workspaces\\SharedUtilitiesAndExtensions\\Compiler\\Core\\CompilerExtensions.shproj",
++      "src\\Workspaces\\SharedUtilitiesAndExtensions\\Workspace\\Core\\WorkspaceExtensions.shproj",
++      "src\\Workspaces\\SharedUtilitiesAndExtensions\\Compiler\\CSharp\\CSharpCompilerExtensions.shproj",
++      "src\\Workspaces\\SharedUtilitiesAndExtensions\\Workspace\\CSharp\\CSharpWorkspaceExtensions.shproj",
++      "src\\Workspaces\\SharedUtilitiesAndExtensions\\Compiler\\VisualBasic\\VisualBasicCompilerExtensions.shproj",
++      "src\\Workspaces\\SharedUtilitiesAndExtensions\\Workspace\\VisualBasic\\VisualBasicWorkspaceExtensions.shproj",
++      "src\\Analyzers\\Core\\Analyzers\\Analyzers.shproj",
++      "src\\Analyzers\\Core\\CodeFixes\\CodeFixes.shproj",
++      "src\\Analyzers\\CSharp\\Analyzers\\CSharpAnalyzers.shproj",
++      "src\\Analyzers\\CSharp\\CodeFixes\\CSharpCodeFixes.shproj",
++      "src\\Analyzers\\VisualBasic\\Analyzers\\VisualBasicAnalyzers.shproj",
++      "src\\Analyzers\\VisualBasic\\CodeFixes\\VisualBasicCodeFixes.shproj",
++      "src\\Tools\\IdeCoreBenchmarks\\IdeCoreBenchmarks.csproj",
++      "src\\Tools\\BuildValidator\\BuildValidator.csproj",
++      "src\\Tools\\BuildActionTelemetryTable\\BuildActionTelemetryTable.csproj",
++      "src\\CodeStyle\\Tools\\CodeStyleConfigFileGenerator.csproj",
++      "src\\Dependencies\\Collections\\Microsoft.CodeAnalysis.Collections.shproj",
++      "src\\Dependencies\\Collections\\Microsoft.CodeAnalysis.Collections.Package.csproj",
++      "src\\Compilers\\Core\\Rebuild\\Microsoft.CodeAnalysis.Rebuild.csproj",
++      "src\\Tools\\ExternalAccess\\OmniSharp\\Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.csproj",
++      "src\\Tools\\ExternalAccess\\OmniSharp.CSharp\\Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.CSharp.csproj",
++      "src\\Workspaces\\Remote\\ServiceHub.CoreComponents\\Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.csproj"
++    ]
++  }
++}
+\ No newline at end of file
+diff --git a/eng/SourceBuild.props b/eng/SourceBuild.props
+index 92e316a4744..9905b35467e 100644
+--- a/eng/SourceBuild.props
++++ b/eng/SourceBuild.props
+@@ -11,7 +11,7 @@
+   -->
+   <Target Name="ConfigureInnerBuildArg" BeforeTargets="GetSourceBuildCommandConfiguration">
+     <PropertyGroup>
+-      <InnerBuildArgs>$(InnerBuildArgs) /p:Projects="$(InnerSourceBuildRepoRoot)\Roslyn.sln"</InnerBuildArgs>
++      <InnerBuildArgs>$(InnerBuildArgs) /p:Projects="$(InnerSourceBuildRepoRoot)\Roslyn.SourceBuild.slnf"</InnerBuildArgs>
+     </PropertyGroup>
+   </Target>
+
+--
+2.31.1
+


### PR DESCRIPTION
Switch roslyn build to build with `.slnf` file to exclude projects with `<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">`.  This enables roslyn to be built with a bootstrapped source-built SDK.