### PR TITLE
[release/6.0.1xx] Retry source-build artifacts download on failure

### DIFF
--- a/src/SourceBuild/tarball/content/prep.sh
+++ b/src/SourceBuild/tarball/content/prep.sh
@@ -79,13 +79,13 @@ while read -r line; do
     if [[ $line == *"Private.SourceBuilt.Artifacts"* ]]; then
         if [ "$downloadArtifacts" == "true" ]; then
             echo "  Downloading source-built artifacts from $line..."
-            (cd $SCRIPT_ROOT/packages/archive/ && curl --retry 5 --retry-all-errors -O $line)
+            (cd $SCRIPT_ROOT/packages/archive/ && curl --retry 5 -O $line)
         fi
     fi
     if [[ $line == *"Private.SourceBuilt.Prebuilts"* ]]; then
         if [ "$downloadPrebuilts" == "true" ]; then
             echo "  Downloading source-built prebuilts from $line..."
-            (cd $SCRIPT_ROOT/packages/archive/ && curl --retry 5 --retry-all-errors -O $line)
+            (cd $SCRIPT_ROOT/packages/archive/ && curl --retry 5 -O $line)
         fi
     fi
 done < $SCRIPT_ROOT/packages/archive/archiveArtifacts.txt

--- a/src/SourceBuild/tarball/content/prep.sh
+++ b/src/SourceBuild/tarball/content/prep.sh
@@ -79,13 +79,13 @@ while read -r line; do
     if [[ $line == *"Private.SourceBuilt.Artifacts"* ]]; then
         if [ "$downloadArtifacts" == "true" ]; then
             echo "  Downloading source-built artifacts from $line..."
-            (cd $SCRIPT_ROOT/packages/archive/ && curl -O $line)
+            (cd $SCRIPT_ROOT/packages/archive/ && curl --retry 5 --retry-all-errors -O $line)
         fi
     fi
     if [[ $line == *"Private.SourceBuilt.Prebuilts"* ]]; then
         if [ "$downloadPrebuilts" == "true" ]; then
             echo "  Downloading source-built prebuilts from $line..."
-            (cd $SCRIPT_ROOT/packages/archive/ && curl -O $line)
+            (cd $SCRIPT_ROOT/packages/archive/ && curl --retry 5 --retry-all-errors -O $line)
         fi
     fi
 done < $SCRIPT_ROOT/packages/archive/archiveArtifacts.txt


### PR DESCRIPTION
Should address https://github.com/dotnet/source-build/issues/2822

Uses built-in curl arguments to automatically retry on any failures.