### PR TITLE
Remove maui workloads from 6.0.100

### DIFF
--- a/src/redist/targets/BundledManifests.targets
+++ b/src/redist/targets/BundledManifests.targets
@@ -52,7 +52,8 @@
       <SignCheckWorkloadManifestMsiInputFiles Include="@(BundledManifestsToValidateSigning->'%(RestoredMsiPathInNupkg)')" />
     </ItemGroup>
 
-    <Exec Command="$(SignCheckExe) ^
+    <Exec Condition="'@(SignCheckWorkloadManifestMsiInputFiles->Count())' != '0'" 
+                   Command="$(SignCheckExe) ^
                    --recursive ^
                    -f UnsignedFiles ^
                    -i @(SignCheckWorkloadManifestMsiInputFiles, ' ') ^

--- a/src/redist/targets/BundledManifests.targets
+++ b/src/redist/targets/BundledManifests.targets
@@ -1,11 +1,5 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <BundledManifests Include="Microsoft.NET.Sdk.Android" FeatureBand="6.0.100" Version="$(XamarinAndroidWorkloadManifestVersion)" />
-    <BundledManifests Include="Microsoft.NET.Sdk.iOS" FeatureBand="6.0.100" Version="$(XamarinIOSWorkloadManifestVersion)" />
-    <BundledManifests Include="Microsoft.NET.Sdk.MacCatalyst" FeatureBand="6.0.100" Version="$(XamarinMacCatalystWorkloadManifestVersion)" />
-    <BundledManifests Include="Microsoft.NET.Sdk.macOS" FeatureBand="6.0.100" Version="$(XamarinMacOSWorkloadManifestVersion)" />
-    <BundledManifests Include="Microsoft.NET.Sdk.Maui" FeatureBand="6.0.100" Version="$(MauiWorkloadManifestVersion)" />
-    <BundledManifests Include="Microsoft.NET.Sdk.tvOS" FeatureBand="6.0.100" Version="$(XamarinTvOSWorkloadManifestVersion)" />
     <BundledManifests Include="Microsoft.NET.Workload.Mono.ToolChain" FeatureBand="6.0.100" Version="$(MonoWorkloadManifestVersion)" />
     <BundledManifests Include="Microsoft.NET.Workload.Emscripten" FeatureBand="6.0.100" Version="$(EmscriptenWorkloadManifestVersion)" />
   </ItemGroup>


### PR DESCRIPTION
## Description
Workloads broke MU updates and require being rebuilt with changes made to Arcade back in January. Because MAUI in 6.0.100 is preview 11, they are not prepared to update their arcade and rebuild those versions. 

## Customer Impact

Customers will have to use 6.0.200 or .300 previews to target MAUI. This is already true in VS as MAUI is not available in 17.0 or 17.1 now.

##Fix
Remove Maui workloads similar to what we did for 7.0.100. Same change as there so same testing.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

## Verification

- [x] Manual (required)
- [x] Automated
- [x] MU testing -- still needed once we have builds
