### PR TITLE
Make NuGet.config copy path in source-build CI more explicit

### DIFF
--- a/src/SourceBuild/Arcade/eng/common/templates/steps/source-build-build-tarball.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/steps/source-build-build-tarball.yml
@@ -88,7 +88,7 @@ steps:
 
       # Use installer repo's NuGet.config during online testing to utilize internal feeds
       rm -f ${{ parameters.tarballDir }}/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/smoke-tests/online.NuGet.Config
-      cp NuGet.config ${{ parameters.tarballDir }}/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/smoke-tests/online.NuGet.Config
+      cp ${{ Build.SourcesDirectory }}/NuGet.config ${{ parameters.tarballDir }}/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/smoke-tests/online.NuGet.Config
 
       dockerVolumeArgs="-v ${{ parameters.tarballDir }}:/tarball"
       dockerEnvArgs="-e EXCLUDE_OMNISHARP_TESTS=${{ parameters.excludeOmniSharpTests}}"

--- a/src/SourceBuild/Arcade/eng/common/templates/steps/source-build-build-tarball.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/steps/source-build-build-tarball.yml
@@ -93,7 +93,7 @@ steps:
       dockerVolumeArgs="-v ${{ parameters.tarballDir }}:/tarball"
       dockerEnvArgs="-e EXCLUDE_OMNISHARP_TESTS=${{ parameters.excludeOmniSharpTests}}"
 
-      if [ '${{ parameters.isBootstrapped }}' != 'true' && '${{ parameters.installerBuildResourceId }}' != 'current' ]; then
+      if [[ '${{ parameters.isBootstrapped }}' != 'true' && '${{ parameters.installerBuildResourceId }}' != 'current' ]]; then
         dockerVolumeArgs+=" -v $(PIPELINE.WORKSPACE)/${{ parameters.installerBuildResourceId }}/BlobArtifacts/:/BlobArtifacts"
         msftSdkTarballName=$(find "$(PIPELINE.WORKSPACE)/${{ parameters.installerBuildResourceId }}/BlobArtifacts/" -name "dotnet-sdk-*-${{ parameters.Platform }}-${{ parameters.buildArch }}.tar.gz" -exec basename {} \;)
         dockerEnvArgs+=" -e MSFT_SDK_TARBALL_PATH=/BlobArtifacts/$msftSdkTarballName"

--- a/src/SourceBuild/Arcade/eng/common/templates/steps/source-build-build-tarball.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/steps/source-build-build-tarball.yml
@@ -88,12 +88,12 @@ steps:
 
       # Use installer repo's NuGet.config during online testing to utilize internal feeds
       rm -f ${{ parameters.tarballDir }}/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/smoke-tests/online.NuGet.Config
-      cp ${{ Build.SourcesDirectory }}/NuGet.config ${{ parameters.tarballDir }}/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/smoke-tests/online.NuGet.Config
+      cp $(Build.SourcesDirectory)/NuGet.config ${{ parameters.tarballDir }}/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/smoke-tests/online.NuGet.Config
 
       dockerVolumeArgs="-v ${{ parameters.tarballDir }}:/tarball"
       dockerEnvArgs="-e EXCLUDE_OMNISHARP_TESTS=${{ parameters.excludeOmniSharpTests}}"
 
-      if [ '${{ parameters.isBootstrapped}}' != 'true' && '${{ parameters.installerBuildResourceId }}' != 'current' ]; then
+      if [ '${{ parameters.isBootstrapped }}' != 'true' && '${{ parameters.installerBuildResourceId }}' != 'current' ]; then
         dockerVolumeArgs+=" -v $(PIPELINE.WORKSPACE)/${{ parameters.installerBuildResourceId }}/BlobArtifacts/:/BlobArtifacts"
         msftSdkTarballName=$(find "$(PIPELINE.WORKSPACE)/${{ parameters.installerBuildResourceId }}/BlobArtifacts/" -name "dotnet-sdk-*-${{ parameters.Platform }}-${{ parameters.buildArch }}.tar.gz" -exec basename {} \;)
         dockerEnvArgs+=" -e MSFT_SDK_TARBALL_PATH=/BlobArtifacts/$msftSdkTarballName"


### PR DESCRIPTION
* Add a missing path prefix to be more explicit about where the NuGet.config file is being copied from in source-build CI
* Add extra square brackets to fix syntax error in conditional