### PR TITLE
Remove sha from source tarball repo dir names

### DIFF
--- a/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
+++ b/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
@@ -119,7 +119,7 @@
 
     <Message Text="--> Start Cloning Repo $(SourceBuildRepoName)" Importance="High" />
     <PropertyGroup>
-      <SourceDir>$(SourceBuildRepoName).$(RepoSha)/</SourceDir>
+      <SourceDir>$(SourceBuildRepoName)/</SourceDir>
       <TarballRepoSourceDir>$(TarballSourceDir)$(SourceDir)</TarballRepoSourceDir>
       <TarballRepoSourceEngDir>$(TarballSourceDir)$(SourceDir)eng/</TarballRepoSourceEngDir>
       <TarballVersionDetailsFile>$(TarballRepoSourceEngDir)Version.Details.xml</TarballVersionDetailsFile>

--- a/src/SourceBuild/tarball/content/prep.sh
+++ b/src/SourceBuild/tarball/content/prep.sh
@@ -108,7 +108,7 @@ if [ "$buildBootstrap" == "true" ]; then
     cp $SCRIPT_ROOT/scripts/bootstrap/buildBootstrapPreviouslySB.csproj $workingDir
 
     # Copy NuGet.config from the installer repo to have the right feeds
-    cp $SCRIPT_ROOT/src/installer.*/NuGet.config $workingDir
+    cp $SCRIPT_ROOT/src/installer/NuGet.config $workingDir
 
     # Get PackageVersions.props from existing prev-sb archive
     echo "  Retrieving PackageVersions.props from existing archive"

--- a/src/SourceBuild/tarball/content/repos/Directory.Build.props
+++ b/src/SourceBuild/tarball/content/repos/Directory.Build.props
@@ -11,7 +11,7 @@
 
   <PropertyGroup>
     <SourceDirectory Condition="'$(SourceDirectory)' == ''">$(RepositoryName)</SourceDirectory>
-    <ProjectDirectory Condition="'$(ProjectDirectory)' == ''">$(SubmoduleDirectory)$(SourceDirectory).$(GitCommitHash)/</ProjectDirectory>
+    <ProjectDirectory Condition="'$(ProjectDirectory)' == ''">$(SubmoduleDirectory)$(SourceDirectory)/</ProjectDirectory>
     <MinimalConsoleLogOutput Condition="'$(MinimalConsoleLogOutput)' == ''">true</MinimalConsoleLogOutput>
     <RepoConsoleLogFile>$(LoggingDir)$(RepositoryName).log</RepoConsoleLogFile>
     <RedirectRepoOutputToLog Condition="'$(MinimalConsoleLogOutput)' == 'true'">&gt;&gt; $(RepoConsoleLogFile) 2&gt;&amp;1</RedirectRepoOutputToLog>

--- a/src/SourceBuild/tarball/content/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection.csproj
+++ b/src/SourceBuild/tarball/content/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core">
       <Version>15.7.179</Version>
     </PackageReference>
-    <ProjectReference Include="$(SubmoduleDirectory)linker.$(linkerGitCommitHash)/external/cecil/Mono.Cecil.csproj">
+    <ProjectReference Include="$(SubmoduleDirectory)linker/external/cecil/Mono.Cecil.csproj">
       <SetConfiguration Condition=" '$(Configuration)' == 'Debug' ">Configuration=netstandard_Debug</SetConfiguration>
       <SetConfiguration Condition=" '$(Configuration)' == 'Release' ">Configuration=netstandard_Release</SetConfiguration>
       <Project>{D68133BD-1E63-496E-9EDE-4FBDBF77B486}</Project>


### PR DESCRIPTION
Cherry-picking changes from https://github.com/dotnet/installer/pull/13726 and https://github.com/dotnet/installer/pull/13745 into main.  For some reason these changes didn't flow.
