### PR TITLE
Revert "[release/7.0.1xx-preview1] Windows SDK projection update"

### DIFF
--- a/eng/ManualVersions.props
+++ b/eng/ManualVersions.props
@@ -9,10 +9,10 @@
      Basically: In this file, choose the highest version when resolving merge conflicts.
  -->
   <PropertyGroup>
-    <MicrosoftWindowsSDKNETRef10_0_17763PackageVersion>10.0.17763.23</MicrosoftWindowsSDKNETRef10_0_17763PackageVersion>
-    <MicrosoftWindowsSDKNETRef10_0_18362PackageVersion>10.0.18362.23</MicrosoftWindowsSDKNETRef10_0_18362PackageVersion>
-    <MicrosoftWindowsSDKNETRef10_0_19041PackageVersion>10.0.19041.23</MicrosoftWindowsSDKNETRef10_0_19041PackageVersion>
-    <MicrosoftWindowsSDKNETRef10_0_20348PackageVersion>10.0.20348.23</MicrosoftWindowsSDKNETRef10_0_20348PackageVersion>
-    <MicrosoftWindowsSDKNETRef10_0_22000PackageVersion>10.0.22000.23</MicrosoftWindowsSDKNETRef10_0_22000PackageVersion>
+    <MicrosoftWindowsSDKNETRef10_0_17763PackageVersion>10.0.17763.22</MicrosoftWindowsSDKNETRef10_0_17763PackageVersion>
+    <MicrosoftWindowsSDKNETRef10_0_18362PackageVersion>10.0.18362.22</MicrosoftWindowsSDKNETRef10_0_18362PackageVersion>
+    <MicrosoftWindowsSDKNETRef10_0_19041PackageVersion>10.0.19041.22</MicrosoftWindowsSDKNETRef10_0_19041PackageVersion>
+    <MicrosoftWindowsSDKNETRef10_0_20348PackageVersion>10.0.20348.22</MicrosoftWindowsSDKNETRef10_0_20348PackageVersion>
+    <MicrosoftWindowsSDKNETRef10_0_22000PackageVersion>10.0.22000.22</MicrosoftWindowsSDKNETRef10_0_22000PackageVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Reverts dotnet/installer#13201 as preview 1 will ship before that projection ships.