### PR TITLE
[release/6.0.1xx] Write and upload updated baselines for source-build content tests

### DIFF
--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-build-tarball.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-build-tarball.yml
@@ -174,6 +174,8 @@ jobs:
       find src/ -type f -name "*.binlog" -exec cp {} --parents -t ${targetFolder} \;
       find src/ -type f -name "*.log" -exec cp {} --parents -t ${targetFolder} \;
       find test/ -type f -name "*.binlog" -exec cp {} --parents -t ${targetFolder} \;
+      find test/ -type f -name "Updated*.diff" -exec cp {} --parents -t ${targetFolder} \;
+      find test/ -type f -name "Updated*.txt" -exec cp {} --parents -t ${targetFolder} \;
     displayName: Prepare BuildLogs staging directory
     continueOnError: true
     condition: succeededOrFailed()

--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/BaselineHelper.cs
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/BaselineHelper.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.SourceBuild.SmokeTests
 
         public static void CompareContents(string baselineFileName, string actualContents, ITestOutputHelper outputHelper, bool warnOnDiffs = false)
         {
-            string actualFilePath = Path.Combine(Environment.CurrentDirectory, $"{baselineFileName}");
+            string actualFilePath = Path.Combine(DotNetHelper.LogsDirectory, $"Updated{baselineFileName}");
             File.WriteAllText(actualFilePath, actualContents);
 
             CompareFiles(baselineFileName, actualFilePath, outputHelper, warnOnDiffs);


### PR DESCRIPTION
Direct port of https://github.com/dotnet/installer/pull/14092. Was going to update the MSFT-to-SB diff for 6.0 servicing, but it is annoying to read and apply a diff of a diff.