### PR TITLE
Update source-build-externals version

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -184,9 +184,9 @@
       <Sha>ab3eb7a525e31dc6fb4d9cc0b7154fa2be58dac1</Sha>
       <SourceBuildTarball RepoName="diagnostics" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="7.0.0-alpha.1.22363.1" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="7.0.0-alpha.1.22370.1">
       <Uri>https://github.com/dotnet/source-build-externals</Uri>
-      <Sha>abff160e44e7b81ade066d176639fc6d78527478</Sha>
+      <Sha>4e0a5ed9d8e2379f79c578197329c3d60b725a73</Sha>
       <SourceBuild RepoName="source-build-externals" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.symreader" Version="1.4.0-beta2-21475-02">


### PR DESCRIPTION
This is needed in order to pickup https://github.com/dotnet/source-build-externals/pull/31
