### PR TITLE
Install the manifests into their specific feature band rather than the current band

### DIFF
--- a/src/redist/targets/BundledManifests.targets
+++ b/src/redist/targets/BundledManifests.targets
@@ -82,19 +82,19 @@
     <ItemGroup>
       <ManifestContent Include="%(BundledManifests.RestoredNupkgContentPath)\data\*"
                        Condition="Exists('%(RestoredNupkgContentPath)\data')"
-                       DestinationPath="$([MSBuild]::ValueOrDefault('%(Identity)', '').ToLower())"
+                       DestinationPath="%(FeatureBand)/$([MSBuild]::ValueOrDefault('%(Identity)', '').ToLower())"
                        RestoredNupkgContentPath="%(RestoredNupkgContentPath)"
                        WorkloadManifestId="%(Identity)"/>
 
       <ManifestContent Include="%(BundledManifests.RestoredNupkgContentPath)\data\localize\*"
                        Condition="Exists('%(RestoredNupkgContentPath)\data\localize')"
-                       DestinationPath="$([MSBuild]::ValueOrDefault('%(Identity)', '').ToLower())/localize"/>
+                       DestinationPath="%(BundledManifests.FeatureBand)/$([MSBuild]::ValueOrDefault('%(Identity)', '').ToLower())/localize"/>
     </ItemGroup>
 
     <Error Text="No workload manifest content found." Condition="'@(ManifestContent->Count())' == '0'" />
     
     <Copy SourceFiles="@(ManifestContent)"
-          DestinationFolder="$(RedistLayoutPath)sdk-manifests/%(FeatureBand)/%(DestinationPath)"/>
+          DestinationFolder="$(RedistLayoutPath)sdk-manifests/%(DestinationPath)"/>
   
   </Target>
 </Project>

--- a/src/redist/targets/BundledManifests.targets
+++ b/src/redist/targets/BundledManifests.targets
@@ -94,7 +94,7 @@
     <Error Text="No workload manifest content found." Condition="'@(ManifestContent->Count())' == '0'" />
     
     <Copy SourceFiles="@(ManifestContent)"
-          DestinationFolder="$(RedistLayoutPath)sdk-manifests/$(CliProductBandVersion)00/%(DestinationPath)"/>
+          DestinationFolder="$(RedistLayoutPath)sdk-manifests/%(FeatureBand)/%(DestinationPath)"/>
   
   </Target>
 </Project>


### PR DESCRIPTION
## Description
File-based 6.0.4xx installs of the SDK are broken for installing newer workloads than what's in the baseline manifest. 

The file-based install is putting the workload-manifests into the FeatureBand folder of the SDK itself. However, all of the workloads in the baseline manifests are 6.0.300 band workloads AND there are only 6.0.400 band workloads for half of them. When you try to update to a newer version using default settings, the SDK treats these workloads as 6.0.400, doesn't find a newer version, and so doesn't update the manifests. When using a rollback file, it will try to update the workloads into a 6.0.300 folder but since the SDK finds a newer workload already in place in the 6.0.400 folder, it'll use that one during install instead.

For example, here's what happened when I tried to install workload updates. The 4 6.0.300 manifests were correctly installed but then the workload packs themselves were the older ones that are in the 6.0.400 folder.
C:\testzip2\sdk-manifests>dir /s /b WorkloadManifest.json
C:\testzip2\sdk-manifests\6.0.300\microsoft.net.sdk.android\WorkloadManifest.json
C:\testzip2\sdk-manifests\6.0.300\microsoft.net.sdk.maui\WorkloadManifest.json
C:\testzip2\sdk-manifests\6.0.300\microsoft.net.workload.emscripten\WorkloadManifest.json
C:\testzip2\sdk-manifests\6.0.300\microsoft.net.workload.mono.toolchain\WorkloadManifest.json
C:\testzip2\sdk-manifests\6.0.400\microsoft.net.sdk.android\WorkloadManifest.json
C:\testzip2\sdk-manifests\6.0.400\microsoft.net.sdk.ios\WorkloadManifest.json
C:\testzip2\sdk-manifests\6.0.400\microsoft.net.sdk.maccatalyst\WorkloadManifest.json
C:\testzip2\sdk-manifests\6.0.400\microsoft.net.sdk.macos\WorkloadManifest.json
C:\testzip2\sdk-manifests\6.0.400\microsoft.net.sdk.maui\WorkloadManifest.json
C:\testzip2\sdk-manifests\6.0.400\microsoft.net.sdk.tvos\WorkloadManifest.json
C:\testzip2\sdk-manifests\6.0.400\microsoft.net.workload.emscripten\WorkloadManifest.json
C:\testzip2\sdk-manifests\6.0.400\microsoft.net.workload.mono.toolchain\WorkloadManifest.json

## Customer Impact

File-based installs are stuck on the May release versions of runtime, Maui, and Android and cannot update without manual intervention.

##Fix

Correctly install the baseline manifests into the folder that matches the manifest feature band, NOT the SDK feature band.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

## Verification

- [x] Manual (required)
- [ ] Automated
