### PR TITLE
Add linux-bionic-* known runtime packs

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -162,8 +162,16 @@
       <!-- In .NET 6 the browser-wasm runtime pack started using the Mono naming pattern -->
       <Net60RuntimePackRids Remove="browser-wasm" />
 
-      <NetCoreAppHostRids Include="@(Net60AppHostRids)" />
-      <NetCoreRuntimePackRids Include="@(Net60RuntimePackRids)" />
+      <NetCoreAppHostRids Include="
+          @(Net60AppHostRids);
+          linux-bionic-arm64;
+          linux-bionic-x64;
+          " />
+      <NetCoreRuntimePackRids Include="
+          @(Net60RuntimePackRids);
+          linux-bionic-arm64;
+          linux-bionic-x64;
+          " />
 
       <!--
         In source-build, we build the current RID from source, which may be

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -162,15 +162,28 @@
       <!-- In .NET 6 the browser-wasm runtime pack started using the Mono naming pattern -->
       <Net60RuntimePackRids Remove="browser-wasm" />
 
-      <NetCoreAppHostRids Include="
+      <Net70AppHostRids Include="
           @(Net60AppHostRids);
+          linux-bionic-arm;
           linux-bionic-arm64;
           linux-bionic-x64;
-          " />
-      <NetCoreRuntimePackRids Include="
+          linux-bionic-x86;
+          "/>
+
+      <Net70RuntimePackRids Include="
           @(Net60RuntimePackRids);
+          linux-bionic-arm;
           linux-bionic-arm64;
           linux-bionic-x64;
+          linux-bionic-x86;
+          " />
+
+      <NetCoreAppHostRids Include="
+          @(Net70AppHostRids);
+          " />
+
+      <NetCoreRuntimePackRids Include="
+          @(Net70RuntimePackRids);
           " />
 
       <!--

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -501,7 +501,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                       TargetFramework="net6.0"
                       AppHostPackNamePattern="Microsoft.NETCore.App.Host.**RID**"
                       AppHostPackVersion="$(_NET60RuntimePackVersion)"
-                      AppHostRuntimeIdentifiers="@(NetCoreAppHostRids, '%3B')"
+                      AppHostRuntimeIdentifiers="@(NetCore60AppHostRids, '%3B')"
                       />
 
     <KnownCrossgen2Pack Include="Microsoft.NETCore.App.Crossgen2"

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -501,7 +501,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                       TargetFramework="net6.0"
                       AppHostPackNamePattern="Microsoft.NETCore.App.Host.**RID**"
                       AppHostPackVersion="$(_NET60RuntimePackVersion)"
-                      AppHostRuntimeIdentifiers="@(NetCore60AppHostRids, '%3B')"
+                      AppHostRuntimeIdentifiers="@(Net60AppHostRids, '%3B')"
                       />
 
     <KnownCrossgen2Pack Include="Microsoft.NETCore.App.Crossgen2"


### PR DESCRIPTION
Without this, `dotnet publish -r linux-bionic-x64` uses vanilla linux-x64. We need to be added to both AppHost and RuntimePack lists, otherwise we end up with a good app but wrong libhostfxr.