### PR TITLE
[release/6.0.1xx] Add arm64 packages to source-build bootstrap

### DIFF
--- a/src/SourceBuild/tarball/content/scripts/bootstrap/buildBootstrapPreviouslySB.csproj
+++ b/src/SourceBuild/tarball/content/scripts/bootstrap/buildBootstrapPreviouslySB.csproj
@@ -19,6 +19,10 @@
     <PackageReference Include="Microsoft.NETCore.ILAsm" Version="$(MicrosoftNETCoreILAsmVersion)" />
     <PackageReference Include="Microsoft.NETCore.ILDAsm" Version="$(MicrosoftNETCoreILDAsmVersion)" />
     <PackageReference Include="Microsoft.NETCore.TestHost" Version="$(MicrosoftNETCoreTestHostVersion)" />
+    <PackageReference Include="runtime.linux-arm64.Microsoft.NETCore.ILAsm" Version="$(RuntimeLinuxX64MicrosoftNETCoreILAsmVersion)" />
+    <PackageReference Include="runtime.linux-arm64.Microsoft.NETCore.ILDAsm" Version="$(RuntimeLinuxX64MicrosoftNETCoreILDAsmVersion)" />
+    <PackageReference Include="runtime.linux-arm64.Microsoft.NETCore.TestHost" Version="$(RuntimeLinuxX64MicrosoftNETCoreTestHostVersion)" />
+    <PackageReference Include="runtime.linux-arm64.runtime.native.System.IO.Ports" Version="$(RuntimeLinuxX64RuntimeNativeSystemIOPortsVersion)" />
     <PackageReference Include="runtime.linux-x64.Microsoft.NETCore.ILAsm" Version="$(RuntimeLinuxX64MicrosoftNETCoreILAsmVersion)" />
     <PackageReference Include="runtime.linux-x64.Microsoft.NETCore.ILDAsm" Version="$(RuntimeLinuxX64MicrosoftNETCoreILDAsmVersion)" />
     <PackageReference Include="runtime.linux-x64.Microsoft.NETCore.TestHost" Version="$(RuntimeLinuxX64MicrosoftNETCoreTestHostVersion)" />


### PR DESCRIPTION
Currently, source-build is failing out-of-the-box on arm64 because ilasm
and friends are missing on arm64.

The errors look like this:

src/source-build-reference-packages.4643b750ccc93ca151eed888da70b67f0198d1fd/artifacts/source-build/self/src/src/targetPacks/ILsrc/microsoft.netframework.referenceassemblies/1.0.2/microsoft.netframework.referenceassemblies.1.0.2.csproj:
error NU1101: Unable to find package
runtime.linux-arm64.microsoft.netcore.ilasm. No packages exist with this
id in source(s): prebuilt, previously-source-built, reference-packages,
source-built
[.dotnet/sdk/6.0.101/NuGet.targets]

Fix this and related errors by ading arm64 artifacts to the bootstrap
step.

This change is sufficient to make source-build work out-of-the-box on
arm64 now using the normal steps:

    ./build.sh /p:ArcadeBuildTarball=true /p:TarballDir=/some/dir
    cd /some/dir
    ./prep.sh --bootstrap && ./build.sh

