### PR TITLE
Update Runtime's Roslyn version to be the source-built version

### DIFF
--- a/src/SourceBuild/tarball/content/Directory.Build.props
+++ b/src/SourceBuild/tarball/content/Directory.Build.props
@@ -247,6 +247,9 @@
     <!-- if MicrosoftSourceLinkCommonPackageVersion is non-empty, then we've already built SourceLink, regardless of whether
          this is the production or offline build, so we should use that version.  -->
     <ExtraPackageVersionPropsPackageInfo Include="MicrosoftSourceLinkVersion" Version="%24(MicrosoftSourceLinkCommonPackageVersion)" />
+
+    <!-- Used by runtime to determine current Roslyn version -->
+    <ExtraPackageVersionPropsPackageInfo Include="MicrosoftCodeAnalysisVersion_4_X" Version="%24(MicrosoftCodeAnalysisVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/SourceBuild/tarball/content/Directory.Build.props
+++ b/src/SourceBuild/tarball/content/Directory.Build.props
@@ -247,9 +247,6 @@
     <!-- if MicrosoftSourceLinkCommonPackageVersion is non-empty, then we've already built SourceLink, regardless of whether
          this is the production or offline build, so we should use that version.  -->
     <ExtraPackageVersionPropsPackageInfo Include="MicrosoftSourceLinkVersion" Version="%24(MicrosoftSourceLinkCommonPackageVersion)" />
-
-    <!-- Used by runtime to determine current Roslyn version -->
-    <ExtraPackageVersionPropsPackageInfo Include="MicrosoftCodeAnalysisVersion_4_X" Version="%24(MicrosoftCodeAnalysisVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/SourceBuild/tarball/content/repos/runtime.common.props
+++ b/src/SourceBuild/tarball/content/repos/runtime.common.props
@@ -40,4 +40,8 @@
     <EnvironmentVariables Include="BuildInParallel=false" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ExtraPackageVersionPropsPackageInfo Include="MicrosoftCodeAnalysisVersion_4_X" Version="%24(MicrosoftCodeAnalysisVersion)" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
A combination of this change in conjunction with https://github.com/dotnet/source-build-reference-packages/pull/416 fixes https://github.com/dotnet/runtime/issues/71741.  

This may need to change once Runtime picks up the latest Roslyn version for .NET 7 RC1.  Hopefully we will just be able to eliminate it.  I will log a follow-up issue to track this.
