### PR TITLE
[release/5.0.4xx] Revert back to 16.04 dockerfile temporarily

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -231,7 +231,7 @@ stages:
               _AdditionalBuildParameters: '/p:OSName="linux-musl"'
             Build_Linux_Portable_Deb_Release_x64:
               _BuildConfig: Release
-              _DockerParameter: '--docker ubuntu.18.04'
+              _DockerParameter: '--docker ubuntu.16.04'
               _LinuxPortable: '--linux-portable'
               _RuntimeIdentifier: ''
               _BuildArchitecture: 'x64'


### PR DESCRIPTION
The 18.04 dockerfile is missing some required tooling necessary to build the debian images packages. This tooling is installed in the 16.04 dockerfile, but it appears that the same attempts to install this in 18.04 fail. Until this is resolved, avoid using the 18.04 image.
https://github.com/dotnet/installer/issues/13079