### PR TITLE
Ensure finalizer.exe is always cached

### DIFF
--- a/src/redist/targets/packaging/windows/clisdk/bundle.wxs
+++ b/src/redist/targets/packaging/windows/clisdk/bundle.wxs
@@ -216,6 +216,7 @@
         being installed.
       -->
       <ExePackage SourceFile="$(var.FinalizerExeSourcePath)"
+                  Cache="always"
                   DetectCondition="WixBundleAction >= 3"
                   Id="Finalizer"
                   InstallCondition="WixBundleAction >= 4"


### PR DESCRIPTION
Fixes #13371 

The finalizer.exe is not being cached, so when the bundle is removed from disk and then uninstalled, it will prompt for the bundle source to extract the EXE. This change forces it to always cache.

The reason it wasn't cached is because it was designed to only run during uninstalls. To avoid the uninstall command from triggering during installs, we have to detect the EXE as installed always. This has a side effect that it won't get cached since it's always detected as present and then skipped during an install. The package will now be marked for caching during the planning phase, e.g. from the log below

```
[1588:16BC][2022-03-10T11:24:11]i101: Detected package: Finalizer, state: Present, cached: None
[1588:16BC][2022-03-10T11:24:20]i201: Planned package: Finalizer, state: Present, default requested: Present, ba requested: Present, execute: None, rollback: None, cache: Yes, uncache: No, dependency: None
```