### PR TITLE
Update source-build's MsftToSbSdk baseline

### DIFF
--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdk.diff
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdk.diff
@@ -764,14 +764,6 @@ index ------------
  ./sdk/x.y.z/ref/mscorlib.dll
  ./sdk/x.y.z/ref/netstandard.dll
 @@ ------------ @@
- ./sdk/x.y.z/Roslyn/bincore/ru/Microsoft.CodeAnalysis.CSharp.resources.dll
- ./sdk/x.y.z/Roslyn/bincore/ru/Microsoft.CodeAnalysis.resources.dll
- ./sdk/x.y.z/Roslyn/bincore/ru/Microsoft.CodeAnalysis.VisualBasic.resources.dll
-+./sdk/x.y.z/Roslyn/bincore/runtimes/
-+./sdk/x.y.z/Roslyn/bincore/runtimes/win/
-+./sdk/x.y.z/Roslyn/bincore/runtimes/win/lib/
-+./sdk/x.y.z/Roslyn/bincore/runtimes/win/lib/netcoreapp3.1/
-+./sdk/x.y.z/Roslyn/bincore/runtimes/win/lib/netcoreapp3.1/System.Text.Encoding.CodePages.dll
  ./sdk/x.y.z/Roslyn/bincore/System.Collections.Immutable.dll
  ./sdk/x.y.z/Roslyn/bincore/System.Reflection.Metadata.dll
  ./sdk/x.y.z/Roslyn/bincore/System.Runtime.CompilerServices.Unsafe.dll


### PR DESCRIPTION
The MsftToSbSdk test is currently failing - https://dev.azure.com/dnceng/internal/_build/results?buildId=1637242&view=logs&j=98ef6fec-a01f-50ba-e703-0db1c31836d5&t=2e010a07-b5d7-57c7-fa73-d2859046954c
