### PR TITLE
Exclude sdk content tests in PR validation and public CI

### DIFF
--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-build-tarball.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-build-tarball.yml
@@ -146,7 +146,7 @@ jobs:
       dockerEnvArgs="-e SMOKE_TESTS_EXCLUDE_OMNISHARP=$(_ExcludeOmniSharpTests) -e SMOKE_TESTS_WARN_SDK_CONTENT_DIFFS=true"
       poisonArg=''
 
-      if [[ '${{ parameters.excludeSdkContentTests}}' != 'true' && '${{ parameters.installerBuildResourceId }}' != 'current' ]]; then
+      if [[ '${{ parameters.excludeSdkContentTests}}' != 'true' ]]; then
         dockerVolumeArgs+=" -v $(PIPELINE.WORKSPACE)/${{ parameters.installerBuildResourceId }}/BlobArtifacts/:/BlobArtifacts"
         msftSdkTarballName=$(find "$(PIPELINE.WORKSPACE)/${{ parameters.installerBuildResourceId }}/BlobArtifacts/" -name "dotnet-sdk-*-linux-${{ parameters.architecture }}.tar.gz" -exec basename {} \;)
         dockerEnvArgs+=" -e SMOKE_TESTS_MSFT_SDK_TARBALL_PATH=/BlobArtifacts/$msftSdkTarballName"

--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build.yml
@@ -34,6 +34,8 @@ jobs:
     architecture: x64
     condition: ${{ parameters.condition }}
     dependsOn: ${{ parameters.dependsOn }}
+    ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+      excludeSdkContentTests: true
     installerBuildResourceId: ${{ parameters.installerBuildResourceId }}
     matrix:
       CentOS7-Online:
@@ -86,6 +88,8 @@ jobs:
       architecture: arm64
       condition: ${{ parameters.condition }}
       dependsOn: ${{ parameters.dependsOn }}
+      ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
+        excludeSdkContentTests: true
       installerBuildResourceId: ${{ parameters.installerBuildResourceId }}
       matrix:
         ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:


### PR DESCRIPTION
The sdk content tests would run a public CI build was queued.  They would fail because in public CI, the installer build doesn't store the blob artifacts therefore the msft tarball cannot be retrieved to compare against.  This PR disables the tests for PRs and public CI.
