### PR TITLE
Updates to produce Microsoft.DotNet.Common.ProjectTemplates.2.1/6.0 in source-build

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -211,9 +211,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>7421b55f46aff8373764016d942b23cbf87c75cb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="6.0.0-servicing.22069.2">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="6.0.0-servicing.22077.1">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>8867610fc0861940f204bcc87f792bd49bbe49d6</Sha>
+      <Sha>71a327c277a022d15af3d103c0796620ecd40471</Sha>
       <SourceBuildTarball RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceLink.GitHub" Version="1.1.0-beta-21480-02" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -211,9 +211,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>7421b55f46aff8373764016d942b23cbf87c75cb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="6.0.0-alpha.1.21561.1">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="6.0.0-servicing.22069.2">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>897a9709eb370a92bce2391d77b03d06149cbb6c</Sha>
+      <Sha>8867610fc0861940f204bcc87f792bd49bbe49d6</Sha>
       <SourceBuildTarball RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceLink.GitHub" Version="1.1.0-beta-21480-02" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -211,9 +211,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>7421b55f46aff8373764016d942b23cbf87c75cb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="6.0.0-servicing.22070.1">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="6.0.0-alpha.1.21561.1">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>b047d49b93597b29986623f3c7c67a65fbccf648</Sha>
+      <Sha>897a9709eb370a92bce2391d77b03d06149cbb6c</Sha>
       <SourceBuildTarball RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceLink.GitHub" Version="1.1.0-beta-21480-02" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">

--- a/src/SourceBuild/Arcade/tools/TextOnlyPackages.csproj
+++ b/src/SourceBuild/Arcade/tools/TextOnlyPackages.csproj
@@ -25,6 +25,7 @@
 
     <PackageDownload Include="Microsoft.DotNet.Web.ItemTemplates.6.0" Version="[$(AspNetCorePackageVersionFor60Templates)]" />
 
+    <PackageDownload Include="Microsoft.DotNet.Common.ProjectTemplates.2.1" Version="[$(MicrosoftDotNetCommonProjectTemplates21PackageVersion)]" />
     <PackageDownload Include="Microsoft.DotNet.Common.ProjectTemplates.3.0" Version="[$(MicrosoftDotNetCommonProjectTemplates30PackageVersion)]" />
     <PackageDownload Include="Microsoft.DotNet.Common.ProjectTemplates.3.1" Version="[$(MicrosoftDotNetCommonProjectTemplates31PackageVersion)]" />
     <PackageDownload Include="Microsoft.DotNet.Common.ProjectTemplates.5.0" Version="[$(MicrosoftDotNetCommonProjectTemplates50PackageVersion)]" />

--- a/src/SourceBuild/Arcade/tools/TextOnlyPackages.csproj
+++ b/src/SourceBuild/Arcade/tools/TextOnlyPackages.csproj
@@ -28,6 +28,7 @@
     <PackageDownload Include="Microsoft.DotNet.Common.ProjectTemplates.3.0" Version="[$(MicrosoftDotNetCommonProjectTemplates30PackageVersion)]" />
     <PackageDownload Include="Microsoft.DotNet.Common.ProjectTemplates.3.1" Version="[$(MicrosoftDotNetCommonProjectTemplates31PackageVersion)]" />
     <PackageDownload Include="Microsoft.DotNet.Common.ProjectTemplates.5.0" Version="[$(MicrosoftDotNetCommonProjectTemplates50PackageVersion)]" />
+    <PackageDownload Include="Microsoft.DotNet.Common.ProjectTemplates.6.0" Version="[$(MicrosoftDotNetCommonProjectTemplates60PackageVersion)]" />
 
     <PackageDownload Include="Microsoft.DotNet.Web.ProjectTemplates.2.1" Version="[$(AspNetCorePackageVersionFor21Templates)]" />
     <PackageDownload Include="Microsoft.DotNet.Web.ProjectTemplates.3.0" Version="[$(AspNetCorePackageVersionFor30Templates)]" />

--- a/src/SourceBuild/Arcade/tools/TextOnlyPackages.csproj
+++ b/src/SourceBuild/Arcade/tools/TextOnlyPackages.csproj
@@ -25,7 +25,6 @@
 
     <PackageDownload Include="Microsoft.DotNet.Web.ItemTemplates.6.0" Version="[$(AspNetCorePackageVersionFor60Templates)]" />
 
-    <PackageDownload Include="Microsoft.DotNet.Common.ProjectTemplates.2.1" Version="[$(MicrosoftDotNetCommonProjectTemplates21PackageVersion)]" />
     <PackageDownload Include="Microsoft.DotNet.Common.ProjectTemplates.3.0" Version="[$(MicrosoftDotNetCommonProjectTemplates30PackageVersion)]" />
     <PackageDownload Include="Microsoft.DotNet.Common.ProjectTemplates.3.1" Version="[$(MicrosoftDotNetCommonProjectTemplates31PackageVersion)]" />
     <PackageDownload Include="Microsoft.DotNet.Common.ProjectTemplates.5.0" Version="[$(MicrosoftDotNetCommonProjectTemplates50PackageVersion)]" />


### PR DESCRIPTION
This adds source-build code to treat Microsoft.DotNet.Common.ProjectTemplates 6.0 as a text-only package so it can be deconstructed and reconstructed as part of the build process, and also reverts our source-build-reference-packages reference to a version that includes Microsoft.DotNet.Common.ProjectTemplates 2.1.  Some cleanup was done which unintentionally removed this package from the build.