### PR TITLE
[release/5.0.2xx] Fix blocking install of ARM64 on clean machine

### DIFF
--- a/src/redist/targets/packaging/windows/clisdk/bundle.wxs
+++ b/src/redist/targets/packaging/windows/clisdk/bundle.wxs
@@ -37,7 +37,7 @@
       <PayloadGroupRef Id="DotnetCoreBAPayloads" />
     </BootstrapperApplicationRef>
 
-    <swid:Tag Regid="microsoft.com" InstallPath="[DOTNETHOME]" />
+    <swid:Tag Regid="microsoft.com" InstallPath="[$(var.Program_Files)]dotnet" />
 
     <util:RegistrySearch Id="CheckDotnetInstallLocation_x86"
               Variable="DotnetInstallLocationExists_x86"


### PR DESCRIPTION
Getting PR up now.  I'm going to do a full review of everything in 6.0 and diff to 5.0 now.  With the change of plans earlier this week to support the SDKs they should be identical, with the minor addition to block x64 on ARM64 windows.