### PR TITLE
[release/5.0.4xx] Permit installation of 5.0 ARM64 SDK

### DIFF
--- a/src/redist/targets/packaging/windows/clisdk/bundle.wxs
+++ b/src/redist/targets/packaging/windows/clisdk/bundle.wxs
@@ -23,7 +23,7 @@
         WixBundleInstalled OR (NOT DOTNETHOME_ARM64 ~= DOTNETHOME_X64) OR (NOT NativeMachine=&quot;$(var.NativeMachine_arm64)&quot;) OR DOTNETHOMESIMILARITYCHECKOVERRIDE
     </bal:Condition>
 
-    <?if $(var.Platform)!=arm64?>
+    <?if $(var.Platform)=x64?>
     <bal:Condition Message="This product is not supported on Arm64.">
         WixBundleInstalled OR (NOT NativeMachine = $(var.NativeMachine_arm64)) OR DOTNETALLOWINSTALLONARM64
     </bal:Condition>


### PR DESCRIPTION
## Customer Impact
Customers cannot install the 3.1 SDK nor 5.0 SDK on ARM64 machines.  This was an intentional decision during our first wave of changes.  We would like a call on adjusting that.
We would like to consider a change that would permit installation of the 3.1 x86 SDK, the 5.0 x86 and Arm64 SDK on Arm64 machines.

## Testing
Manual build of bundle to validate conditions.

## Risk
Low, but schedule risk to 3.1/5.0 if we take the change.  Changes are only to installer so build impact/time is low but it will cause a delay.