### PR TITLE
Extend productCommit-rid.txt

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -45,11 +45,11 @@
     </GetDependencyInfo>
 
     <!-- Format for productCommits-%rid%.txt:
-       installer:%commit%, %version
-       runtime:%commit%, $version
-       aspnetcore:%commit%, $version
-       windowsdesktop:%commit%, $version
-       sdk:%commit%, $version
+       installer:%commit%, %version%
+       runtime:%commit%, %version%
+       aspnetcore:%commit%, %version%
+       windowsdesktop:%commit%, %version%
+       sdk:%commit%, %version%
     -->
     <WriteLinesToFile
       File="$(ArtifactsShippingPackagesDir)productCommit-$(Rid).txt"

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -23,13 +23,37 @@
        <Output TaskParameter="DependencyCommit" PropertyName="DepRuntimeCommit" />
     </GetDependencyInfo>
 
+    <GetDependencyInfo
+      VersionDetailsXmlFile="$(RepoRoot)eng/Version.Details.xml"
+      DependencyName="Microsoft.AspNetCore.App.Ref">
+       <Output TaskParameter="DependencyVersion" PropertyName="DepAspNetCoreVersion" />
+       <Output TaskParameter="DependencyCommit" PropertyName="DepAspNetCoreCommit" />
+    </GetDependencyInfo>
+
+    <GetDependencyInfo
+      VersionDetailsXmlFile="$(RepoRoot)eng/Version.Details.xml"
+      DependencyName="Microsoft.WindowsDesktop.App.Ref">
+       <Output TaskParameter="DependencyVersion" PropertyName="DepWindowsDesktopVersion" />
+       <Output TaskParameter="DependencyCommit" PropertyName="DepWindowsDesktopCommit" />
+    </GetDependencyInfo>
+
+    <GetDependencyInfo
+      VersionDetailsXmlFile="$(RepoRoot)eng/Version.Details.xml"
+      DependencyName="Microsoft.NET.Sdk">
+       <Output TaskParameter="DependencyVersion" PropertyName="DepDotNetSdkVersion" />
+       <Output TaskParameter="DependencyCommit" PropertyName="DepDotNetSdCommit" />
+    </GetDependencyInfo>
+
     <!-- Format for productCommits-%rid%.txt:
        installer:%commit%, %version
        runtime:%commit%, $version
+       aspnetcore:%commit%, $version
+       windowsdesktop:%commit%, $version
+       sdk:%commit%, $version
     -->
     <WriteLinesToFile
       File="$(ArtifactsShippingPackagesDir)productCommit-$(Rid).txt"
-      Lines="installer%3A$(BUILD_SOURCEVERSION)%2C%20$(PackageVersion)%0Aruntime%3A$(DepRuntimeCommit)%2C%20$(DepRuntimeVersion)%0A"
+      Lines="installer%3A$(BUILD_SOURCEVERSION)%2C%20$(PackageVersion)%0Aruntime%3A$(DepRuntimeCommit)%2C%20$(DepRuntimeVersion)%0Aaspnetcore%3A$(DepAspNetCoreCommit)%2C%20$(DepAspNetCoreVersion)%0Awindowsdesktop%3A$(DepWindowsDesktopCommit)%2C%20$(DepWindowsDesktopVersion)%0Asdk%3A$(DepDotNetSdkCommit)%2C%20$(DepDotNetSdkVersion)%0A"
       Overwrite="true"
       Encoding="ASCII"/>
 

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -41,7 +41,7 @@
       VersionDetailsXmlFile="$(RepoRoot)eng/Version.Details.xml"
       DependencyName="Microsoft.NET.Sdk">
        <Output TaskParameter="DependencyVersion" PropertyName="DepDotNetSdkVersion" />
-       <Output TaskParameter="DependencyCommit" PropertyName="DepDotNetSdCommit" />
+       <Output TaskParameter="DependencyCommit" PropertyName="DepDotNetSdkCommit" />
     </GetDependencyInfo>
 
     <!-- Format for productCommits-%rid%.txt:


### PR DESCRIPTION
Extend the changes from #13132 to include the versions of the ASP.NET Core shared runtime, Windows Desktop and the .NET SDK itself.

There might be more things others might find useful to be present too, but with these additions everything installed into in the `dotnet/shared` directory is now included.
