### PR TITLE
Remove template references to previous versions from source-build

### DIFF
--- a/src/SourceBuild/Arcade/tools/TextOnlyPackages.csproj
+++ b/src/SourceBuild/Arcade/tools/TextOnlyPackages.csproj
@@ -11,35 +11,10 @@
     should be added to source-build-reference-packages.
   -->
   <ItemGroup>
-    <PackageDownload Include="Microsoft.DotNet.Common.ItemTemplates"
-                     Version="[$(MicrosoftDotNetCommonItemTemplates30PackageVersion)];
-                              [$(MicrosoftDotNetCommonItemTemplates31PackageVersion)];
-                              [$(MicrosoftDotNetCommonItemTemplates50PackageVersion)];
-                              [$(MicrosoftDotNetCommonItemTemplates60PackageVersion)]" />
-
-    <PackageDownload Include="Microsoft.DotNet.Web.ItemTemplates"
-                     Version="[$(AspNetCorePackageVersionFor21Templates)];
-                              [$(AspNetCorePackageVersionFor30Templates)];
-                              [$(AspNetCorePackageVersionFor31Templates)];
-                              [$(AspNetCorePackageVersionFor50Templates)]" />
-
+    <PackageDownload Include="Microsoft.DotNet.Common.ItemTemplates" Version="[$(MicrosoftDotNetCommonItemTemplates60PackageVersion)]" />
     <PackageDownload Include="Microsoft.DotNet.Web.ItemTemplates.6.0" Version="[$(AspNetCorePackageVersionFor60Templates)]" />
-
-    <PackageDownload Include="Microsoft.DotNet.Common.ProjectTemplates.3.0" Version="[$(MicrosoftDotNetCommonProjectTemplates30PackageVersion)]" />
-    <PackageDownload Include="Microsoft.DotNet.Common.ProjectTemplates.3.1" Version="[$(MicrosoftDotNetCommonProjectTemplates31PackageVersion)]" />
-    <PackageDownload Include="Microsoft.DotNet.Common.ProjectTemplates.5.0" Version="[$(MicrosoftDotNetCommonProjectTemplates50PackageVersion)]" />
     <PackageDownload Include="Microsoft.DotNet.Common.ProjectTemplates.6.0" Version="[$(MicrosoftDotNetCommonProjectTemplates60PackageVersion)]" />
-
-    <PackageDownload Include="Microsoft.DotNet.Web.ProjectTemplates.2.1" Version="[$(AspNetCorePackageVersionFor21Templates)]" />
-    <PackageDownload Include="Microsoft.DotNet.Web.ProjectTemplates.3.0" Version="[$(AspNetCorePackageVersionFor30Templates)]" />
-    <PackageDownload Include="Microsoft.DotNet.Web.ProjectTemplates.3.1" Version="[$(AspNetCorePackageVersionFor31Templates)]" />
-    <PackageDownload Include="Microsoft.DotNet.Web.ProjectTemplates.5.0" Version="[$(AspNetCorePackageVersionFor50Templates)]" />
     <PackageDownload Include="Microsoft.DotNet.Web.ProjectTemplates.6.0" Version="[$(AspNetCorePackageVersionFor60Templates)]" />
-
-    <PackageDownload Include="Microsoft.DotNet.Web.Spa.ProjectTemplates.2.1" Version="[$(AspNetCorePackageVersionFor21Templates)]" />
-    <PackageDownload Include="Microsoft.DotNet.Web.Spa.ProjectTemplates.3.0" Version="[$(AspNetCorePackageVersionFor30Templates)]" />
-    <PackageDownload Include="Microsoft.DotNet.Web.Spa.ProjectTemplates.3.1" Version="[$(AspNetCorePackageVersionFor31Templates)]" />
-    <PackageDownload Include="Microsoft.DotNet.Web.Spa.ProjectTemplates.5.0" Version="[$(AspNetCorePackageVersionFor50Templates)]" />
     <PackageDownload Include="Microsoft.DotNet.Web.Spa.ProjectTemplates.6.0" Version="[$(AspNetCorePackageVersionFor60Templates)]" />
 
     <PackageDownload Include="Microsoft.NET.Sdk.Android.Manifest-6.0.100" Version="[$(XamarinAndroidWorkloadManifestVersion)]" />

--- a/src/redist/targets/BundledTemplates.targets
+++ b/src/redist/targets/BundledTemplates.targets
@@ -85,13 +85,21 @@
   </ItemGroup>
 
   <ItemGroup>
-    <BundledTemplates Include="@(Bundled60Templates)" TemplateFrameworkVersion="6.0"/>
-    <BundledTemplates Include="@(Bundled50Templates)" TemplateFrameworkVersion="5.0"/>
-    <BundledTemplates Include="@(Bundled31Templates)" TemplateFrameworkVersion="3.1"/>
-    <BundledTemplates Include="@(Bundled30Templates)" TemplateFrameworkVersion="3.0"/>
-    <BundledTemplates Include="@(Bundled21Templates)" TemplateFrameworkVersion="2.1"/>
+    <CurrentVersionBundledTemplates Include="@(Bundled60Templates)" TemplateFrameworkVersion="6.0"/>
   </ItemGroup>
-  
+
+  <ItemGroup>
+    <PreviousVersionBundledTemplates Include="@(Bundled50Templates)" TemplateFrameworkVersion="5.0"/>
+    <PreviousVersionBundledTemplates Include="@(Bundled31Templates)" TemplateFrameworkVersion="3.1"/>
+    <PreviousVersionBundledTemplates Include="@(Bundled30Templates)" TemplateFrameworkVersion="3.0"/>
+    <PreviousVersionBundledTemplates Include="@(Bundled21Templates)" TemplateFrameworkVersion="2.1"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <BundledTemplates Include="@(CurrentVersionBundledTemplates)" />
+    <BundledTemplates Include="@(PreviousVersionBundledTemplates)" Condition="$(ProductMonikerRid.StartsWith('win'))" />
+  </ItemGroup>
+
   <ItemGroup>
     <BundledTemplates Update="@(BundledTemplates)">
       <NupkgPathRelativeToPackageRoot>%(Identity)/%(PackageVersion)/%(Identity).%(PackageVersion).nupkg</NupkgPathRelativeToPackageRoot>


### PR DESCRIPTION
Related to https://github.com/dotnet/templating/issues/4337#issuecomment-1030061888

The motivation for making this change is it eliminates the need to include all of these templates in source-build.  They are treated as text-only packages which is a maintenance problem.  They are causing numerous component governance alerts which would need to be addressed.