### PR TITLE
Fix source-build graph in Version.Details.xml

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -20,7 +20,6 @@
     <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.7.0" Version="7.0.0-preview.3.22151.6" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>2330b4bef645bf8bcd3011f35968e55192c697f5</Sha>
-      <SourceBuildTarball RepoName="runtime" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="7.0.0-preview.3.22151.6" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
@@ -33,6 +32,7 @@
     <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="7.0.0-preview.3.22151.6" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>2330b4bef645bf8bcd3011f35968e55192c697f5</Sha>
+      <SourceBuildTarball RepoName="runtime" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Host.win-x64" Version="7.0.0-preview.3.22151.6" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
@@ -63,11 +63,11 @@
     <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="7.0.0-preview.3.22158.12" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>3bc56046a2b8076f2e771cb99c35daabf5147d7b</Sha>
+      <SourceBuildTarball RepoName="aspnetcore" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="VS.Redist.Common.AspNetCore.SharedFramework.x64.7.0" Version="7.0.0-preview.3.22158.12" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>3bc56046a2b8076f2e771cb99c35daabf5147d7b</Sha>
-      <SourceBuild RepoName="aspnetcore" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="dotnet-dev-certs" Version="7.0.0-preview.3.22158.12" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
@@ -88,7 +88,6 @@
     <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.6.0" Version="1.0.2-beta4.22157.1">
       <Uri>https://github.com/dotnet/test-templates</Uri>
       <Sha>9c17a4a6ee6327c95faa6ce5dba391e0dd91cacd</Sha>
-      <SourceBuild RepoName="test-templates" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.7.0" Version="1.0.2-beta4.22157.1">
       <Uri>https://github.com/dotnet/test-templates</Uri>
@@ -162,18 +161,34 @@
       <Sha>53b80940842204f78708a538628288ff5d741a1d</Sha>
     </Dependency>
     <!-- Temporarily pinning Microsoft.Web.Xdt until strict coherency is enabled by default -->
-    <Dependency Name="Microsoft.Web.Xdt" Version="3.1.0" CoherentParentDependency="Microsoft.NET.Sdk" Pinned="true">
-      <Uri>https://github.com/aspnet/xdt</Uri>
-      <Sha>c01a538851a8ab1a1fbeb2e6243f391fff7587b4</Sha>
+    <Dependency Name="Microsoft.Web.Xdt" Version="5.0.0-preview.21431.1" CoherentParentDependency="Microsoft.NET.Sdk" Pinned="true">
+      <Uri>https://github.com/dotnet/xdt</Uri>
+      <Sha>698fdad58fa64a55f16cd9562c90224cc498ed02</Sha>
+      <SourceBuildTarball RepoName="xdt" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-7.0.100" Version="7.0.0-preview.3.22122.1" CoherentParentDependency="VS.Redist.Common.NetCore.SharedFramework.x64.7.0">
       <Uri>https://github.com/dotnet/emsdk</Uri>
       <Sha>50d92d57d5a760017cd7fbd9b97cdac86b68c233</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.Deployment.DotNet.Releases" Version="1.0.247101">
+      <Uri>https://github.com/dotnet/deployment-tools</Uri>
+      <Sha>7431bf2f3c204cbbc326c8d55ce4ac5cad7661d6</Sha>
+      <SourceBuildTarball RepoName="deployment-tools" ManagedOnly="true" />
+    </Dependency>
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.diagnostics" Version="5.0.0-preview.21506.1">
+      <Uri>https://github.com/dotnet/diagnostics</Uri>
+      <Sha>ab3eb7a525e31dc6fb4d9cc0b7154fa2be58dac1</Sha>
+      <SourceBuildTarball RepoName="diagnostics" ManagedOnly="true" />
+    </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="7.0.0-alpha.1.22154.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/source-build-externals</Uri>
       <Sha>c349f5f0326edcd47b302a8c6731fc3c7ae7a1ef</Sha>
       <SourceBuild RepoName="source-build-externals" ManagedOnly="true" />
+    </Dependency>
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.symreader" Version="1.4.0-beta2-21475-02">
+      <Uri>https://github.com/dotnet/symreader</Uri>
+      <Sha>7b9791daa3a3477eb22ec805946c9fff8b42d8ca</Sha>
+      <SourceBuildTarball RepoName="symreader" ManagedOnly="true" />
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -189,7 +189,7 @@
       or minor release, prebuilts may be needed. When the release is mature, prebuilts are not
       necessary, and this property is removed from the file.
     -->
-    <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-6.0.100-bootstrap.29</PrivateSourceBuiltArtifactsPackageVersion>
+    <PrivateSourceBuiltArtifactsPackageVersion>6.0.103</PrivateSourceBuiltArtifactsPackageVersion>
   </PropertyGroup>
   <!-- Workload manifest package versions -->
   <PropertyGroup>

--- a/src/SourceBuild/tarball/content/global.json
+++ b/src/SourceBuild/tarball/content/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "6.0.200-preview.21603.2"
+    "dotnet": "7.0.100-alpha.1.21518.14"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.1",


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/2585.

These changes were lost from 6.0
