### PR TITLE
Update to 6.0 in our wxl files as that was reverted a while back.

### DIFF
--- a/src/redist/targets/packaging/windows/clisdk/LCID/1028/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1028/bundle.wxl
@@ -61,7 +61,7 @@
 資源
     • 如需 .NET 文件，請前往 https://aka.ms/dotnet-docs
     • 如需 SDK 文件，請前往 https://aka.ms/dotnet-sdk-docs
-    • 如需版本資訊，請前往 https://aka.ms/dotnet5-release-notes
+    • 如需版本資訊，請前往 https://aka.ms/dotnet6-release-notes
     • 如需教學課程，請前往 https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">.NET SDK</String>
   <String Id="WelcomeDescription">
@@ -76,7 +76,7 @@
   <String Id="InstallationNoteTitle">安裝附註</String>
   <String Id="InstallationNote">安裝程序期間將會執行命令，加快專案還原速度並啟用離線存取。最多需要一分鐘的時間完成。
   </String>
-  <String Id="VisualStudioWarning">若預計要搭配 Visual Studio 使用 .NET 6.0，需要 Visual Studio 2022 17.0 或更新版本。&lt;A HREF="https://aka.ms/dotnet5-release-notes"&gt;深入了解&lt;/A&gt;.
+  <String Id="VisualStudioWarning">若預計要搭配 Visual Studio 使用 .NET 6.0，需要 Visual Studio 2022 17.0 或更新版本。&lt;A HREF="https://aka.ms/dotnet6-release-notes"&gt;深入了解&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">按一下 [\[]安裝[\[] 即表示您同意下列條款。</String>
 </WixLocalization>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1028/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1028/bundle.wxl
@@ -76,7 +76,7 @@
   <String Id="InstallationNoteTitle">安裝附註</String>
   <String Id="InstallationNote">安裝程序期間將會執行命令，加快專案還原速度並啟用離線存取。最多需要一分鐘的時間完成。
   </String>
-  <String Id="VisualStudioWarning">若預計要搭配 Visual Studio 使用 .NET 5.0，需要 Visual Studio 2022 17.0 或更新版本。&lt;A HREF="https://aka.ms/dotnet5-release-notes"&gt;深入了解&lt;/A&gt;.
+  <String Id="VisualStudioWarning">若預計要搭配 Visual Studio 使用 .NET 6.0，需要 Visual Studio 2022 17.0 或更新版本。&lt;A HREF="https://aka.ms/dotnet5-release-notes"&gt;深入了解&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">按一下 [\[]安裝[\[] 即表示您同意下列條款。</String>
 </WixLocalization>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1029/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1029/bundle.wxl
@@ -61,7 +61,7 @@ Tento produkt shromažďuje data o využití.
 Zdroje informací
     • Dokumentace k .NET : https://aka.ms/dotnet-docs
     • Dokumentace k sadě SDK: https://aka.ms/dotnet-sdk-docs
-    • Zpráva k vydání verze: https://aka.ms/dotnet5-release-notes
+    • Zpráva k vydání verze: https://aka.ms/dotnet6-release-notes
     • Kurzy: https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">Sada .NET SDK</String>
   <String Id="WelcomeDescription">
@@ -76,7 +76,7 @@ Zdroje informací
   <String Id="InstallationNoteTitle">Poznámka k instalaci</String>
   <String Id="InstallationNote">Během procesu instalace se spustí příkaz, který zlepší rychlost obnovení projektu a povolí offline přístup. Akce se dokončí přibližně za minutu.
   </String>
-  <String Id="VisualStudioWarning">Pokud se chystáte používat .NET 6.0 se sadou Visual Studio, potřebujete Visual Studio 2022 17.0 nebo novější. &lt;A HREF="https://aka.ms/dotnet5-release-notes"&gt;Další informace&lt;/A&gt;.
+  <String Id="VisualStudioWarning">Pokud se chystáte používat .NET 6.0 se sadou Visual Studio, potřebujete Visual Studio 2022 17.0 nebo novější. &lt;A HREF="https://aka.ms/dotnet6-release-notes"&gt;Další informace&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Kliknutím na Nainstalovat vyjadřujete souhlas s následujícími podmínkami.</String>
 </WixLocalization>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1029/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1029/bundle.wxl
@@ -76,7 +76,7 @@ Zdroje informací
   <String Id="InstallationNoteTitle">Poznámka k instalaci</String>
   <String Id="InstallationNote">Během procesu instalace se spustí příkaz, který zlepší rychlost obnovení projektu a povolí offline přístup. Akce se dokončí přibližně za minutu.
   </String>
-  <String Id="VisualStudioWarning">Pokud se chystáte používat .NET 5.0 se sadou Visual Studio, potřebujete Visual Studio 2022 17.0 nebo novější. &lt;A HREF="https://aka.ms/dotnet5-release-notes"&gt;Další informace&lt;/A&gt;.
+  <String Id="VisualStudioWarning">Pokud se chystáte používat .NET 6.0 se sadou Visual Studio, potřebujete Visual Studio 2022 17.0 nebo novější. &lt;A HREF="https://aka.ms/dotnet5-release-notes"&gt;Další informace&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Kliknutím na Nainstalovat vyjadřujete souhlas s následujícími podmínkami.</String>
 </WixLocalization>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1031/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1031/bundle.wxl
@@ -76,7 +76,7 @@ Ressourcen
   <String Id="InstallationNoteTitle">Installationshinweis</String>
   <String Id="InstallationNote">Während des Installationsvorgangs wird ein Befehl ausgeführt, durch den die Geschwindigkeit der Projektwiederherstellung verbessert und der Offlinezugriff aktiviert wird. Der Vorgang dauert bis zu einer Minute.
   </String>
-  <String Id="VisualStudioWarning">Wenn Sie .NET 5.0 mit Visual Studio verwenden möchten, ist Visual Studio 2022 17.0 oder höher erforderlich. &lt;A HREF="https://aka.ms/dotnet5-release-notes"&gt;Weitere Informationen&lt;/A&gt;
+  <String Id="VisualStudioWarning">Wenn Sie .NET 6.0 mit Visual Studio verwenden möchten, ist Visual Studio 2022 17.0 oder höher erforderlich. &lt;A HREF="https://aka.ms/dotnet5-release-notes"&gt;Weitere Informationen&lt;/A&gt;
   </String>
   <String Id="LicenseAssent">Durch Klicken auf "Installieren" stimmen Sie den nachstehenden Bedingungen zu.</String>
 </WixLocalization>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1031/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1031/bundle.wxl
@@ -61,7 +61,7 @@ Dieses Produkt erfasst Nutzungsdaten.
 Ressourcen
     • .NET-Dokumentation: https://aka.ms/dotnet-docs
     • SDK-Dokumentation: https://aka.ms/dotnet-sdk-docs
-    • Versionshinweise: https://aka.ms/dotnet5-release-notes
+    • Versionshinweise: https://aka.ms/dotnet6-release-notes
     • Tutorials: https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">.NET SDK</String>
   <String Id="WelcomeDescription">
@@ -76,7 +76,7 @@ Ressourcen
   <String Id="InstallationNoteTitle">Installationshinweis</String>
   <String Id="InstallationNote">Während des Installationsvorgangs wird ein Befehl ausgeführt, durch den die Geschwindigkeit der Projektwiederherstellung verbessert und der Offlinezugriff aktiviert wird. Der Vorgang dauert bis zu einer Minute.
   </String>
-  <String Id="VisualStudioWarning">Wenn Sie .NET 6.0 mit Visual Studio verwenden möchten, ist Visual Studio 2022 17.0 oder höher erforderlich. &lt;A HREF="https://aka.ms/dotnet5-release-notes"&gt;Weitere Informationen&lt;/A&gt;
+  <String Id="VisualStudioWarning">Wenn Sie .NET 6.0 mit Visual Studio verwenden möchten, ist Visual Studio 2022 17.0 oder höher erforderlich. &lt;A HREF="https://aka.ms/dotnet6-release-notes"&gt;Weitere Informationen&lt;/A&gt;
   </String>
   <String Id="LicenseAssent">Durch Klicken auf "Installieren" stimmen Sie den nachstehenden Bedingungen zu.</String>
 </WixLocalization>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1036/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1036/bundle.wxl
@@ -61,7 +61,7 @@ Ce produit collecte des données d'utilisation
 Ressources
     • Documentation .NET sur https://aka.ms/dotnet-docs
     • Documentation de kit SDK sur https://aka.ms/dotnet-sdk-docs
-    • Notes de publication sur https://aka.ms/dotnet5-release-notes
+    • Notes de publication sur https://aka.ms/dotnet6-release-notes
     • Tutoriels sur https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">SDK .NET</String>
   <String Id="WelcomeDescription">
@@ -76,7 +76,7 @@ Ressources
   <String Id="InstallationNoteTitle">Note d'installation</String>
   <String Id="InstallationNote">Une commande va être exécutée pendant le processus d'installation, ce qui va améliorer la vitesse de restauration du projet et permettre l'accès hors connexion. L'opération va prendre environ une minute.
   </String>
-  <String Id="VisualStudioWarning">Si vous comptez utiliser .NET 6.0 avec Visual Studio, Visual Studio 2022 17.0 ou une version ultérieure est nécessaire. &lt;A HREF="https://aka.ms/dotnet5-release-notes"&gt;En savoir plus&lt;/A&gt;.
+  <String Id="VisualStudioWarning">Si vous comptez utiliser .NET 6.0 avec Visual Studio, Visual Studio 2022 17.0 ou une version ultérieure est nécessaire. &lt;A HREF="https://aka.ms/dotnet6-release-notes"&gt;En savoir plus&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">En cliquant sur Installer, vous acceptez les conditions suivantes.</String>
 </WixLocalization>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1036/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1036/bundle.wxl
@@ -76,7 +76,7 @@ Ressources
   <String Id="InstallationNoteTitle">Note d'installation</String>
   <String Id="InstallationNote">Une commande va être exécutée pendant le processus d'installation, ce qui va améliorer la vitesse de restauration du projet et permettre l'accès hors connexion. L'opération va prendre environ une minute.
   </String>
-  <String Id="VisualStudioWarning">Si vous comptez utiliser .NET 5.0 avec Visual Studio, Visual Studio 2022 17.0 ou une version ultérieure est nécessaire. &lt;A HREF="https://aka.ms/dotnet5-release-notes"&gt;En savoir plus&lt;/A&gt;.
+  <String Id="VisualStudioWarning">Si vous comptez utiliser .NET 6.0 avec Visual Studio, Visual Studio 2022 17.0 ou une version ultérieure est nécessaire. &lt;A HREF="https://aka.ms/dotnet5-release-notes"&gt;En savoir plus&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">En cliquant sur Installer, vous acceptez les conditions suivantes.</String>
 </WixLocalization>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1040/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1040/bundle.wxl
@@ -61,7 +61,7 @@ Questo prodotto consente di raccogliere i dati sull'utilizzo
 Risorse
     • Documentazione di .NET https://aka.ms/dotnet-docs
     • Documentazione dell'SDK https://aka.ms/dotnet-sdk-docs
-    • Note sulla versione https://aka.ms/dotnet5-release-notes
+    • Note sulla versione https://aka.ms/dotnet6-release-notes
     • Esercitazioni https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">.NET SDK</String>
   <String Id="WelcomeDescription">

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1041/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1041/bundle.wxl
@@ -61,7 +61,7 @@
 リソース
     • .NET ドキュメント https://aka.ms/dotnet-docs
     • SDK ドキュメント https://aka.ms/dotnet-sdk-docs
-    • リリース ノート https://aka.ms/dotnet5-release-notes
+    • リリース ノート https://aka.ms/dotnet6-release-notes
     • チュートリアル https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">.NET SDK</String>
   <String Id="WelcomeDescription">
@@ -76,7 +76,7 @@
   <String Id="InstallationNoteTitle">インストール メモ</String>
   <String Id="InstallationNote">コマンドはインストール処理中に実行されるので、プロジェクトの復元速度が向上し、オフラインでアクセスできます。完了するまでに最大 1 分かかります。
   </String>
-  <String Id="VisualStudioWarning">.NET 6.0 を Visual Studio で使用する場合は、Visual Studio 2022 17.0 以降が必要です。&lt;A HREF="https://aka.ms/dotnet5-release-notes"&gt;詳細情報&lt;/A&gt;。
+  <String Id="VisualStudioWarning">.NET 6.0 を Visual Studio で使用する場合は、Visual Studio 2022 17.0 以降が必要です。&lt;A HREF="https://aka.ms/dotnet6-release-notes"&gt;詳細情報&lt;/A&gt;。
   </String>
   <String Id="LicenseAssent">[インストール] をクリックすると、次の条項に同意したものと見なされます。</String>
 </WixLocalization>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1041/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1041/bundle.wxl
@@ -76,7 +76,7 @@
   <String Id="InstallationNoteTitle">インストール メモ</String>
   <String Id="InstallationNote">コマンドはインストール処理中に実行されるので、プロジェクトの復元速度が向上し、オフラインでアクセスできます。完了するまでに最大 1 分かかります。
   </String>
-  <String Id="VisualStudioWarning">.NET 5.0 を Visual Studio で使用する場合は、Visual Studio 2022 17.0 以降が必要です。&lt;A HREF="https://aka.ms/dotnet5-release-notes"&gt;詳細情報&lt;/A&gt;。
+  <String Id="VisualStudioWarning">.NET 6.0 を Visual Studio で使用する場合は、Visual Studio 2022 17.0 以降が必要です。&lt;A HREF="https://aka.ms/dotnet5-release-notes"&gt;詳細情報&lt;/A&gt;。
   </String>
   <String Id="LicenseAssent">[インストール] をクリックすると、次の条項に同意したものと見なされます。</String>
 </WixLocalization>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1042/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1042/bundle.wxl
@@ -61,7 +61,7 @@
 리소스
     • .NET 설명서 https://aka.ms/dotnet-docs
     • SDK 설명서 https://aka.ms/dotnet-sdk-docs
-    • 릴리스 정보 https://aka.ms/dotnet5-release-notes
+    • 릴리스 정보 https://aka.ms/dotnet6-release-notes
     • 자습서 https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">.NET SDK</String>
   <String Id="WelcomeDescription">

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1045/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1045/bundle.wxl
@@ -61,7 +61,7 @@ Ten produkt gromadzi dane dotyczące użycia
 Zasoby
     • Dokumentacja platformy .NET: https://aka.ms/dotnet-docs
     • Dokumentacja zestawu SDK: https://aka.ms/dotnet-sdk-docs
-    • Informacje o wersji: https://aka.ms/dotnet5-release-notes
+    • Informacje o wersji: https://aka.ms/dotnet6-release-notes
     • Samouczki: https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">.NET SDK</String>
   <String Id="WelcomeDescription">

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1046/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1046/bundle.wxl
@@ -61,7 +61,7 @@ Este produto coleta dados de uso
 Recursos
     • Documentação do .NET: https://aka.ms/dotnet-docs
     • Documentação do SDK: https://aka.ms/dotnet-sdk-docs
-    • Notas sobre a Versão: https://aka.ms/dotnet5-release-notes
+    • Notas sobre a Versão: https://aka.ms/dotnet6-release-notes
     • Tutoriais: https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">SDK do .NET</String>
   <String Id="WelcomeDescription">
@@ -76,7 +76,7 @@ Recursos
   <String Id="InstallationNoteTitle">Nota de instalação</String>
   <String Id="InstallationNote">Um comando será executado durante o processo de instalação que melhorará a velocidade de restauração do projeto e habilitará o acesso offline. Isso levará até um minuto para ser concluído.
   </String>
-  <String Id="VisualStudioWarning">Se você planeja usar o .NET 6.0 com o Visual Studio, é necessário usar o Visual Studio 2022 17.0 ou mais recente. &lt;A HREF="https://aka.ms/dotnet5-release-notes"&gt;Saiba mais&lt;/A&gt;.
+  <String Id="VisualStudioWarning">Se você planeja usar o .NET 6.0 com o Visual Studio, é necessário usar o Visual Studio 2022 17.0 ou mais recente. &lt;A HREF="https://aka.ms/dotnet6-release-notes"&gt;Saiba mais&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Ao clicar em instalar, você concorda com os termos a seguir.</String>
 </WixLocalization>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1046/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1046/bundle.wxl
@@ -76,7 +76,7 @@ Recursos
   <String Id="InstallationNoteTitle">Nota de instalação</String>
   <String Id="InstallationNote">Um comando será executado durante o processo de instalação que melhorará a velocidade de restauração do projeto e habilitará o acesso offline. Isso levará até um minuto para ser concluído.
   </String>
-  <String Id="VisualStudioWarning">Se você planeja usar o .NET 5.0 com o Visual Studio, é necessário usar o Visual Studio 2022 17.0 ou mais recente. &lt;A HREF="https://aka.ms/dotnet5-release-notes"&gt;Saiba mais&lt;/A&gt;.
+  <String Id="VisualStudioWarning">Se você planeja usar o .NET 6.0 com o Visual Studio, é necessário usar o Visual Studio 2022 17.0 ou mais recente. &lt;A HREF="https://aka.ms/dotnet5-release-notes"&gt;Saiba mais&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Ao clicar em instalar, você concorda com os termos a seguir.</String>
 </WixLocalization>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1049/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1049/bundle.wxl
@@ -61,7 +61,7 @@
 Ресурсы
     • Документация по .NET: https://aka.ms/dotnet-docs
     • Документация по SDK: https://aka.ms/dotnet-sdk-docs
-    • Заметки о выпуске: https://aka.ms/dotnet5-release-notes
+    • Заметки о выпуске: https://aka.ms/dotnet6-release-notes
     • Учебники: https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">Пакет SDK для .NET</String>
   <String Id="WelcomeDescription">

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1055/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1055/bundle.wxl
@@ -61,7 +61,7 @@ Bu ürün, kullanım verilerini toplar
 Kaynaklar
     • .NET Belgeleri https://aka.ms/dotnet-docs
     • SDK Belgeleri https://aka.ms/dotnet-sdk-docs
-    • Sürüm Notları https://aka.ms/dotnet5-release-notes
+    • Sürüm Notları https://aka.ms/dotnet6-release-notes
     • Öğreticiler https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">.NET SDK'sı</String>
   <String Id="WelcomeDescription">
@@ -76,7 +76,7 @@ Kaynaklar
   <String Id="InstallationNoteTitle">Yükleme notu</String>
   <String Id="InstallationNote">Yükleme işlemi sırasında, proje geri yükleme hızını artıran ve çevrimdışı erişimi etkinleştiren bir komut çalıştırılır. Tamamlanması bir dakikanızı alır.
   </String>
-  <String Id="VisualStudioWarning">Visual Studio ile .NET 6.0 kullanmayı planlıyorsanız Visual Studio 2022 17.0 veya üzeri bir sürüm gerekir. &lt;A HREF="https://aka.ms/dotnet5-release-notes"&gt;Daha Fazla Bilgi&lt;/A&gt;.
+  <String Id="VisualStudioWarning">Visual Studio ile .NET 6.0 kullanmayı planlıyorsanız Visual Studio 2022 17.0 veya üzeri bir sürüm gerekir. &lt;A HREF="https://aka.ms/dotnet6-release-notes"&gt;Daha Fazla Bilgi&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Yükle'ye tıklayarak aşağıdaki koşulları kabul etmiş olursunuz.</String>
 </WixLocalization>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1055/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1055/bundle.wxl
@@ -76,7 +76,7 @@ Kaynaklar
   <String Id="InstallationNoteTitle">Yükleme notu</String>
   <String Id="InstallationNote">Yükleme işlemi sırasında, proje geri yükleme hızını artıran ve çevrimdışı erişimi etkinleştiren bir komut çalıştırılır. Tamamlanması bir dakikanızı alır.
   </String>
-  <String Id="VisualStudioWarning">Visual Studio ile .NET 5.0 kullanmayı planlıyorsanız Visual Studio 2022 17.0 veya üzeri bir sürüm gerekir. &lt;A HREF="https://aka.ms/dotnet5-release-notes"&gt;Daha Fazla Bilgi&lt;/A&gt;.
+  <String Id="VisualStudioWarning">Visual Studio ile .NET 6.0 kullanmayı planlıyorsanız Visual Studio 2022 17.0 veya üzeri bir sürüm gerekir. &lt;A HREF="https://aka.ms/dotnet5-release-notes"&gt;Daha Fazla Bilgi&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Yükle'ye tıklayarak aşağıdaki koşulları kabul etmiş olursunuz.</String>
 </WixLocalization>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/2052/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/2052/bundle.wxl
@@ -61,7 +61,7 @@
 资源
     • .NET 文档: https://aka.ms/dotnet-docs
     • SDK 文档: https://aka.ms/dotnet-sdk-docs
-    • 发行说明: https://aka.ms/dotnet5-release-notes
+    • 发行说明: https://aka.ms/dotnet6-release-notes
     • 教程: https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">.NET SDK</String>
   <String Id="WelcomeDescription">
@@ -76,7 +76,7 @@
   <String Id="InstallationNoteTitle">安装说明</String>
   <String Id="InstallationNote">将在要提升项目还原速度并实现脱机访问的安装进程期间运行命令。此操作最多 1 分钟即可完成。
   </String>
-  <String Id="VisualStudioWarning">如果打算结合使用 .NET 6.0 和 Visual Studio，需要 Visual Studio 2022 17.0 或更高版本。&lt;A HREF="https://aka.ms/dotnet5-release-notes"&gt;了解详细信息&lt;/A&gt;。
+  <String Id="VisualStudioWarning">如果打算结合使用 .NET 6.0 和 Visual Studio，需要 Visual Studio 2022 17.0 或更高版本。&lt;A HREF="https://aka.ms/dotnet6-release-notes"&gt;了解详细信息&lt;/A&gt;。
   </String>
   <String Id="LicenseAssent">单击“安装”即表示你同意以下条款。</String>
 </WixLocalization>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/2052/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/2052/bundle.wxl
@@ -76,7 +76,7 @@
   <String Id="InstallationNoteTitle">安装说明</String>
   <String Id="InstallationNote">将在要提升项目还原速度并实现脱机访问的安装进程期间运行命令。此操作最多 1 分钟即可完成。
   </String>
-  <String Id="VisualStudioWarning">如果打算结合使用 .NET 5.0 和 Visual Studio，需要 Visual Studio 2022 17.0 或更高版本。&lt;A HREF="https://aka.ms/dotnet5-release-notes"&gt;了解详细信息&lt;/A&gt;。
+  <String Id="VisualStudioWarning">如果打算结合使用 .NET 6.0 和 Visual Studio，需要 Visual Studio 2022 17.0 或更高版本。&lt;A HREF="https://aka.ms/dotnet5-release-notes"&gt;了解详细信息&lt;/A&gt;。
   </String>
   <String Id="LicenseAssent">单击“安装”即表示你同意以下条款。</String>
 </WixLocalization>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/3082/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/3082/bundle.wxl
@@ -76,7 +76,7 @@ Recursos
   <String Id="InstallationNoteTitle">Nota de instalación</String>
   <String Id="InstallationNote">Se ejecutará un comando durante el proceso de instalación que mejorará la velocidad de restauración del proyecto y permitirá el acceso sin conexión. La operación tardará hasta un minuto en completarse.
   </String>
-  <String Id="VisualStudioWarning">Si tiene previsto usar .NET 5.0 con Visual Studio, se requiere Visual Studio 2022 17.0 o una versión más reciente. &lt;A HREF="https://aka.ms/dotnet5-release-notes"&gt;Obtenga más información&lt;/A&gt;.
+  <String Id="VisualStudioWarning">Si tiene previsto usar .NET 6.0 con Visual Studio, se requiere Visual Studio 2022 17.0 o una versión más reciente. &lt;A HREF="https://aka.ms/dotnet5-release-notes"&gt;Obtenga más información&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Al hacer clic en Instalar, acepta los términos siguientes.</String>
 </WixLocalization>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/3082/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/3082/bundle.wxl
@@ -61,7 +61,7 @@ Este producto recopila datos de uso
 Recursos
     • Documentación de .NET https://aka.ms/dotnet-docs
     • Documentación del SDK https://aka.ms/dotnet-sdk-docs
-    • Notas de la versión https://aka.ms/dotnet5-release-notes
+    • Notas de la versión https://aka.ms/dotnet6-release-notes
     • Tutoriales https://aka.ms/dotnet-tutorials</String>
   <String Id="WelcomeHeaderMessage">SDK de .NET</String>
   <String Id="WelcomeDescription">
@@ -76,7 +76,7 @@ Recursos
   <String Id="InstallationNoteTitle">Nota de instalación</String>
   <String Id="InstallationNote">Se ejecutará un comando durante el proceso de instalación que mejorará la velocidad de restauración del proyecto y permitirá el acceso sin conexión. La operación tardará hasta un minuto en completarse.
   </String>
-  <String Id="VisualStudioWarning">Si tiene previsto usar .NET 6.0 con Visual Studio, se requiere Visual Studio 2022 17.0 o una versión más reciente. &lt;A HREF="https://aka.ms/dotnet5-release-notes"&gt;Obtenga más información&lt;/A&gt;.
+  <String Id="VisualStudioWarning">Si tiene previsto usar .NET 6.0 con Visual Studio, se requiere Visual Studio 2022 17.0 o una versión más reciente. &lt;A HREF="https://aka.ms/dotnet6-release-notes"&gt;Obtenga más información&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Al hacer clic en Instalar, acepta los términos siguientes.</String>
 </WixLocalization>


### PR DESCRIPTION
## Description
This repo is not opted in to translation as the strings don't change frequently. This branding was done 9 months ago but then reverted when 5.0.4xx was merged up. Let's fix this in the December servicing release.

## Customer Impact

The release notes links and customer visible text say 5.0 for many of the languages.

##Fix
Modified 5.0 and dotnet5 to say 6 in all of the wxl loc files

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

## Verification

- [x] Manual (required)
- [ ] Automated
