### PR TITLE
Remove template text-only packages which are alread included in source-build

### DIFF
--- a/src/SourceBuild/Arcade/tools/TextOnlyPackages.csproj
+++ b/src/SourceBuild/Arcade/tools/TextOnlyPackages.csproj
@@ -11,9 +11,7 @@
     should be added to source-build-reference-packages.
   -->
   <ItemGroup>
-    <PackageDownload Include="Microsoft.DotNet.Common.ItemTemplates" Version="[$(MicrosoftDotNetCommonItemTemplates60PackageVersion)]" />
     <PackageDownload Include="Microsoft.DotNet.Web.ItemTemplates.6.0" Version="[$(AspNetCorePackageVersionFor60Templates)]" />
-    <PackageDownload Include="Microsoft.DotNet.Common.ProjectTemplates.6.0" Version="[$(MicrosoftDotNetCommonProjectTemplates60PackageVersion)]" />
     <PackageDownload Include="Microsoft.DotNet.Web.ProjectTemplates.6.0" Version="[$(AspNetCorePackageVersionFor60Templates)]" />
     <PackageDownload Include="Microsoft.DotNet.Web.Spa.ProjectTemplates.6.0" Version="[$(AspNetCorePackageVersionFor60Templates)]" />
 


### PR DESCRIPTION
This is responding to the changes made in https://github.com/dotnet/templating/issues/4337 which have flown in.

The remaining templates are tracked with https://github.com/dotnet/aspnetcore/issues/40637

Related to https://github.com/dotnet/source-build/issues/2614