### PR TITLE
[main] Introduce Source-Build release pipeline

### DIFF
--- a/eng/source-build-release-announcement.md
+++ b/eng/source-build-release-announcement.md
@@ -1,1 +1,3 @@
-The source build team is testing automation for release announcements. You can ignore this post.
+[Release Notes]($RELEASE_NOTES_URL) | [Tag]($TAG_URL)
+
+Please use the [$TAG tag]($TAG_URL) to source-build .NET version $RUNTIME_VERSION / $SDK_VERSION.

--- a/eng/source-build-release-announcement.md
+++ b/eng/source-build-release-announcement.md
@@ -1,3 +1,5 @@
 [Release Notes]($RELEASE_NOTES_URL) | [Tag]($TAG_URL)
 
 Please use the [$TAG tag]($TAG_URL) to source-build .NET version $RUNTIME_VERSION / $SDK_VERSION.
+
+@distro-maintainers

--- a/eng/source-build-release-announcement.md
+++ b/eng/source-build-release-announcement.md
@@ -1,0 +1,1 @@
+The source build team is testing automation for release announcements. You can ignore this post.

--- a/eng/source-build-release.yml
+++ b/eng/source-build-release.yml
@@ -48,7 +48,7 @@ stages:
         set -euxo pipefail
         tag="$(SetTag.Tag)"
         cd $(Build.SourcesDirectory)
-        git show-ref --tags 
+        git show-ref --tags
         if git rev-parse "$tag" >/dev/null 2>&1; then
           echo "Tag $tag exists.";
         else

--- a/eng/source-build-release.yml
+++ b/eng/source-build-release.yml
@@ -107,7 +107,7 @@ stages:
 
         # Switch back to current branch to read announcement template
         git checkout -
-        title="Automation Test"
+        title=".NET $SDK_VERSION Source-Build Released"
         body="$(envsubst < $(Build.SourcesDirectory)/eng/source-build-release-announcement.md)"
 
         query='mutation($repoId: ID!, $categoryId: ID!, $body: String!, $title: String!) { createDiscussion(input: {repositoryId: $repoId, categoryId: $categoryId, body: $body, title: $title}) { discussion { url } } }'

--- a/eng/source-build-release.yml
+++ b/eng/source-build-release.yml
@@ -9,7 +9,7 @@ parameters:
   - name: sdkVersion
     displayName: SDK Version
     type: string
-    default: 6.0.103
+    default: 6.0.XYY
   - name: useCustomTag
     displayName: Use custom tag?
     type: boolean
@@ -17,7 +17,7 @@ parameters:
   - name: customTag
     displayName: Installer custom tag
     type: string
-    default: v6.0.XXX-source-build
+    default: v6.0.XYY-source-build
 
 variables:
   repoId: ''

--- a/eng/source-build-release.yml
+++ b/eng/source-build-release.yml
@@ -1,0 +1,121 @@
+trigger: none
+pr: none
+
+pool:
+  name: NetCore1ESPool-Svc-Internal
+  demands: ImageOverride -equals 1es-ubuntu-2004
+
+parameters:
+  - name: sdkVersion
+    displayName: SDK Version
+    type: string
+    default: 6.0.103
+  - name: useCustomTag
+    displayName: Use custom tag?
+    type: boolean
+    default: false
+  - name: customTag
+    displayName: Installer custom tag
+    type: string
+    default: v6.0.XXX-source-build
+
+variables:
+  repoId: ''
+  discussionCategoryId: ''
+  announcementOrg: 'dotnet'
+  announcementRepo: 'source-build'
+
+stages:
+
+- stage: Setup
+  jobs:
+  - job: SetupJob
+    displayName: Setup
+    steps:
+    - script: |
+        set -euxo pipefail
+        if [ "${{ parameters.useCustomTag }}" = "True" ] ; then
+          tag=${{ parameters.customTag }}
+          echo "Using custom tag $(tag)"
+        else
+          tag=v${{ parameters.sdkVersion }}
+          echo "Using tag $(tag)"
+        fi
+        echo "##vso[task.setvariable variable=Tag;isOutput=true]${tag}"
+      name: SetTag
+      displayName: Set tag
+    - script: |
+        set -euxo pipefail
+        tag="$(SetTag.Tag)"
+        cd $(Build.SourcesDirectory)
+        git show-ref --tags 
+        if git rev-parse "$tag" >/dev/null 2>&1; then
+          echo "Tag $tag exists.";
+        else
+          echo "Tag $tag does not exist."
+          exit 1
+        fi
+      displayName: Ensure tag exists
+
+- stage: ReleaseAnnouncement
+  displayName: Release Announcement
+  dependsOn: Setup
+  jobs:
+  - job: create_release_discussion_announcement
+    displayName: Create Announcement
+    variables:
+    - name: Tag
+      value: $[ stageDependencies.Setup.SetupJob.outputs['SetTag.Tag'] ]
+    steps:
+
+    - script: |
+        set -euxo pipefail
+        query='query { repository(owner: "${{ variables.announcementOrg }}", name: "${{ variables.announcementRepo }}") { id } }'
+        repo_id=$( gh api graphql -f query="$query" --template '{{.data.repository.id}}' )
+        echo ${{ variables.announcementOrg }}/${{ variables.announcementRepo }} repo ID is ${repo_id}
+        echo "##vso[task.setvariable variable=repoId;]${repo_id}"
+      displayName: Get repo ID
+      env:
+        GH_TOKEN: $(BotAccount-dotnet-sb-bot-pat)
+
+    - script: |
+        set -euxo pipefail
+        query='query { repository(name: "${{ variables.announcementRepo }}", owner: "${{ variables.announcementOrg }}") { discussionCategories(first: 10) { edges { node { id, name } } } } }'
+        category_id=$( gh api graphql -f query="$query" --template '{{range .data.repository.discussionCategories.edges}}{{if eq .node.name "Announcements"}}{{.node.id}}{{end}}{{end}}' )
+        echo Discussion Category ID is ${category_id}
+        echo "##vso[task.setvariable variable=discussionCategoryId;]${category_id}"
+      displayName: Get announcement discussion category ID
+      env:
+        GH_TOKEN: $(BotAccount-dotnet-sb-bot-pat)
+
+    - script: |
+        set -euxo pipefail
+        echo Repo ID is $(repoId)
+        echo Discussion Category ID is $(discussionCategoryId)
+
+        # Read runtime version from release commit
+        git checkout $(Tag)
+        runtime_version=$(cat $(Build.SourcesDirectory)/eng/Version.Details.xml | grep 'Microsoft.NETCore.App.Runtime.win-x64' | grep -P -o -e '(?<=Version=").*?(?=")')
+        dotnet_version=$(echo "$runtime_version" | head -c 3)
+
+        # Set environment variables that go in the announcement template
+        export TAG=$(Tag)
+        export RUNTIME_VERSION="$runtime_version"
+        export SDK_VERSION="${{ parameters.sdkVersion }}"
+        export TAG_URL="https://github.com/dotnet/installer/releases/tag/$TAG"
+        export RELEASE_NOTES_URL="https://github.com/dotnet/core/blob/main/release-notes/$dotnet_version/$runtime_version/${{ parameters.sdkVersion }}.md"
+
+        # Switch back to current branch to read announcement template
+        git checkout -
+        title="Automation Test"
+        body="$(envsubst < $(Build.SourcesDirectory)/eng/source-build-release-announcement.md)"
+
+        query='mutation($repoId: ID!, $categoryId: ID!, $body: String!, $title: String!) { createDiscussion(input: {repositoryId: $repoId, categoryId: $categoryId, body: $body, title: $title}) { discussion { url } } }'
+        announcement_url=$( gh api graphql -F repoId=$(repoId) -F categoryId=$(discussionCategoryId) -F body="${body}" -F title="${title}" -f query="$query" --template '{{.data.createDiscussion.discussion.url}}' )
+
+        echo "Announcement URL: $announcement_url"
+        echo "Tag URL: $TAG_URL"
+        echo "Release Notes URL: $RELEASE_NOTES_URL"
+      displayName: Submit announcement discussion
+      env:
+        GH_TOKEN: $(BotAccount-dotnet-sb-bot-pat)


### PR DESCRIPTION
fixes https://github.com/dotnet/source-build/issues/2776

This is the baseline for the source-build release pipeline that will automate our release day tasks for 6.0-onwards. The pipeline will always live in `main` and (when we have multiple post-6.0 releases) we will trigger it once for each release with the corresponding inputs.

Basic flow of the pipeline:

Inputs: SDK Version, Optional tag override

1. Detect tag from SDK version, or use the optional tag override. For example, if the SDK version `6.0.103` is provided, we will try to find the release tag `v6.0.103` since that is the current naming scheme. The optional tag override is for when we need to make a source-build specific tag, like [v6.0.103-source-build](https://github.com/dotnet/installer/releases/tag/v6.0.103-source-build). In this case you should still submit the correct SDK version because it is used in the announcement post.
2. Determine that the tag actually exists.
3. Find the correct repo and discussion category IDs to give to the GitHub API.
4. Submit the announcement discussion using the template in `source-build-release-announcement.md`. Discussion will be submitted by our [bot](https://github.com/dotnet-sb-bot)

In the future we can submit PRs to update `global.json` in dotnet/installer and automatically let our distro maintainers know about new .NET versions.