### PR TITLE
Refactor tarball CI build to support both official and public builds

### DIFF
--- a/eng/source-build-tarball-build-official.yml
+++ b/eng/source-build-tarball-build-official.yml
@@ -3,7 +3,7 @@ pr: none
 resources:
   pipelines:
   - pipeline: installer-build-resource
-    source: installer
+    source: dotnet-installer-official-ci
     trigger: true
 
 stages:


### PR DESCRIPTION
Utilizing multiple pipelines which was attempted in https://github.com/dotnet/installer/pull/12658 didn't work because all resources need to be accessible within any given build.  Because of this limitation, we have to use separate pipeline definitions.
