### PR TITLE
[release/6.0.3xx] manually updated MicrosoftDotNetCommonItemTemplatesPackageVersion 

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -31,7 +31,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/templating -->
-    <MicrosoftDotNetCommonItemTemplatesPackageVersion>6.0.300</MicrosoftDotNetCommonItemTemplatesPackageVersion>
+    <MicrosoftDotNetCommonItemTemplatesPackageVersion>6.0.302</MicrosoftDotNetCommonItemTemplatesPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/test-templates -->


### PR DESCRIPTION
`MicrosoftDotNetCommonItemTemplatesPackageVersion` should match the SDK version. 
Due to dependency flow issue it is not getting automatically updated.
It is important to get it updated as 6.0.301 fixes localization issues.