### PR TITLE
[release/6.0.4xx] Fix cross-gen for DumpMinitool

### DIFF
--- a/src/redist/targets/Crossgen.targets
+++ b/src/redist/targets/Crossgen.targets
@@ -44,7 +44,7 @@
       <!-- Removing Full CLR built TestHost assemblies from getting Crossgen as it is throwing error, and they need to stay their original architecture. -->
       <RemainingFiles Remove="$(SdkOutputDirectory)TestHost*\**\*" />
       <!-- Removing Full CLR built DumpMiniTool executables from Crossgen, because they need to stay their original architecture to allow creating dumps with a given bitness. -->
-      <RemainingFiles Remove="$(SdkOutputDirectory)Extensions\DumpMinitool*.exe" />
+      <RemainingFiles Remove="$(SdkOutputDirectory)Extensions\**\*" />
       <RemainingFiles Remove="$(SdkOutputDirectory)Sdks\**\*" />
       <RemainingFiles Remove="$(SdkOutputDirectory)**\Microsoft.TestPlatform.Extensions.EventLogCollector.dll" />
 

--- a/src/redist/targets/Crossgen.targets
+++ b/src/redist/targets/Crossgen.targets
@@ -44,7 +44,7 @@
       <!-- Removing Full CLR built TestHost assemblies from getting Crossgen as it is throwing error, and they need to stay their original architecture. -->
       <RemainingFiles Remove="$(SdkOutputDirectory)TestHost*\**\*" />
       <!-- Removing Full CLR built DumpMiniTool executables from Crossgen, because they need to stay their original architecture to allow creating dumps with a given bitness. -->
-      <RemainingFiles Remove="$(SdkOutputDirectory)Extensions\dump*\**\*" />
+      <RemainingFiles Remove="$(SdkOutputDirectory)Extensions\DumpMinitool*.exe" />
       <RemainingFiles Remove="$(SdkOutputDirectory)Sdks\**\*" />
       <RemainingFiles Remove="$(SdkOutputDirectory)**\Microsoft.TestPlatform.Extensions.EventLogCollector.dll" />
 


### PR DESCRIPTION
Exclude DumpMinitool from cross gen because it prevents it from starting.

On Windows when we create a hang dump of a process, we need to ensure that the native minidump api is called from a process that has the same bitness as the target process. If we fail to do that dotnet test produces a 64-bit dump of 32-bit process which is unusable for debugging. For this reason, there is DumpMinitool.*.exe shipped for each supported architecture, which must remain as is rather than being crossgened.

Fix for dotnet/sdk#25421
Fix for #13942 (That PR was cherrypicked from .NET7, but the the path to those tools differs from .NET 7).