### PR TITLE
Fix installertype path for patches

### DIFF
--- a/src/redist/targets/GenerateMSIs.targets
+++ b/src/redist/targets/GenerateMSIs.targets
@@ -167,7 +167,7 @@
                       '$(SdkMSIInstallerFile)' ^
                       '$(WixRoot)' ^
                       '$(ToolsetBrandName)' ^
-                      '$(VersionPrefix)' ^
+                      '$(CliProductBandVersion)00' ^
                       '$(MsiVersion)' ^
                       '$(SDKBundleVersion)' ^
                       '$(Version)' ^


### PR DESCRIPTION
Fix the path for the marker file that indicates that the .NET SDK is installed via MSI.  It will now use the feature band (such as 6.0.100) for the folder this file goes in, instead of the version number with patch (such as 6.0.101).  The new path will match what the logic that reads this file is expecting.

# Customer Impact

`dotnet workload` commands (such as `install`, `update`, or `list`) would either fail or do the wrong thing.

The .NET SDK would not detect that the SDK was installed via MSI.  This means that commands that installed or uninstalled anything would think the SDK was a file-based install and try to write the workload files directly to the `dotnet` install folder instead of using the MSIs to install.  This would either fail if run from a non-elevated command prompt, or succeed in copying files directly to the Program Files directory without being managed by an MSI install.

# Regression

Yes.  This was a regression in 6.0.101.

(The logic was also incorrect in 6.0.100, but the result ended up being correct as long as the patch number was zero, so this didn't manifest until 6.0.101).

# Risk

Low

# Verification

Manual - tested old and new builds of SDK installer bundle and verified that the path changed as expected.

Also, we had manual test scenarios which would have covered this, but they were only run once, and weren't part of the regular manual tests.