### PR TITLE
Fixups to make the tarball committable

### DIFF
--- a/src/SourceBuild/Arcade/src/Tarball_WriteSourceRepoProperties.cs
+++ b/src/SourceBuild/Arcade/src/Tarball_WriteSourceRepoProperties.cs
@@ -72,6 +72,7 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
                     ["OutputPackageVersion"] = dependency.Version,
                     ["PreReleaseVersionLabel"] = derivedVersion.PreReleaseVersionLabel,
                     ["IsStable"] = string.IsNullOrWhiteSpace(derivedVersion.PreReleaseVersionLabel) ? "true" : "false",
+                    ["Uri"] = dependency.Uri,
                 };
                 if (!string.IsNullOrEmpty(dependency.GitCommitCount))
                 {

--- a/src/SourceBuild/Arcade/src/Tarball_WriteSourceRepoProperties.cs
+++ b/src/SourceBuild/Arcade/src/Tarball_WriteSourceRepoProperties.cs
@@ -72,7 +72,6 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
                     ["OutputPackageVersion"] = dependency.Version,
                     ["PreReleaseVersionLabel"] = derivedVersion.PreReleaseVersionLabel,
                     ["IsStable"] = string.IsNullOrWhiteSpace(derivedVersion.PreReleaseVersionLabel) ? "true" : "false",
-                    ["Uri"] = dependency.Uri,
                 };
                 if (!string.IsNullOrEmpty(dependency.GitCommitCount))
                 {

--- a/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
+++ b/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
@@ -176,12 +176,6 @@
       Command="git submodule update --init --recursive --depth 1"
       WorkingDirectory="$(TarballRepoSourceDir)" />
 
-    <!-- Remove the git objects folder to free up tarball space -->
-    <Exec
-      Command="git submodule foreach 'rm -rf %24%28git rev-parse --git-dir%29/objects ||:'"
-      WorkingDirectory="$(TarballRepoSourceDir)"
-      Condition="$(PreserveTarballGitFolders) != 'true' AND '$(SourceBuildRepoName)' != 'source-build'" />
-
     <Exec
       Command="git config --file $(TarballRepoSourceDir)/.git/config --unset remote.origin.url"
       WorkingDirectory="$(RepoRoot)"/>
@@ -190,6 +184,7 @@
       Command="git config --file $(TarballRepoSourceDir)/.git/config --add remote.origin.url $(OriginalRepoUri)"
       WorkingDirectory="$(RepoRoot)"/>
 
+    <!-- Remove the git objects folder to free up tarball space -->
     <Exec
       Command="rm -rf objects"
       WorkingDirectory="$(TarballRepoSourceDir).git"

--- a/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
+++ b/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
@@ -124,6 +124,7 @@
       <TarballRepoSourceEngDir>$(TarballSourceDir)$(SourceDir)eng/</TarballRepoSourceEngDir>
       <TarballVersionDetailsFile>$(TarballRepoSourceEngDir)Version.Details.xml</TarballVersionDetailsFile>
       <CloneParam Condition=" '$(CloneVerbosity)' == 'quiet' ">-q</CloneParam>
+      <OriginalRepoUri>$(RepoUri)</OriginalRepoUri>
       <RepoUri Condition=" '$(AzDoPat)' != '' ">$(RepoUri.Replace('https://dev.azure.com', 'https://dn-bot:$(AzDoPat)@dev.azure.com'))</RepoUri>
     </PropertyGroup>
 
@@ -186,7 +187,7 @@
       WorkingDirectory="$(RepoRoot)"/>
 
     <Exec
-      Command="git config --file $(TarballRepoSourceDir)/.git/config --add remote.origin.url $(RepoUri)"
+      Command="git config --file $(TarballRepoSourceDir)/.git/config --add remote.origin.url $(OriginalRepoUri)"
       WorkingDirectory="$(RepoRoot)"/>
 
     <Exec

--- a/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
+++ b/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
@@ -177,8 +177,21 @@
 
     <!-- Remove the git objects folder to free up tarball space -->
     <Exec
+      Command="git submodule foreach 'rm -rf %24%28git rev-parse --git-dir%29/objects ||:'"
+      WorkingDirectory="$(TarballRepoSourceDir)"
+      Condition="$(PreserveTarballGitFolders) != 'true' AND '$(SourceBuildRepoName)' != 'source-build'" />
+
+    <Exec
+      Command="git config --file $(TarballRepoSourceDir)/.git/config --unset remote.origin.url"
+      WorkingDirectory="$(RepoRoot)"/>
+
+    <Exec
+      Command="git config --file $(TarballRepoSourceDir)/.git/config --add remote.origin.url $(RepoUri)"
+      WorkingDirectory="$(RepoRoot)"/>
+
+    <Exec
       Command="rm -rf objects"
-      WorkingDirectory="$(TarballRepoSourceDir).git" 
+      WorkingDirectory="$(TarballRepoSourceDir).git"
       Condition="$(PreserveTarballGitFolders) != 'true'" />
 
     <Message Text="--> Done Cloning Repo $(SourceBuildRepoName)" Importance="High" />


### PR DESCRIPTION
These changes should make the tarball able to be committed to a git repo, then later checked out and built without problems or loss of functionality.
- Make the original git repo URL available in git-info.props.
- Delete the `objects` directory in submodule `.git` folders so they are treated the same way as top-level repo `.git` directories (ignored).
- Set the origin URL to the original git repo URL after cloning to replace the local path it would otherwise have.