### PR TITLE
Fix cross-gen for DumpMinitool

### DIFF
--- a/src/redist/targets/Crossgen.targets
+++ b/src/redist/targets/Crossgen.targets
@@ -41,8 +41,10 @@
       
       <RemainingFiles Include="$(SdkOutputDirectory)**\*" Exclude="$(SdkOutputDirectory)FSharp\FSharp.Build.dll;@(RoslynFiles);@(FSharpFiles)" />
 
-      <!-- Removing Full CLR built TestHost assemblies from getting Crossgen as it is throwing error -->
+      <!-- Removing Full CLR built TestHost assemblies from getting Crossgen as it is throwing error, and they need to stay their original architecture. -->
       <RemainingFiles Remove="$(SdkOutputDirectory)TestHost*\**\*" />
+      <!-- Removing Full CLR built DumpMiniTool executables from Crossgen, because they need to stay their original architecture to allow creating dumps with a given bitness. -->
+      <RemainingFiles Remove="$(SdkOutputDirectory)Extensions\dump*\**\*" />
       <RemainingFiles Remove="$(SdkOutputDirectory)Sdks\**\*" />
       <RemainingFiles Remove="$(SdkOutputDirectory)**\Microsoft.TestPlatform.Extensions.EventLogCollector.dll" />
 


### PR DESCRIPTION
Exclude DumpMinitool from cross gen because it prevents it from starting. 

On Windows when we create a hang dump of a process, we need to ensure that the native minidump api is called from a process that has the same bitness as the target process. If we fail to do that dotnet test produces a 64-bit dump of 32-bit process which is unusable for debugging. For this reason there is DumpMinitool.*.exe shipped for each supported architecture, which must remain as is rather than being crossgened.

Half of a fix for https://github.com/dotnet/sdk/issues/25421