### PR TITLE
[source-build] [release/6.0.1xx] Additional changes to make the tarball commitable.

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -152,8 +152,8 @@
       <SourceBuildTarball RepoName="msbuild" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="NuGet.Build.Tasks" Version="6.0.2-rc.3" CoherentParentDependency="Microsoft.NET.Sdk">
-      <Uri>https://dev.azure.com/devdiv/DevDiv/_git/NuGet-NuGet.Client-Trusted</Uri>
-      <Sha>a5782faf46b91a7b43935a28d1e185e79a50588a</Sha>
+      <Uri>https://github.com/NuGet/NuGet.Client</Uri>
+      <Sha>75551652b352f860ea0b29095b64fa63715dd672</Sha>
       <SourceBuildTarball RepoName="nuget-client" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.ApplicationInsights" Version="2.0.0">
@@ -170,9 +170,9 @@
       <Uri>https://github.com/dotnet/emsdk</Uri>
       <Sha>52e9452f82e26f9fcae791e84c082ae22f1ef66f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build" Version="0.1.0-alpha.1.21519.2" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build" Version="6.0.0-servicing.22320.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/source-build</Uri>
-      <Sha>10d0f7e94aa45889155c312f51cfc01bf326b853</Sha>
+      <Sha>126aed9b11b5aece8ebcf7bdbb82d0654206d5a4</Sha>
       <SourceBuild RepoName="source-build" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Cli.CommandLine" Version="1.0.0-preview.21310.2">

--- a/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
+++ b/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
@@ -177,6 +177,11 @@
       WorkingDirectory="$(TarballRepoSourceDir)" />
 
     <Exec
+      Command="git submodule foreach 'rm -rf %24%28git rev-parse --git-dir%29/objects ||:'"
+      WorkingDirectory="$(TarballRepoSourceDir)"
+      Condition="$(PreserveTarballGitFolders) != 'true'" />
+
+    <Exec
       Command="git config --file $(TarballRepoSourceDir)/.git/config --unset remote.origin.url"
       WorkingDirectory="$(RepoRoot)"/>
 
@@ -329,6 +334,8 @@
       Overwrite="true" />
 
     <MakeDir Directories="$(TarballRootDir)packages/prebuilt" />
+    <!-- make sure this directory is persisted through source control, NuGet depends on it existing -->
+    <Exec Command="touch $(TarballRootDir)packages/prebuilt/_" />
   </Target>
 
   <!--

--- a/src/SourceBuild/tarball/patches/command-line-api/0001-Enable-work-tree-and-unsafe-paths-to-be-able-to-appl.patch
+++ b/src/SourceBuild/tarball/patches/command-line-api/0001-Enable-work-tree-and-unsafe-paths-to-be-able-to-appl.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Chris Rummel <crummel@microsoft.com>
+Date: Wed, 22 Jun 2022 05:50:57 -0500
+Subject: [PATCH] Enable work-tree and unsafe-paths to be able to apply in the
+ checked-in tarball.
+
+---
+ eng/SourceBuild.props | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/eng/SourceBuild.props b/eng/SourceBuild.props
+index 6cc8501..a862003 100644
+--- a/eng/SourceBuild.props
++++ b/eng/SourceBuild.props
+@@ -15,7 +15,7 @@
+     </ItemGroup>
+ 
+     <Exec
+-      Command="git apply --ignore-whitespace --whitespace=nowarn &quot;%(SourceBuildPatchFile.FullPath)&quot;"
++      Command="git --work-tree=$(RepoRoot) apply --ignore-whitespace --whitespace=nowarn --unsafe-paths &quot;%(SourceBuildPatchFile.FullPath)&quot;"
+       WorkingDirectory="$(RepoRoot)"
+       Condition="'@(SourceBuildPatchFile)' != ''" />
+   </Target>

--- a/src/SourceBuild/tarball/patches/fsharp/0001-Enable-work-tree-and-unsafe-paths-to-be-able-to-appl.patch
+++ b/src/SourceBuild/tarball/patches/fsharp/0001-Enable-work-tree-and-unsafe-paths-to-be-able-to-appl.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Chris Rummel <crummel@microsoft.com>
+Date: Wed, 22 Jun 2022 05:53:06 -0500
+Subject: [PATCH] Enable work-tree and unsafe-paths to be able to apply in the
+ checked-in tarball.
+
+---
+ eng/SourceBuild.props | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/eng/SourceBuild.props b/eng/SourceBuild.props
+index 903ee00..4c85819 100644
+--- a/eng/SourceBuild.props
++++ b/eng/SourceBuild.props
+@@ -15,7 +15,7 @@
+     </ItemGroup>
+ 
+     <Exec
+-      Command="git apply --ignore-whitespace --whitespace=nowarn &quot;%(SourceBuildPatchFile.FullPath)&quot;"
++      Command="git --work-tree=$(RepoRoot) apply --ignore-whitespace --whitespace=nowarn --unsafe-paths &quot;%(SourceBuildPatchFile.FullPath)&quot;"
+       WorkingDirectory="$(RepoRoot)"
+       Condition="'@(SourceBuildPatchFile)' != ''" />
+   </Target>

--- a/src/SourceBuild/tarball/patches/nuget-client/0001-Enable-work-tree-and-unsafe-paths-to-be-able-to-appl.patch
+++ b/src/SourceBuild/tarball/patches/nuget-client/0001-Enable-work-tree-and-unsafe-paths-to-be-able-to-appl.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Chris Rummel <crummel@microsoft.com>
+Date: Wed, 22 Jun 2022 05:55:51 -0500
+Subject: [PATCH] Enable work-tree and unsafe-paths to be able to apply in the
+ checked-in tarball.
+
+---
+ eng/source-build/source-build.proj | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/eng/source-build/source-build.proj b/eng/source-build/source-build.proj
+index cbdd6d8..a3e3d63 100644
+--- a/eng/source-build/source-build.proj
++++ b/eng/source-build/source-build.proj
+@@ -57,7 +57,7 @@
+     </ItemGroup>
+ 
+     <Exec
+-      Command="git --work-tree=$(ProjectRoot) apply --ignore-whitespace --whitespace=nowarn &quot;%(SourceBuildPatchFile.FullPath)&quot;"
++      Command="git --work-tree=$(ProjectRoot) apply --ignore-whitespace --whitespace=nowarn  --unsafe-paths&quot;%(SourceBuildPatchFile.FullPath)&quot;"
+       WorkingDirectory="$(ProjectRoot)"
+       Condition="'@(SourceBuildPatchFile)' != ''" />
+   </Target>

--- a/src/SourceBuild/tarball/patches/nuget-client/0001-Enable-work-tree-and-unsafe-paths-to-be-able-to-appl.patch
+++ b/src/SourceBuild/tarball/patches/nuget-client/0001-Enable-work-tree-and-unsafe-paths-to-be-able-to-appl.patch
@@ -17,7 +17,7 @@ index cbdd6d8..a3e3d63 100644
  
      <Exec
 -      Command="git --work-tree=$(ProjectRoot) apply --ignore-whitespace --whitespace=nowarn &quot;%(SourceBuildPatchFile.FullPath)&quot;"
-+      Command="git --work-tree=$(ProjectRoot) apply --ignore-whitespace --whitespace=nowarn  --unsafe-paths&quot;%(SourceBuildPatchFile.FullPath)&quot;"
++      Command="git --work-tree=$(ProjectRoot) apply --ignore-whitespace --whitespace=nowarn --unsafe-paths &quot;%(SourceBuildPatchFile.FullPath)&quot;"
        WorkingDirectory="$(ProjectRoot)"
        Condition="'@(SourceBuildPatchFile)' != ''" />
    </Target>

--- a/src/SourceBuild/tarball/patches/vstest/0001-Enable-work-tree-and-unsafe-paths-to-be-able-to-appl.patch
+++ b/src/SourceBuild/tarball/patches/vstest/0001-Enable-work-tree-and-unsafe-paths-to-be-able-to-appl.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Chris Rummel <crummel@microsoft.com>
+Date: Wed, 22 Jun 2022 05:57:36 -0500
+Subject: [PATCH] Enable work-tree and unsafe-paths to be able to apply in the
+ checked-in tarball.
+
+---
+ eng/SourceBuild.props | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/eng/SourceBuild.props b/eng/SourceBuild.props
+index b365645..36a7ba9 100644
+--- a/eng/SourceBuild.props
++++ b/eng/SourceBuild.props
+@@ -24,7 +24,7 @@
+     </ItemGroup>
+ 
+     <Exec
+-      Command="git apply --ignore-whitespace --whitespace=nowarn &quot;%(SourceBuildPatchFile.FullPath)&quot;"
++      Command="git --work-tree=$(InnerSourceBuildRepoRoot) apply --ignore-whitespace --whitespace=nowarn --unsafe-paths &quot;%(SourceBuildPatchFile.FullPath)&quot;"
+       WorkingDirectory="$(InnerSourceBuildRepoRoot)"
+       Condition="'@(SourceBuildPatchFile)' != ''" />
+   </Target>

--- a/src/SourceBuild/tarball/patches/xliff-tasks/0001-Enable-work-tree-and-unsafe-paths-to-be-able-to-appl.patch
+++ b/src/SourceBuild/tarball/patches/xliff-tasks/0001-Enable-work-tree-and-unsafe-paths-to-be-able-to-appl.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Chris Rummel <crummel@microsoft.com>
+Date: Wed, 22 Jun 2022 05:59:17 -0500
+Subject: [PATCH] Enable work-tree and unsafe-paths to be able to apply in the
+ checked-in tarball.
+
+---
+ eng/SourceBuild.props | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/eng/SourceBuild.props b/eng/SourceBuild.props
+index 82243ab..147de20 100644
+--- a/eng/SourceBuild.props
++++ b/eng/SourceBuild.props
+@@ -15,7 +15,7 @@
+     </ItemGroup>
+ 
+     <Exec
+-      Command="git apply --ignore-whitespace --whitespace=nowarn &quot;%(SourceBuildPatchFile.FullPath)&quot;"
++      Command="git --work-tree=$(RepoRoot) apply --ignore-whitespace --whitespace=nowarn --unsafe-paths &quot;%(SourceBuildPatchFile.FullPath)&quot;"
+       WorkingDirectory="$(RepoRoot)"
+       Condition="'@(SourceBuildPatchFile)' != ''" />
+   </Target>


### PR DESCRIPTION
- Add an empty file so an empty packages/prebuilt directory is not removed (NuGet depends on all file sources existing even if empty).
- Use version of source-build-externals with fix for patching in a broken git repo.
- Delete `objects` directory from submodule .gitdirs.
