### PR TITLE
Looks like our logic for the RID for WindowsDesktop was merged incorrectly into 6.0

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -191,8 +191,8 @@
 
       <WindowsDesktop30RuntimePackRids Include="win-x64;win-x86" />
       <WindowsDesktop31RuntimePackRids Include="@(WindowsDesktop30RuntimePackRids)" />
-      <WindowsDesktop50RuntimePackRids Include="@(WindowsDesktop31RuntimePackRids)" />
-      <WindowsDesktopRuntimePackRids Include="@(WindowsDesktop50RuntimePackRids);win-arm64" />
+      <WindowsDesktop50RuntimePackRids Include="@(WindowsDesktop31RuntimePackRids);win-arm64" />
+      <WindowsDesktopRuntimePackRids Include="@(WindowsDesktop50RuntimePackRids)" />
     </ItemGroup>
 
     <!--

--- a/test/EndToEnd/ProjectBuildTests.cs
+++ b/test/EndToEnd/ProjectBuildTests.cs
@@ -85,13 +85,15 @@ namespace EndToEnd.Tests
                 .Should().Pass().And.HaveStdOutContaining("Hello, World!");
         }
 
-        [WindowsOnlyFact]
-        public void ItCanPublishArm64Winforms()
+        [WindowsOnlyTheory]
+        [InlineData("net5.0")]
+        [InlineData("net6.0")]
+        public void ItCanPublishArm64Winforms(string TargetFramework)
         {
             DirectoryInfo directory = TestAssets.CreateTestDirectory();
             string projectDirectory = directory.FullName;
 
-            string newArgs = "winforms --no-restore";
+            string newArgs = $"winforms -f {TargetFramework} --no-restore";
             new NewCommandShim()
                 .WithWorkingDirectory(projectDirectory)
                 .Execute(newArgs)
@@ -111,13 +113,15 @@ namespace EndToEnd.Tests
             selfContainedPublishDir.Should().HaveFilesMatching($"{directory.Name}.dll", SearchOption.TopDirectoryOnly);
         }
 
-        [WindowsOnlyFact]
-        public void ItCanPublishArm64Wpf()
+        [WindowsOnlyTheory]
+        [InlineData("net5.0")]
+        [InlineData("net6.0")]
+        public void ItCanPublishArm64Wpf(string TargetFramework)
         {
             DirectoryInfo directory = TestAssets.CreateTestDirectory();
             string projectDirectory = directory.FullName;
 
-            string newArgs = "wpf --no-restore";
+            string newArgs = $"wpf -f {TargetFramework} --no-restore";
             new NewCommandShim()
                 .WithWorkingDirectory(projectDirectory)
                 .Execute(newArgs)

--- a/test/EndToEnd/ProjectBuildTests.cs
+++ b/test/EndToEnd/ProjectBuildTests.cs
@@ -85,15 +85,13 @@ namespace EndToEnd.Tests
                 .Should().Pass().And.HaveStdOutContaining("Hello, World!");
         }
 
-        [WindowsOnlyTheory]
-        [InlineData("net5.0")]
-        [InlineData("net6.0")]
-        public void ItCanPublishArm64Winforms(string TargetFramework)
+        [WindowsOnlyFact]
+        public void ItCanPublishArm64Winforms()
         {
             DirectoryInfo directory = TestAssets.CreateTestDirectory();
             string projectDirectory = directory.FullName;
 
-            string newArgs = $"winforms -f {TargetFramework} --no-restore";
+            string newArgs = "winforms --no-restore";
             new NewCommandShim()
                 .WithWorkingDirectory(projectDirectory)
                 .Execute(newArgs)
@@ -113,15 +111,13 @@ namespace EndToEnd.Tests
             selfContainedPublishDir.Should().HaveFilesMatching($"{directory.Name}.dll", SearchOption.TopDirectoryOnly);
         }
 
-        [WindowsOnlyTheory]
-        [InlineData("net5.0")]
-        [InlineData("net6.0")]
-        public void ItCanPublishArm64Wpf(string TargetFramework)
+        [WindowsOnlyFact]
+        public void ItCanPublishArm64Wpf()
         {
             DirectoryInfo directory = TestAssets.CreateTestDirectory();
             string projectDirectory = directory.FullName;
 
-            string newArgs = $"wpf -f {TargetFramework} --no-restore";
+            string newArgs = "wpf --no-restore";
             new NewCommandShim()
                 .WithWorkingDirectory(projectDirectory)
                 .Execute(newArgs)


### PR DESCRIPTION
## Description
Currently you can target windows desktop to arm64 with 5.0.400 or targeting 6.0 with 6.0.100 but can't target 5.0 with 6.0.100
Fixes https://github.com/dotnet/sdk/issues/22565

## Customer Impact

Anyone doing WindowsDesktop development using the current SDK, target 5.0, and publishing for arm64 will be impacted.

##Fix
Updated the RuntimePackRuntimeIdentifiers for the 5.0 KnownFrameworkReferences.

## Regression?

- [x] Yes
- [ ] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

## Verification

- [x] Manual (required)
- [ ] Automated
