### PR TITLE
Flow environment variables into run-build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -55,5 +55,5 @@ if [ ! -z "$BUILD_IN_DOCKER" ]; then
 else
     # Run under sudo so we can set ulimit
     # See https://github.com/dotnet/core-eng/issues/14808
-    sudo $DIR/run-build.sh $args
+    sudo -E $DIR/run-build.sh $args
 fi


### PR DESCRIPTION
The changes made with https://github.com/dotnet/installer/pull/12590/commits/500bc39ef49d916bfeb4c18a337263f334ba99e5 regressed source-build because environment variables are no longer flown into the build with the default usage of `sudo`.  I imagine other local dev scenario would be impacted similarly.

