### PR TITLE
Disable repo prebuilt baseline during tarball builds

### DIFF
--- a/src/SourceBuild/tarball/content/ArcadeOverrides/AfterSourceBuild.proj
+++ b/src/SourceBuild/tarball/content/ArcadeOverrides/AfterSourceBuild.proj
@@ -72,7 +72,8 @@
       OutputBaselineFile="$(SourceBuildSelfPrebuiltReportDir)generated-new-baseline.xml"
       OutputReportFile="$(SourceBuildSelfPrebuiltReportDir)baseline-comparison.xml"
       AllowTestProjectUsage="$(AllowTestProjectUsage)"
-      ContinueOnError="$(ContinueOnPrebuiltBaselineError)" />
+      ContinueOnError="$(ContinueOnPrebuiltBaselineError)"
+      Condition="'$(DotNetBuildFromSourceFlavor)' != 'Product'" />
   </Target>
 
   <!--

--- a/src/SourceBuild/tarball/content/repos/Directory.Build.props
+++ b/src/SourceBuild/tarball/content/repos/Directory.Build.props
@@ -45,6 +45,7 @@
 
   <ItemGroup>
     <EnvironmentVariables Include="DotNetBuildFromSource=true" />
+    <EnvironmentVariables Include="DotNetBuildFromSourceFlavor=Product" />
     <EnvironmentVariables Include="DotNetPackageVersionPropsPath=$(PackageVersionPropsPath)" />
     <EnvironmentVariables Include="DotNetRestorePackagesPath=$(PackagesDir)" />
     <EnvironmentVariables Include="DotNetBuildOffline=true" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/2947

This change introduces a new `DotNetBuildFromSourceFlavor` property.  Eventually we will want to get this set to `Repo` for repo level source-builds and eliminate the `ArcadeBuildFromSource` property in favor of this new one.  I will log an issue for this if proposal is accepted.
