### PR TITLE
Source-build tweaks to aid release process

### DIFF
--- a/src/SourceBuild/Arcade/eng/common/templates/steps/source-build-build-tarball.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/steps/source-build-build-tarball.yml
@@ -108,3 +108,5 @@ steps:
   - publish: '${{ parameters.tarballDir }}/artifacts/${{ parameters.buildArch}}/Release/'
     artifact: $(Agent.JobName)_Artifacts
     displayName: Publish Artifacts
+    condition: succeededOrFailed()
+    continueOnError: true

--- a/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
+++ b/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
@@ -87,8 +87,8 @@
     <ItemGroup>
       <SourceBuildRepos Include="$(GitHubRepositoryName)">
         <Name>$(GitHubRepositoryName)</Name>
-        <Version>1.0.0</Version>
-        <ExactVersion>1.0.0</ExactVersion>
+        <Version>$(VersionPrefix)</Version>
+        <ExactVersion>$(VersionPrefix)</ExactVersion>
         <Sha>@(RootRepoCommitSha)</Sha>
         <Uri>@(RootRepoUri)</Uri>
         <GitCommitCount>@(RootRepoCommitCount)</GitCommitCount>

--- a/src/SourceBuild/tarball/content/build.proj
+++ b/src/SourceBuild/tarball/content/build.proj
@@ -149,8 +149,7 @@
   <Target Name="CreatePrebuiltsTarballIfPrebuiltsExist"
           Condition="'@(PrebuiltFile->Count())' != '0'">
     <PropertyGroup>
-      <TarballFileVersion>$(PrivateSourceBuiltPrebuiltsPackageVersionPrefix)$([MSBuild]::Add($(PrivateSourceBuiltPrebuiltsPackageVersionSuffix), 1))</TarballFileVersion>
-      <TarballFilePath>$(OutputPath)$(SourceBuiltPrebuiltsTarballName).$(TarballFileVersion).tar.gz</TarballFilePath>
+      <TarballFilePath>$(OutputPath)$(SourceBuiltPrebuiltsTarballName).$(installerOutputPackageVersion).tar.gz</TarballFilePath>
       <TarballWorkingDir>$(ResultingPrebuiltPackagesDir)</TarballWorkingDir>
     </PropertyGroup>
 

--- a/src/SourceBuild/tarball/content/eng/Versions.props
+++ b/src/SourceBuild/tarball/content/eng/Versions.props
@@ -9,9 +9,4 @@
   <PropertyGroup>
     <HumanizerCorePackageVersion>2.2.0</HumanizerCorePackageVersion>
   </PropertyGroup>
-  <!-- Production Dependencies -->
-  <PropertyGroup>
-    <PrivateSourceBuiltPrebuiltsPackageVersionPrefix>0.1.0-6.0.100-</PrivateSourceBuiltPrebuiltsPackageVersionPrefix>
-    <PrivateSourceBuiltPrebuiltsPackageVersionSuffix>36</PrivateSourceBuiltPrebuiltsPackageVersionSuffix>
-  </PropertyGroup>
 </Project>

--- a/src/SourceBuild/tarball/content/repos/package-source-build.proj
+++ b/src/SourceBuild/tarball/content/repos/package-source-build.proj
@@ -47,7 +47,7 @@
       Directories="$(SourceBuildReferencePackagesDestination)extractArtifacts/" />
 
     <PropertyGroup>
-      <SourceBuiltTarballName>$(OutputPath)$(SourceBuiltArtifactsTarballName).$(VersionPrefix)-$(VersionSuffix).tar.gz</SourceBuiltTarballName>
+      <SourceBuiltTarballName>$(OutputPath)$(SourceBuiltArtifactsTarballName).$(installerOutputPackageVersion).tar.gz</SourceBuiltTarballName>
     </PropertyGroup>
 
     <Exec Command="tar --numeric-owner --exclude='$(SBRPIntermediateWildcard)' -czf $(SourceBuiltTarballName) *.nupkg *.props SourceBuildReferencePackages/" WorkingDirectory="$(SourceBuiltPackagesPath)" />


### PR DESCRIPTION
This addresses the following issues:

1. During builds, SB artifacts are not captured if smoke-tests fail.  Capturing the built artifacts is useful if you want to quickly repo the smoke-test failure locally w/o building the entire tarball.
2. Change the versioning of the source-build artifacts tarball to align with release version.
