### PR TITLE
Update release/6.0.1xx build machines

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -314,10 +314,10 @@ stages:
       pool:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: NetCore1ESPool-Svc-Public
-          demands: ImageOverride -equals Build.Ubuntu.1604.Amd64.Open
+          demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: NetCore1ESPool-Svc-Internal
-          demands: ImageOverride -equals Build.Ubuntu.1604.Amd64
+          demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
       timeoutInMinutes: 180
       strategy:
         matrix:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -142,10 +142,10 @@ stages:
       pool:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: NetCore1ESPool-Svc-Public
-          demands: ImageOverride -equals Build.Ubuntu.1604.Amd64.Open
+          demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: NetCore1ESPool-Svc-Internal
-          demands: ImageOverride -equals Build.Ubuntu.1604.Amd64
+          demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
       timeoutInMinutes: 180
       strategy:
         matrix:

--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-create-tarball.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-create-tarball.yml
@@ -7,10 +7,10 @@ jobs:
   pool:
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
       name: NetCore1ESPool-Svc-Public
-      demands: ImageOverride -equals Build.Ubuntu.1604.Amd64.Open
+      demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
     ${{ if eq(variables['System.TeamProject'], 'internal') }}:
       name: NetCore1ESPool-Svc-Internal
-      demands: ImageOverride -equals Build.Ubuntu.1604.Amd64
+      demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
   variables:
     _BuildConfig: Release
   workspace:

--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build.yml
@@ -15,10 +15,10 @@ parameters:
   fedora33Container: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-33-20210222183538-031e7d2
   poolInternal:
     name: NetCore1ESPool-Svc-Internal
-    demands: ImageOverride -equals Build.Ubuntu.1604.Amd64
+    demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
   poolPublic:
     name: NetCore1ESPool-Svc-Public
-    demands: ImageOverride -equals Build.Ubuntu.1604.Amd64.Open
+    demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
   tarballDir: $(Build.StagingDirectory)/tarball
 
 jobs:


### PR DESCRIPTION
Cherry-picked changes from release/6.0.2xx to get CI working in release/6.0.1xx.

I did this to unblock some source-build work.
