### PR TITLE
Add runtime and aspnetcore patches to always build libs, app.ref and targetting packs

### DIFF
--- a/src/SourceBuild/tarball/patches/aspnetcore/0005-Always-build-App.Ref-and-the-targeting-packs.patch
+++ b/src/SourceBuild/tarball/patches/aspnetcore/0005-Always-build-App.Ref-and-the-targeting-packs.patch
@@ -1,0 +1,32 @@
+From c5211f8557f2fb019416cf1f6c01142965270479 Mon Sep 17 00:00:00 2001
+From: Doug Bunting <6431421+dougbu@users.noreply.github.com>
+Date: Sun, 16 Jan 2022 22:55:10 -0800
+Subject: [PATCH] Always build App.Ref and the targeting packs - set
+ `$(IsTargetingPackBuilding)` to `true` unconditionally - leave all _use_ of
+ `$(IsTargetingPackBuilding)`
+
+See https://github.com/dotnet/aspnetcore/issues/39471 for details and backporting.
+---
+ Directory.Build.props | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
+diff --git a/Directory.Build.props b/Directory.Build.props
+index e100d883e9..d71b308905 100644
+--- a/Directory.Build.props
++++ b/Directory.Build.props
+@@ -138,11 +138,7 @@
+     <TargetingPackName>Microsoft.AspNetCore.App.Ref</TargetingPackName>
+     <RuntimeInstallerBaseName>aspnetcore-runtime</RuntimeInstallerBaseName>
+     <TargetingPackInstallerBaseName>aspnetcore-targeting-pack</TargetingPackInstallerBaseName>
+-
+-    <!-- This is used to produce targeting pack installers/packages once per major.minor. -->
+-    <IsTargetingPackBuilding
+-        Condition=" '$(IsTargetingPackBuilding)' == '' AND '$(AspNetCorePatchVersion)' != '0' ">false</IsTargetingPackBuilding>
+-    <IsTargetingPackBuilding Condition=" '$(IsTargetingPackBuilding)' == '' ">true</IsTargetingPackBuilding>
++    <IsTargetingPackBuilding>true</IsTargetingPackBuilding>
+ 
+     <!--
+       Archives and installers using this prefix are intended for internal use only.
+-- 
+2.28.0.windows.1
+

--- a/src/SourceBuild/tarball/patches/runtime/0004-release-6.0-Build-all-packages-when-in-source-build.patch
+++ b/src/SourceBuild/tarball/patches/runtime/0004-release-6.0-Build-all-packages-when-in-source-build.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Santiago Fernandez Madero <safern@microsoft.com>
+Date: Tue, 11 Jan 2022 13:55:22 -0800
+Subject: [PATCH] [release/6.0] Build all packages when in source-build
+
+Originating PR:  https://github.com/dotnet/runtime/pull/63653
+---
+ eng/packaging.targets | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/eng/packaging.targets b/eng/packaging.targets
+index 6bcf86dc9f2..ee8e95167d9 100644
+--- a/eng/packaging.targets
++++ b/eng/packaging.targets
+@@ -34,6 +34,10 @@
+                                        '$(IsRIDSpecificProject)' != 'true' and
+                                        '$(PreReleaseVersionLabel)' == 'servicing' and
+                                        '$(GitHubRepositoryName)' != 'runtimelab'">false</GeneratePackageOnBuild>
++    <!-- When in source-build we need to generate all packages when building for all configurations even in servicing. -->
++    <GeneratePackageOnBuild Condition="!$(GeneratePackageOnBuild) and
++                                       '$(BuildAllConfigurations)' == 'true' and
++                                       '$(DotNetBuildFromSource)' == 'true'">true</GeneratePackageOnBuild>
+     <!-- Search for the documentation file in the intellisense package and otherwise pick up the generated one. -->
+     <LibIntellisenseDocumentationFilePath>$(XmlDocFileRoot)1033\$(AssemblyName).xml</LibIntellisenseDocumentationFilePath>
+     <UseIntellisenseDocumentationFile Condition="'$(UseIntellisenseDocumentationFile)' == '' and Exists('$(LibIntellisenseDocumentationFilePath)')">true</UseIntellisenseDocumentationFile>
+@@ -279,7 +283,7 @@
+   </Target>
+ 
+   <Target Name="ValidateServicingVersionIsPropertlySet"
+-          Condition="'$(PreReleaseVersionLabel)' == 'servicing'"
++          Condition="'$(PreReleaseVersionLabel)' == 'servicing' and '$(DotNetBuildFromSource)' != 'true'"
+           AfterTargets="GenerateNuspec">
+     <Error Condition="'$(ServicingVersion)' == '0'" Text="ServicingVersion is set to 0 and it should be an increment of the patch version from the last released package." />
+   </Target>


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/2706

Related to https://github.com/dotnet/runtime/pull/63653
