### PR TITLE
Remove maui workloads from 6.0.200

### DIFF
--- a/src/redist/targets/BundledManifests.targets
+++ b/src/redist/targets/BundledManifests.targets
@@ -52,7 +52,8 @@
       <SignCheckWorkloadManifestMsiInputFiles Include="@(BundledManifestsToValidateSigning->'%(RestoredMsiPathInNupkg)')" />
     </ItemGroup>
 
-    <Exec Command="$(SignCheckExe) ^
+    <Exec Condition="'@(SignCheckWorkloadManifestMsiInputFiles->Count())' != '0'" 
+                   Command="$(SignCheckExe) ^
                    --recursive ^
                    -f UnsignedFiles ^
                    -i @(SignCheckWorkloadManifestMsiInputFiles, ' ') ^

--- a/src/redist/targets/BundledManifests.targets
+++ b/src/redist/targets/BundledManifests.targets
@@ -1,11 +1,5 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <BundledManifests Include="Microsoft.NET.Sdk.Android" FeatureBand="6.0.200" Version="$(XamarinAndroidWorkloadManifestVersion)" />
-    <BundledManifests Include="Microsoft.NET.Sdk.iOS" FeatureBand="6.0.200" Version="$(XamarinIOSWorkloadManifestVersion)" />
-    <BundledManifests Include="Microsoft.NET.Sdk.MacCatalyst" FeatureBand="6.0.200" Version="$(XamarinMacCatalystWorkloadManifestVersion)" />
-    <BundledManifests Include="Microsoft.NET.Sdk.macOS" FeatureBand="6.0.200" Version="$(XamarinMacOSWorkloadManifestVersion)" />
-    <BundledManifests Include="Microsoft.NET.Sdk.Maui" FeatureBand="6.0.200" Version="$(MauiWorkloadManifestVersion)" />
-    <BundledManifests Include="Microsoft.NET.Sdk.tvOS" FeatureBand="6.0.200" Version="$(XamarinTvOSWorkloadManifestVersion)" />
     <BundledManifests Include="Microsoft.NET.Workload.Mono.ToolChain" FeatureBand="6.0.200" Version="$(MonoWorkloadManifestVersion)" />
     <BundledManifests Include="Microsoft.NET.Workload.Emscripten" FeatureBand="6.0.200" Version="$(EmscriptenWorkloadManifestVersion)" />
   </ItemGroup>


### PR DESCRIPTION
The old workloads break MU so we either have to update them or remove them.

- Please add description for changes you are making.
- If there is an issue related to this PR, please add the reference.
