### PR TITLE
[release/6.0.1xx] Fix compatibility with BSD df

### DIFF
--- a/src/SourceBuild/tarball/content/repos/Directory.Build.targets
+++ b/src/SourceBuild/tarball/content/repos/Directory.Build.targets
@@ -561,20 +561,20 @@
           BeforeTargets="Build"
           Condition=" '$(CleanWhileBuilding)' == 'true' ">
     <Message Text="DirSize Before Building $(RepositoryName)" Importance="High" />
-    <Exec Command="df --block-size=1M $(ProjectDir)" />
+    <Exec Command="df -h $(ProjectDir)" />
   </Target>
   <Target Name="DisplayDirSizeAfterBuild"
           AfterTargets="Build"
           BeforeTargets="CleanupRepo"
           Condition=" '$(CleanWhileBuilding)' == 'true' ">
     <Message Text="DirSize After Building $(RepositoryName)" Importance="High" />
-    <Exec Command="df --block-size=1M $(ProjectDir)" />
+    <Exec Command="df -h $(ProjectDir)" />
   </Target>
   <Target Name="DisplayDirSizeAfterClean"
           AfterTargets="CleanupRepo"
           Condition=" '$(CleanWhileBuilding)' == 'true' ">
     <Message Text="DirSize After CleanupRepo $(RepositoryName)" Importance="High" />
-    <Exec Command="df --block-size=1M $(ProjectDir)" />
+    <Exec Command="df -h $(ProjectDir)" />
   </Target>
 
   <Target Name="CleanupRepo" 


### PR DESCRIPTION
`--block-size` is GNU specific and does not work with BSD df (or at least the `df` which ships with macOS).