### PR TITLE
We keep getting this config file added by the insertion pipeline and it fails the build.

### DIFF
--- a/src/redist/targets/GenerateMSBuildExtensions.targets
+++ b/src/redist/targets/GenerateMSBuildExtensions.targets
@@ -37,6 +37,9 @@
       <!-- Don't include .NET Core targets in the Full Framework MSBuild layout-->
       <VSMSBuildExtensionsContent Remove="$(MSBuildExtensionsNuPkgPath)\msbuildExtensions-ver\SolutionFile\**" />
 
+      <!-- Don't include the config file in 5.0.2xx that is sometimes built and sometimes not-->
+      <VSMSBuildExtensionsContent Remove="$(MSBuildExtensionsNuPkgPath)\msbuildExtensions\Microsoft\Microsoft.NET.Build.Extensions\tools\net472\Microsoft.NET.Build.Extensions.Tasks.dll.config" />
+
       <VSMSBuildExtensionsContent Include="$(NETStandardLibraryNETFrameworkNuPkgPath)\build\**\*.*"
                                   Exclude="$(NETStandardLibraryNETFrameworkNuPkgPath)\build\**\*.props;$(NETStandardLibraryNETFrameworkNuPkgPath)\build\**\*.targets"
                                   DeploymentSubpath="msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/" />


### PR DESCRIPTION
From testing, it's sometimes generated in the SDK build and sometimes not and doesn't appear to be needed.
Removing from the files.swr file.
