### PR TITLE
Remove daily servicing builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,25 +125,25 @@ We strongly recommend using `--skip-manifest-update` with `dotnet workload insta
 </configuration>
 ```
 
-Please do not directly edit the table below. Use https://github.com/dotnet/installer/tree/main/tools/sdk-readme-table-generator to help you generate it. Make sure to run the table generator test and make any changes to the generator along with your changes to the table.
+Please do not directly edit the table below. Use https://github.com/dotnet/installer/tree/main/tools/sdk-readme-table-generator to help you generate it. Make sure to run the table generator test and make any changes to the generator along with your changes to the table. Daily servicing builds have been removed as all servicing is done in private repos to avoid disclosure of critical security fixes. All public servicing builds can be downloaded at http://aka.ms/dotnet-download.
 
 ### Table
 
-| Platform | main<br>(7.0.x&nbsp;Runtime) | Release/7.0.1xx-preview4<br>(7.0.x&nbsp;Runtime) | Release/6.0.4XX<br>(6.0.x&nbsp;Runtime) | Release/6.0.3XX<br>(6.0.x&nbsp;Runtime) | Release/6.0.1XX<br>(6.0.x&nbsp;Runtime) | Release/5.0.4XX<br>(5.0 Runtime) | Release/5.0.2XX<br>(5.0 Runtime) | Release/3.1.4XX<br>(3.1.x Runtime) |
-| :--------- | :----------: | :----------: | :----------: | :----------: | :----------: | :----------: | :----------: | :----------: |
-| **Windows x64** | [![][win-x64-badge-main]][win-x64-version-main]<br>[Installer][win-x64-installer-main] - [Checksum][win-x64-installer-checksum-main]<br>[zip][win-x64-zip-main] - [Checksum][win-x64-zip-checksum-main] | [![][win-x64-badge-7.0.1XX-preview4]][win-x64-version-7.0.1XX-preview4]<br>[Installer][win-x64-installer-7.0.1XX-preview4] - [Checksum][win-x64-installer-checksum-7.0.1XX-preview4]<br>[zip][win-x64-zip-7.0.1XX-preview4] - [Checksum][win-x64-zip-checksum-7.0.1XX-preview4] | [![][win-x64-badge-6.0.4XX]][win-x64-version-6.0.4XX]<br>[Installer][win-x64-installer-6.0.4XX] - [Checksum][win-x64-installer-checksum-6.0.4XX]<br>[zip][win-x64-zip-6.0.4XX] - [Checksum][win-x64-zip-checksum-6.0.4XX] | [![][win-x64-badge-6.0.3XX]][win-x64-version-6.0.3XX]<br>[Installer][win-x64-installer-6.0.3XX] - [Checksum][win-x64-installer-checksum-6.0.3XX]<br>[zip][win-x64-zip-6.0.3XX] - [Checksum][win-x64-zip-checksum-6.0.3XX] | [![][win-x64-badge-6.0.1XX]][win-x64-version-6.0.1XX]<br>[Installer][win-x64-installer-6.0.1XX] - [Checksum][win-x64-installer-checksum-6.0.1XX]<br>[zip][win-x64-zip-6.0.1XX] - [Checksum][win-x64-zip-checksum-6.0.1XX] | [![][win-x64-badge-5.0.4XX]][win-x64-version-5.0.4XX]<br>[Installer][win-x64-installer-5.0.4XX] - [Checksum][win-x64-installer-checksum-5.0.4XX]<br>[zip][win-x64-zip-5.0.4XX] - [Checksum][win-x64-zip-checksum-5.0.4XX] | [![][win-x64-badge-5.0.2XX]][win-x64-version-5.0.2XX]<br>[Installer][win-x64-installer-5.0.2XX] - [Checksum][win-x64-installer-checksum-5.0.2XX]<br>[zip][win-x64-zip-5.0.2XX] - [Checksum][win-x64-zip-checksum-5.0.2XX] | [![][win-x64-badge-3.1.4XX]][win-x64-version-3.1.4XX]<br>[Installer][win-x64-installer-3.1.4XX] - [Checksum][win-x64-installer-checksum-3.1.4XX]<br>[zip][win-x64-zip-3.1.4XX] - [Checksum][win-x64-zip-checksum-3.1.4XX] |
-| **Windows x86** | [![][win-x86-badge-main]][win-x86-version-main]<br>[Installer][win-x86-installer-main] - [Checksum][win-x86-installer-checksum-main]<br>[zip][win-x86-zip-main] - [Checksum][win-x86-zip-checksum-main] | [![][win-x86-badge-7.0.1XX-preview4]][win-x86-version-7.0.1XX-preview4]<br>[Installer][win-x86-installer-7.0.1XX-preview4] - [Checksum][win-x86-installer-checksum-7.0.1XX-preview4]<br>[zip][win-x86-zip-7.0.1XX-preview4] - [Checksum][win-x86-zip-checksum-7.0.1XX-preview4] | [![][win-x86-badge-6.0.4XX]][win-x86-version-6.0.4XX]<br>[Installer][win-x86-installer-6.0.4XX] - [Checksum][win-x86-installer-checksum-6.0.4XX]<br>[zip][win-x86-zip-6.0.4XX] - [Checksum][win-x86-zip-checksum-6.0.4XX] | [![][win-x86-badge-6.0.3XX]][win-x86-version-6.0.3XX]<br>[Installer][win-x86-installer-6.0.3XX] - [Checksum][win-x86-installer-checksum-6.0.3XX]<br>[zip][win-x86-zip-6.0.3XX] - [Checksum][win-x86-zip-checksum-6.0.3XX] | [![][win-x86-badge-6.0.1XX]][win-x86-version-6.0.1XX]<br>[Installer][win-x86-installer-6.0.1XX] - [Checksum][win-x86-installer-checksum-6.0.1XX]<br>[zip][win-x86-zip-6.0.1XX] - [Checksum][win-x86-zip-checksum-6.0.1XX] | [![][win-x86-badge-5.0.4XX]][win-x86-version-5.0.4XX]<br>[Installer][win-x86-installer-5.0.4XX] - [Checksum][win-x86-installer-checksum-5.0.4XX]<br>[zip][win-x86-zip-5.0.4XX] - [Checksum][win-x86-zip-checksum-5.0.4XX] | [![][win-x86-badge-5.0.2XX]][win-x86-version-5.0.2XX]<br>[Installer][win-x86-installer-5.0.2XX] - [Checksum][win-x86-installer-checksum-5.0.2XX]<br>[zip][win-x86-zip-5.0.2XX] - [Checksum][win-x86-zip-checksum-5.0.2XX] | [![][win-x86-badge-3.1.4XX]][win-x86-version-3.1.4XX]<br>[Installer][win-x86-installer-3.1.4XX] - [Checksum][win-x86-installer-checksum-3.1.4XX]<br>[zip][win-x86-zip-3.1.4XX] - [Checksum][win-x86-zip-checksum-3.1.4XX] |
-| **Windows arm** | **N/A** | **N/A** | **N/A** | **N/A** | **N/A** | **N/A** | **N/A** | [![][win-arm-badge-3.1.4XX]][win-arm-version-3.1.4XX]<br>[zip][win-arm-zip-3.1.4XX] - [Checksum][win-arm-zip-checksum-3.1.4XX] |
-| **Windows arm64** | [![][win-arm64-badge-main]][win-arm64-version-main]<br>[Installer][win-arm64-installer-main] - [Checksum][win-arm64-installer-checksum-main]<br>[zip][win-arm64-zip-main] | [![][win-arm64-badge-7.0.1XX-preview4]][win-arm64-version-7.0.1XX-preview4]<br>[Installer][win-arm64-installer-7.0.1XX-preview4] - [Checksum][win-arm64-installer-checksum-7.0.1XX-preview4]<br>[zip][win-arm64-zip-7.0.1XX-preview4] | [![][win-arm64-badge-6.0.4XX]][win-arm64-version-6.0.4XX]<br>[Installer][win-arm64-installer-6.0.4XX] - [Checksum][win-arm64-installer-checksum-6.0.4XX]<br>[zip][win-arm64-zip-6.0.4XX] | [![][win-arm64-badge-6.0.3XX]][win-arm64-version-6.0.3XX]<br>[Installer][win-arm64-installer-6.0.3XX] - [Checksum][win-arm64-installer-checksum-6.0.3XX]<br>[zip][win-arm64-zip-6.0.3XX] | [![][win-arm64-badge-6.0.1XX]][win-arm64-version-6.0.1XX]<br>[Installer][win-arm64-installer-6.0.1XX] - [Checksum][win-arm64-installer-checksum-6.0.1XX]<br>[zip][win-arm64-zip-6.0.1XX] | [![][win-arm64-badge-5.0.4XX]][win-arm64-version-5.0.4XX]<br>[Installer][win-arm64-installer-5.0.4XX] - [Checksum][win-arm64-installer-checksum-5.0.4XX]<br>[zip][win-arm64-zip-5.0.4XX] | [![][win-arm64-badge-5.0.2XX]][win-arm64-version-5.0.2XX]<br>[Installer][win-arm64-installer-5.0.2XX] - [Checksum][win-arm64-installer-checksum-5.0.2XX]<br>[zip][win-arm64-zip-5.0.2XX] | **N/A** |
-| **macOS x64** | [![][osx-x64-badge-main]][osx-x64-version-main]<br>[Installer][osx-x64-installer-main] - [Checksum][osx-x64-installer-checksum-main]<br>[tar.gz][osx-x64-targz-main] - [Checksum][osx-x64-targz-checksum-main] | [![][osx-x64-badge-7.0.1XX-preview4]][osx-x64-version-7.0.1XX-preview4]<br>[Installer][osx-x64-installer-7.0.1XX-preview4] - [Checksum][osx-x64-installer-checksum-7.0.1XX-preview4]<br>[tar.gz][osx-x64-targz-7.0.1XX-preview4] - [Checksum][osx-x64-targz-checksum-7.0.1XX-preview4] | [![][osx-x64-badge-6.0.4XX]][osx-x64-version-6.0.4XX]<br>[Installer][osx-x64-installer-6.0.4XX] - [Checksum][osx-x64-installer-checksum-6.0.4XX]<br>[tar.gz][osx-x64-targz-6.0.4XX] - [Checksum][osx-x64-targz-checksum-6.0.4XX] | [![][osx-x64-badge-6.0.3XX]][osx-x64-version-6.0.3XX]<br>[Installer][osx-x64-installer-6.0.3XX] - [Checksum][osx-x64-installer-checksum-6.0.3XX]<br>[tar.gz][osx-x64-targz-6.0.3XX] - [Checksum][osx-x64-targz-checksum-6.0.3XX] | [![][osx-x64-badge-6.0.1XX]][osx-x64-version-6.0.1XX]<br>[Installer][osx-x64-installer-6.0.1XX] - [Checksum][osx-x64-installer-checksum-6.0.1XX]<br>[tar.gz][osx-x64-targz-6.0.1XX] - [Checksum][osx-x64-targz-checksum-6.0.1XX] | [![][osx-x64-badge-5.0.4XX]][osx-x64-version-5.0.4XX]<br>[Installer][osx-x64-installer-5.0.4XX] - [Checksum][osx-x64-installer-checksum-5.0.4XX]<br>[tar.gz][osx-x64-targz-5.0.4XX] - [Checksum][osx-x64-targz-checksum-5.0.4XX] | [![][osx-x64-badge-5.0.2XX]][osx-x64-version-5.0.2XX]<br>[Installer][osx-x64-installer-5.0.2XX] - [Checksum][osx-x64-installer-checksum-5.0.2XX]<br>[tar.gz][osx-x64-targz-5.0.2XX] - [Checksum][osx-x64-targz-checksum-5.0.2XX] | [![][osx-x64-badge-3.1.4XX]][osx-x64-version-3.1.4XX]<br>[Installer][osx-x64-installer-3.1.4XX] - [Checksum][osx-x64-installer-checksum-3.1.4XX]<br>[tar.gz][osx-x64-targz-3.1.4XX] - [Checksum][osx-x64-targz-checksum-3.1.4XX] |
-| **macOS arm64** | [![][osx-arm64-badge-main]][osx-arm64-version-main]<br>[Installer][osx-arm64-installer-main] - [Checksum][osx-arm64-installer-checksum-main]<br>[tar.gz][osx-arm64-targz-main] - [Checksum][osx-arm64-targz-checksum-main] | [![][osx-arm64-badge-7.0.1XX-preview4]][osx-arm64-version-7.0.1XX-preview4]<br>[Installer][osx-arm64-installer-7.0.1XX-preview4] - [Checksum][osx-arm64-installer-checksum-7.0.1XX-preview4]<br>[tar.gz][osx-arm64-targz-7.0.1XX-preview4] - [Checksum][osx-arm64-targz-checksum-7.0.1XX-preview4] | [![][osx-arm64-badge-6.0.4XX]][osx-arm64-version-6.0.4XX]<br>[Installer][osx-arm64-installer-6.0.4XX] - [Checksum][osx-arm64-installer-checksum-6.0.4XX]<br>[tar.gz][osx-arm64-targz-6.0.4XX] - [Checksum][osx-arm64-targz-checksum-6.0.4XX] | [![][osx-arm64-badge-6.0.3XX]][osx-arm64-version-6.0.3XX]<br>[Installer][osx-arm64-installer-6.0.3XX] - [Checksum][osx-arm64-installer-checksum-6.0.3XX]<br>[tar.gz][osx-arm64-targz-6.0.3XX] - [Checksum][osx-arm64-targz-checksum-6.0.3XX] | [![][osx-arm64-badge-6.0.1XX]][osx-arm64-version-6.0.1XX]<br>[Installer][osx-arm64-installer-6.0.1XX] - [Checksum][osx-arm64-installer-checksum-6.0.1XX]<br>[tar.gz][osx-arm64-targz-6.0.1XX] - [Checksum][osx-arm64-targz-checksum-6.0.1XX] | **N/A** | **N/A** | **N/A** |
-| **Linux x64** | [![][linux-badge-main]][linux-version-main]<br>[DEB Installer][linux-DEB-installer-main] - [Checksum][linux-DEB-installer-checksum-main]<br>[RPM Installer][linux-RPM-installer-main] - [Checksum][linux-RPM-installer-checksum-main]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-main] - [Checksum][linux-targz-checksum-main] | [![][linux-badge-7.0.1XX-preview4]][linux-version-7.0.1XX-preview4]<br>[DEB Installer][linux-DEB-installer-7.0.1XX-preview4] - [Checksum][linux-DEB-installer-checksum-7.0.1XX-preview4]<br>[RPM Installer][linux-RPM-installer-7.0.1XX-preview4] - [Checksum][linux-RPM-installer-checksum-7.0.1XX-preview4]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-7.0.1XX-preview4] - [Checksum][linux-targz-checksum-7.0.1XX-preview4] | [![][linux-badge-6.0.4XX]][linux-version-6.0.4XX]<br>[DEB Installer][linux-DEB-installer-6.0.4XX] - [Checksum][linux-DEB-installer-checksum-6.0.4XX]<br>[RPM Installer][linux-RPM-installer-6.0.4XX] - [Checksum][linux-RPM-installer-checksum-6.0.4XX]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-6.0.4XX] - [Checksum][linux-targz-checksum-6.0.4XX] | [![][linux-badge-6.0.3XX]][linux-version-6.0.3XX]<br>[DEB Installer][linux-DEB-installer-6.0.3XX] - [Checksum][linux-DEB-installer-checksum-6.0.3XX]<br>[RPM Installer][linux-RPM-installer-6.0.3XX] - [Checksum][linux-RPM-installer-checksum-6.0.3XX]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-6.0.3XX] - [Checksum][linux-targz-checksum-6.0.3XX] | [![][linux-badge-6.0.1XX]][linux-version-6.0.1XX]<br>[DEB Installer][linux-DEB-installer-6.0.1XX] - [Checksum][linux-DEB-installer-checksum-6.0.1XX]<br>[RPM Installer][linux-RPM-installer-6.0.1XX] - [Checksum][linux-RPM-installer-checksum-6.0.1XX]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-6.0.1XX] - [Checksum][linux-targz-checksum-6.0.1XX] | [![][linux-badge-5.0.4XX]][linux-version-5.0.4XX]<br>[DEB Installer][linux-DEB-installer-5.0.4XX] - [Checksum][linux-DEB-installer-checksum-5.0.4XX]<br>[RPM Installer][linux-RPM-installer-5.0.4XX] - [Checksum][linux-RPM-installer-checksum-5.0.4XX]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-5.0.4XX] - [Checksum][linux-targz-checksum-5.0.4XX] | [![][linux-badge-5.0.2XX]][linux-version-5.0.2XX]<br>[DEB Installer][linux-DEB-installer-5.0.2XX] - [Checksum][linux-DEB-installer-checksum-5.0.2XX]<br>[RPM Installer][linux-RPM-installer-5.0.2XX] - [Checksum][linux-RPM-installer-checksum-5.0.2XX]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-5.0.2XX] - [Checksum][linux-targz-checksum-5.0.2XX] | [![][linux-badge-3.1.4XX]][linux-version-3.1.4XX]<br>[DEB Installer][linux-DEB-installer-3.1.4XX] - [Checksum][linux-DEB-installer-checksum-3.1.4XX]<br>[RPM Installer][linux-RPM-installer-3.1.4XX] - [Checksum][linux-RPM-installer-checksum-3.1.4XX]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-3.1.4XX] - [Checksum][linux-targz-checksum-3.1.4XX] |
-| **Linux arm** | [![][linux-arm-badge-main]][linux-arm-version-main]<br>[tar.gz][linux-arm-targz-main] - [Checksum][linux-arm-targz-checksum-main] | [![][linux-arm-badge-7.0.1XX-preview4]][linux-arm-version-7.0.1XX-preview4]<br>[tar.gz][linux-arm-targz-7.0.1XX-preview4] - [Checksum][linux-arm-targz-checksum-7.0.1XX-preview4] | [![][linux-arm-badge-6.0.4XX]][linux-arm-version-6.0.4XX]<br>[tar.gz][linux-arm-targz-6.0.4XX] - [Checksum][linux-arm-targz-checksum-6.0.4XX] | [![][linux-arm-badge-6.0.3XX]][linux-arm-version-6.0.3XX]<br>[tar.gz][linux-arm-targz-6.0.3XX] - [Checksum][linux-arm-targz-checksum-6.0.3XX] | [![][linux-arm-badge-6.0.1XX]][linux-arm-version-6.0.1XX]<br>[tar.gz][linux-arm-targz-6.0.1XX] - [Checksum][linux-arm-targz-checksum-6.0.1XX] | [![][linux-arm-badge-5.0.4XX]][linux-arm-version-5.0.4XX]<br>[tar.gz][linux-arm-targz-5.0.4XX] - [Checksum][linux-arm-targz-checksum-5.0.4XX] | [![][linux-arm-badge-5.0.2XX]][linux-arm-version-5.0.2XX]<br>[tar.gz][linux-arm-targz-5.0.2XX] - [Checksum][linux-arm-targz-checksum-5.0.2XX] | [![][linux-arm-badge-3.1.4XX]][linux-arm-version-3.1.4XX]<br>[tar.gz][linux-arm-targz-3.1.4XX] - [Checksum][linux-arm-targz-checksum-3.1.4XX] |
-| **Linux arm64** | [![][linux-arm64-badge-main]][linux-arm64-version-main]<br>[tar.gz][linux-arm64-targz-main] - [Checksum][linux-arm64-targz-checksum-main] | [![][linux-arm64-badge-7.0.1XX-preview4]][linux-arm64-version-7.0.1XX-preview4]<br>[tar.gz][linux-arm64-targz-7.0.1XX-preview4] - [Checksum][linux-arm64-targz-checksum-7.0.1XX-preview4] | [![][linux-arm64-badge-6.0.4XX]][linux-arm64-version-6.0.4XX]<br>[tar.gz][linux-arm64-targz-6.0.4XX] - [Checksum][linux-arm64-targz-checksum-6.0.4XX] | [![][linux-arm64-badge-6.0.3XX]][linux-arm64-version-6.0.3XX]<br>[tar.gz][linux-arm64-targz-6.0.3XX] - [Checksum][linux-arm64-targz-checksum-6.0.3XX] | [![][linux-arm64-badge-6.0.1XX]][linux-arm64-version-6.0.1XX]<br>[tar.gz][linux-arm64-targz-6.0.1XX] - [Checksum][linux-arm64-targz-checksum-6.0.1XX] | [![][linux-arm64-badge-5.0.4XX]][linux-arm64-version-5.0.4XX]<br>[tar.gz][linux-arm64-targz-5.0.4XX] - [Checksum][linux-arm64-targz-checksum-5.0.4XX] | [![][linux-arm64-badge-5.0.2XX]][linux-arm64-version-5.0.2XX]<br>[tar.gz][linux-arm64-targz-5.0.2XX] - [Checksum][linux-arm64-targz-checksum-5.0.2XX] | [![][linux-arm64-badge-3.1.4XX]][linux-arm64-version-3.1.4XX]<br>[tar.gz][linux-arm64-targz-3.1.4XX] - [Checksum][linux-arm64-targz-checksum-3.1.4XX] |
-| **Linux-musl-x64** | [![][linux-musl-x64-badge-main]][linux-musl-x64-version-main]<br>[tar.gz][linux-musl-x64-targz-main] - [Checksum][linux-musl-x64-targz-checksum-main] | [![][linux-musl-x64-badge-7.0.1XX-preview4]][linux-musl-x64-version-7.0.1XX-preview4]<br>[tar.gz][linux-musl-x64-targz-7.0.1XX-preview4] - [Checksum][linux-musl-x64-targz-checksum-7.0.1XX-preview4] | [![][linux-musl-x64-badge-6.0.4XX]][linux-musl-x64-version-6.0.4XX]<br>[tar.gz][linux-musl-x64-targz-6.0.4XX] - [Checksum][linux-musl-x64-targz-checksum-6.0.4XX] | [![][linux-musl-x64-badge-6.0.3XX]][linux-musl-x64-version-6.0.3XX]<br>[tar.gz][linux-musl-x64-targz-6.0.3XX] - [Checksum][linux-musl-x64-targz-checksum-6.0.3XX] | [![][linux-musl-x64-badge-6.0.1XX]][linux-musl-x64-version-6.0.1XX]<br>[tar.gz][linux-musl-x64-targz-6.0.1XX] - [Checksum][linux-musl-x64-targz-checksum-6.0.1XX] | [![][linux-musl-x64-badge-5.0.4XX]][linux-musl-x64-version-5.0.4XX]<br>[tar.gz][linux-musl-x64-targz-5.0.4XX] - [Checksum][linux-musl-x64-targz-checksum-5.0.4XX] | [![][linux-musl-x64-badge-5.0.2XX]][linux-musl-x64-version-5.0.2XX]<br>[tar.gz][linux-musl-x64-targz-5.0.2XX] - [Checksum][linux-musl-x64-targz-checksum-5.0.2XX] | [![][linux-musl-x64-badge-3.1.4XX]][linux-musl-x64-version-3.1.4XX]<br>[tar.gz][linux-musl-x64-targz-3.1.4XX] - [Checksum][linux-musl-x64-targz-checksum-3.1.4XX] |
-| **Linux-musl-arm** | [![][linux-musl-arm-badge-main]][linux-musl-arm-version-main]<br>[tar.gz][linux-musl-arm-targz-main] - [Checksum][linux-musl-arm-targz-checksum-main] | [![][linux-musl-arm-badge-7.0.1XX-preview4]][linux-musl-arm-version-7.0.1XX-preview4]<br>[tar.gz][linux-musl-arm-targz-7.0.1XX-preview4] - [Checksum][linux-musl-arm-targz-checksum-7.0.1XX-preview4] | [![][linux-musl-arm-badge-6.0.4XX]][linux-musl-arm-version-6.0.4XX]<br>[tar.gz][linux-musl-arm-targz-6.0.4XX] - [Checksum][linux-musl-arm-targz-checksum-6.0.4XX] | [![][linux-musl-arm-badge-6.0.3XX]][linux-musl-arm-version-6.0.3XX]<br>[tar.gz][linux-musl-arm-targz-6.0.3XX] - [Checksum][linux-musl-arm-targz-checksum-6.0.3XX] | [![][linux-musl-arm-badge-6.0.1XX]][linux-musl-arm-version-6.0.1XX]<br>[tar.gz][linux-musl-arm-targz-6.0.1XX] - [Checksum][linux-musl-arm-targz-checksum-6.0.1XX] | [![][linux-musl-arm-badge-5.0.4XX]][linux-musl-arm-version-5.0.4XX]<br>[tar.gz][linux-musl-arm-targz-5.0.4XX] - [Checksum][linux-musl-arm-targz-checksum-5.0.4XX] | [![][linux-musl-arm-badge-5.0.2XX]][linux-musl-arm-version-5.0.2XX]<br>[tar.gz][linux-musl-arm-targz-5.0.2XX] - [Checksum][linux-musl-arm-targz-checksum-5.0.2XX] | **N/A** |
-| **Linux-musl-arm64** | [![][linux-musl-arm64-badge-main]][linux-musl-arm64-version-main]<br>[tar.gz][linux-musl-arm64-targz-main] - [Checksum][linux-musl-arm64-targz-checksum-main] | [![][linux-musl-arm64-badge-7.0.1XX-preview4]][linux-musl-arm64-version-7.0.1XX-preview4]<br>[tar.gz][linux-musl-arm64-targz-7.0.1XX-preview4] - [Checksum][linux-musl-arm64-targz-checksum-7.0.1XX-preview4] | [![][linux-musl-arm64-badge-6.0.4XX]][linux-musl-arm64-version-6.0.4XX]<br>[tar.gz][linux-musl-arm64-targz-6.0.4XX] - [Checksum][linux-musl-arm64-targz-checksum-6.0.4XX] | [![][linux-musl-arm64-badge-6.0.3XX]][linux-musl-arm64-version-6.0.3XX]<br>[tar.gz][linux-musl-arm64-targz-6.0.3XX] - [Checksum][linux-musl-arm64-targz-checksum-6.0.3XX] | [![][linux-musl-arm64-badge-6.0.1XX]][linux-musl-arm64-version-6.0.1XX]<br>[tar.gz][linux-musl-arm64-targz-6.0.1XX] - [Checksum][linux-musl-arm64-targz-checksum-6.0.1XX] | [![][linux-musl-arm64-badge-5.0.4XX]][linux-musl-arm64-version-5.0.4XX]<br>[tar.gz][linux-musl-arm64-targz-5.0.4XX] - [Checksum][linux-musl-arm64-targz-checksum-5.0.4XX] | [![][linux-musl-arm64-badge-5.0.2XX]][linux-musl-arm64-version-5.0.2XX]<br>[tar.gz][linux-musl-arm64-targz-5.0.2XX] - [Checksum][linux-musl-arm64-targz-checksum-5.0.2XX] | **N/A** |
-| **RHEL 6** | **N/A** | **N/A** | **N/A** | **N/A** | **N/A** | **N/A** | **N/A** | [![][rhel-6-badge-3.1.4XX]][rhel-6-version-3.1.4XX]<br>[tar.gz][rhel-6-targz-3.1.4XX] - [Checksum][rhel-6-targz-checksum-3.1.4XX] |
+| Platform | main<br>(7.0.x&nbsp;Runtime) | Release/7.0.1xx-preview4<br>(7.0.x&nbsp;Runtime) | Release/6.0.4XX<br>(6.0.x&nbsp;Runtime) |
+| :--------- | :----------: | :----------: | :----------: |
+| **Windows x64** | [![][win-x64-badge-main]][win-x64-version-main]<br>[Installer][win-x64-installer-main] - [Checksum][win-x64-installer-checksum-main]<br>[zip][win-x64-zip-main] - [Checksum][win-x64-zip-checksum-main] | [![][win-x64-badge-7.0.1XX-preview4]][win-x64-version-7.0.1XX-preview4]<br>[Installer][win-x64-installer-7.0.1XX-preview4] - [Checksum][win-x64-installer-checksum-7.0.1XX-preview4]<br>[zip][win-x64-zip-7.0.1XX-preview4] - [Checksum][win-x64-zip-checksum-7.0.1XX-preview4] | [![][win-x64-badge-6.0.4XX]][win-x64-version-6.0.4XX]<br>[Installer][win-x64-installer-6.0.4XX] - [Checksum][win-x64-installer-checksum-6.0.4XX]<br>[zip][win-x64-zip-6.0.4XX] - [Checksum][win-x64-zip-checksum-6.0.4XX] |
+| **Windows x86** | [![][win-x86-badge-main]][win-x86-version-main]<br>[Installer][win-x86-installer-main] - [Checksum][win-x86-installer-checksum-main]<br>[zip][win-x86-zip-main] - [Checksum][win-x86-zip-checksum-main] | [![][win-x86-badge-7.0.1XX-preview4]][win-x86-version-7.0.1XX-preview4]<br>[Installer][win-x86-installer-7.0.1XX-preview4] - [Checksum][win-x86-installer-checksum-7.0.1XX-preview4]<br>[zip][win-x86-zip-7.0.1XX-preview4] - [Checksum][win-x86-zip-checksum-7.0.1XX-preview4] | [![][win-x86-badge-6.0.4XX]][win-x86-version-6.0.4XX]<br>[Installer][win-x86-installer-6.0.4XX] - [Checksum][win-x86-installer-checksum-6.0.4XX]<br>[zip][win-x86-zip-6.0.4XX] - [Checksum][win-x86-zip-checksum-6.0.4XX] |
+| **Windows arm** | **N/A** | **N/A** | **N/A** |
+| **Windows arm64** | [![][win-arm64-badge-main]][win-arm64-version-main]<br>[Installer][win-arm64-installer-main] - [Checksum][win-arm64-installer-checksum-main]<br>[zip][win-arm64-zip-main] | [![][win-arm64-badge-7.0.1XX-preview4]][win-arm64-version-7.0.1XX-preview4]<br>[Installer][win-arm64-installer-7.0.1XX-preview4] - [Checksum][win-arm64-installer-checksum-7.0.1XX-preview4]<br>[zip][win-arm64-zip-7.0.1XX-preview4] | [![][win-arm64-badge-6.0.4XX]][win-arm64-version-6.0.4XX]<br>[Installer][win-arm64-installer-6.0.4XX] - [Checksum][win-arm64-installer-checksum-6.0.4XX]<br>[zip][win-arm64-zip-6.0.4XX] |
+| **macOS x64** | [![][osx-x64-badge-main]][osx-x64-version-main]<br>[Installer][osx-x64-installer-main] - [Checksum][osx-x64-installer-checksum-main]<br>[tar.gz][osx-x64-targz-main] - [Checksum][osx-x64-targz-checksum-main] | [![][osx-x64-badge-7.0.1XX-preview4]][osx-x64-version-7.0.1XX-preview4]<br>[Installer][osx-x64-installer-7.0.1XX-preview4] - [Checksum][osx-x64-installer-checksum-7.0.1XX-preview4]<br>[tar.gz][osx-x64-targz-7.0.1XX-preview4] - [Checksum][osx-x64-targz-checksum-7.0.1XX-preview4] | [![][osx-x64-badge-6.0.4XX]][osx-x64-version-6.0.4XX]<br>[Installer][osx-x64-installer-6.0.4XX] - [Checksum][osx-x64-installer-checksum-6.0.4XX]<br>[tar.gz][osx-x64-targz-6.0.4XX] - [Checksum][osx-x64-targz-checksum-6.0.4XX] |
+| **macOS arm64** | [![][osx-arm64-badge-main]][osx-arm64-version-main]<br>[Installer][osx-arm64-installer-main] - [Checksum][osx-arm64-installer-checksum-main]<br>[tar.gz][osx-arm64-targz-main] - [Checksum][osx-arm64-targz-checksum-main] | [![][osx-arm64-badge-7.0.1XX-preview4]][osx-arm64-version-7.0.1XX-preview4]<br>[Installer][osx-arm64-installer-7.0.1XX-preview4] - [Checksum][osx-arm64-installer-checksum-7.0.1XX-preview4]<br>[tar.gz][osx-arm64-targz-7.0.1XX-preview4] - [Checksum][osx-arm64-targz-checksum-7.0.1XX-preview4] | [![][osx-arm64-badge-6.0.4XX]][osx-arm64-version-6.0.4XX]<br>[Installer][osx-arm64-installer-6.0.4XX] - [Checksum][osx-arm64-installer-checksum-6.0.4XX]<br>[tar.gz][osx-arm64-targz-6.0.4XX] - [Checksum][osx-arm64-targz-checksum-6.0.4XX] |
+| **Linux x64** | [![][linux-badge-main]][linux-version-main]<br>[DEB Installer][linux-DEB-installer-main] - [Checksum][linux-DEB-installer-checksum-main]<br>[RPM Installer][linux-RPM-installer-main] - [Checksum][linux-RPM-installer-checksum-main]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-main] - [Checksum][linux-targz-checksum-main] | [![][linux-badge-7.0.1XX-preview4]][linux-version-7.0.1XX-preview4]<br>[DEB Installer][linux-DEB-installer-7.0.1XX-preview4] - [Checksum][linux-DEB-installer-checksum-7.0.1XX-preview4]<br>[RPM Installer][linux-RPM-installer-7.0.1XX-preview4] - [Checksum][linux-RPM-installer-checksum-7.0.1XX-preview4]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-7.0.1XX-preview4] - [Checksum][linux-targz-checksum-7.0.1XX-preview4] | [![][linux-badge-6.0.4XX]][linux-version-6.0.4XX]<br>[DEB Installer][linux-DEB-installer-6.0.4XX] - [Checksum][linux-DEB-installer-checksum-6.0.4XX]<br>[RPM Installer][linux-RPM-installer-6.0.4XX] - [Checksum][linux-RPM-installer-checksum-6.0.4XX]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-6.0.4XX] - [Checksum][linux-targz-checksum-6.0.4XX] |
+| **Linux arm** | [![][linux-arm-badge-main]][linux-arm-version-main]<br>[tar.gz][linux-arm-targz-main] - [Checksum][linux-arm-targz-checksum-main] | [![][linux-arm-badge-7.0.1XX-preview4]][linux-arm-version-7.0.1XX-preview4]<br>[tar.gz][linux-arm-targz-7.0.1XX-preview4] - [Checksum][linux-arm-targz-checksum-7.0.1XX-preview4] | [![][linux-arm-badge-6.0.4XX]][linux-arm-version-6.0.4XX]<br>[tar.gz][linux-arm-targz-6.0.4XX] - [Checksum][linux-arm-targz-checksum-6.0.4XX] |
+| **Linux arm64** | [![][linux-arm64-badge-main]][linux-arm64-version-main]<br>[tar.gz][linux-arm64-targz-main] - [Checksum][linux-arm64-targz-checksum-main] | [![][linux-arm64-badge-7.0.1XX-preview4]][linux-arm64-version-7.0.1XX-preview4]<br>[tar.gz][linux-arm64-targz-7.0.1XX-preview4] - [Checksum][linux-arm64-targz-checksum-7.0.1XX-preview4] | [![][linux-arm64-badge-6.0.4XX]][linux-arm64-version-6.0.4XX]<br>[tar.gz][linux-arm64-targz-6.0.4XX] - [Checksum][linux-arm64-targz-checksum-6.0.4XX] |
+| **Linux-musl-x64** | [![][linux-musl-x64-badge-main]][linux-musl-x64-version-main]<br>[tar.gz][linux-musl-x64-targz-main] - [Checksum][linux-musl-x64-targz-checksum-main] | [![][linux-musl-x64-badge-7.0.1XX-preview4]][linux-musl-x64-version-7.0.1XX-preview4]<br>[tar.gz][linux-musl-x64-targz-7.0.1XX-preview4] - [Checksum][linux-musl-x64-targz-checksum-7.0.1XX-preview4] | [![][linux-musl-x64-badge-6.0.4XX]][linux-musl-x64-version-6.0.4XX]<br>[tar.gz][linux-musl-x64-targz-6.0.4XX] - [Checksum][linux-musl-x64-targz-checksum-6.0.4XX] |
+| **Linux-musl-arm** | [![][linux-musl-arm-badge-main]][linux-musl-arm-version-main]<br>[tar.gz][linux-musl-arm-targz-main] - [Checksum][linux-musl-arm-targz-checksum-main] | [![][linux-musl-arm-badge-7.0.1XX-preview4]][linux-musl-arm-version-7.0.1XX-preview4]<br>[tar.gz][linux-musl-arm-targz-7.0.1XX-preview4] - [Checksum][linux-musl-arm-targz-checksum-7.0.1XX-preview4] | [![][linux-musl-arm-badge-6.0.4XX]][linux-musl-arm-version-6.0.4XX]<br>[tar.gz][linux-musl-arm-targz-6.0.4XX] - [Checksum][linux-musl-arm-targz-checksum-6.0.4XX] |
+| **Linux-musl-arm64** | [![][linux-musl-arm64-badge-main]][linux-musl-arm64-version-main]<br>[tar.gz][linux-musl-arm64-targz-main] - [Checksum][linux-musl-arm64-targz-checksum-main] | [![][linux-musl-arm64-badge-7.0.1XX-preview4]][linux-musl-arm64-version-7.0.1XX-preview4]<br>[tar.gz][linux-musl-arm64-targz-7.0.1XX-preview4] - [Checksum][linux-musl-arm64-targz-checksum-7.0.1XX-preview4] | [![][linux-musl-arm64-badge-6.0.4XX]][linux-musl-arm64-version-6.0.4XX]<br>[tar.gz][linux-musl-arm64-targz-6.0.4XX] - [Checksum][linux-musl-arm64-targz-checksum-6.0.4XX] |
+| **RHEL 6** | **N/A** | **N/A** | **N/A** |
 
 Reference notes:
 > **1**: Our Debian packages are put together slightly differently than the other OS specific installers. Instead of combining everything, we have separate component packages that depend on each other. If you're installing the SDK from the .deb file (via dpkg or similar), then you'll need to install the corresponding dependencies first:
@@ -173,41 +173,6 @@ Reference notes:
 [win-x64-zip-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-win-x64.zip
 [win-x64-zip-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-win-x64.zip.sha
 
-[win-x64-badge-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/win_x64_Release_version_badge.svg
-[win-x64-version-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/productCommit-win-x64.txt
-[win-x64-installer-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-win-x64.exe
-[win-x64-installer-checksum-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-win-x64.exe.sha
-[win-x64-zip-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-win-x64.zip
-[win-x64-zip-checksum-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-win-x64.zip.sha
-
-[win-x64-badge-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/win_x64_Release_version_badge.svg
-[win-x64-version-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/productCommit-win-x64.txt
-[win-x64-installer-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-win-x64.exe
-[win-x64-installer-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-win-x64.exe.sha
-[win-x64-zip-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-win-x64.zip
-[win-x64-zip-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-win-x64.zip.sha
-
-[win-x64-badge-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/win_x64_Release_version_badge.svg
-[win-x64-version-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/productCommit-win-x64.txt
-[win-x64-installer-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-win-x64.exe
-[win-x64-installer-checksum-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-win-x64.exe.sha
-[win-x64-zip-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-win-x64.zip
-[win-x64-zip-checksum-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-win-x64.zip.sha
-
-[win-x64-badge-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/win_x64_Release_version_badge.svg
-[win-x64-version-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/productCommit-win-x64.txt
-[win-x64-installer-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-win-x64.exe
-[win-x64-installer-checksum-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-win-x64.exe.sha
-[win-x64-zip-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-win-x64.zip
-[win-x64-zip-checksum-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-win-x64.zip.sha
-
-[win-x64-badge-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/win_x64_Release_version_badge.svg
-[win-x64-version-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/latest.version
-[win-x64-installer-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-win-x64.exe
-[win-x64-installer-checksum-3.1.4XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-win-x64.exe.sha
-[win-x64-zip-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-win-x64.zip
-[win-x64-zip-checksum-3.1.4XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-win-x64.zip.sha
-
 [win-x86-badge-main]: https://aka.ms/dotnet/7.0.1xx/daily/win_x86_Release_version_badge.svg
 [win-x86-version-main]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-win-x86.txt
 [win-x86-installer-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-win-x86.exe
@@ -228,41 +193,6 @@ Reference notes:
 [win-x86-installer-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-win-x86.exe.sha
 [win-x86-zip-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-win-x86.zip
 [win-x86-zip-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-win-x86.zip.sha
-
-[win-x86-badge-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/win_x86_Release_version_badge.svg
-[win-x86-version-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/productCommit-win-x86.txt
-[win-x86-installer-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-win-x86.exe
-[win-x86-installer-checksum-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-win-x86.exe.sha
-[win-x86-zip-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-win-x86.zip
-[win-x86-zip-checksum-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-win-x86.zip.sha
-
-[win-x86-badge-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/win_x86_Release_version_badge.svg
-[win-x86-version-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/productCommit-win-x86.txt
-[win-x86-installer-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-win-x86.exe
-[win-x86-installer-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-win-x86.exe.sha
-[win-x86-zip-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-win-x86.zip
-[win-x86-zip-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-win-x86.zip.sha
-
-[win-x86-badge-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/win_x86_Release_version_badge.svg
-[win-x86-version-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/productCommit-win-x86.txt
-[win-x86-installer-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-win-x86.exe
-[win-x86-installer-checksum-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-win-x86.exe.sha
-[win-x86-zip-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-win-x86.zip
-[win-x86-zip-checksum-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-win-x86.zip.sha
-
-[win-x86-badge-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/win_x86_Release_version_badge.svg
-[win-x86-version-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/productCommit-win-x86.txt
-[win-x86-installer-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-win-x86.exe
-[win-x86-installer-checksum-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-win-x86.exe.sha
-[win-x86-zip-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-win-x86.zip
-[win-x86-zip-checksum-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-win-x86.zip.sha
-
-[win-x86-badge-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/win_x86_Release_version_badge.svg
-[win-x86-version-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/latest.version
-[win-x86-installer-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-win-x86.exe
-[win-x86-installer-checksum-3.1.4XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-win-x86.exe.sha
-[win-x86-zip-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-win-x86.zip
-[win-x86-zip-checksum-3.1.4XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-win-x86.zip.sha
 
 [osx-x64-badge-main]: https://aka.ms/dotnet/7.0.1xx/daily/osx_x64_Release_version_badge.svg
 [osx-x64-version-main]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-osx-x64.txt
@@ -285,41 +215,6 @@ Reference notes:
 [osx-x64-targz-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-osx-x64.tar.gz
 [osx-x64-targz-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-osx-x64.pkg.tar.gz.sha
 
-[osx-x64-badge-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/osx_x64_Release_version_badge.svg
-[osx-x64-version-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/productCommit-osx-x64.txt
-[osx-x64-installer-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-osx-x64.pkg
-[osx-x64-installer-checksum-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-osx-x64.pkg.sha
-[osx-x64-targz-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-osx-x64.tar.gz
-[osx-x64-targz-checksum-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-osx-x64.pkg.tar.gz.sha
-
-[osx-x64-badge-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/osx_x64_Release_version_badge.svg
-[osx-x64-version-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/productCommit-osx-x64.txt
-[osx-x64-installer-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-osx-x64.pkg
-[osx-x64-installer-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-osx-x64.pkg.sha
-[osx-x64-targz-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-osx-x64.tar.gz
-[osx-x64-targz-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-osx-x64.pkg.tar.gz.sha
-
-[osx-x64-badge-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/osx_x64_Release_version_badge.svg
-[osx-x64-version-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/productCommit-osx-x64.txt
-[osx-x64-installer-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-osx-x64.pkg
-[osx-x64-installer-checksum-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-osx-x64.pkg.sha
-[osx-x64-targz-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-osx-x64.tar.gz
-[osx-x64-targz-checksum-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-osx-x64.pkg.tar.gz.sha
-
-[osx-x64-badge-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/osx_x64_Release_version_badge.svg
-[osx-x64-version-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/productCommit-osx-x64.txt
-[osx-x64-installer-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-osx-x64.pkg
-[osx-x64-installer-checksum-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-osx-x64.pkg.sha
-[osx-x64-targz-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-osx-x64.tar.gz
-[osx-x64-targz-checksum-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-osx-x64.pkg.tar.gz.sha
-
-[osx-x64-badge-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/osx_x64_Release_version_badge.svg
-[osx-x64-version-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/latest.version
-[osx-x64-installer-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-osx-x64.pkg
-[osx-x64-installer-checksum-3.1.4XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-osx-x64.pkg.sha
-[osx-x64-targz-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-osx-x64.tar.gz
-[osx-x64-targz-checksum-3.1.4XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-osx-x64.tar.gz.sha
-
 [osx-arm64-badge-main]: https://aka.ms/dotnet/7.0.1xx/daily/osx_arm64_Release_version_badge.svg
 [osx-arm64-version-main]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-osx-arm64.txt
 [osx-arm64-installer-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-osx-arm64.pkg
@@ -340,20 +235,6 @@ Reference notes:
 [osx-arm64-installer-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-osx-arm64.pkg.sha
 [osx-arm64-targz-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-osx-arm64.tar.gz
 [osx-arm64-targz-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-osx-arm64.pkg.tar.gz.sha
-
-[osx-arm64-badge-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/osx_arm64_Release_version_badge.svg
-[osx-arm64-version-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/productCommit-osx-arm64.txt
-[osx-arm64-installer-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-osx-arm64.pkg
-[osx-arm64-installer-checksum-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-osx-arm64.pkg.sha
-[osx-arm64-targz-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-osx-arm64.tar.gz
-[osx-arm64-targz-checksum-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-osx-arm64.pkg.tar.gz.sha
-
-[osx-arm64-badge-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/osx_arm64_Release_version_badge.svg
-[osx-arm64-version-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/productCommit-osx-arm64.txt
-[osx-arm64-installer-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-osx-arm64.pkg
-[osx-arm64-installer-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-osx-arm64.pkg.sha
-[osx-arm64-targz-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-osx-arm64.tar.gz
-[osx-arm64-targz-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-osx-arm64.pkg.tar.gz.sha
 
 [linux-badge-main]: https://aka.ms/dotnet/7.0.1xx/daily/linux_x64_Release_version_badge.svg
 [linux-version-main]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-linux-x64.txt
@@ -382,51 +263,6 @@ Reference notes:
 [linux-targz-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-linux-x64.tar.gz
 [linux-targz-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-linux-x64.tar.gz.sha
 
-[linux-badge-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/linux_x64_Release_version_badge.svg
-[linux-version-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/productCommit-linux-x64.txt
-[linux-DEB-installer-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-x64.deb
-[linux-DEB-installer-checksum-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-x64.deb.sha
-[linux-RPM-installer-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-x64.rpm
-[linux-RPM-installer-checksum-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-x64.rpm.sha
-[linux-targz-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-linux-x64.tar.gz
-[linux-targz-checksum-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-linux-x64.tar.gz.sha
-
-[linux-badge-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/linux_x64_Release_version_badge.svg
-[linux-version-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/productCommit-linux-x64.txt
-[linux-DEB-installer-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-x64.deb
-[linux-DEB-installer-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-x64.deb.sha
-[linux-RPM-installer-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-x64.rpm
-[linux-RPM-installer-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-x64.rpm.sha
-[linux-targz-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-linux-x64.tar.gz
-[linux-targz-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-linux-x64.tar.gz.sha
-
-[linux-badge-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/linux_x64_Release_version_badge.svg
-[linux-version-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/productCommit-linux-x64.txt
-[linux-DEB-installer-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-x64.deb
-[linux-DEB-installer-checksum-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-x64.deb.sha
-[linux-RPM-installer-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-x64.rpm
-[linux-RPM-installer-checksum-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-x64.rpm.sha
-[linux-targz-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-linux-x64.tar.gz
-[linux-targz-checksum-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-linux-x64.tar.gz.sha
-
-[linux-badge-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/linux_x64_Release_version_badge.svg
-[linux-version-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/productCommit-linux-x64.txt
-[linux-DEB-installer-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-x64.deb
-[linux-DEB-installer-checksum-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-x64.deb.sha
-[linux-RPM-installer-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-x64.rpm
-[linux-RPM-installer-checksum-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-x64.rpm.sha
-[linux-targz-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-linux-x64.tar.gz
-[linux-targz-checksum-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-linux-x64.tar.gz.sha
-
-[linux-badge-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/linux_x64_Release_version_badge.svg
-[linux-version-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/latest.version
-[linux-DEB-installer-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-x64.deb
-[linux-DEB-installer-checksum-3.1.4XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-x64.deb.sha
-[linux-RPM-installer-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-x64.rpm
-[linux-RPM-installer-checksum-3.1.4XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-x64.rpm.sha
-[linux-targz-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-linux-x64.tar.gz
-[linux-targz-checksum-3.1.4XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-linux-x64.tar.gz.sha
-
 [linux-arm-badge-main]: https://aka.ms/dotnet/7.0.1xx/daily/linux_arm_Release_version_badge.svg
 [linux-arm-version-main]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-linux-arm.txt
 [linux-arm-targz-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-linux-arm.tar.gz
@@ -441,31 +277,6 @@ Reference notes:
 [linux-arm-version-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/productCommit-linux-arm.txt
 [linux-arm-targz-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-linux-arm.tar.gz
 [linux-arm-targz-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-linux-arm.tar.gz.sha
-
-[linux-arm-badge-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/linux_arm_Release_version_badge.svg
-[linux-arm-version-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/productCommit-linux-arm.txt
-[linux-arm-targz-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-linux-arm.tar.gz
-[linux-arm-targz-checksum-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-linux-arm.tar.gz.sha
-
-[linux-arm-badge-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/linux_arm_Release_version_badge.svg
-[linux-arm-version-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/productCommit-linux-arm.txt
-[linux-arm-targz-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-linux-arm.tar.gz
-[linux-arm-targz-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-linux-arm.tar.gz.sha
-
-[linux-arm-badge-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/linux_arm_Release_version_badge.svg
-[linux-arm-version-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/productCommit-linux-arm.txt
-[linux-arm-targz-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-linux-arm.tar.gz
-[linux-arm-targz-checksum-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-linux-arm.tar.gz.sha
-
-[linux-arm-badge-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/linux_arm_Release_version_badge.svg
-[linux-arm-version-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/productCommit-linux-arm.txt
-[linux-arm-targz-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-linux-arm.tar.gz
-[linux-arm-targz-checksum-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-linux-arm.tar.gz.sha
-
-[linux-arm-badge-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/linux_arm_Release_version_badge.svg
-[linux-arm-version-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/latest.version
-[linux-arm-targz-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-linux-arm.tar.gz
-[linux-arm-targz-checksum-3.1.4XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-linux-arm.tar.gz.sha
 
 [linux-arm64-badge-main]: https://aka.ms/dotnet/7.0.1xx/daily/linux_arm64_Release_version_badge.svg
 [linux-arm64-version-main]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-linux-arm64.txt
@@ -482,31 +293,6 @@ Reference notes:
 [linux-arm64-targz-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-linux-arm64.tar.gz
 [linux-arm64-targz-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-linux-arm64.tar.gz.sha
 
-[linux-arm64-badge-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/linux_arm64_Release_version_badge.svg
-[linux-arm64-version-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/productCommit-linux-arm64.txt
-[linux-arm64-targz-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-linux-arm64.tar.gz
-[linux-arm64-targz-checksum-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-linux-arm64.tar.gz.sha
-
-[linux-arm64-badge-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/linux_arm64_Release_version_badge.svg
-[linux-arm64-version-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/productCommit-linux-arm64.txt
-[linux-arm64-targz-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-linux-arm64.tar.gz
-[linux-arm64-targz-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-linux-arm64.tar.gz.sha
-
-[linux-arm64-badge-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/linux_arm64_Release_version_badge.svg
-[linux-arm64-version-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/productCommit-linux-arm64.txt
-[linux-arm64-targz-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-linux-arm64.tar.gz
-[linux-arm64-targz-checksum-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-linux-arm64.tar.gz.sha
-
-[linux-arm64-badge-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/linux_arm64_Release_version_badge.svg
-[linux-arm64-version-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/productCommit-linux-arm64.txt
-[linux-arm64-targz-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-linux-arm64.tar.gz
-[linux-arm64-targz-checksum-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-linux-arm64.tar.gz.sha
-
-[linux-arm64-badge-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/linux_arm64_Release_version_badge.svg
-[linux-arm64-version-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/latest.version
-[linux-arm64-targz-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-linux-arm64.tar.gz
-[linux-arm64-targz-checksum-3.1.4XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-linux-arm64.tar.gz.sha
-
 [rhel-6-badge-main]: https://aka.ms/dotnet/7.0.1xx/daily/rhel.6_x64_Release_version_badge.svg
 [rhel-6-version-main]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-rhel.6-x64.txt
 [rhel-6-targz-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-rhel.6-x64.tar.gz
@@ -521,31 +307,6 @@ Reference notes:
 [rhel-6-version-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/productCommit-rhel.6-x64.txt
 [rhel-6-targz-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-rhel.6-x64.tar.gz
 [rhel-6-targz-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-rhel.6-x64.tar.gz.sha
-
-[rhel-6-badge-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/rhel.6_x64_Release_version_badge.svg
-[rhel-6-version-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/productCommit-rhel.6-x64.txt
-[rhel-6-targz-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-rhel.6-x64.tar.gz
-[rhel-6-targz-checksum-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-rhel.6-x64.tar.gz.sha
-
-[rhel-6-badge-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/rhel.6_x64_Release_version_badge.svg
-[rhel-6-version-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/productCommit-rhel.6-x64.txt
-[rhel-6-targz-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-rhel.6-x64.tar.gz
-[rhel-6-targz-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-rhel.6-x64.tar.gz.sha
-
-[rhel-6-badge-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/rhel.6_x64_Release_version_badge.svg
-[rhel-6-version-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/productCommit-rhel.6-x64.txt
-[rhel-6-targz-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-rhel.6-x64.tar.gz
-[rhel-6-targz-checksum-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-rhel.6-x64.tar.gz.sha
-
-[rhel-6-badge-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/rhel.6_x64_Release_version_badge.svg
-[rhel-6-version-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/productCommit-rhel.6-x64.txt
-[rhel-6-targz-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-rhel.6-x64.tar.gz
-[rhel-6-targz-checksum-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-rhel.6-x64.tar.gz.sha
-
-[rhel-6-badge-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/rhel.6_x64_Release_version_badge.svg
-[rhel-6-version-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/latest.version
-[rhel-6-targz-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-rhel.6-x64.tar.gz
-[rhel-6-targz-checksum-3.1.4XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-rhel.6-x64.tar.gz.sha
 
 [linux-musl-x64-badge-main]: https://aka.ms/dotnet/7.0.1xx/daily/linux_musl_x64_Release_version_badge.svg
 [linux-musl-x64-version-main]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-linux-musl-x64.txt
@@ -562,31 +323,6 @@ Reference notes:
 [linux-musl-x64-targz-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-linux-musl-x64.tar.gz
 [linux-musl-x64-targz-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-linux-musl-x64.tar.gz.sha
 
-[linux-musl-x64-badge-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/linux_musl_x64_Release_version_badge.svg
-[linux-musl-x64-version-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/productCommit-linux-musl-x64.txt
-[linux-musl-x64-targz-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-linux-musl-x64.tar.gz
-[linux-musl-x64-targz-checksum-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-linux-musl-x64.tar.gz.sha
-
-[linux-musl-x64-badge-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/linux_musl_x64_Release_version_badge.svg
-[linux-musl-x64-version-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/productCommit-linux-musl-x64.txt
-[linux-musl-x64-targz-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-linux-musl-x64.tar.gz
-[linux-musl-x64-targz-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-linux-musl-x64.tar.gz.sha
-
-[linux-musl-x64-badge-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/linux_musl_x64_Release_version_badge.svg
-[linux-musl-x64-version-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/productCommit-linux-musl-x64.txt
-[linux-musl-x64-targz-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-linux-musl-x64.tar.gz
-[linux-musl-x64-targz-checksum-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-linux-musl-x64.tar.gz.sha
-
-[linux-musl-x64-badge-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/linux_musl_x64_Release_version_badge.svg
-[linux-musl-x64-version-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/productCommit-linux-musl-x64.txt
-[linux-musl-x64-targz-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-linux-musl-x64.tar.gz
-[linux-musl-x64-targz-checksum-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-linux-musl-x64.tar.gz.sha
-
-[linux-musl-x64-badge-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/linux_musl_x64_Release_version_badge.svg
-[linux-musl-x64-version-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/latest.version
-[linux-musl-x64-targz-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-linux-musl-x64.tar.gz
-[linux-musl-x64-targz-checksum-3.1.4XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-linux-musl-x64.tar.gz.sha
-
 [linux-musl-arm-badge-main]: https://aka.ms/dotnet/7.0.1xx/daily/linux_musl_arm_Release_version_badge.svg
 [linux-musl-arm-version-main]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-linux-musl-arm.txt
 [linux-musl-arm-targz-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-linux-musl-arm.tar.gz
@@ -601,26 +337,6 @@ Reference notes:
 [linux-musl-arm-version-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/productCommit-linux-musl-arm.txt
 [linux-musl-arm-targz-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-linux-musl-arm.tar.gz
 [linux-musl-arm-targz-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-linux-musl-arm.tar.gz.sha
-
-[linux-musl-arm-badge-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/linux_musl_arm_Release_version_badge.svg
-[linux-musl-arm-version-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/productCommit-linux-musl-arm.txt
-[linux-musl-arm-targz-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-linux-musl-arm.tar.gz
-[linux-musl-arm-targz-checksum-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-linux-musl-arm.tar.gz.sha
-
-[linux-musl-arm-badge-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/linux_musl_arm_Release_version_badge.svg
-[linux-musl-arm-version-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/productCommit-linux-musl-arm.txt
-[linux-musl-arm-targz-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-linux-musl-arm.tar.gz
-[linux-musl-arm-targz-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-linux-musl-arm.tar.gz.sha
-
-[linux-musl-arm-badge-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/linux_musl_arm_Release_version_badge.svg
-[linux-musl-arm-version-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/productCommit-linux-musl-arm.txt
-[linux-musl-arm-targz-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-linux-musl-arm.tar.gz
-[linux-musl-arm-targz-checksum-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-linux-musl-arm.tar.gz.sha
-
-[linux-musl-arm-badge-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/linux_musl_arm_Release_version_badge.svg
-[linux-musl-arm-version-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/productCommit-linux-musl-arm.txt
-[linux-musl-arm-targz-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-linux-musl-arm.tar.gz
-[linux-musl-arm-targz-checksum-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-linux-musl-arm.tar.gz.sha
 
 [linux-musl-arm64-badge-main]: https://aka.ms/dotnet/7.0.1xx/daily/linux_musl_arm64_Release_version_badge.svg
 [linux-musl-arm64-version-main]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-linux-musl-arm64.txt
@@ -637,26 +353,6 @@ Reference notes:
 [linux-musl-arm64-targz-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-linux-musl-arm64.tar.gz
 [linux-musl-arm64-targz-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-linux-musl-arm64.tar.gz.sha
 
-[linux-musl-arm64-badge-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/linux_musl_arm64_Release_version_badge.svg
-[linux-musl-arm64-version-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/productCommit-linux-musl-arm64.txt
-[linux-musl-arm64-targz-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-linux-musl-arm64.tar.gz
-[linux-musl-arm64-targz-checksum-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-linux-musl-arm64.tar.gz.sha
-
-[linux-musl-arm64-badge-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/linux_musl_arm64_Release_version_badge.svg
-[linux-musl-arm64-version-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/productCommit-linux-musl-arm64.txt
-[linux-musl-arm64-targz-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-linux-musl-arm64.tar.gz
-[linux-musl-arm64-targz-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-linux-musl-arm64.tar.gz.sha
-
-[linux-musl-arm64-badge-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/linux_musl_arm64_Release_version_badge.svg
-[linux-musl-arm64-version-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/productCommit-linux-musl-arm64.txt
-[linux-musl-arm64-targz-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-linux-musl-arm64.tar.gz
-[linux-musl-arm64-targz-checksum-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-linux-musl-arm64.tar.gz.sha
-
-[linux-musl-arm64-badge-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/linux_musl_arm64_Release_version_badge.svg
-[linux-musl-arm64-version-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/productCommit-linux-musl-arm64.txt
-[linux-musl-arm64-targz-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-linux-musl-arm64.tar.gz
-[linux-musl-arm64-targz-checksum-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-linux-musl-arm64.tar.gz.sha
-
 [win-arm-badge-main]: https://aka.ms/dotnet/7.0.1xx/daily/win_arm_Release_version_badge.svg
 [win-arm-version-main]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-win-arm.txt
 [win-arm-zip-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-win-arm.zip
@@ -671,31 +367,6 @@ Reference notes:
 [win-arm-version-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/productCommit-win-arm.txt
 [win-arm-zip-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-win-arm.zip
 [win-arm-zip-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-win-arm.zip.sha
-
-[win-arm-badge-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/win_arm_Release_version_badge.svg
-[win-arm-version-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/productCommit-win-arm.txt
-[win-arm-zip-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-win-arm.zip
-[win-arm-zip-checksum-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-win-arm.zip.sha
-
-[win-arm-badge-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/win_arm_Release_version_badge.svg
-[win-arm-version-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/productCommit-win-arm.txt
-[win-arm-zip-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-win-arm.zip
-[win-arm-zip-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-win-arm.zip.sha
-
-[win-arm-badge-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/win_arm_Release_version_badge.svg
-[win-arm-version-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/productCommit-win-arm.txt
-[win-arm-zip-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-win-arm.zip
-[win-arm-zip-checksum-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-win-arm.zip.sha
-
-[win-arm-badge-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/win_arm_Release_version_badge.svg
-[win-arm-version-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/productCommit-win-arm.txt
-[win-arm-zip-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-win-arm.zip
-[win-arm-zip-checksum-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-win-arm.zip.sha
-
-[win-arm-badge-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/win_arm_Release_version_badge.svg
-[win-arm-version-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/latest.version
-[win-arm-zip-3.1.4XX]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-win-arm.zip
-[win-arm-zip-checksum-3.1.4XX]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/3.1.4xx/dotnet-sdk-latest-win-arm.zip.sha
 
 [win-arm64-badge-main]: https://aka.ms/dotnet/7.0.1xx/daily/win_arm64_Release_version_badge.svg
 [win-arm64-version-main]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-win-arm64.txt
@@ -717,34 +388,6 @@ Reference notes:
 [win-arm64-installer-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-win-arm64.exe.sha
 [win-arm64-zip-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-win-arm64.zip
 [win-arm64-zip-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-win-arm64.zip.sha
-
-[win-arm64-badge-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/win_arm64_Release_version_badge.svg
-[win-arm64-version-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/productCommit-win-arm64.txt
-[win-arm64-installer-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-win-arm64.exe
-[win-arm64-installer-checksum-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-win-arm64.exe.sha
-[win-arm64-zip-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-win-arm64.zip
-[win-arm64-zip-checksum-6.0.3XX]: https://aka.ms/dotnet/6.0.3xx/daily/dotnet-sdk-win-arm64.zip.sha
-
-[win-arm64-badge-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/win_arm64_Release_version_badge.svg
-[win-arm64-version-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/productCommit-win-arm64.txt
-[win-arm64-installer-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-win-arm64.exe
-[win-arm64-installer-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-win-arm64.exe.sha
-[win-arm64-zip-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-win-arm64.zip
-[win-arm64-zip-checksum-6.0.1XX]: https://aka.ms/dotnet/6.0.1xx/daily/dotnet-sdk-win-arm64.zip.sha
-
-[win-arm64-badge-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/win_arm64_Release_version_badge.svg
-[win-arm64-version-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/productCommit-win-arm64.txt
-[win-arm64-installer-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-win-arm64.exe
-[win-arm64-installer-checksum-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-win-arm64.exe.sha
-[win-arm64-zip-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-win-arm64.zip
-[win-arm64-zip-checksum-5.0.4XX]: https://aka.ms/dotnet/5.0.4xx/daily/dotnet-sdk-win-arm64.zip.sha
-
-[win-arm64-badge-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/win_arm64_Release_version_badge.svg
-[win-arm64-version-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/productCommit-win-arm64.txt
-[win-arm64-installer-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-win-arm64.exe
-[win-arm64-installer-checksum-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-win-arm64.exe.sha
-[win-arm64-zip-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-win-arm64.zip
-[win-arm64-zip-checksum-5.0.2XX]: https://aka.ms/dotnet/5.0.2xx/daily/Sdk/dotnet-sdk-win-arm64.zip.sha
 
 [sdk-shas-2.2.1XX]: https://github.com/dotnet/versions/tree/master/build-info/dotnet/product/cli/release/2.2#built-repositories
 

--- a/tools/sdk-readme-table-generator/TableGenerator/Program.fs
+++ b/tools/sdk-readme-table-generator/TableGenerator/Program.fs
@@ -14,22 +14,7 @@ let inputBranches =
             AkaMsChannel = Some("7.0.1xx-preview4/daily") }
           { GitBranchName = "release/6.0.4xx"
             DisplayName = "Release/6.0.4XX<br>(6.0.x&nbsp;Runtime)"
-            AkaMsChannel = Some("6.0.4xx/daily") }
-          { GitBranchName = "release/6.0.3xx"
-            DisplayName = "Release/6.0.3XX<br>(6.0.x&nbsp;Runtime)"
-            AkaMsChannel = Some("6.0.3xx/daily") }
-          { GitBranchName = "release/6.0.1xx"
-            DisplayName = "Release/6.0.1XX<br>(6.0.x&nbsp;Runtime)"
-            AkaMsChannel = Some("6.0.1xx/daily") }
-          { GitBranchName = "release/5.0.4xx"
-            DisplayName = "Release/5.0.4XX<br>(5.0 Runtime)"
-            AkaMsChannel = Some("5.0.4xx/daily") }
-          { GitBranchName = "release/5.0.2xx"
-            DisplayName = "Release/5.0.2XX<br>(5.0 Runtime)"
-            AkaMsChannel = Some("5.0.2xx/daily") }
-          { GitBranchName = "release/3.1.4xx"
-            DisplayName = "Release/3.1.4XX<br>(3.1.x Runtime)"
-            AkaMsChannel = None }]
+            AkaMsChannel = Some("6.0.4xx/daily") }]
 
 
 let referentNotes = """Reference notes:


### PR DESCRIPTION
We realized that some customers were installing the daily servicing builds. These builds only included public changes to the installer repo itself and didn't include any changes from the SDK repo or any other upstream repos. This is because all codeflow and upstream changes are done in private repos to avoid security disclosure. 

Removing these links as they are only useful for testing changes to installer only which was confusing customers.