### PR TITLE
Add support for ppc64le architecture

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,7 @@
     <BuildArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</BuildArchitecture>
     <Architecture Condition="'$(Architecture)' == '' AND '$(BuildArchitecture)' == 'arm64'">$(BuildArchitecture)</Architecture>
     <Architecture Condition="'$(Architecture)' == '' AND '$(BuildArchitecture)' == 's390x'">$(BuildArchitecture)</Architecture>
+    <Architecture Condition="'$(Architecture)' == '' AND '$(BuildArchitecture)' == 'ppc64le'">$(BuildArchitecture)</Architecture>
     <Architecture Condition="'$(Architecture)' == ''">x64</Architecture>
   </PropertyGroup>
   <PropertyGroup Condition="'$(PgoInstrument)' == 'true'">

--- a/src/SourceBuild/tarball/content/Directory.Build.props
+++ b/src/SourceBuild/tarball/content/Directory.Build.props
@@ -19,6 +19,7 @@
     <BuildArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</BuildArchitecture>
     <Platform Condition="'$(Platform)' == '' AND '$(BuildArchitecture)' == 'arm64'">$(BuildArchitecture)</Platform>
     <Platform Condition="'$(Platform)' == '' AND '$(BuildArchitecture)' == 's390x'">$(BuildArchitecture)</Platform>
+    <Platform Condition="'$(Platform)' == '' AND '$(BuildArchitecture)' == 'ppc64le'">$(BuildArchitecture)</Platform>
     <Platform Condition="'$(Platform)' == ''">x64</Platform>
 
     <UseStableVersions Condition="'$(UseStableVersions)' == ''">false</UseStableVersions>

--- a/src/redist/targets/Crossgen.targets
+++ b/src/redist/targets/Crossgen.targets
@@ -1,7 +1,7 @@
 <Project>
   <!-- Crossgen is currently not supported on the s390x architecture. -->
   <Target Name="CrossgenLayout"
-          Condition="'$(DISABLE_CROSSGEN)' == '' AND '$(Architecture)' != 's390x'"
+          Condition="'$(DISABLE_CROSSGEN)' == '' AND '$(Architecture)' != 's390x' AND '$(Architecture)' != 'ppc64le'"
           DependsOnTargets="SetSdkBrandingInfo">
     
     <PropertyGroup>

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -149,19 +149,6 @@
           @(Net50AppHostRids);
           osx-arm64;
           linux-s390x;
-          "/>
-
-      <Net60RuntimePackRids Include="
-          @(Net50RuntimePackRids);
-          osx-arm64;
-          maccatalyst-x64;
-          maccatalyst-arm64;
-          linux-s390x;
-          " />
-
-      <Net60AppHostRids Include="
-          @(Net50AppHostRids);
-          osx-arm64;
           linux-ppc64le;
           "/>
 
@@ -170,6 +157,7 @@
           osx-arm64;
           maccatalyst-x64;
           maccatalyst-arm64;
+          linux-s390x;
           linux-ppc64le;
           " />
 

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -159,6 +159,20 @@
           linux-s390x;
           " />
 
+      <Net60AppHostRids Include="
+          @(Net50AppHostRids);
+          osx-arm64;
+          linux-ppc64le;
+          "/>
+
+      <Net60RuntimePackRids Include="
+          @(Net50RuntimePackRids);
+          osx-arm64;
+          maccatalyst-x64;
+          maccatalyst-arm64;
+          linux-ppc64le;
+          " />
+
       <!-- In .NET 6 the browser-wasm runtime pack started using the Mono naming pattern -->
       <Net60RuntimePackRids Remove="browser-wasm" />
 
@@ -232,7 +246,7 @@
 
       <AspNetCore31RuntimePackRids Include="@(AspNetCore30RuntimePackRids)" />
       <AspNetCore50RuntimePackRids Include="@(AspNetCore31RuntimePackRids);linux-musl-arm;win-arm64" />
-      <AspNetCoreRuntimePackRids Include="@(AspNetCore50RuntimePackRids);osx-arm64;linux-s390x" />
+      <AspNetCoreRuntimePackRids Include="@(AspNetCore50RuntimePackRids);osx-arm64;linux-s390x;linux-ppc64le" />
 
       <WindowsDesktop30RuntimePackRids Include="win-x64;win-x86" />
       <WindowsDesktop31RuntimePackRids Include="@(WindowsDesktop30RuntimePackRids)" />


### PR DESCRIPTION
- Add ppc64le platform in Directory.Build.props
- Disable crossgen2 for the ppc64le target
- Add linux-ppc64le RIDs for net6.0 to GenerateBundledVersions