### PR TITLE
[release/6.0.1xx] dotnet/runtime: Enable source-link in source-build for '.version' file

### DIFF
--- a/src/SourceBuild/tarball/patches/runtime/0003-Enable-source-link-in-source-build-for-.version-file.patch
+++ b/src/SourceBuild/tarball/patches/runtime/0003-Enable-source-link-in-source-build-for-.version-file.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Davis Goodin <dagood@microsoft.com>
+Date: Tue, 26 Oct 2021 15:41:57 -0500
+Subject: [PATCH] Enable source-link in source-build for '.version' file
+
+See https://github.com/dotnet/source-build/issues/2569
+---
+ eng/SourceBuild.props | 8 --------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/eng/SourceBuild.props b/eng/SourceBuild.props
+index bba40f534e5..b70f668a15b 100644
+--- a/eng/SourceBuild.props
++++ b/eng/SourceBuild.props
+@@ -23,14 +23,6 @@
+     <LogVerbosity Condition="'$(LogVerbosity)' == ''">minimal</LogVerbosity>
+   </PropertyGroup>
+ 
+-  <ItemGroup>
+-    <!-- Work around issue where local clone may cause failure using non-origin remote fallback: https://github.com/dotnet/sourcelink/issues/629 -->
+-    <InnerBuildEnv Include="EnableSourceControlManagerQueries=false" />
+-    <InnerBuildEnv Include="EnableSourceLink=false" />
+-    <InnerBuildEnv Include="DisableSourceLink=true" />
+-    <InnerBuildEnv Include="DeterministicSourcePaths=false" />
+-  </ItemGroup>
+-
+   <Target Name="GetRuntimeSourceBuildCommandConfiguration"
+           BeforeTargets="GetSourceBuildCommandConfiguration">
+     <PropertyGroup>


### PR DESCRIPTION
* For https://github.com/dotnet/source-build/issues/2569