### PR TITLE
[main] Use arcade version that targets net7.0

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -204,7 +204,7 @@
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="7.0.0-beta.22215.2">
       <Uri>https://github.com/lbussell/arcade</Uri>
-      <Sha>bc91aae4c4442102024f0f3a48c0ffa83c8ca25e</Sha>
+      <Sha>1db4d433a989531551345df187f02447945e2d18</Sha>
     </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="7.0.0-alpha.1.22215.1">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -194,17 +194,17 @@
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="7.0.0-beta.22215.2">
       <Uri>https://github.com/lbussell/arcade</Uri>
-      <Sha>bc91aae4c4442102024f0f3a48c0ffa83c8ca25e</Sha>
+      <Sha>08c78486a2dd4e7ee9733b4edcee696d7ef92d79</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.DotNet.CMake.Sdk" Version="7.0.0-beta.22215.2">
       <Uri>https://github.com/lbussell/arcade</Uri>
-      <Sha>bc91aae4c4442102024f0f3a48c0ffa83c8ca25e</Sha>
+      <Sha>08c78486a2dd4e7ee9733b4edcee696d7ef92d79</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="7.0.0-beta.22215.2">
       <Uri>https://github.com/lbussell/arcade</Uri>
-      <Sha>1db4d433a989531551345df187f02447945e2d18</Sha>
+      <Sha>08c78486a2dd4e7ee9733b4edcee696d7ef92d79</Sha>
     </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="7.0.0-alpha.1.22215.1">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -193,18 +193,18 @@
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="7.0.0-beta.22215.2">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>4000024394df3049886c50e54ad0a2b903221ef0</Sha>
+      <Uri>https://github.com/lbussell/arcade</Uri>
+      <Sha>bc91aae4c4442102024f0f3a48c0ffa83c8ca25e</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.DotNet.CMake.Sdk" Version="7.0.0-beta.22215.2">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>4000024394df3049886c50e54ad0a2b903221ef0</Sha>
+      <Uri>https://github.com/lbussell/arcade</Uri>
+      <Sha>bc91aae4c4442102024f0f3a48c0ffa83c8ca25e</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="7.0.0-beta.22215.2">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>4000024394df3049886c50e54ad0a2b903221ef0</Sha>
+      <Uri>https://github.com/lbussell/arcade</Uri>
+      <Sha>bc91aae4c4442102024f0f3a48c0ffa83c8ca25e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="7.0.0-alpha.1.22215.1">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>

--- a/src/SourceBuild/tarball/content/repos/Directory.Build.props
+++ b/src/SourceBuild/tarball/content/repos/Directory.Build.props
@@ -61,7 +61,7 @@
     <EnvironmentVariables Include="_InitializeDotNetCli=$(DotNetCliToolDir)" />
     <EnvironmentVariables Include="_DotNetInstallDir=$(DotNetCliToolDir)" />
     <EnvironmentVariables Include="_InitializeToolset=$(ProjectDir)Tools/source-built/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj" Condition="'$(UseBootstrapArcade)' != 'true'" />
-    <EnvironmentVariables Include="_OverrideArcadeInitializeBuildToolFramework=net6.0" />
+    <EnvironmentVariables Include="_OverrideArcadeInitializeBuildToolFramework=net7.0" />
 
     <EnvironmentVariables Include="DotNetUseShippingVersions=true" />
 

--- a/src/SourceBuild/tarball/content/repos/Directory.Build.targets
+++ b/src/SourceBuild/tarball/content/repos/Directory.Build.targets
@@ -126,11 +126,11 @@
          See https://github.com/dotnet/source-build/issues/1914 for details. -->
     <PropertyGroup>
       <ArcadeSdkReplacementText>
-      logger_path=&quot;%24toolset_dir&quot;/%24%28cd &quot;$toolset_dir&quot; &amp;&amp; find . -name Microsoft.DotNet.Arcade.Sdk.dll \( -regex &apos;.*netcoreapp2.1.*&apos; -or -regex &apos;.*net6.0.*&apos; \) )
+      logger_path=&quot;%24toolset_dir&quot;/%24%28cd &quot;$toolset_dir&quot; &amp;&amp; find . -name Microsoft.DotNet.Arcade.Sdk.dll \( -regex &apos;.*netcoreapp2.1.*&apos; -or -regex &apos;.*net7.0.*&apos; \) )
       </ArcadeSdkReplacementText>
 
       <ArcadeLoggingReplacementText>
-      logger_path=&quot;%24toolset_dir&quot;/%24%28cd &quot;$toolset_dir&quot; &amp;&amp; find . -name Microsoft.DotNet.ArcadeLogging.dll \( -regex &apos;.*netcoreapp2.1.*&apos; -or -regex &apos;.*net6.0.*&apos; \) )
+      logger_path=&quot;%24toolset_dir&quot;/%24%28cd &quot;$toolset_dir&quot; &amp;&amp; find . -name Microsoft.DotNet.ArcadeLogging.dll \( -regex &apos;.*netcoreapp2.1.*&apos; -or -regex &apos;.*net7.0.*&apos; \) )
       </ArcadeLoggingReplacementText>
 
       <LoggerPathReplacementText>

--- a/src/SourceBuild/tarball/patches/arcade/0001-look-for-arcade-assemblies-in-net6.0-artifacts-direc.patch
+++ b/src/SourceBuild/tarball/patches/arcade/0001-look-for-arcade-assemblies-in-net6.0-artifacts-direc.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Logan Bussell <loganbussell@microsoft.com>
+Date: Mon, 25 Apr 2022 15:07:55 -0700
+Subject: [PATCH] look for arcade assemblies in net6.0 artifacts directory
+
+---
+ eng/common/tools.sh | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/eng/common/tools.sh b/eng/common/tools.sh
+index 17f0a365..f8852dbb 100755
+--- a/eng/common/tools.sh
++++ b/eng/common/tools.sh
+@@ -435,6 +435,8 @@ function MSBuild {
+     possiblePaths+=( "$toolset_dir/netcoreapp2.1/Microsoft.DotNet.Arcade.Sdk.dll" )
+     possiblePaths+=( "$toolset_dir/netcoreapp3.1/Microsoft.DotNet.ArcadeLogging.dll" )
+     possiblePaths+=( "$toolset_dir/netcoreapp3.1/Microsoft.DotNet.Arcade.Sdk.dll" )
++    possiblePaths+=( "$toolset_dir/net6.0/Microsoft.DotNet.ArcadeLogging.dll" )
++    possiblePaths+=( "$toolset_dir/net6.0/Microsoft.DotNet.Arcade.Sdk.dll" )
+     for path in "${possiblePaths[@]}"; do
+       if [[ -f $path ]]; then
+         selectedPath=$path

--- a/src/SourceBuild/tarball/patches/source-build-reference-packages/0001-look-for-arcade-assemblies-in-net6.0-artifacts-direc.patch
+++ b/src/SourceBuild/tarball/patches/source-build-reference-packages/0001-look-for-arcade-assemblies-in-net6.0-artifacts-direc.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Logan Bussell <loganbussell@microsoft.com>
+Date: Mon, 25 Apr 2022 15:07:55 -0700
+Subject: [PATCH] look for arcade assemblies in net6.0 artifacts directory
+
+---
+ eng/common/tools.sh | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/eng/common/tools.sh b/eng/common/tools.sh
+index 17f0a365..f8852dbb 100755
+--- a/eng/common/tools.sh
++++ b/eng/common/tools.sh
+@@ -435,6 +435,8 @@ function MSBuild {
+     possiblePaths+=( "$toolset_dir/netcoreapp2.1/Microsoft.DotNet.Arcade.Sdk.dll" )
+     possiblePaths+=( "$toolset_dir/netcoreapp3.1/Microsoft.DotNet.ArcadeLogging.dll" )
+     possiblePaths+=( "$toolset_dir/netcoreapp3.1/Microsoft.DotNet.Arcade.Sdk.dll" )
++    possiblePaths+=( "$toolset_dir/net6.0/Microsoft.DotNet.ArcadeLogging.dll" )
++    possiblePaths+=( "$toolset_dir/net6.0/Microsoft.DotNet.Arcade.Sdk.dll" )
+     for path in "${possiblePaths[@]}"; do
+       if [[ -f $path ]]; then
+         selectedPath=$path

--- a/src/SourceBuild/tarball/patches/sourcelink/0001-look-for-arcade-assemblies-in-net6.0-artifacts-direc.patch
+++ b/src/SourceBuild/tarball/patches/sourcelink/0001-look-for-arcade-assemblies-in-net6.0-artifacts-direc.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Logan Bussell <loganbussell@microsoft.com>
+Date: Mon, 25 Apr 2022 15:07:55 -0700
+Subject: [PATCH] look for arcade assemblies in net6.0 artifacts directory
+
+---
+ eng/common/tools.sh | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/eng/common/tools.sh b/eng/common/tools.sh
+index 17f0a365..f8852dbb 100755
+--- a/eng/common/tools.sh
++++ b/eng/common/tools.sh
+@@ -435,6 +435,8 @@ function MSBuild {
+     possiblePaths+=( "$toolset_dir/netcoreapp2.1/Microsoft.DotNet.Arcade.Sdk.dll" )
+     possiblePaths+=( "$toolset_dir/netcoreapp3.1/Microsoft.DotNet.ArcadeLogging.dll" )
+     possiblePaths+=( "$toolset_dir/netcoreapp3.1/Microsoft.DotNet.Arcade.Sdk.dll" )
++    possiblePaths+=( "$toolset_dir/net6.0/Microsoft.DotNet.ArcadeLogging.dll" )
++    possiblePaths+=( "$toolset_dir/net6.0/Microsoft.DotNet.Arcade.Sdk.dll" )
+     for path in "${possiblePaths[@]}"; do
+       if [[ -f $path ]]; then
+         selectedPath=$path


### PR DESCRIPTION
Don't merge - Testing changes from my PR that upgrades the arcade TFMs to net7.0:
- https://github.com/dotnet/arcade/pull/9127