### PR TITLE
Remove pathcch dependency

### DIFF
--- a/src/finalizer/CMakeLists.txt
+++ b/src/finalizer/CMakeLists.txt
@@ -31,7 +31,6 @@ target_link_libraries(Finalizer shell32.lib)
 target_link_libraries(Finalizer advapi32.lib)
 target_link_libraries(Finalizer version.lib)
 target_link_libraries(Finalizer msi.lib)
-target_link_libraries(Finalizer pathcch.lib)
 
 # Add WiX libraries
 target_link_libraries(Finalizer wcautil.lib)

--- a/src/finalizer/finalizer.cpp
+++ b/src/finalizer/finalizer.cpp
@@ -38,6 +38,39 @@ LExit:
     return hr;
 }
 
+extern "C" HRESULT StrTrimBackslash(LPWSTR* ppwz, LPCWSTR wzSource)
+{
+    HRESULT hr = S_OK;
+    LPWSTR sczResult = NULL;
+
+    int i = lstrlenW(wzSource);
+
+    if (0 < i)
+    {
+        for (i = i - 1; i > 0; --i)
+        {
+            if (L'\\' != wzSource[i])
+            {
+                break;
+            }
+        }
+
+        ++i;
+    }
+
+    hr = StrAllocString(&sczResult, wzSource, i);
+    ExitOnFailure(hr, "Failed to copy result string");
+
+    // Output result
+    *ppwz = sczResult;
+    sczResult = NULL;
+
+LExit:
+    ReleaseStr(sczResult);
+
+    return hr;
+}
+
 extern "C" HRESULT DeleteWorkloadRecords(LPWSTR sczSdkFeatureBandVersion, LPWSTR sczArchitecture)
 {
     HRESULT hr = S_OK;
@@ -112,7 +145,7 @@ extern "C" HRESULT DeleteWorkloadRecords(LPWSTR sczSdkFeatureBandVersion, LPWSTR
         ExitOnFailure(hr, "Failed to get size of key name.");
 
         // Need to remove trailing backslash otherwise PathFile returns an empty string.
-        hr = PathCchRemoveBackslash(sczKeyName, cbKeyName);
+        hr = StrTrimBackslash(&sczKeyName, sczKeyName);
         ExitOnFailure(hr, "Failed to remove backslash.");
 
         hr = StrAllocString(&sczSubKey, PathFile(sczKeyName), 0);


### PR DESCRIPTION
Fixes #13527 

pathcch.lib is only available on Win8, so we need to remove this as Win7 SP1 is still a supported platform.
