### PR TITLE
Exclude ASP.NET  runtime packs from Android

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -370,6 +370,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                               TargetingPackVersion="$(MicrosoftAspNetCoreAppRefPackageVersion)"
                               RuntimePackNamePatterns="Microsoft.AspNetCore.App.Runtime.**RID**"
                               RuntimePackRuntimeIdentifiers="@(AspNetCoreRuntimePackRids, '%3B')"
+                              RuntimePackExcludedRuntimeIdentifiers="android"
                               />
 
     <KnownFrameworkReference Include="Microsoft.Windows.SDK.NET.Ref"


### PR DESCRIPTION
Add metadata which dotnet/sdk#22658 will consume to fix dotnet/sdk#19891.