### PR TITLE
Fix publish-build-assets.yml job

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -378,6 +378,9 @@ stages:
           - Source_Build_Managed
           - Source_Build_Create_Tarball
         publishUsingPipelines: true
+        pool:
+          name: NetCore1ESPool-Internal
+          demands: ImageOverride -equals build.windows.10.amd64.vs2019
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng\common\templates\post-build\post-build.yml


### PR DESCRIPTION
Since this repo doesn't use the jobs.yml template, when it calls the publish-build-assets.yml template it needs to specify a pool.