### PR TITLE
Disable test that's downloading an out of support 3.0 runtime pack.

### DIFF
--- a/test/SdkTests/TestConfig.xml
+++ b/test/SdkTests/TestConfig.xml
@@ -181,5 +181,9 @@
             Skip="true"
             Issue=""
             Reason="Targets out of support aspnet"/>
+    <Method Name="Microsoft.NET.Build.Tests.GivenWeWantToRequireWindowsForDesktopApps.It_does_not_download_desktop_runtime_packs_on_unix"
+            Skip="true"
+            Issue=""
+            Reason="Targets out of support runtime"/>
   </SkippedTests>
 </Tests>


### PR DESCRIPTION
- Please add description for changes you are making.
- If there is an issue related to this PR, please add the reference.
