### PR TITLE
Fix previously-source-built bootstrap

### DIFF
--- a/src/SourceBuild/tarball/content/scripts/bootstrap/buildBootstrapPreviouslySB.csproj
+++ b/src/SourceBuild/tarball/content/scripts/bootstrap/buildBootstrapPreviouslySB.csproj
@@ -84,14 +84,17 @@
     <PropertyGroup>
       <VersionTag>$([System.String]::concat('%3C','$(PackageName)','Version','%3E').Replace('.',''))</VersionTag>
       <PackageVersionTag>$([System.String]::concat('%3C','$(PackageName)','PackageVersion','%3E').Replace('.',''))</PackageVersionTag>
+      <FilePath>$(DestinationPath)PackageVersions.props</FilePath>
     </PropertyGroup>
-    <Exec
-      Command="sed -i 's/$(VersionTag)$(PackageVersion)/$(VersionTag)$(NewVersion)/g' 'PackageVersions.props'"
-      WorkingDirectory="$(DestinationPath)"
+    <WriteLinesToFile
+      File="$(FilePath)"
+      Lines="$([System.IO.File]::ReadAllText($(FilePath)).Replace('$(VersionTag)$(PackageVersion)','$(VersionTag)$(NewVersion)'))"
+      Overwrite="true"
       Condition=" '$(PackageVersion)' != '$(NewVersion)' " />
-    <Exec
-      Command="sed -i 's/$(PackageVersionTag)$(PackageVersion)/$(PackageVersionTag)$(NewVersion)/g' 'PackageVersions.props'"
-      WorkingDirectory="$(DestinationPath)"
+    <WriteLinesToFile
+      File="$(FilePath)"
+      Lines="$([System.IO.File]::ReadAllText($(FilePath)).Replace('$(PackageVersionTag)$(PackageVersion)','$(PackageVersionTag)$(NewVersion)'))"
+      Overwrite="true"
       Condition=" '$(PackageVersion)' != '$(NewVersion)' " />
   </Target>
 </Project>

--- a/src/SourceBuild/tarball/content/scripts/bootstrap/buildBootstrapPreviouslySB.csproj
+++ b/src/SourceBuild/tarball/content/scripts/bootstrap/buildBootstrapPreviouslySB.csproj
@@ -88,12 +88,7 @@
     </PropertyGroup>
     <WriteLinesToFile
       File="$(FilePath)"
-      Lines="$([System.IO.File]::ReadAllText($(FilePath)).Replace('$(VersionTag)$(PackageVersion)','$(VersionTag)$(NewVersion)'))"
-      Overwrite="true"
-      Condition=" '$(PackageVersion)' != '$(NewVersion)' " />
-    <WriteLinesToFile
-      File="$(FilePath)"
-      Lines="$([System.IO.File]::ReadAllText($(FilePath)).Replace('$(PackageVersionTag)$(PackageVersion)','$(PackageVersionTag)$(NewVersion)'))"
+      Lines="$([System.IO.File]::ReadAllText($(FilePath)).Replace('$(VersionTag)$(PackageVersion)','$(VersionTag)$(NewVersion)').Replace('$(PackageVersionTag)$(PackageVersion)','$(PackageVersionTag)$(NewVersion)'))"
       Overwrite="true"
       Condition=" '$(PackageVersion)' != '$(NewVersion)' " />
   </Target>

--- a/src/SourceBuild/tarball/content/scripts/bootstrap/buildBootstrapPreviouslySB.csproj
+++ b/src/SourceBuild/tarball/content/scripts/bootstrap/buildBootstrapPreviouslySB.csproj
@@ -49,13 +49,49 @@
 
     <!-- Copy files specified in package references above from restored package dir to unpacked archive dir -->
     <Message Text="  Replacing restored files in $(UnpackedTarPath)" Importance="High" />
-    <Copy
-        SourceFiles="$(RestorePackagesPath)$([System.String]::copy('%(PackageReference.Identity)').ToLower()).%(PackageReference.Version).nupkg"
-        DestinationFiles="$(UnpackedTarPath)%(PackageReference.Identity).%(PackageReference.Version).nupkg" />
+    <MSBuild Projects="$(MSBuildProjectFile)"
+      Targets="CopyDownloadedPackage"
+      Properties="SourcePath=$(RestorePackagesPath);DestinationPath=$(UnpackedTarPath);PackageName=%(PackageReference.Identity);PackageVersion=%(PackageReference.Version)" />
 
     <!-- Repack tarball with new bootstrap name -->
     <Message Text="  Repacking tarball to $(NewTarballName)" Importance="High" />
     <Exec Command="tar --numeric-owner -czf $(NewTarballName) *.nupkg *.props SourceBuildReferencePackages/" WorkingDirectory="$(UnpackedTarPath)" />
 
+  </Target>
+
+  <Target Name="CopyDownloadedPackage">
+    <!--
+      Copy downloaded package to the output path.
+      Note: The package version may be different than the version specified
+      since the source-build build number can be different than the official
+      package build number.
+    -->
+    <ItemGroup>
+      <SourceFileName Include="$(SourcePath)$(PackageName.ToLower()).*.nupkg" />
+    </ItemGroup>
+    <PropertyGroup>
+      <DestinationFileName>@(SourceFileName->'%(Filename)')</DestinationFileName>
+      <NewVersion>$(DestinationFileName.Replace('$(PackageName.ToLower()).',''))</NewVersion>
+    </PropertyGroup>
+    <Copy
+      SourceFiles="@(SourceFileName)"
+      DestinationFiles="$(DestinationPath)$(PackageName).$(NewVersion).nupkg" />
+
+    <!--
+      Update the PackageVersions.props if restored version is
+      different than the specified version.
+    -->
+    <PropertyGroup>
+      <VersionTag>$([System.String]::concat('%3C','$(PackageName)','Version','%3E').Replace('.',''))</VersionTag>
+      <PackageVersionTag>$([System.String]::concat('%3C','$(PackageName)','PackageVersion','%3E').Replace('.',''))</PackageVersionTag>
+    </PropertyGroup>
+    <Exec
+      Command="sed -i 's/$(VersionTag)$(PackageVersion)/$(VersionTag)$(NewVersion)/g' 'PackageVersions.props'"
+      WorkingDirectory="$(DestinationPath)"
+      Condition=" '$(PackageVersion)' != '$(NewVersion)' " />
+    <Exec
+      Command="sed -i 's/$(PackageVersionTag)$(PackageVersion)/$(PackageVersionTag)$(NewVersion)/g' 'PackageVersions.props'"
+      WorkingDirectory="$(DestinationPath)"
+      Condition=" '$(PackageVersion)' != '$(NewVersion)' " />
   </Target>
 </Project>


### PR DESCRIPTION
Update the bootstrap project to:
1. Restore desired packages
2. If downloaded packages have a different version (i.e. the build sequence can be different between MS build and source-build):

    - Copy the package that got downloaded, renaming to match source package casing.
    - Update the PackageVersions.props file to include the new version.

Fixes: https://github.com/dotnet/source-build/issues/2599

