### PR TITLE
Switching to 7.0 test templates

### DIFF
--- a/src/redist/targets/BundledTemplates.targets
+++ b/src/redist/targets/BundledTemplates.targets
@@ -31,7 +31,7 @@
     <Bundled70Templates Include="Microsoft.Dotnet.WinForms.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWinFormsProjectTemplates70PackageVersion)" Condition="'$(DotNetBuildFromSource)' != 'true'" />
     
     <!-- NUnit templates are shipped in Test.ProjectTemplates -->
-    <Bundled70Templates Include="Microsoft.DotNet.Test.ProjectTemplates.6.0" PackageVersion="$(MicrosoftDotNetTestProjectTemplates60PackageVersion)" />
+    <Bundled70Templates Include="Microsoft.DotNet.Test.ProjectTemplates.7.0" PackageVersion="$(MicrosoftDotNetTestProjectTemplates70PackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/EndToEnd/ProjectBuildTests.cs
+++ b/test/EndToEnd/ProjectBuildTests.cs
@@ -396,13 +396,9 @@ namespace EndToEnd.Tests
             {
                 // TODO: This block need to be updated when every template updates their default tfm.
                 // Currently winforms updated their default templates target but not others.
-                if (template.StartsWith("mstest") 
-                    || template.StartsWith("mstest") 
-                    || template.StartsWith("nunit")
-                    || template.StartsWith("xunit")
-                    || template.StartsWith("wpf"))
+                if (template.StartsWith("wpf"))
                 {
-                    return "net6.0";                    
+                    return "net6.0";
                 }
                 return $"net{latestMajorVersion}.0";
             }


### PR DESCRIPTION
**Customer Scenario**
Without this change, all xunit, nunit, and mstest templates will target 6.0 by default.

**Testing**
Updated the automated tests for this