### PR TITLE
Adjust handling of reference packages directory

### DIFF
--- a/src/SourceBuild/tarball/content/Directory.Build.props
+++ b/src/SourceBuild/tarball/content/Directory.Build.props
@@ -148,18 +148,9 @@
     <PoisonedReportFile>$(PackageReportDir)poisoned.txt</PoisonedReportFile>
     <ConflictingPackageReportDir>$(BaseOutputPath)conflict-report/</ConflictingPackageReportDir>
     <PrebuiltBurndownDataFile>$(PackageReportDir)PrebuiltBurndownData.csv</PrebuiltBurndownDataFile>
-    <ReferencePackagesBaseDir>$(IntermediatePath)reference-packages/</ReferencePackagesBaseDir>
-    <TextOnlyPackageBaseDir>$(IntermediatePath)text-only-packages/</TextOnlyPackageBaseDir>
-    <ExternalTarballsDir>$(IntermediatePath)external-tarballs/</ExternalTarballsDir>
-    <!--
-      Change ReferencePackagesBaseDir & ExternalTarballsDir conditionally in offline build.
-      See corresponding change in build-source-tarball.sh to copy reference-packages & external-tarballs
-      from source-build bin dir to tarball packages/reference dir & packages/archive.
-    -->
     <ExternalTarballsDir>$(ProjectDir)packages/archive/</ExternalTarballsDir>
-    <ReferencePackagesBaseDir>$(ProjectDir)packages/reference/</ReferencePackagesBaseDir>
     <TextOnlyPackageBaseDir>$(ProjectDir)packages/text-only/</TextOnlyPackageBaseDir>
-    <ReferencePackagesDir>$(ReferencePackagesBaseDir)packages/</ReferencePackagesDir>
+    <ReferencePackagesDir>$(ProjectDir)packages/reference/</ReferencePackagesDir>
     <SourceBuiltArtifactsTarballName>Private.SourceBuilt.Artifacts</SourceBuiltArtifactsTarballName>
     <SourceBuiltPrebuiltsTarballName>Private.SourceBuilt.Prebuilts</SourceBuiltPrebuiltsTarballName>
     <SourceBuiltArtifactsTarballUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/</SourceBuiltArtifactsTarballUrl>

--- a/src/SourceBuild/tarball/content/tools-local/init-build.proj
+++ b/src/SourceBuild/tarball/content/tools-local/init-build.proj
@@ -57,13 +57,13 @@
           WorkingDirectory="$(PrebuiltPackagesPath)"
           Condition="'@(SourceBuiltPrebuiltsTarballFile)' != ''" />
 
-    <!-- Move SBRP packages to reference packages location -->
+    <!-- Copy SBRP packages to reference packages location -->
     <MakeDir Directories="$(ReferencePackagesDir)" />
     <ItemGroup>
       <UnpackedSourceBuildReferencePackages Include="$(PrebuiltSourceBuiltPackagesPath)SourceBuildReferencePackages/*"/>
     </ItemGroup>
 
-    <Move SourceFiles="@(UnpackedSourceBuildReferencePackages)" DestinationFiles="$(ReferencePackagesDir)%(Filename)%(Extension)" />
+    <Copy SourceFiles="@(UnpackedSourceBuildReferencePackages)" DestinationFiles="$(ReferencePackagesDir)%(Filename)%(Extension)" />
 
     <!-- remove some reference packages that are generated incorrectly and instead use the prebuilt checked-in version instead -->
     <!-- relevant issues: https://github.com/dotnet/runtime/issues/44646, https://github.com/dotnet/runtime/issues/45183,


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/2734

1. Copy ref packs from previous source built location instead of moving.  This is necessary when `--with-packages` is specified.
2. Cleanup duplicate `ReferencePackages` properties that were leftover from offline cleanup.
3. Removed the redundance in the `packages/reference/packages` location to be `packages/reference`.
