### PR TITLE
[release/6.0.4xx] Update MAUI GA manifests

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -176,13 +176,13 @@
   </PropertyGroup>
   <!-- Workload manifest package versions -->
   <PropertyGroup>
-    <MauiWorkloadManifestVersion>6.0.300-rc.1.5355</MauiWorkloadManifestVersion>
-    <XamarinAndroidWorkloadManifestVersion>32.0.300-rc.1.4</XamarinAndroidWorkloadManifestVersion>
-    <XamarinIOSWorkloadManifestVersion>15.4.100-rc.1.125</XamarinIOSWorkloadManifestVersion>
-    <XamarinMacCatalystWorkloadManifestVersion>15.4.100-rc.1.125</XamarinMacCatalystWorkloadManifestVersion>
-    <XamarinMacOSWorkloadManifestVersion>12.3.100-rc.1.125</XamarinMacOSWorkloadManifestVersion>
-    <XamarinTvOSWorkloadManifestVersion>15.4.100-rc.1.125</XamarinTvOSWorkloadManifestVersion>
-    <MonoWorkloadManifestVersion>6.0.4</MonoWorkloadManifestVersion>
+    <MauiWorkloadManifestVersion>6.0.312</MauiWorkloadManifestVersion>
+    <XamarinAndroidWorkloadManifestVersion>32.0.301</XamarinAndroidWorkloadManifestVersion>
+    <XamarinIOSWorkloadManifestVersion>15.4.303</XamarinIOSWorkloadManifestVersion>
+    <XamarinMacCatalystWorkloadManifestVersion>15.4.303</XamarinMacCatalystWorkloadManifestVersion>
+    <XamarinMacOSWorkloadManifestVersion>12.3.303</XamarinMacOSWorkloadManifestVersion>
+    <XamarinTvOSWorkloadManifestVersion>15.4.303</XamarinTvOSWorkloadManifestVersion>
+    <MonoWorkloadManifestVersion>6.0.5</MonoWorkloadManifestVersion>
     <MicrosoftNETWorkloadEmscriptenManifest60200Version>6.0.4</MicrosoftNETWorkloadEmscriptenManifest60200Version>
     <EmscriptenWorkloadManifestVersion>$(MicrosoftNETWorkloadEmscriptenManifest60200Version)</EmscriptenWorkloadManifestVersion>
   </PropertyGroup>


### PR DESCRIPTION
Context: https://aka.ms/dotnet/maui/6.0.300.json

Update to MAUI GA releases.

After `.\build.cmd -pack -publish`, manually tested the workloads:

    > .\bin\redist\Debug\dotnet\dotnet.exe workload install android --skip-manifest-update
    Installing pack Microsoft.Android.Sdk version 32.0.301...
    ...
    Installing pack Microsoft.NETCore.App.Runtime.Mono.android-arm version 6.0.5...

I updated `$(MonoWorkloadManifestVersion)` as we require at least
6.0.5 in MAUI GA.
