### PR TITLE
Also publish non-portable RID runtime symbols tarball

### DIFF
--- a/src/SourceBuild/tarball/content/repos/runtime.common.targets
+++ b/src/SourceBuild/tarball/content/repos/runtime.common.targets
@@ -23,7 +23,7 @@
   </Target>
 
   <Target Name="CopyBinariesToBinFolder"
-          AfterTargets="Build"
+          AfterTargets="ExtractIntermediatePackages"
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(RepoCompletedSemaphorePath)CopyBinariesToBinFolder.complete">
     <ItemGroup>


### PR DESCRIPTION
This fixes a regression in .NET 6 source-build compared to the .NET
5 source-build.

source-build wants to publish runtime symbols tarball for portable (eg,
linux-x64) and non-portable (eg, fedora.33-x64) RIDs here after a build.
Following .NET 5 conventions, I expected to see:

    ./artifacts/x64/Release/runtime/dotnet-runtime-symbols-fedora.34-x64-6.0.0.tar.gz
    ./artifacts/x64/Release/runtime/dotnet-runtime-symbols-linux-x64-6.0.0.tar.gz

Unfortunately, only the portable RID (linux-x64) tarball is present
after a full source-build in .NET 6.

It turns out this is a bug in our build scripts. We try and copy
binaries - including the symbol tarballs - after building each of
runtime-portable and runtime. However, the target dependency is wrong:
after `Build`, the intermediate package doesn't exist from the
just-built repo.

What ends up happening is that nothing is copied after building
runtime-portable. However, after building runtime, the runtime-portable
intermediate artifacts are found and copied over. So the end
build has portable RID symbos, but not the non-portable ones.

Fix that by changing the dependency of this target so it runs after
intermediate packages are available.

cc  @crummel @dseefeld @lbussell @MichaelSimons 