### PR TITLE
Fix two broken <repo.sha> path references

### DIFF
--- a/src/SourceBuild/tarball/content/prep.sh
+++ b/src/SourceBuild/tarball/content/prep.sh
@@ -108,7 +108,7 @@ if [ "$buildBootstrap" == "true" ]; then
     cp $SCRIPT_ROOT/scripts/bootstrap/buildBootstrapPreviouslySB.csproj $workingDir
 
     # Copy NuGet.config from the installer repo to have the right feeds
-    cp $SCRIPT_ROOT/src/installer.*/NuGet.config $workingDir
+    cp $SCRIPT_ROOT/src/installer/NuGet.config $workingDir
 
     # Get PackageVersions.props from existing prev-sb archive
     echo "  Retrieving PackageVersions.props from existing archive"

--- a/src/SourceBuild/tarball/content/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection.csproj
+++ b/src/SourceBuild/tarball/content/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core">
       <Version>15.7.179</Version>
     </PackageReference>
-    <ProjectReference Include="$(SubmoduleDirectory)linker.$(linkerGitCommitHash)/external/cecil/Mono.Cecil.csproj">
+    <ProjectReference Include="$(SubmoduleDirectory)linker/external/cecil/Mono.Cecil.csproj">
       <SetConfiguration Condition=" '$(Configuration)' == 'Debug' ">Configuration=netstandard_Debug</SetConfiguration>
       <SetConfiguration Condition=" '$(Configuration)' == 'Release' ">Configuration=netstandard_Release</SetConfiguration>
       <Project>{D68133BD-1E63-496E-9EDE-4FBDBF77B486}</Project>


### PR DESCRIPTION
These paths were missed as part of the changes made for https://github.com/dotnet/source-build/issues/2847.
