### PR TITLE
Remove the welcome text from the postinstall scripts in favor of the first run experience

### DIFF
--- a/src/redist/targets/packaging/deb/postinst
+++ b/src/redist/targets/packaging/deb/postinst
@@ -1,22 +1,4 @@
 #!/usr/bin/env sh
-echo "This software may collect information about you and your use of the software, and send that to Microsoft."
-echo "Please visit http://aka.ms/dotnet-cli-eula for more information."
-
-# Run 'dotnet new' to trigger the first time experience to initialize the cache
-echo "Welcome to .NET!
----------------------
-Learn more about .NET: https://aka.ms/dotnet-docs
-Use 'dotnet --help' to see available commands or visit: https://aka.ms/dotnet-cli-docs
-
-Telemetry
----------
-The .NET tools collect usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the DOTNET_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
-
-Read more about .NET CLI Tools telemetry: https://aka.ms/dotnet-cli-telemetry
-
-Configuring...
---------------
-A command is running to populate your local package cache to improve restore speed and enable offline access. This command takes up to one minute to complete and only runs once."
 
 first_run() {
     /usr/share/dotnet/dotnet exec /usr/share/dotnet/sdk/%SDK_VERSION%/dotnet.dll internal-reportinstallsuccess "debianpackage" > /dev/null 2>&1 || true

--- a/src/redist/targets/packaging/rpm/scripts/after_install_host.sh
+++ b/src/redist/targets/packaging/rpm/scripts/after_install_host.sh
@@ -3,24 +3,6 @@
 # Copyright (c) .NET Foundation and contributors. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #
-echo "This software may collect information about you and your use of the software, and send that to Microsoft."
-echo "Please visit http://aka.ms/dotnet-cli-eula for more information."
-
-# Run 'dotnet new' as the user to trigger the first time experience to initialize the cache
-echo "Welcome to .NET!
----------------------
-Learn more about .NET: https://aka.ms/dotnet-docs
-Use 'dotnet --help' to see available commands or visit: https://aka.ms/dotnet-cli-docs
-
-Telemetry
----------
-The .NET tools collect usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the DOTNET_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
-
-Read more about .NET CLI Tools telemetry: https://aka.ms/dotnet-cli-telemetry
-
-Configuring...
---------------
-A command is running to populate your local package cache to improve restore speed and enable offline access. This command takes up to one minute to complete and only runs once."
 
 first_run() {
     /usr/share/dotnet/dotnet exec /usr/share/dotnet/sdk/%SDK_VERSION%/dotnet.dll internal-reportinstallsuccess "rpmpackage" > /dev/null 2>&1 || true


### PR DESCRIPTION
Fixes #13751 by removing all post install informational text since that's already covered by the first run experience.