### PR TITLE
[main] Add razor-compiler to source-build

### DIFF
--- a/src/SourceBuild/tarball/content/repos/known-good.proj
+++ b/src/SourceBuild/tarball/content/repos/known-good.proj
@@ -33,6 +33,7 @@
         <!-- Tier 1 -->
         <RepositoryReference Include="command-line-api" />
         <RepositoryReference Include="diagnostics" />
+        <RepositoryReference Include="razor-compiler" />
         <RepositoryReference Include="roslyn" />
         <RepositoryReference Include="source-build-externals" />
         <RepositoryReference Include="symreader" />

--- a/src/SourceBuild/tarball/content/repos/razor-compiler.proj
+++ b/src/SourceBuild/tarball/content/repos/razor-compiler.proj
@@ -1,0 +1,21 @@
+<Project>
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
+  <PropertyGroup>
+    <BuildCommand>$(StandardSourceBuildCommand) $(StandardSourceBuildArgs)</BuildCommand>
+
+    <GlobalJsonFile>$(ProjectDirectory)global.json</GlobalJsonFile>
+    <NuGetConfigFile>$(ProjectDirectory)NuGet.config</NuGetConfigFile>
+    <OutputPlacementRepoApiImplemented>false</OutputPlacementRepoApiImplemented>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <RepositoryReference Include="arcade" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <UseSourceBuiltSdkOverride Include="@(ArcadeSdkOverride)" />
+  </ItemGroup>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+</Project>

--- a/src/SourceBuild/tarball/content/repos/sdk.proj
+++ b/src/SourceBuild/tarball/content/repos/sdk.proj
@@ -39,6 +39,7 @@
     <RepositoryReference Include="fsharp" />
     <RepositoryReference Include="format" />
     <RepositoryReference Include="deployment-tools" />
+    <RepositoryReference Include="razor-compiler" />
   </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />


### PR DESCRIPTION
Port of https://github.com/dotnet/razor-compiler/pull/214 to main

Not including the patches because we are not focusing on prebuilts at the moment and they will hopefully be upstreamed by https://github.com/dotnet/razor-compiler/pull/214