### PR TITLE
Refactor build.sh to optimize PackageVersions.props retrieval

### DIFF
--- a/src/SourceBuild/tarball/content/build.sh
+++ b/src/SourceBuild/tarball/content/build.sh
@@ -114,14 +114,14 @@ restoredPackagesDir="$SCRIPT_ROOT/packages/restored"
 
 if [ -d "$SCRIPT_ROOT/packages/archive" ]; then
   sourceBuiltArchive=`find $SCRIPT_ROOT/packages/archive -maxdepth 1 -name 'Private.SourceBuilt.Artifacts*.tar.gz'`
-  if [ -f "$sourceBuiltArchive" ]; then
+  if [ -f "$SCRIPT_ROOT/packages/previously-source-built/PackageVersions.props" ]; then
+    packageVersionsPath=$SCRIPT_ROOT/packages/previously-source-built/PackageVersions.props
+  elif [ -f "$sourceBuiltArchive" ]; then
     tar -xzf "$sourceBuiltArchive" -C /tmp PackageVersions.props
     packageVersionsPath=/tmp/PackageVersions.props
   fi
-else
-  if [ -f "$CUSTOM_PREVIOUSLY_BUILT_PACKAGES_DIR/PackageVersions.props" ]; then
-    packageVersionsPath="$CUSTOM_PREVIOUSLY_BUILT_PACKAGES_DIR/PackageVersions.props"
-  fi
+elif [ -f "$CUSTOM_PREVIOUSLY_BUILT_PACKAGES_DIR/PackageVersions.props" ]; then
+  packageVersionsPath="$CUSTOM_PREVIOUSLY_BUILT_PACKAGES_DIR/PackageVersions.props"
 fi
 
 if [ ! -f "$packageVersionsPath" ]; then


### PR DESCRIPTION
The build script was always retrieving `PackageVersions.props` from the previous source-build artifacts tarball whenever a `CUSTOM_PREVIOUSLY_BUILT_PACKAGES_DIR` was not specified.  This is slow and unnecessary during rebuilds and running tests.  When running a single test case in dev cycles, this often took many times longer than the test itself.  To fix this, a check was added to retrieve the file from the `packages/previously-source-built` directory.
