### PR TITLE
Add devcontainer configurations for source build

### DIFF
--- a/.devcontainer/create-tarball/devcontainer.json
+++ b/.devcontainer/create-tarball/devcontainer.json
@@ -1,0 +1,25 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.238.0/containers/dotnet
+{
+	"name": "Source-Build Create Tarball",
+	"image": "mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-33-20210222183538-031e7d2",
+	// A completely built .NET source tarball is >64 GB
+	"hostRequirements": {
+		"storage": "128gb"
+	},
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"ms-dotnettools.csharp",
+				"eamodio.gitlens"
+			]
+		}
+	},
+	// Use 'onCreateCommand' to run pre-build commands inside the codespace.
+	"onCreateCommand": "${containerWorkspaceFolder}/.devcontainer/scripts/tarballCreate.sh",
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "${containerWorkspaceFolder}/.devcontainer/scripts/postCreateCommand.sh"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.238.0/containers/dotnet
+{
+	"name": "Source-Build Build Tarball",
+	"image": "mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-33-20210222183538-031e7d2",
+	// A completely built .NET source-tarball is >64 GB
+	"hostRequirements": {
+		"storage": "128gb"
+	},
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"ms-dotnettools.csharp",
+				"eamodio.gitlens"
+			]
+		}
+	},
+	// Use 'onCreateCommand' to run pre-build commands inside the codespace.
+	"onCreateCommand": "${containerWorkspaceFolder}/.devcontainer/scripts/tarballBuild.sh",
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "${containerWorkspaceFolder}/.devcontainer/scripts/postCreateCommand.sh"
+}

--- a/.devcontainer/scripts/postCreateCommand.sh
+++ b/.devcontainer/scripts/postCreateCommand.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+
+# reset the repo to the commit hash that was used to build the prebuilt Codespace
+git reset --hard $(cat ./artifacts/prebuild.sha)

--- a/.devcontainer/scripts/tarballBuild.sh
+++ b/.devcontainer/scripts/tarballBuild.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Always return exit code 0 so that we can use the codespaces prebuild to diagnose build errors.
+./build.sh /p:ArcadeBuildTarball=true /p:TarballDir=/workspaces/dotnet-source/ /p:PreserveTarballGitFolders=true || true
+
+# save the commit hash of the currently built repo, so developers know which version was built
+git rev-parse HEAD > ./artifacts/prebuild.sha
+
+cd /workspaces/dotnet-source/
+
+./prep.sh
+./build.sh --online || true

--- a/.devcontainer/scripts/tarballCreate.sh
+++ b/.devcontainer/scripts/tarballCreate.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Always return exit code 0 so that we can use the codespaces prebuild to diagnose build errors.
+./build.sh /p:ArcadeBuildTarball=true /p:TarballDir=/workspaces/dotnet-source/ /p:PreserveTarballGitFolders=true || true
+
+# save the commit hash of the currently built repo, so developers know which version was built
+git rev-parse HEAD > ./artifacts/prebuild.sha


### PR DESCRIPTION
I added two configurations: one that creates the source-build tarball and one that creates and builds the source-build tarball.

I tested on the `codespaces` branch and the prebuild should work with the tarball build configuration and reproduce errors without failing the prebuild. If you don't want to use the prebuild, at your codespace creation time, you can specify the create-tarball devcontainer which will open up a vscode instance and create the tarball in the background. If we want, I can also create a devcontainer setup that doesn't involve any builds at all.

Even if we decide not to use codespaces prebuilds, the devcontainers and build scripts can still be used locally in vscode or in codespaces without prebuilds.