### PR TITLE
Simplify our PR builds.

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -99,7 +99,7 @@ stages:
               # Never run tests on arm64
               _TestArg: ''
 
-  ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - template: /eng/build.yml
       parameters:
         agentOs: Windows_NT
@@ -275,7 +275,7 @@ stages:
             _BuildArchitecture: 'x64'
             _TestArg: $(_NonWindowsTestArg)
 
-  ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - template: /eng/build.yml
       parameters:
         agentOs: Linux

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -71,50 +71,45 @@ stages:
         matrix:
           # Public-only builds
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-            Build_Debug_x86:
-              _BuildConfig: Debug
-              _BuildArchitecture: x86
-              _DOTNET_CLI_UI_LANGUAGE: ''
-              _AdditionalBuildParameters: ''
-              _TestArg: $(_WindowsTestArg)
+            Build_Release_x64:
+            _BuildConfig: Debug
+            _BuildArchitecture: x64
+            _DOTNET_CLI_UI_LANGUAGE: ''
+            _AdditionalBuildParameters: '/p:PublishInternalAsset=true'
+            _TestArg: $(_WindowsTestArg)
           # Internal-only builds
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+            Build_Release_x64:
+            _BuildConfig: Release
+            _BuildArchitecture: x64
+            _DOTNET_CLI_UI_LANGUAGE: ''
+            _AdditionalBuildParameters: '/p:PublishInternalAsset=true'
+            _TestArg: $(_WindowsTestArg)
             Build_Release_x86:
               _BuildConfig: Release
               _BuildArchitecture: x86
               _DOTNET_CLI_UI_LANGUAGE: ''
               _AdditionalBuildParameters: ''
               _TestArg: $(_WindowsTestArg)
-          # Always run builds
-          Build_Release_x64:
-            _BuildConfig: Release
-            _BuildArchitecture: x64
-            _DOTNET_CLI_UI_LANGUAGE: ''
-            _AdditionalBuildParameters: '/p:PublishInternalAsset=true'
-            _TestArg: $(_WindowsTestArg)
-          Build_Release_arm64:
-            _BuildConfig: Release
-            _BuildArchitecture: arm64
-            _DOTNET_CLI_UI_LANGUAGE: ''
-            _AdditionalBuildParameters: ''
-            # Never run tests on arm64
-            _TestArg: ''
+            Build_Release_arm64:
+              _BuildConfig: Release
+              _BuildArchitecture: arm64
+              _DOTNET_CLI_UI_LANGUAGE: ''
+              _AdditionalBuildParameters: ''
+              # Never run tests on arm64
+              _TestArg: ''
 
-  - template: /eng/build.yml
-    parameters:
-      agentOs: Windows_NT
-      pool:
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: NetCore1ESPool-Public
-          demands: ImageOverride -equals build.windows.10.amd64.vs2019.open
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals build.windows.10.amd64.vs2019
-      timeoutInMinutes: 180
-      strategy:
-        matrix:
-          ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-            # Always run builds
+  ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - template: /eng/build.yml
+      parameters:
+        agentOs: Windows_NT
+        pool:
+          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+            name: NetCore1ESPool-Internal
+            demands: ImageOverride -equals build.windows.10.amd64.vs2019
+        timeoutInMinutes: 180
+        strategy:
+          matrix:
             Build_Release_x64:
               _BuildConfig: Release
               _BuildArchitecture: x64
@@ -135,7 +130,7 @@ stages:
               _AdditionalBuildParameters: ''
               # Never run tests on arm64
               _TestArg: ''
-      pgoInstrument: true
+        pgoInstrument: true
 
   - template: /eng/build.yml
     parameters:
@@ -186,15 +181,6 @@ stages:
               _LinuxPortable: '--linux-portable'
               _RuntimeIdentifier: '--runtime-id linux-arm64'
               _BuildArchitecture: 'arm64'
-              # Never run tests on arm64
-              _TestArg: ''
-            Build_Linux_musl_Debug_arm64:
-              _BuildConfig: Debug
-              _DockerParameter: ''
-              _LinuxPortable: ''
-              _RuntimeIdentifier: '--runtime-id linux-musl-arm64'
-              _BuildArchitecture: 'arm64'
-              _AdditionalBuildParameters: '/p:OSName="linux-musl"'
               # Never run tests on arm64
               _TestArg: ''
             Build_Linux_musl_Debug_x64:
@@ -289,21 +275,17 @@ stages:
             _BuildArchitecture: 'x64'
             _TestArg: $(_NonWindowsTestArg)
 
-  - template: /eng/build.yml
-    parameters:
-      agentOs: Linux
-      pool:
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: NetCore1ESPool-Public
-          demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
-      timeoutInMinutes: 180
-      strategy:
-        matrix:
-          ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-            # Always run builds
+  ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - template: /eng/build.yml
+      parameters:
+        agentOs: Linux
+        pool:
+          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+            name: NetCore1ESPool-Internal
+            demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+        timeoutInMinutes: 180
+        strategy:
+          matrix:
             Build_LinuxPortable_Release_x64:
               _BuildConfig: Release
               _DockerParameter: ''
@@ -318,7 +300,7 @@ stages:
               _AdditionalBuildParameters: ''
               # Never run tests on arm64
               _TestArg: ''
-      pgoInstrument: true
+        pgoInstrument: true
 
   - template: /eng/build.yml
     parameters:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -72,19 +72,19 @@ stages:
           # Public-only builds
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
             Build_Release_x64:
-            _BuildConfig: Debug
-            _BuildArchitecture: x64
-            _DOTNET_CLI_UI_LANGUAGE: ''
-            _AdditionalBuildParameters: '/p:PublishInternalAsset=true'
-            _TestArg: $(_WindowsTestArg)
+              _BuildConfig: Debug
+              _BuildArchitecture: x64
+              _DOTNET_CLI_UI_LANGUAGE: ''
+              _AdditionalBuildParameters: '/p:PublishInternalAsset=true'
+              _TestArg: $(_WindowsTestArg)
           # Internal-only builds
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
             Build_Release_x64:
-            _BuildConfig: Release
-            _BuildArchitecture: x64
-            _DOTNET_CLI_UI_LANGUAGE: ''
-            _AdditionalBuildParameters: '/p:PublishInternalAsset=true'
-            _TestArg: $(_WindowsTestArg)
+              _BuildConfig: Release
+              _BuildArchitecture: x64
+              _DOTNET_CLI_UI_LANGUAGE: ''
+              _AdditionalBuildParameters: '/p:PublishInternalAsset=true'
+              _TestArg: $(_WindowsTestArg)
             Build_Release_x86:
               _BuildConfig: Release
               _BuildArchitecture: x86

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -92,13 +92,6 @@ stages:
             _DOTNET_CLI_UI_LANGUAGE: ''
             _AdditionalBuildParameters: '/p:PublishInternalAsset=true'
             _TestArg: $(_WindowsTestArg)
-          Build_Release_arm:
-            _BuildConfig: Release
-            _BuildArchitecture: arm
-            _DOTNET_CLI_UI_LANGUAGE: ''
-            _AdditionalBuildParameters: ''
-            # Never run tests on arm64
-            _TestArg: ''
           Build_Release_arm64:
             _BuildConfig: Release
             _BuildArchitecture: arm64
@@ -120,27 +113,28 @@ stages:
       timeoutInMinutes: 180
       strategy:
         matrix:
-          # Always run builds
-          Build_Release_x64:
-            _BuildConfig: Release
-            _BuildArchitecture: x64
-            _DOTNET_CLI_UI_LANGUAGE: ''
-            _AdditionalBuildParameters: '/p:PublishInternalAsset=true'
-            # Never run tests on PGO bits
-            _TestArg: ''
-          Build_Release_x86:
-            _BuildConfig: Release
-            _BuildArchitecture: x86
-            _DOTNET_CLI_UI_LANGUAGE: ''
-            _AdditionalBuildParameters: ''
-            _TestArg: ''
-          Build_Release_arm64:
-            _BuildConfig: Release
-            _BuildArchitecture: arm64
-            _DOTNET_CLI_UI_LANGUAGE: ''
-            _AdditionalBuildParameters: ''
-            # Never run tests on arm64
-            _TestArg: ''
+          ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+            # Always run builds
+            Build_Release_x64:
+              _BuildConfig: Release
+              _BuildArchitecture: x64
+              _DOTNET_CLI_UI_LANGUAGE: ''
+              _AdditionalBuildParameters: '/p:PublishInternalAsset=true'
+              # Never run tests on PGO bits
+              _TestArg: ''
+            Build_Release_x86:
+              _BuildConfig: Release
+              _BuildArchitecture: x86
+              _DOTNET_CLI_UI_LANGUAGE: ''
+              _AdditionalBuildParameters: ''
+              _TestArg: ''
+            Build_Release_arm64:
+              _BuildConfig: Release
+              _BuildArchitecture: arm64
+              _DOTNET_CLI_UI_LANGUAGE: ''
+              _AdditionalBuildParameters: ''
+              # Never run tests on arm64
+              _TestArg: ''
       pgoInstrument: true
 
   - template: /eng/build.yml
@@ -186,30 +180,6 @@ stages:
               _BuildArchitecture: 'x64'
               _AdditionalBuildParameters: '/p:BuildSdkDeb=true'
               _TestArg: $(_NonWindowsTestArg)
-            Build_Rhel_7_2_Release_x64:
-              _BuildConfig: Release
-              _DockerParameter: '--docker centos'
-              _LinuxPortable: ''
-              _RuntimeIdentifier: ''
-              _BuildArchitecture: 'x64'
-              _TestArg: $(_NonWindowsTestArg)
-            Build_Rhel_7_2_Release_Arm64:
-              _BuildConfig: Release
-              _DockerParameter: '--docker centos'
-              _LinuxPortable: ''
-              _RuntimeIdentifier: '--runtime-id linux-arm64'
-              _BuildArchitecture: 'arm64'
-              # Never run tests on arm
-              _TestArg: ''
-              _AdditionalBuildParameters: '/p:CLIBUILD_SKIP_TESTS=true'
-            Build_Arm_Debug:
-              _BuildConfig: Debug
-              _DockerParameter: ''
-              _LinuxPortable: '--linux-portable'
-              _RuntimeIdentifier: '--runtime-id linux-arm'
-              _BuildArchitecture: 'arm'
-              # Never run tests on arm
-              _TestArg: ''
             Build_Arm64_Debug:
               _BuildConfig: Debug
               _DockerParameter: ''
@@ -217,16 +187,6 @@ stages:
               _RuntimeIdentifier: '--runtime-id linux-arm64'
               _BuildArchitecture: 'arm64'
               # Never run tests on arm64
-              _TestArg: ''
-            Build_Linux_musl_Debug_arm:
-              _BuildConfig: Debug
-              # linux-musl-arm cross gen depends on glibc 2.27 (this OS has it)
-              _DockerParameter: '--docker ubuntu.18.04'
-              _LinuxPortable: ''
-              _RuntimeIdentifier: '--runtime-id linux-musl-arm'
-              _BuildArchitecture: 'arm'
-              _AdditionalBuildParameters: '/p:OSName="linux-musl"'
-              # Never run tests on arm
               _TestArg: ''
             Build_Linux_musl_Debug_arm64:
               _BuildConfig: Debug
@@ -342,21 +302,22 @@ stages:
       timeoutInMinutes: 180
       strategy:
         matrix:
-          # Always run builds
-          Build_LinuxPortable_Release_x64:
-            _BuildConfig: Release
-            _DockerParameter: ''
-            _LinuxPortable: '--linux-portable'
-            _RuntimeIdentifier: ''
-            _BuildArchitecture: 'x64'
-            _TestArg: ''
-          Build_Release_arm64:
-            _BuildConfig: Release
-            _BuildArchitecture: arm64
-            _DOTNET_CLI_UI_LANGUAGE: ''
-            _AdditionalBuildParameters: ''
-            # Never run tests on arm64
-            _TestArg: ''
+          ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+            # Always run builds
+            Build_LinuxPortable_Release_x64:
+              _BuildConfig: Release
+              _DockerParameter: ''
+              _LinuxPortable: '--linux-portable'
+              _RuntimeIdentifier: ''
+              _BuildArchitecture: 'x64'
+              _TestArg: ''
+            Build_Release_arm64:
+              _BuildConfig: Release
+              _BuildArchitecture: arm64
+              _DOTNET_CLI_UI_LANGUAGE: ''
+              _AdditionalBuildParameters: ''
+              # Never run tests on arm64
+              _TestArg: ''
       pgoInstrument: true
 
   - template: /eng/build.yml
@@ -372,12 +333,13 @@ stages:
             _RuntimeIdentifier: ''
             _BuildArchitecture: 'x64'
             _TestArg: $(_NonWindowsTestArg)
-          Build_Release_arm64:
-            _BuildConfig: Release
-            _RuntimeIdentifier: '--runtime-id osx-arm64'
-            _BuildArchitecture: 'arm64'
-            # Never run tests on arm64
-            _TestArg: ''
+          ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+            Build_Release_arm64:
+              _BuildConfig: Release
+              _RuntimeIdentifier: '--runtime-id osx-arm64'
+              _BuildArchitecture: 'arm64'
+              # Never run tests on arm64
+              _TestArg: ''
 
   - template: /eng/common/templates/jobs/source-build.yml
 


### PR DESCRIPTION
- Remove winarm from PR and CI
- Remove all pgo legs from PR
- remove all arm from PR
- remove specific targeted linux legs from PR
- rhel and centos PR legs were identical other than config
