### PR TITLE
Only add intermediates to previous source-built archive

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -172,7 +172,7 @@
       or minor release, prebuilts may be needed. When the release is mature, prebuilts are not
       necessary, and this property is removed from the file.
     -->
-    <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-6.0.100-bootstrap.29</PrivateSourceBuiltArtifactsPackageVersion>
+    <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-6.0.100-bootstrap.30</PrivateSourceBuiltArtifactsPackageVersion>
   </PropertyGroup>
   <!-- Workload manifest package versions -->
   <PropertyGroup>

--- a/src/SourceBuild/tarball/content/repos/package-source-build.proj
+++ b/src/SourceBuild/tarball/content/repos/package-source-build.proj
@@ -18,39 +18,11 @@
     <!-- Copy PVP to packages dir in order to package them together -->
     <Copy SourceFiles="$(IncludedPackageVersionPropsFile)" DestinationFiles="$(SourceBuiltPackagesPath)PackageVersions.props" />
 
-    <!-- Expand SBRP intermediate package into separate folder and remove intermediate package -->
-    <PropertyGroup>
-      <SourceBuildReferencePackagesDestination>$(SourceBuiltPackagesPath)SourceBuildReferencePackages/</SourceBuildReferencePackagesDestination>
-      <SBRPIntermediateWildcard>Microsoft.SourceBuild.Intermediate.source-build-reference-packages*.nupkg</SBRPIntermediateWildcard>
-    </PropertyGroup>
-    <ItemGroup>
-      <SourceBuildReferencePackagesIntermediatePackage Include="$(SourceBuiltPackagesPath)$(SBRPIntermediateWildcard)"/>
-    </ItemGroup>
-
-    <MakeDir Directories="$(SourceBuildReferencePackagesDestination)" />
-    <ZipFileExtractToDirectory Condition="'@(SourceBuildReferencePackagesIntermediatePackage)' != ''"
-                            SourceArchive="%(SourceBuildReferencePackagesIntermediatePackage.Identity)"
-                            DestinationDirectory="$(SourceBuildReferencePackagesDestination)extractArtifacts/"
-                            OverwriteDestination="true" />
-
-    <ItemGroup>
-      <SourceBuildReferencePackagesNupkgFiles Include="$(SourceBuildReferencePackagesDestination)extractArtifacts/**/*.nupkg" />
-    </ItemGroup>
-
-    <Copy
-      Condition="'@(SourceBuildReferencePackagesNupkgFiles)' != ''"
-      SourceFiles="@(SourceBuildReferencePackagesNupkgFiles)"
-      DestinationFiles="@(SourceBuildReferencePackagesNupkgFiles -> '$(SourceBuildReferencePackagesDestination)%(Filename)%(Extension)')" />
-
-    <RemoveDir
-      Condition="Exists('$(SourceBuildReferencePackagesDestination)extractArtifacts/')"
-      Directories="$(SourceBuildReferencePackagesDestination)extractArtifacts/" />
-
     <PropertyGroup>
       <SourceBuiltTarballName>$(OutputPath)$(SourceBuiltArtifactsTarballName).$(VersionPrefix)-$(VersionSuffix).tar.gz</SourceBuiltTarballName>
     </PropertyGroup>
 
-    <Exec Command="tar --numeric-owner --exclude='$(SBRPIntermediateWildcard)' -czf $(SourceBuiltTarballName) *.nupkg *.props SourceBuildReferencePackages/" WorkingDirectory="$(SourceBuiltPackagesPath)" />
+    <Exec Command="tar --numeric-owner -czf $(SourceBuiltTarballName) Microsoft.SourceBuild.Intermediate.*.nupkg *.props" WorkingDirectory="$(SourceBuiltPackagesPath)" />
 
     <Message Importance="High" Text="Packaged source-built artifacts to $(SourceBuiltTarballName)" />
   </Target>

--- a/src/SourceBuild/tarball/content/tools-local/init-build.proj
+++ b/src/SourceBuild/tarball/content/tools-local/init-build.proj
@@ -41,29 +41,41 @@
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(CompletedSemaphorePath)UnpackTarballs.complete" >
 
+    <!-- Expand previous source-built packages -->
     <MakeDir Directories="$(PrebuiltSourceBuiltPackagesPath)" Condition="'$(CustomPrebuiltSourceBuiltPackagesPath)' == ''" />
     <Exec Command="tar -xzf $(ExternalTarballsDir)$(SourceBuiltArtifactsTarballName).*.tar.gz"
           WorkingDirectory="$(PrebuiltSourceBuiltPackagesPath)"
           Condition="'$(CustomPrebuiltSourceBuiltPackagesPath)' == ''" />
 
-    <!--
-      Check for a prebuilt dependency tarball and extract if exists. If there isn't one, we expect
-      the build to be working without prebuilts.
-    -->
+    <!-- Expand SourceBuild.Intermediate packages -->
     <ItemGroup>
-      <SourceBuiltPrebuiltsTarballFile Include="$(ExternalTarballsDir)$(SourceBuiltPrebuiltsTarballName).*.tar.gz" />
+      <SourceBuildIntermediatePackages Include="$(PrebuiltSourceBuiltPackagesPath)Microsoft.SourceBuild.Intermediate.*.nupkg" />
     </ItemGroup>
-    <Exec Command="tar -xzf %(SourceBuiltPrebuiltsTarballFile.FullPath)"
-          WorkingDirectory="$(PrebuiltPackagesPath)"
-          Condition="'@(SourceBuiltPrebuiltsTarballFile)' != ''" />
+    <PropertyGroup>
+      <ExtractPath>$(PrebuiltSourceBuiltPackagesPath)extractArtifacts/</ExtractPath>
+    </PropertyGroup>
+    <Unzip SourceFiles="%(SourceBuildIntermediatePackages.Identity)"
+           DestinationFolder="$(ExtractPath)%(SourceBuildIntermediatePackages.Filename)/" />
+
+    <ItemGroup>
+      <SourceBuildIntermediateArtifactPackages Include="$(ExtractPath)**/artifacts/*.nupkg"
+                                               Exclude="$(ExtractPath)Microsoft.SourceBuild.Intermediate.source-build-reference-packages*/artifacts/*.nupkg" />
+    </ItemGroup>
+    <Move
+      Condition="'@(SourceBuildIntermediateArtifactPackages)' != ''"
+      SourceFiles="@(SourceBuildIntermediateArtifactPackages)"
+      DestinationFiles="@(SourceBuildIntermediateArtifactPackages -> '$(PrebuiltSourceBuiltPackagesPath)%(Filename)%(Extension)')" />
 
     <!-- Move SBRP packages to reference packages location -->
     <MakeDir Directories="$(ReferencePackagesDir)" />
     <ItemGroup>
-      <UnpackedSourceBuildReferencePackages Include="$(PrebuiltSourceBuiltPackagesPath)SourceBuildReferencePackages/*"/>
+      <UnpackedSourceBuildReferencePackages Include="$(ExtractPath)Microsoft.SourceBuild.Intermediate.source-build-reference-packages*/artifacts/*.nupkg" />
     </ItemGroup>
-
     <Move SourceFiles="@(UnpackedSourceBuildReferencePackages)" DestinationFiles="$(ReferencePackagesDir)%(Filename)%(Extension)" />
+    
+    <RemoveDir
+      Condition="Exists('$(ExtractPath)')"
+      Directories="$(ExtractPath)" />
 
     <!-- remove some reference packages that are generated incorrectly and instead use the prebuilt checked-in version instead -->
     <!-- relevant issues: https://github.com/dotnet/runtime/issues/44646, https://github.com/dotnet/runtime/issues/45183,
@@ -95,6 +107,17 @@
     <WriteLinesToFile File="$(PackageVersionsPropsFile)"
                       Lines="$(PackageVersionsPropsContents)"
                       Overwrite="true" />
+
+    <!--
+      Check for a prebuilt dependency tarball and extract if exists. If there isn't one, we expect
+      the build to be working without prebuilts.
+    -->
+    <ItemGroup>
+      <SourceBuiltPrebuiltsTarballFile Include="$(ExternalTarballsDir)$(SourceBuiltPrebuiltsTarballName).*.tar.gz" />
+    </ItemGroup>
+    <Exec Command="tar -xzf %(SourceBuiltPrebuiltsTarballFile.FullPath)"
+          WorkingDirectory="$(PrebuiltPackagesPath)"
+          Condition="'@(SourceBuiltPrebuiltsTarballFile)' != ''" />
 
     <WriteLinesToFile File="$(CompletedSemaphorePath)UnpackTarballs.complete" Overwrite="true" />
   </Target>


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/2262 by only including the intermediates in the archive.  This is the preferred long-term approach as there will be dependencies on the intermediates in the future.  This reduces the archive by ~1 GB.

Previously previous source-built included the text-only prebuilts created as part of the tarball creation process.  These are no longer included as they are not part of any intermediate.

https://github.com/dotnet/source-build/issues/2357 and https://github.com/dotnet/source-build/issues/2472 are remaining issues that will reduce the archive size further.
