### PR TITLE
Remove non-shipping project template from installer

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -57,10 +57,6 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-aspnetcore</Uri>
       <Sha>7b22a279ec975335bbb0a7cbadef2e45ee15aa9c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly.Templates" Version="3.2.1">
-      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-aspnetcore</Uri>
-      <Sha>331b52b370cd4e7fe2919d4d4cda27412e2ab1cc</Sha>
-    </Dependency>
     <Dependency Name="dotnet-dev-certs" Version="3.1.22-servicing.21579.4">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-aspnetcore</Uri>
       <Sha>7b22a279ec975335bbb0a7cbadef2e45ee15aa9c</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -43,7 +43,6 @@
     <dotnetdevcertsPackageVersion>3.1.22-servicing.21579.4</dotnetdevcertsPackageVersion>
     <dotnetusersecretsPackageVersion>3.1.22-servicing.21579.4</dotnetusersecretsPackageVersion>
     <dotnetwatchPackageVersion>3.1.22-servicing.21579.4</dotnetwatchPackageVersion>
-    <MicrosoftAspNetCoreComponentsWebAssemblyTemplatesPackageVersion>3.2.1</MicrosoftAspNetCoreComponentsWebAssemblyTemplatesPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/cli -->

--- a/src/redist/targets/BundledTemplates.targets
+++ b/src/redist/targets/BundledTemplates.targets
@@ -28,7 +28,6 @@
   </Target>
 
   <ItemGroup>
-    <Bundled31Templates Include="Microsoft.AspNetCore.Components.WebAssembly.Templates" PackageVersion="$(MicrosoftAspNetCoreComponentsWebAssemblyTemplatesPackageVersion)" />
     <Bundled31Templates Include="Microsoft.DotNet.Common.ItemTemplates" PackageVersion="$(MicrosoftDotNetCommonItemTemplates31PackageVersion)" />
     <Bundled31Templates Include="Microsoft.DotNet.Common.ProjectTemplates.3.1" PackageVersion="$(MicrosoftDotNetCommonProjectTemplates31PackageVersion)" />
     <Bundled31Templates Include="Microsoft.DotNet.Test.ProjectTemplates.3.1" PackageVersion="$(MicrosoftDotNetTestProjectTemplates31PackageVersion)" />


### PR DESCRIPTION
Blazor WebAssembly 3.2 was discontinued and removed from the installer, but appears
to have been revived during a merge.

