### PR TITLE
[release/6.0.2xx] Add razor-compiler to Source Build

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -199,6 +199,21 @@
       <Sha>7b9791daa3a3477eb22ec805946c9fff8b42d8ca</Sha>
       <SourceBuildTarball RepoName="symreader" ManagedOnly="true" />
     </Dependency>
+    <Dependency Name="Microsoft.CodeAnalysis.Razor.Tooling.Internal" Version="6.0.2-1.22181.1">
+      <Uri>https://github.com/dotnet/razor-compiler</Uri>
+      <Sha>c9961aa628a7fd7a64e106310290d9e147f2759d</Sha>
+      <SourceBuild RepoName="razor-compiler" ManagedOnly="true" />
+    </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.Mvc.Razor.Extensions.Tooling.Internal" Version="6.0.2-1.22181.1">
+      <Uri>https://github.com/dotnet/razor-compiler</Uri>
+      <Sha>c9961aa628a7fd7a64e106310290d9e147f2759d</Sha>
+      <SourceBuild RepoName="razor-compiler" ManagedOnly="true" />
+    </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal" Version="6.0.2-1.22181.1">
+      <Uri>https://github.com/dotnet/razor-compiler</Uri>
+      <Sha>c9961aa628a7fd7a64e106310290d9e147f2759d</Sha>
+      <SourceBuild RepoName="razor-compiler" ManagedOnly="true" />
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.22206.7">

--- a/src/SourceBuild/tarball/content/repos/known-good.proj
+++ b/src/SourceBuild/tarball/content/repos/known-good.proj
@@ -34,6 +34,7 @@
         <RepositoryReference Include="clicommandlineparser" />
         <RepositoryReference Include="command-line-api" />
         <RepositoryReference Include="diagnostics" />
+        <RepositoryReference Include="razor-compiler" />
         <RepositoryReference Include="roslyn" />
         <RepositoryReference Include="source-build" />
         <RepositoryReference Include="symreader" />

--- a/src/SourceBuild/tarball/content/repos/razor-compiler.proj
+++ b/src/SourceBuild/tarball/content/repos/razor-compiler.proj
@@ -1,0 +1,21 @@
+<Project>
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
+  <PropertyGroup>
+    <BuildCommand>$(StandardSourceBuildCommand) $(StandardSourceBuildArgs)</BuildCommand>
+
+    <GlobalJsonFile>$(ProjectDirectory)global.json</GlobalJsonFile>
+    <NuGetConfigFile>$(ProjectDirectory)NuGet.config</NuGetConfigFile>
+    <OutputPlacementRepoApiImplemented>false</OutputPlacementRepoApiImplemented>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <RepositoryReference Include="arcade" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <UseSourceBuiltSdkOverride Include="@(ArcadeSdkOverride)" />
+  </ItemGroup>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+</Project>

--- a/src/SourceBuild/tarball/content/repos/sdk.proj
+++ b/src/SourceBuild/tarball/content/repos/sdk.proj
@@ -39,6 +39,7 @@
     <RepositoryReference Include="fsharp" />
     <RepositoryReference Include="format" />
     <RepositoryReference Include="deployment-tools" />
+    <RepositoryReference Include="razor-compiler" />
   </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />

--- a/src/SourceBuild/tarball/patches/razor-compiler/0001-Exclude-test-projects-from-source-build.patch
+++ b/src/SourceBuild/tarball/patches/razor-compiler/0001-Exclude-test-projects-from-source-build.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Logan Bussell <loganbussell@microsoft.com>
+Date: Wed, 13 Apr 2022 15:03:44 -0700
+Subject: [PATCH] Exclude test projects from source-build
+
+---
+ src/test/Directory.Build.props | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/test/Directory.Build.props b/src/test/Directory.Build.props
+index 95172906..047e4619 100644
+--- a/src/test/Directory.Build.props
++++ b/src/test/Directory.Build.props
+@@ -8,5 +8,6 @@
+     -->
+     <IsTestAssetProject>true</IsTestAssetProject>
+     <IsPackable>false</IsPackable>
++    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+   </PropertyGroup>
+ </Project>

--- a/src/SourceBuild/tarball/patches/razor-compiler/0002-retarget-Razor-Syntax-Genreator-to-net6.0.patch
+++ b/src/SourceBuild/tarball/patches/razor-compiler/0002-retarget-Razor-Syntax-Genreator-to-net6.0.patch
@@ -1,0 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Logan Bussell <loganbussell@microsoft.com>
+Date: Thu, 14 Apr 2022 16:27:26 -0700
+Subject: [PATCH] retarget Razor Syntax Genreator to net6.0
+
+---
+ src/tools/RazorSyntaxGenerator/RazorSyntaxGenerator.csproj | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/tools/RazorSyntaxGenerator/RazorSyntaxGenerator.csproj b/src/tools/RazorSyntaxGenerator/RazorSyntaxGenerator.csproj
+index 924379ac..362f0e3b 100644
+--- a/src/tools/RazorSyntaxGenerator/RazorSyntaxGenerator.csproj
++++ b/src/tools/RazorSyntaxGenerator/RazorSyntaxGenerator.csproj
+@@ -3,6 +3,7 @@
+   <PropertyGroup>
+     <Description>Generates Razor syntax nodes from xml. For internal use only.</Description>
+     <TargetFramework>netcoreapp3.1</TargetFramework>
++    <TargetFramework Condition="'$(DotNetBuildFromSource)' == 'true'">net6.0</TargetFramework>
+     <AssemblyName>dotnet-razorsyntaxgenerator</AssemblyName>
+     <PackageId>RazorSyntaxGenerator</PackageId>
+     <OutputType>Exe</OutputType>


### PR DESCRIPTION
Addresses https://github.com/dotnet/source-build/issues/2825

Needed one patch to disable building test projects. I will start a bootstrap CI run and if everything is clean then I will submit a PR to razor-compiler to upstream that patch.

Opening this as a draft because we need to wait for this commit to flow into installer: https://github.com/dotnet/sdk/commit/c3c7e3ec4a4f382d6d041d3739d23731ae39687d. Once it has flown in I will remove the razor-compiler dependencies from `eng/Version.Details.xml`.
