### PR TITLE
Update source-build patches with backporting issues/PRs

### DIFF
--- a/src/SourceBuild/tarball/patches/arcade/0001-Retarget-arcade-projects-to-net7.0.patch
+++ b/src/SourceBuild/tarball/patches/arcade/0001-Retarget-arcade-projects-to-net7.0.patch
@@ -3,7 +3,7 @@ From: Logan Bussell <loganbussell@microsoft.com>
 Date: Tue, 19 Apr 2022 14:29:27 -0700
 Subject: [PATCH] Retarget arcade projects to net7.0
 
-Backport PR: https://github.com/dotnet/arcade/pull/9127 
+Backport: https://github.com/dotnet/arcade/pull/9127
 ---
  eng/SourceBuild.props                         | 35 -------------------
  eng/TargetFrameworkDefaults.props             |  7 +---

--- a/src/SourceBuild/tarball/patches/arcade/0001-look-for-arcade-assemblies-in-net6.0-artifacts-direc.patch
+++ b/src/SourceBuild/tarball/patches/arcade/0001-look-for-arcade-assemblies-in-net6.0-artifacts-direc.patch
@@ -3,6 +3,7 @@ From: Logan Bussell <loganbussell@microsoft.com>
 Date: Mon, 25 Apr 2022 15:07:55 -0700
 Subject: [PATCH] look for arcade assemblies in net6.0 artifacts directory
 
+Workaround for: https://github.com/dotnet/arcade/pull/9127
 ---
  eng/common/tools.sh | 2 ++
  1 file changed, 2 insertions(+)

--- a/src/SourceBuild/tarball/patches/aspnetcore/0001-Revert-sourcelink-submodule-workaround.patch
+++ b/src/SourceBuild/tarball/patches/aspnetcore/0001-Revert-sourcelink-submodule-workaround.patch
@@ -5,6 +5,8 @@ Subject: [PATCH] Revert sourcelink submodule workaround
 
 aspnetcore will fail the offline tarball build because of the sourcelink workaround being removed here.
 To fix this, a sourcelink patch was added to address the issue.
+
+Backport: https://github.com/dotnet/source-build/issues/2708
 ---
  eng/SourceBuild.props | 14 --------------
  1 file changed, 14 deletions(-)

--- a/src/SourceBuild/tarball/patches/aspnetcore/0002-Disable-warning-CS0618.patch
+++ b/src/SourceBuild/tarball/patches/aspnetcore/0002-Disable-warning-CS0618.patch
@@ -5,6 +5,8 @@ Subject: [PATCH] Disable warning CS0618
 
 This is needed because IOperation.Children is deprecated in
 Microsoft.CodeAnalysis 4.3.0, but aspnetcore references version 4.2.0.
+
+Requires https://github.com/dotnet/source-build/issues/2482 in order to eliminate this patch
 ---
  .../src/Microsoft.AspNetCore.Mvc.Api.Analyzers.csproj            | 1 +
  1 file changed, 1 insertion(+)

--- a/src/SourceBuild/tarball/patches/diagnostics/0001-Pin-the-Microsoft.Extensions.Logging-version-so-that.patch
+++ b/src/SourceBuild/tarball/patches/diagnostics/0001-Pin-the-Microsoft.Extensions.Logging-version-so-that.patch
@@ -4,6 +4,7 @@ Date: Thu, 2 Jun 2022 19:27:41 +0000
 Subject: [PATCH] Pin the Microsoft.Extensions.Logging version so that
  source-build does not pick up latest
 
+Backport: https://github.com/dotnet/diagnostics/pull/3121
 ---
  eng/Versions.props                                            | 2 +-
  .../Microsoft.Diagnostics.Monitoring.EventPipe.csproj         | 2 +-

--- a/src/SourceBuild/tarball/patches/format/0001-Update-nullability-constraints-for-BeginScope-in-Sim.patch
+++ b/src/SourceBuild/tarball/patches/format/0001-Update-nullability-constraints-for-BeginScope-in-Sim.patch
@@ -4,8 +4,7 @@ Date: Mon, 16 May 2022 16:29:43 -0700
 Subject: [PATCH] Update nullability constraints for BeginScope in
  SimpleConsoleLogger
 
-Remove when issue is closed: https://github.com/dotnet/format/issues/1609
-
+Workaround for: https://github.com/dotnet/format/issues/1609
 ---
  src/Logging/SimpleConsoleLogger.cs | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/src/SourceBuild/tarball/patches/nuget-client/0001-Pin-Microsoft.Build-and-Microsoft.Extensions.Command.patch
+++ b/src/SourceBuild/tarball/patches/nuget-client/0001-Pin-Microsoft.Build-and-Microsoft.Extensions.Command.patch
@@ -6,6 +6,8 @@ Subject: [PATCH] Pin Microsoft.Build and
 
 Update package version reference to not pick up the source-build PVP versions and instead utilize SBRP versions 
 so that source-build builds closer to the normal repo build.
+
+Backport: https://github.com/NuGet/NuGet.Client/pull/4643
 ---
  build/packages.targets | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)

--- a/src/SourceBuild/tarball/patches/razor-compiler/0001-Add-NoWarn-for-NU1507.patch
+++ b/src/SourceBuild/tarball/patches/razor-compiler/0001-Add-NoWarn-for-NU1507.patch
@@ -6,8 +6,7 @@ Subject: [PATCH] Add NoWarn for NU1507
 This warning occurs when using NuGet central package management without defining
 any Package Source Mappings.
 
-Remove when issue is closed: https://github.com/dotnet/razor-compiler/issues/242
-
+Workaround for: https://github.com/dotnet/razor-compiler/issues/242
 ---
  Directory.Build.props | 1 +
  1 file changed, 1 insertion(+)

--- a/src/SourceBuild/tarball/patches/roslyn-analyzers/0001-Eliminate-pre-built-assets-during-source-build-for-r.patch
+++ b/src/SourceBuild/tarball/patches/roslyn-analyzers/0001-Eliminate-pre-built-assets-during-source-build-for-r.patch
@@ -14,6 +14,8 @@ This is taking the approach used in previous versions of source-build: update th
 
 Contributes to https://github.com/dotnet/source-build/issues/2420
 Contributes to https://github.com/dotnet/source-build/issues/2527
+
+Backport: https://github.com/dotnet/source-build/issues/2708
 ---
  eng/Versions.props                                 | 14 --------------
  src/Directory.Build.targets                        |  5 +++--

--- a/src/SourceBuild/tarball/patches/roslyn/0001-lift-version-of-Microsoft.CodeAnalysis.Common-depend.patch
+++ b/src/SourceBuild/tarball/patches/roslyn/0001-lift-version-of-Microsoft.CodeAnalysis.Common-depend.patch
@@ -4,6 +4,7 @@ Date: Thu, 21 Oct 2021 23:15:23 +0000
 Subject: [PATCH] lift version of Microsoft.CodeAnalysis.Common dependencies to
  previously source built versions
 
+Requires https://github.com/dotnet/source-build/issues/2482 in order to eliminate this patch
 ---
  .../Source/CSharpSyntaxGenerator/CSharpSyntaxGenerator.csproj | 4 ++++
  1 file changed, 4 insertions(+)

--- a/src/SourceBuild/tarball/patches/runtime/0001-Temporarily-patch-out-native-sourcelink-file-check-i.patch
+++ b/src/SourceBuild/tarball/patches/runtime/0001-Temporarily-patch-out-native-sourcelink-file-check-i.patch
@@ -2,10 +2,9 @@ From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Chris Rummel <crummel@microsoft.com>
 Date: Wed, 1 Jun 2022 10:10:01 -0500
 Subject: [PATCH] Temporarily patch out native sourcelink file check in
- source-build. This returns source-build to its old behavior.  
- https://github.com/dotnet/source-build/issues/2883 tracks the follow-up to
- confirm a proper fix.
+ source-build. This returns source-build to its old behavior.
 
+Backport: https://github.com/dotnet/source-build/issues/2883
 ---
  src/coreclr/runtime-prereqs.proj | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/src/SourceBuild/tarball/patches/sdk/0001-Define-SystemCollectionsImmutableVersion-Versions.pr.patch
+++ b/src/SourceBuild/tarball/patches/sdk/0001-Define-SystemCollectionsImmutableVersion-Versions.pr.patch
@@ -3,6 +3,7 @@ From: MichaelSimons <msimons@microsoft.com>
 Date: Fri, 10 Jun 2022 20:31:15 +0000
 Subject: [PATCH] Define SystemCollectionsImmutableVersion Versions.props
 
+Backport: https://github.com/dotnet/sdk/pull/26007
 ---
  eng/Versions.props                                              | 1 +
  .../Microsoft.NET.Build.Tasks/Microsoft.NET.Build.Tasks.csproj  | 2 +-

--- a/src/SourceBuild/tarball/patches/source-build-reference-packages/0001-look-for-arcade-assemblies-in-net6.0-artifacts-direc.patch
+++ b/src/SourceBuild/tarball/patches/source-build-reference-packages/0001-look-for-arcade-assemblies-in-net6.0-artifacts-direc.patch
@@ -3,6 +3,7 @@ From: Logan Bussell <loganbussell@microsoft.com>
 Date: Mon, 25 Apr 2022 15:07:55 -0700
 Subject: [PATCH] look for arcade assemblies in net6.0 artifacts directory
 
+Workaround for: https://github.com/dotnet/arcade/pull/9127
 ---
  eng/common/tools.sh | 2 ++
  1 file changed, 2 insertions(+)

--- a/src/SourceBuild/tarball/patches/sourcelink/0001-look-for-arcade-assemblies-in-net6.0-artifacts-direc.patch
+++ b/src/SourceBuild/tarball/patches/sourcelink/0001-look-for-arcade-assemblies-in-net6.0-artifacts-direc.patch
@@ -3,6 +3,7 @@ From: Logan Bussell <loganbussell@microsoft.com>
 Date: Mon, 25 Apr 2022 15:07:55 -0700
 Subject: [PATCH] look for arcade assemblies in net6.0 artifacts directory
 
+Workaround for: https://github.com/dotnet/arcade/pull/9127
 ---
  eng/common/tools.sh | 2 ++
  1 file changed, 2 insertions(+)

--- a/src/SourceBuild/tarball/patches/xdt/0001-Also-build-for-netstandard2.0-to-support-NuGet.patch
+++ b/src/SourceBuild/tarball/patches/xdt/0001-Also-build-for-netstandard2.0-to-support-NuGet.patch
@@ -3,8 +3,7 @@ From: Chris Rummel <crummel@microsoft.com>
 Date: Thu, 21 Oct 2021 16:29:32 -0500
 Subject: [PATCH] Also build for netstandard2.0 to support NuGet.
 
-Patch removal is tracked by https://github.com/dotnet/source-build/issues/2557.
-
+Backport: https://github.com/dotnet/source-build/issues/2557.
 ---
  .../Microsoft.Web.XmlTransform.csproj                           | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)


### PR DESCRIPTION
Update source-build patches to include backporting links.  I also updated a few patches that included this info to utilize a consistent format.
