### PR TITLE
[release/6.0.1xx] [ArPow] Delete optional files under non-open source licenses

### DIFF
--- a/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
+++ b/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
@@ -246,6 +246,20 @@
     </ItemGroup>
 
     <Delete Files="@(TarballSrcBinaryToRemove)" />
+
+    <!-- We have some not-strictly-required files that are under non-open source licenses.
+         See https://github.com/dotnet/source-build/issues/2359.
+         Remove them. -->
+    <ItemGroup>
+      <TarballSrcNonOpenSourceFiles Include="$(TarballSourceDir)**\humanizer\samples\**\*.js" />
+      <TarballSrcNonOpenSourceFiles Include="$(TarballSourceDir)**\*nuget-client.*\**\EndToEnd\**\jquery-validation-unobtrusive\*.js" />
+      <TarballSrcNonOpenSourceFiles Include="$(TarballSourceDir)**\*nuget-client.*\**\EndToEnd\**\jquery-validation-unobtrusive\.bower.json" />
+      <TarballSrcNonOpenSourceFiles Include="$(TarballSourceDir)**\*aspnetcore.*\**\samples\**\jquery-validation-unobtrusive\.bower.json" />
+      <TarballSrcNonOpenSourceFiles Include="$(TarballSourceDir)**\*aspnetcore.*\**\samples\**\jquery-validation-unobtrusive\*.js" />
+    </ItemGroup>
+
+    <Message Importance="High" Text="Deleting files with questionable licenses: @(TarballSrcNonOpenSourceFiles, ' ')" />
+    <Delete Files="@(TarballSrcNonOpenSourceFiles)" />
   </Target>
 
   <Target Name="RestoreTextOnlyPackages">


### PR DESCRIPTION
These files are not required as part of source-build, and are under non-free licenses. Delete them when building the source-build tarball.

Fixes: https://github.com/dotnet/source-build/issues/2359