### PR TITLE
Fix ArcadeBuildTarball on s390x

### DIFF
--- a/eng/restore-toolset.sh
+++ b/eng/restore-toolset.sh
@@ -13,10 +13,6 @@ function InitializeCustomSDKToolset {
   #InstallDotNetSharedFramework "1.1.2"
 
   InitializeDotNetCli true
-  # Install 2.1 framework for dotnet-deb-tool.
-  # Failures on this call will be ignored, as this is expected to fail on some
-  # OSes.
-  InstallDotNetSharedFramework "2.1.0"
 }
 
 # Installs additional shared frameworks for testing purposes


### PR DESCRIPTION
Do not install 2.1.0 framework, since it's not supported on s390x.

This helps with https://github.com/dotnet/source-build/issues/2937, but does not resolve it completely (now `./build.sh` fails, but it must be a different issue).