### PR TITLE
[release/6.0.1xx] Fix build against musl

### DIFF
--- a/src/SourceBuild/tarball/content/Directory.Build.props
+++ b/src/SourceBuild/tarball/content/Directory.Build.props
@@ -171,21 +171,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetRid Condition="'$(TargetRid)' == ''">$([System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier)</TargetRid>
-
-    <TargetOS Condition="'$(TargetOS)' == '' AND $([MSBuild]::IsOSPlatform('WINDOWS'))">Windows_NT</TargetOS>
-    <TargetOS Condition="'$(TargetOS)' == '' AND $([MSBuild]::IsOSPlatform('OSX'))">OSX</TargetOS>
-    <TargetOS Condition="'$(TargetOS)' == '' AND $([MSBuild]::IsOSPlatform('LINUX'))">Linux</TargetOS>
-    <TargetOS Condition="'$(TargetOS)' == '' AND $([MSBuild]::IsOSPlatform('FREEBSD'))">FreeBSD</TargetOS>
-
-    <PortableRid Condition="'$(TargetOS)' == 'FreeBSD'">freebsd-$(Platform)</PortableRid>
-    <PortableRid Condition="'$(TargetOS)' == 'OSX'">osx-$(Platform)</PortableRid>
-    <PortableRid Condition="'$(TargetOS)' == 'Linux'">linux-$(Platform)</PortableRid>
-    <PortableRid Condition="'$(TargetOS)' == 'Windows_NT'">win-$(Platform)</PortableRid>
-    <TargetRid Condition="'$(PortableBuild)' == 'true' AND '$(PortableRid)' != ''">$(PortableRid)</TargetRid>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <!-- known-good (repos/known-good.proj) conditionally includes submodules based on the platform,
          so this will not always correspond to the same repos - see that file for details.
          We need an "empty" project after the last real project in order for prebuilt detection

--- a/src/SourceBuild/tarball/content/Directory.Build.targets
+++ b/src/SourceBuild/tarball/content/Directory.Build.targets
@@ -10,6 +10,13 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="GetOSPlatformIsMuslCheck"
+          BeforeTargets="CollectPackageReferences">
+    <Exec IgnoreExitCode="true" Command="ldd --version 2&gt;&amp;1 | grep -q musl">
+      <Output TaskParameter="ExitCode" PropertyName="OSPlatformIsMuslCheck" />
+    </Exec>
+  </Target>
+
   <Import Condition="'$(SkipArcadeSdkImport)' != 'true'" Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
 </Project>

--- a/src/SourceBuild/tarball/content/repos/aspnetcore.proj
+++ b/src/SourceBuild/tarball/content/repos/aspnetcore.proj
@@ -15,6 +15,8 @@
     <!-- https://github.com/dotnet/sdk/pull/20136 has not flowed into our bootstrap SDK yet, which causes file-in-use issues in ASP.NET
          due to an interaction with the RemoveSharedFrameworkDependencies task.  disable package validation until this is fixed.  -->
     <BuildCommandArgs>$(BuildCommandArgs) /p:EnablePackageValidation=false</BuildCommandArgs>
+    <!-- below is temporary fix till https://github.com/dotnet/aspnetcore/issues/39822 is addressed -->
+    <BuildCommandArgs Condition="'$(OSPlatformIsMusl)' == 'true'">$(BuildCommandArgs) --os-name linux-musl</BuildCommandArgs>
     <BuildCommand>$(ProjectDirectory)\eng\build$(ShellExtension) $(BuildCommandArgs)</BuildCommand>
 
     <LogVerbosityOptOut>true</LogVerbosityOptOut>

--- a/src/SourceBuild/tarball/content/repos/installer.proj
+++ b/src/SourceBuild/tarball/content/repos/installer.proj
@@ -25,7 +25,9 @@
     <BuildCommandArgs Condition="'$(TargetOS)' == 'Linux'">$(BuildCommandArgs) /p:Rid=$(TargetRid)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:DOTNET_INSTALL_DIR=$(DotNetCliToolDir)</BuildCommandArgs>
 
-    <BuildCommandArgs Condition="'$(TargetOS)' == 'Linux'">$(BuildCommandArgs) /p:AspNetCoreInstallerRid=linux-$(Platform)</BuildCommandArgs>
+    <BuildCommandArgs Condition="'$(TargetOS)' == 'Linux' AND '$(OSPlatformIsMusl)' == 'false'">$(BuildCommandArgs) /p:AspNetCoreSharedFxInstallerRid=linux-$(Platform)</BuildCommandArgs>
+    <BuildCommandArgs Condition="'$(TargetOS)' == 'Linux' AND '$(OSPlatformIsMusl)' == 'true'">$(BuildCommandArgs) /p:AspNetCoreSharedFxInstallerRid=linux-musl-$(Platform)</BuildCommandArgs>
+
     <!-- core-sdk always wants to build portable on OSX and FreeBSD -->
     <BuildCommandArgs Condition="'$(TargetOS)' == 'FreeBSD'">$(BuildCommandArgs) /p:CoreSetupRid=freebsd-x64 /p:PortableBuild=true</BuildCommandArgs>
     <BuildCommandArgs Condition="'$(TargetOS)' == 'OSX'">$(BuildCommandArgs) /p:CoreSetupRid=osx-x64</BuildCommandArgs>

--- a/src/SourceBuild/tarball/content/tools-local/init-build.proj
+++ b/src/SourceBuild/tarball/content/tools-local/init-build.proj
@@ -20,6 +20,7 @@
 
   <Target Name="Build">
     <CallTarget Targets="
+      InitTargetRid; 
       UnpackTarballs;
       BuildXPlatTasks;
       BuildLeakDetection;
@@ -27,6 +28,26 @@
       GenerateRootFs;
       BuildTextOnlyPackages;
       PoisonPrebuiltPackages" />
+  </Target>
+
+  <Target Name="InitTargetRid"
+          DependsOnTargets="GetOSPlatformIsMuslCheck" />
+    <PropertyGroup> 
+      <OSPlatformIsMusl Condition="$(OSPlatformIsMuslCheck) == '0'">true</OSPlatformIsMusl>
+      <OSPlatformIsMusl Condition="$(OSPlatformIsMusl) == ''">false</OSPlatformIsMusl>
+      <TargetRid Condition="'$(TargetRid)' == ''">$([System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier)</TargetRid>
+
+      <TargetOS Condition="'$(TargetOS)' == '' AND $([MSBuild]::IsOSPlatform('WINDOWS'))">Windows_NT</TargetOS>
+      <TargetOS Condition="'$(TargetOS)' == '' AND $([MSBuild]::IsOSPlatform('OSX'))">OSX</TargetOS>
+      <TargetOS Condition="'$(TargetOS)' == '' AND $([MSBuild]::IsOSPlatform('LINUX'))">Linux</TargetOS>
+      <TargetOS Condition="'$(TargetOS)' == '' AND $([MSBuild]::IsOSPlatform('FREEBSD'))">FreeBSD</TargetOS>
+
+      <PortableRid Condition="'$(TargetOS)' == 'FreeBSD'">freebsd-$(Platform)</PortableRid>
+      <PortableRid Condition="'$(TargetOS)' == 'OSX'">osx-$(Platform)</PortableRid>
+      <PortableRid Condition="'$(TargetOS)' == 'Linux'">linux-$(Platform)</PortableRid>
+      <PortableRid Condition="'$(TargetOS)' == 'Windows_NT'">win-$(Platform)</PortableRid>
+      <TargetRid Condition="'$(PortableBuild)' == 'true' AND '$(PortableRid)' != ''">$(PortableRid)</TargetRid>
+	</PropertyGroup>
   </Target>
 
   <Target Name="PrepareOfflineLocalTools"

--- a/src/SourceBuild/tarball/patches/aspnetcore/0001-fix-musl-build.patch
+++ b/src/SourceBuild/tarball/patches/aspnetcore/0001-fix-musl-build.patch
@@ -1,0 +1,31 @@
+From 451aa3e9544b0214d0e8e844c27af3847f5bf391 Mon Sep 17 00:00:00 2001
+From: Antoine Martin <dev@ayakael.net>
+Date: Fri, 18 Feb 2022 05:14:39 +0000
+Subject: [PATCH 1/1] musl build fix
+
+Line causes build of aspnetcore on arm to look for linux version of
+CrossGen2 rather than linux-musl. This removes the line so that
+BuildOsName is pulled from TargetOsName as expected
+
+Will be fixed once https://github.com/dotnet/aspnetcore/issues/37400
+is addressed.
+
+---
+ .../App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj      | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
+index aeb3c08f13..380fc5fbac 100644
+--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
++++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
+@@ -104,7 +104,6 @@ This package is an internal implementation of the .NET Core SDK and is not meant
+       Special case the crossgen2 package reference on Windows to avoid the x86 package when building in Visual Studio.
+     -->
+     <BuildOsName>$(TargetOsName)</BuildOsName>
+-    <BuildOsName Condition="'$(TargetOsName)' == 'linux-musl' and '$(TargetArchitecture)'!='x64'">linux</BuildOsName>
+     <Crossgen2BuildArchitecture Condition=" '$(BuildOsName)' == 'win' ">x64</Crossgen2BuildArchitecture>
+     <Crossgen2BuildArchitecture Condition=" '$(Crossgen2BuildArchitecture)' == '' ">$(BuildArchitecture)</Crossgen2BuildArchitecture>
+     <Crossgen2PackageRootVariableName>PkgMicrosoft_NETCore_App_Crossgen2_$(BuildOsName)-$(Crossgen2BuildArchitecture)</Crossgen2PackageRootVariableName>
+-- 
+2.34.1
+

--- a/src/redist/targets/GetRuntimeInformation.targets
+++ b/src/redist/targets/GetRuntimeInformation.targets
@@ -1,6 +1,13 @@
 <Project>
   <Target Name="GetCurrentRuntimeInformation">
+    <Exec IgnoreExitCode="true" Command="ldd --version 2&gt;&amp;1 | grep -q musl">
+      <Output TaskParameter="ExitCode" PropertyName="OSPlatformIsMuslCheck" />
+    </Exec>
+
     <PropertyGroup>
+      <OSPlatformIsMusl Condition="$(OSPlatformIsMuslCheck) == '0'">true</OSPlatformIsMusl>
+      <OSPlatformIsMusl Condition="$(OSPlatformIsMusl) == ''">false</OSPlatformIsMusl>
+
       <HostRid Condition="'$(HostRid)' == '' and '$(MSBuildRuntimeType)' == 'core'">$([System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier)</HostRid>
       <HostRid Condition="'$(HostRid)' == '' and '$(MSBuildRuntimeType)' != 'core'">win-$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant)</HostRid>
 
@@ -9,6 +16,8 @@
       <HostOSName Condition=" '$(HostOSName)' == '' AND $([MSBuild]::IsOSPlatform('OSX')) ">osx</HostOSName>
       <HostOSName Condition=" '$(HostOSName)' == '' AND $([MSBuild]::IsOSPlatform('FREEBSD')) ">freebsd</HostOSName>
       <HostOSName Condition=" '$(HostOSName)' == '' AND '$(IsLinux)' == 'True' ">linux</HostOSName>
+      <!-- If platform is musl based, adds information to HostOSName -->
+      <HostOSName Condition="$(OSPlatformIsMusl) == 'true'">$(HostOSName)-musl</HostOSName>
       
       <OSName Condition=" '$(OSName)' == '' ">$(HostOSName)</OSName>
 


### PR DESCRIPTION
## Description
Proper implementation of changes discussed in https://github.com/dotnet/source-build/issues/2782

Includes aspnetcore patch that is a workaround till https://github.com/dotnet/aspnetcore/issues/37400 is addressed.

## Related PRs
https://github.com/dotnet/command-line-api/pull/1673 

Made as part of Alpine Linux dotnet6 packaging project, see https://github.com/dotnet/source-build/issues/2782