### PR TITLE
Update to the latest set of templates in the msi installer

### DIFF
--- a/src/redist/targets/GenerateMSIs.targets
+++ b/src/redist/targets/GenerateMSIs.targets
@@ -320,11 +320,8 @@
 
     <!-- Choose "latest" template MSI to go in bundle. -->
     <ItemGroup>
-      <!-- While we don't have 7.0 templates available (need SDK update, choose the 6.0 templates -->
-      <!-- <LatestTemplateInstallerComponent Include="@(TemplatesMsiComponent)"
-                                        Condition="'%(TemplatesMajorMinorVersion)' == '$(MajorMinorVersion)'"/> -->
       <LatestTemplateInstallerComponent Include="@(TemplatesMsiComponent)"
-                                        Condition="'%(TemplatesMajorMinorVersion)' == '6.0'"/>
+                                        Condition="'%(TemplatesMajorMinorVersion)' == '$(MajorMinorVersion)'"/>
     </ItemGroup>
     <PropertyGroup>
       <LatestTemplateMsiInstallerFile>@(LatestTemplateInstallerComponent->'%(MSIInstallerFile)')</LatestTemplateMsiInstallerFile>


### PR DESCRIPTION
The MSI was hardcoded to pull in the 6.0 templates as we didn't have 7.0 templates yet.