### PR TITLE
Update to latest SBRP to cleanup csprojs from text only packages

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -212,8 +212,8 @@
       <Sha>879df783283dfb44c7653493fdf7fd7b07ba6b01</Sha>
     </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="6.0.0-servicing.22161.1">
-      <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>a4550df3cb245c4dfd9601c67f86a27a88aad962</Sha>
+      <Uri>https://github.com/MichaelSimons/source-build-reference-packages</Uri>
+      <Sha>a84123d6a419aca724a3dae175b8b7a1c3310984</Sha>
       <SourceBuildTarball RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceLink.GitHub" Version="1.1.0-beta-21480-02" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">

--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdk.diff
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdk.diff
@@ -857,14 +857,6 @@ index ------------
  ./sdk/x.y.z/SdkResolvers/
  ./sdk/x.y.z/SdkResolvers/Microsoft.Build.NuGetSdkResolver/
 @@ ------------ @@
- ./sdk/x.y.z/Sdks/FSharp.NET.Sdk/Sdk/Sdk.props
- ./sdk/x.y.z/Sdks/FSharp.NET.Sdk/Sdk/Sdk.targets
- ./sdk/x.y.z/Sdks/Microsoft.Docker.Sdk/
-+./sdk/x.y.z/Sdks/Microsoft.Docker.Sdk/microsoft.docker.sdk.1.1.0.csproj
- ./sdk/x.y.z/Sdks/Microsoft.Docker.Sdk/Sdk/
- ./sdk/x.y.z/Sdks/Microsoft.Docker.Sdk/Sdk/Sdk.props
- ./sdk/x.y.z/Sdks/Microsoft.Docker.Sdk/Sdk/Sdk.targets
-@@ ------------ @@
  ./sdk/x.y.z/Sdks/Microsoft.NET.ILLink.Tasks/tools/netx.y/System.Buffers.dll
  ./sdk/x.y.z/Sdks/Microsoft.NET.ILLink.Tasks/tools/netx.y/System.Collections.Immutable.dll
  ./sdk/x.y.z/Sdks/Microsoft.NET.ILLink.Tasks/tools/netx.y/System.Memory.dll


### PR DESCRIPTION
E2E testing of https://github.com/dotnet/source-build-reference-packages/pull/361
