### PR TITLE
Fix the logic that generates the fallback text file

### DIFF
--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -463,9 +463,13 @@
   </Target>
 
   <Target Name="CopyIncludedWorkloadManifestFile" >
+
     <ItemGroup>
-      <WorkloadManifestFilesContent Include="$([MSBuild]::ValueOrDefault('%(BundledManifests.WorkloadManifestId)', '').ToLower())" />
+      <WorkloadManifestFilesContent Include="$([MSBuild]::ValueOrDefault('%(BundledManifests.Identity)', '').ToLower())" />
     </ItemGroup>
+
+    <Error Text="No workload manifest content found." Condition="'@(WorkloadManifestFilesContent->Count())' == '0'" />
+
     <WriteLinesToFile File="$(SdkOutputDirectory)IncludedWorkloadManifests.txt"
                       Lines="@(WorkloadManifestFilesContent)"
                       Overwrite="true" />


### PR DESCRIPTION
## Description
Fixes #12789. The workloads fallback file is now empty which means if your current band manifests get deleted, we will not fall back to an older SDK. This is critical in 6.0.200 but we want it in 6.0.100 as well for continued testing.

## Customer Impact

Workloads includes a fallback text file that lists which workloads we should search older SDKs for manifests when one is missing.  This is mainly for previews and when sunsetting workloads but can be useful if your current SDK workload manifests get deleted somehow. 

##Fix
Fix the msbuild logic that was refactored and add an error check in the build if that file is ever empty.

## Regression?

- [x] Yes
- [ ] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

## Verification

- [x] Manual (required)
- [x] Automated
