### PR TITLE
Add additional clause in ConvertInternalRepos condition

### DIFF
--- a/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
+++ b/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
@@ -19,7 +19,7 @@
     <TarballSourceDir>$(TarballRootDir)src/</TarballSourceDir>
     <TarballGitInfoDir>$(TarballRootDir)git-info/</TarballGitInfoDir>
     <CloneVerbosity>quiet</CloneVerbosity> <!-- Support quiet and full -->
-    <ConvertInternalRepos Condition="'$(ConvertInternalRepos)' == '' and '$(VSS_NUGET_EXTERNAL_FEED_ENDPOINTS)' == '' ">true</ConvertInternalRepos>
+    <ConvertInternalRepos Condition="'$(ConvertInternalRepos)' == '' and '$(VSS_NUGET_EXTERNAL_FEED_ENDPOINTS)' == '' and '$(AzDoPat)' == ''">true</ConvertInternalRepos>
   </PropertyGroup>
 
   <Target Name="CreateSourceTarball"


### PR DESCRIPTION
ConvertInternalRepos is not getting set defaulted correctly in some internal builds.  The logic should also be checking for the presence of AzDoPat.
