### PR TITLE
Remove un-needed version properties

### DIFF
--- a/src/SourceBuild/tarball/content/eng/Versions.props
+++ b/src/SourceBuild/tarball/content/eng/Versions.props
@@ -1,15 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <!-- SDK/Runtime Version Information -->
-  <PropertyGroup>
-    <MajorVersion>6</MajorVersion>
-    <MinorVersion>0</MinorVersion>
-    <RuntimePatchVersion>0-preview.6</RuntimePatchVersion>
-    <SdkPatchVersion>100-preview.6</SdkPatchVersion>
-    <RuntimeProductVersion>$(MajorVersion).$(MinorVersion).$(RuntimePatchVersion)</RuntimeProductVersion>
-    <AspNetCoreProductVersion>$(MajorVersion).$(MinorVersion).$(RuntimePatchVersion)</AspNetCoreProductVersion>
-    <SdkProductVersion>$(MajorVersion).$(MinorVersion).$(SdkPatchVersion)</SdkProductVersion>
-  </PropertyGroup>
   <!-- Repo Version Information -->
   <PropertyGroup>
     <VersionPrefix>0.1.0</VersionPrefix>

--- a/src/SourceBuild/tarball/content/repos/aspnetcore.proj
+++ b/src/SourceBuild/tarball/content/repos/aspnetcore.proj
@@ -53,24 +53,5 @@
 
   <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="ReplaceRegexInFiles" />
 
-  <Target Name="FixAspNetCoreVersion"
-          BeforeTargets="RepoBuild">
-
-    <ItemGroup>
-      <MinifiedJavascriptFile Include="$(ProjectDirectory)**\blazor.server.js" />
-    </ItemGroup>
-
-    <!--
-        Patch the version embedded in minified js files. Because they are
-        minified files, git patch doesn't work too well and produces unreadable
-        binary patches.
-    -->
-    <ReplaceRegexInFiles
-      InputFiles="@(MinifiedJavascriptFile)"
-      OldTextRegex=",l=&quot;5\.0\.\d+&quot;}]\);"
-      NewText=",l=&quot;$(AspNetCoreProductVersion)&quot;}]);" />
-
-  </Target>
-
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>


### PR DESCRIPTION
The Versions.props file in a generated tarball contains versions that correspond to the current version of the product.  These were used previously to update a minified js file in aspnetcore.   The file in aspnetcore has been updated to not include the version, so this is no longer needed. 

Removing these properties and code in aspnetcore.
