### PR TITLE
Update MAUI GA manifests

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -193,12 +193,12 @@
   </PropertyGroup>
   <!-- Workload manifest package versions -->
   <PropertyGroup>
-    <MauiWorkloadManifestVersion>6.0.300-rc.1.5355</MauiWorkloadManifestVersion>
-    <XamarinAndroidWorkloadManifestVersion>32.0.300-rc.1.4</XamarinAndroidWorkloadManifestVersion>
-    <XamarinIOSWorkloadManifestVersion>15.4.100-rc.1.125</XamarinIOSWorkloadManifestVersion>
-    <XamarinMacCatalystWorkloadManifestVersion>15.4.100-rc.1.125</XamarinMacCatalystWorkloadManifestVersion>
-    <XamarinMacOSWorkloadManifestVersion>12.3.100-rc.1.125</XamarinMacOSWorkloadManifestVersion>
-    <XamarinTvOSWorkloadManifestVersion>15.4.100-rc.1.125</XamarinTvOSWorkloadManifestVersion>
+    <MauiWorkloadManifestVersion>6.0.312</MauiWorkloadManifestVersion>
+    <XamarinAndroidWorkloadManifestVersion>32.0.301</XamarinAndroidWorkloadManifestVersion>
+    <XamarinIOSWorkloadManifestVersion>15.4.303</XamarinIOSWorkloadManifestVersion>
+    <XamarinMacCatalystWorkloadManifestVersion>15.4.303</XamarinMacCatalystWorkloadManifestVersion>
+    <XamarinMacOSWorkloadManifestVersion>12.3.303</XamarinMacOSWorkloadManifestVersion>
+    <XamarinTvOSWorkloadManifestVersion>15.4.303</XamarinTvOSWorkloadManifestVersion>
     <MonoWorkloadManifestVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MonoWorkloadManifestVersion>
     <MicrosoftNETWorkloadEmscriptenManifest70100Version>7.0.0-preview.5.22252.1</MicrosoftNETWorkloadEmscriptenManifest70100Version>
     <EmscriptenWorkloadManifestVersion>$(MicrosoftNETWorkloadEmscriptenManifest70100Version)</EmscriptenWorkloadManifestVersion>

--- a/src/redist/targets/BundledManifests.targets
+++ b/src/redist/targets/BundledManifests.targets
@@ -1,5 +1,11 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
+    <BundledManifests Include="Microsoft.NET.Sdk.Android" FeatureBand="6.0.300" Version="$(XamarinAndroidWorkloadManifestVersion)" />
+    <BundledManifests Include="Microsoft.NET.Sdk.iOS" FeatureBand="6.0.300" Version="$(XamarinIOSWorkloadManifestVersion)" />
+    <BundledManifests Include="Microsoft.NET.Sdk.MacCatalyst" FeatureBand="6.0.300" Version="$(XamarinMacCatalystWorkloadManifestVersion)" />
+    <BundledManifests Include="Microsoft.NET.Sdk.macOS" FeatureBand="6.0.300" Version="$(XamarinMacOSWorkloadManifestVersion)" />
+    <BundledManifests Include="Microsoft.NET.Sdk.Maui" FeatureBand="6.0.300" Version="$(MauiWorkloadManifestVersion)" />
+    <BundledManifests Include="Microsoft.NET.Sdk.tvOS" FeatureBand="6.0.300" Version="$(XamarinTvOSWorkloadManifestVersion)" />
     <BundledManifests Include="Microsoft.NET.Workload.Mono.ToolChain" FeatureBand="7.0.100" Version="$(MonoWorkloadManifestVersion)" />
     <BundledManifests Include="Microsoft.NET.Workload.Emscripten" FeatureBand="7.0.100" Version="$(EmscriptenWorkloadManifestVersion)" />
   </ItemGroup>


### PR DESCRIPTION
This partially reverts c365b60b, and adds MAUI 6.0.300 manifests to
the .NET 7 SDK.

After `.\build.cmd -pack -publish`, manually tested the workloads:

    > .\bin\redist\Debug\dotnet\dotnet.exe workload install android --skip-manifest-update
    Installing pack Microsoft.Android.Sdk version 32.0.301...

I could `dotnet new android` and the app would build & run using:

    ~\.nuget\packages\microsoft.netcore.app.runtime.mono.android-arm64\6.0.5\runtimes\android-arm64\native\libmonosgen-2.0.so

Next, I installed `artifacts\packages\Debug\Shipping\dotnet-sdk-7.0.100-dev-win-x64.exe`
and installed the `maui` workload:

    > dotnet workload install maui --skip-manifest-update
    Skipping NuGet package signature verification.
    ...
    Successfully installed workload(s) maui.

After this I could still open Visual Studio, create MAUI projects, and
build/run them.

In a future PR, we can update the SDK to use .NET 7 workloads. We are
still working on getting every platform & pack under MAUI over to .NET 7.