### PR TITLE
Update manifests for MAUI Preview 13

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -9,6 +9,7 @@
     <!--  Begin: Package sources from dotnet-aspnetcore -->
     <!--  End: Package sources from dotnet-aspnetcore -->
     <!--  Begin: Package sources from dotnet-emsdk -->
+    <add key="darc-pub-dotnet-emsdk-e8ffccb" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-e8ffccbd/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-emsdk -->
     <!--  Begin: Package sources from DotNet-msbuild-Trusted -->
     <add key="darc-pub-DotNet-msbuild-Trusted-ae57d10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-DotNet-msbuild-Trusted-ae57d105/nuget/v3/index.json" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -182,9 +182,9 @@
     <XamarinMacCatalystWorkloadManifestVersion>15.2.301-preview.13.2</XamarinMacCatalystWorkloadManifestVersion>
     <XamarinMacOSWorkloadManifestVersion>12.1.301-preview.13.2</XamarinMacOSWorkloadManifestVersion>
     <XamarinTvOSWorkloadManifestVersion>15.2.301-preview.13.2</XamarinTvOSWorkloadManifestVersion>
-    <MonoWorkloadManifestVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MonoWorkloadManifestVersion>
-    <MicrosoftNETWorkloadEmscriptenManifest60100Version>6.0.0</MicrosoftNETWorkloadEmscriptenManifest60100Version>
-    <EmscriptenWorkloadManifestVersion>$(MicrosoftNETWorkloadEmscriptenManifest60100Version)</EmscriptenWorkloadManifestVersion>
+    <MonoWorkloadManifestVersion>6.0.2</MonoWorkloadManifestVersion>
+    <MicrosoftNETWorkloadEmscriptenManifest60200Version>6.0.1</MicrosoftNETWorkloadEmscriptenManifest60200Version>
+    <EmscriptenWorkloadManifestVersion>$(MicrosoftNETWorkloadEmscriptenManifest60200Version)</EmscriptenWorkloadManifestVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- pinned dependency. This package is not being produced outside of the 2.0 branch of corefx and should not change. -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -182,7 +182,7 @@
     <XamarinMacCatalystWorkloadManifestVersion>15.2.301-preview.13.2</XamarinMacCatalystWorkloadManifestVersion>
     <XamarinMacOSWorkloadManifestVersion>12.1.301-preview.13.2</XamarinMacOSWorkloadManifestVersion>
     <XamarinTvOSWorkloadManifestVersion>15.2.301-preview.13.2</XamarinTvOSWorkloadManifestVersion>
-    <MonoWorkloadManifestVersion>6.0.2</MonoWorkloadManifestVersion>
+    <MonoWorkloadManifestVersion>6.0.2-mauipre.1.22102.15</MonoWorkloadManifestVersion>
     <MicrosoftNETWorkloadEmscriptenManifest60200Version>6.0.1</MicrosoftNETWorkloadEmscriptenManifest60200Version>
     <EmscriptenWorkloadManifestVersion>$(MicrosoftNETWorkloadEmscriptenManifest60200Version)</EmscriptenWorkloadManifestVersion>
   </PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -176,12 +176,12 @@
   </PropertyGroup>
   <!-- Workload manifest package versions -->
   <PropertyGroup>
-    <MauiWorkloadManifestVersion>6.0.101-preview.9.1805</MauiWorkloadManifestVersion>
-    <XamarinAndroidWorkloadManifestVersion>31.0.101-preview.9.16</XamarinAndroidWorkloadManifestVersion>
-    <XamarinIOSWorkloadManifestVersion>15.0.101-preview.9.31</XamarinIOSWorkloadManifestVersion>
-    <XamarinMacCatalystWorkloadManifestVersion>15.0.101-preview.9.31</XamarinMacCatalystWorkloadManifestVersion>
-    <XamarinMacOSWorkloadManifestVersion>12.0.101-preview.9.31</XamarinMacOSWorkloadManifestVersion>
-    <XamarinTvOSWorkloadManifestVersion>15.0.101-preview.9.31</XamarinTvOSWorkloadManifestVersion>
+    <MauiWorkloadManifestVersion>6.0.200-preview.13.2747</MauiWorkloadManifestVersion>
+    <XamarinAndroidWorkloadManifestVersion>31.0.200-preview.13.41</XamarinAndroidWorkloadManifestVersion>
+    <XamarinIOSWorkloadManifestVersion>15.2.301-preview.13.2</XamarinIOSWorkloadManifestVersion>
+    <XamarinMacCatalystWorkloadManifestVersion>15.2.301-preview.13.2</XamarinMacCatalystWorkloadManifestVersion>
+    <XamarinMacOSWorkloadManifestVersion>12.1.301-preview.13.2</XamarinMacOSWorkloadManifestVersion>
+    <XamarinTvOSWorkloadManifestVersion>15.2.301-preview.13.2</XamarinTvOSWorkloadManifestVersion>
     <MonoWorkloadManifestVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MonoWorkloadManifestVersion>
     <MicrosoftNETWorkloadEmscriptenManifest60100Version>6.0.0</MicrosoftNETWorkloadEmscriptenManifest60100Version>
     <EmscriptenWorkloadManifestVersion>$(MicrosoftNETWorkloadEmscriptenManifest60100Version)</EmscriptenWorkloadManifestVersion>

--- a/src/SourceBuild/Arcade/tools/TextOnlyPackages.csproj
+++ b/src/SourceBuild/Arcade/tools/TextOnlyPackages.csproj
@@ -41,14 +41,14 @@
     <PackageDownload Include="Microsoft.DotNet.Web.Spa.ProjectTemplates.5.0" Version="[$(AspNetCorePackageVersionFor50Templates)]" />
     <PackageDownload Include="Microsoft.DotNet.Web.Spa.ProjectTemplates.6.0" Version="[$(AspNetCorePackageVersionFor60Templates)]" />
 
-    <PackageDownload Include="Microsoft.NET.Sdk.Android.Manifest-6.0.100" Version="[$(XamarinAndroidWorkloadManifestVersion)]" />
-    <PackageDownload Include="Microsoft.NET.Sdk.iOS.Manifest-6.0.100" Version="[$(XamarinIOSWorkloadManifestVersion)]" />
-    <PackageDownload Include="Microsoft.NET.Sdk.MacCatalyst.Manifest-6.0.100" Version="[$(XamarinMacCatalystWorkloadManifestVersion)]" />
-    <PackageDownload Include="Microsoft.NET.Sdk.macOS.Manifest-6.0.100" Version="[$(XamarinMacOSWorkloadManifestVersion)]" />
-    <PackageDownload Include="Microsoft.NET.Sdk.Maui.Manifest-6.0.100" Version="[$(MauiWorkloadManifestVersion)]" />
-    <PackageDownload Include="Microsoft.NET.Sdk.tvOS.Manifest-6.0.100" Version="[$(XamarinTvOSWorkloadManifestVersion)]" />
-    <PackageDownload Include="Microsoft.NET.Workload.Emscripten.Manifest-6.0.100" Version="[$(EmscriptenWorkloadManifestVersion)]" />
-    <PackageDownload Include="Microsoft.NET.Workload.Mono.ToolChain.Manifest-6.0.100" Version="[$(MonoWorkloadManifestVersion)]" />
+    <PackageDownload Include="Microsoft.NET.Sdk.Android.Manifest-6.0.200" Version="[$(XamarinAndroidWorkloadManifestVersion)]" />
+    <PackageDownload Include="Microsoft.NET.Sdk.iOS.Manifest-6.0.200" Version="[$(XamarinIOSWorkloadManifestVersion)]" />
+    <PackageDownload Include="Microsoft.NET.Sdk.MacCatalyst.Manifest-6.0.200" Version="[$(XamarinMacCatalystWorkloadManifestVersion)]" />
+    <PackageDownload Include="Microsoft.NET.Sdk.macOS.Manifest-6.0.200" Version="[$(XamarinMacOSWorkloadManifestVersion)]" />
+    <PackageDownload Include="Microsoft.NET.Sdk.Maui.Manifest-6.0.200" Version="[$(MauiWorkloadManifestVersion)]" />
+    <PackageDownload Include="Microsoft.NET.Sdk.tvOS.Manifest-6.0.200" Version="[$(XamarinTvOSWorkloadManifestVersion)]" />
+    <PackageDownload Include="Microsoft.NET.Workload.Emscripten.Manifest-6.0.200" Version="[$(EmscriptenWorkloadManifestVersion)]" />
+    <PackageDownload Include="Microsoft.NET.Workload.Mono.ToolChain.Manifest-6.0.200" Version="[$(MonoWorkloadManifestVersion)]" />
   </ItemGroup>
 
   <!--

--- a/src/redist/targets/BundledManifests.targets
+++ b/src/redist/targets/BundledManifests.targets
@@ -6,8 +6,8 @@
     <BundledManifests Include="Microsoft.NET.Sdk.macOS" FeatureBand="6.0.200" Version="$(XamarinMacOSWorkloadManifestVersion)" />
     <BundledManifests Include="Microsoft.NET.Sdk.Maui" FeatureBand="6.0.200" Version="$(MauiWorkloadManifestVersion)" />
     <BundledManifests Include="Microsoft.NET.Sdk.tvOS" FeatureBand="6.0.200" Version="$(XamarinTvOSWorkloadManifestVersion)" />
-    <BundledManifests Include="Microsoft.NET.Workload.Mono.ToolChain" FeatureBand="6.0.100" Version="$(MonoWorkloadManifestVersion)" />
-    <BundledManifests Include="Microsoft.NET.Workload.Emscripten" FeatureBand="6.0.100" Version="$(EmscriptenWorkloadManifestVersion)" />
+    <BundledManifests Include="Microsoft.NET.Workload.Mono.ToolChain" FeatureBand="6.0.200" Version="$(MonoWorkloadManifestVersion)" />
+    <BundledManifests Include="Microsoft.NET.Workload.Emscripten" FeatureBand="6.0.200" Version="$(EmscriptenWorkloadManifestVersion)" />
   </ItemGroup>
 
   <!-- Calculate NuGet package IDs for bundled manifests -->

--- a/src/redist/targets/BundledManifests.targets
+++ b/src/redist/targets/BundledManifests.targets
@@ -1,11 +1,11 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <BundledManifests Include="Microsoft.NET.Sdk.Android" FeatureBand="6.0.100" Version="$(XamarinAndroidWorkloadManifestVersion)" />
-    <BundledManifests Include="Microsoft.NET.Sdk.iOS" FeatureBand="6.0.100" Version="$(XamarinIOSWorkloadManifestVersion)" />
-    <BundledManifests Include="Microsoft.NET.Sdk.MacCatalyst" FeatureBand="6.0.100" Version="$(XamarinMacCatalystWorkloadManifestVersion)" />
-    <BundledManifests Include="Microsoft.NET.Sdk.macOS" FeatureBand="6.0.100" Version="$(XamarinMacOSWorkloadManifestVersion)" />
-    <BundledManifests Include="Microsoft.NET.Sdk.Maui" FeatureBand="6.0.100" Version="$(MauiWorkloadManifestVersion)" />
-    <BundledManifests Include="Microsoft.NET.Sdk.tvOS" FeatureBand="6.0.100" Version="$(XamarinTvOSWorkloadManifestVersion)" />
+    <BundledManifests Include="Microsoft.NET.Sdk.Android" FeatureBand="6.0.200" Version="$(XamarinAndroidWorkloadManifestVersion)" />
+    <BundledManifests Include="Microsoft.NET.Sdk.iOS" FeatureBand="6.0.200" Version="$(XamarinIOSWorkloadManifestVersion)" />
+    <BundledManifests Include="Microsoft.NET.Sdk.MacCatalyst" FeatureBand="6.0.200" Version="$(XamarinMacCatalystWorkloadManifestVersion)" />
+    <BundledManifests Include="Microsoft.NET.Sdk.macOS" FeatureBand="6.0.200" Version="$(XamarinMacOSWorkloadManifestVersion)" />
+    <BundledManifests Include="Microsoft.NET.Sdk.Maui" FeatureBand="6.0.200" Version="$(MauiWorkloadManifestVersion)" />
+    <BundledManifests Include="Microsoft.NET.Sdk.tvOS" FeatureBand="6.0.200" Version="$(XamarinTvOSWorkloadManifestVersion)" />
     <BundledManifests Include="Microsoft.NET.Workload.Mono.ToolChain" FeatureBand="6.0.100" Version="$(MonoWorkloadManifestVersion)" />
     <BundledManifests Include="Microsoft.NET.Workload.Emscripten" FeatureBand="6.0.100" Version="$(EmscriptenWorkloadManifestVersion)" />
   </ItemGroup>


### PR DESCRIPTION
Insertion: https://devdiv.visualstudio.com/DevDiv/_git/VS/commit/38aa7894a1a98073332c3ff0549525ac8a68a53b
Bump to: xamarin/xamarin-android/release/6.0.2xx-preview13@d23abbd7
Bump to: xamarin/xamarin-macios/release/6.0.2xx-preview13@88f54c5e
Bump to: dotnet/maui/release/6.0.2xx-preview13@8354ef23

The .NET MAUI workload manifests are now 6.0.200. This also uses the
builds we are tentatively shipping for Preview 13.

Note, that I think xamarin-macios had to adjust their version numbers
for other reasons. Their x.x.301 builds should align to 6.0.200.

After `.\build.cmd -pack -publish`, manually tested the workloads:

    > $env:DOTNET_MULTILEVEL_LOOKUP=0
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install android --skip-manifest-update
    Installing pack Microsoft.Android.Sdk version 31.0.200-preview.13.41...
    ...
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install ios --skip-manifest-update
    Installing pack Microsoft.iOS.Sdk version 15.2.301-preview.13.2...
    ...
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install maccatalyst --skip-manifest-update
    Installing pack Microsoft.MacCatalyst.Sdk version 15.2.301-preview.13.2...
    ...
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install macos --skip-manifest-update
    Installing pack Microsoft.macOS.Sdk version 12.1.301-preview.13.2...
    ...
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install tvos --skip-manifest-update
    Installing pack Microsoft.tvOS.Sdk version 15.2.301-preview.13.2...
    ...
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install maui --skip-manifest-update
    Installing pack Microsoft.Maui.Core.Ref.android version 6.0.200-preview.13.2747...