### PR TITLE
Update GenerateBundledVersions.targets

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -27,7 +27,7 @@
   <PropertyGroup>
       <VersionFeature21>30</VersionFeature21>
       <VersionFeature31>$([MSBuild]::Add($(VersionFeature), 20))</VersionFeature31>
-      <VersionFeature50>$([MSBuild]::Add($(VersionFeature), 12))</VersionFeature50>
+      <VersionFeature50>17</VersionFeature50>
   </PropertyGroup>
 
   <Target Name="GenerateBundledVersionsProps" DependsOnTargets="SetupBundledComponents">


### PR DESCRIPTION
5.0 is out of support and 17 is the last one