### PR TITLE
Exclude intermediate and rid specific packages from artifacts tarball

### DIFF
--- a/src/SourceBuild/tarball/content/ArcadeOverrides/SourceBuildArcadeTools.targets
+++ b/src/SourceBuild/tarball/content/ArcadeOverrides/SourceBuildArcadeTools.targets
@@ -12,9 +12,9 @@
 
   <Target Name="CollectSourceBuildIntermediateNupkgDependencies"
           Condition="
-            ('$(ArcadeBuildFromSource)' == 'true' and
-              '$(ArcadeInnerBuildFromSource)' == 'true') or
-            '$(SetUpSourceBuildIntermediateNupkgCache)' == 'true'"
+            '$(DotNetBuildFromSourceFlavor)' != 'Product' and
+            (('$(ArcadeBuildFromSource)' == 'true' and '$(ArcadeInnerBuildFromSource)' == 'true') or
+              '$(SetUpSourceBuildIntermediateNupkgCache)' == 'true')"
           DependsOnTargets="GetSourceBuildIntermediateNupkgNameConvention"
           BeforeTargets="CollectPackageReferences">
     <ReadSourceBuildIntermediateNupkgDependencies
@@ -31,10 +31,9 @@
 
   <Target Name="SetUpSourceBuildIntermediateNupkgCache"
           Condition="
-            ('$(ArcadeBuildFromSource)' == 'true' and
-              '$(ArcadeInnerBuildFromSource)' == 'true' and
-              '@(SourceBuildIntermediateNupkgReference)' != '') or
-            '$(SetUpSourceBuildIntermediateNupkgCache)' == 'true'"
+            '$(DotNetBuildFromSourceFlavor)' != 'Product' and
+            (('$(ArcadeBuildFromSource)' == 'true' and '$(ArcadeInnerBuildFromSource)' == 'true' and '@(SourceBuildIntermediateNupkgReference)' != '') or
+              '$(SetUpSourceBuildIntermediateNupkgCache)' == 'true')"
           AfterTargets="Restore">
     <PropertyGroup>
       <SourceBuiltNupkgCacheDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsObjDir)', 'source-built-upstream-cache'))</SourceBuiltNupkgCacheDir>

--- a/src/SourceBuild/tarball/content/ArcadeOverrides/SourceBuildArcadeTools.targets
+++ b/src/SourceBuild/tarball/content/ArcadeOverrides/SourceBuildArcadeTools.targets
@@ -1,0 +1,63 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+<Project>
+
+  <Import Project="SourceBuildArcade.targets" />
+
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SourceBuild.AddSourceToNuGetConfig" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
+  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SourceBuild.ReadSourceBuildIntermediateNupkgDependencies" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.SourceBuild.Tasks" Version="$(MicrosoftDotNetSourceBuildTasksVersion)" IsImplicitlyDefined="true" />
+  </ItemGroup>
+
+  <Target Name="CollectSourceBuildIntermediateNupkgDependencies"
+          Condition="
+            ('$(ArcadeBuildFromSource)' == 'true' and
+              '$(ArcadeInnerBuildFromSource)' == 'true') or
+            '$(SetUpSourceBuildIntermediateNupkgCache)' == 'true'"
+          DependsOnTargets="GetSourceBuildIntermediateNupkgNameConvention"
+          BeforeTargets="CollectPackageReferences">
+    <ReadSourceBuildIntermediateNupkgDependencies
+      VersionDetailsXmlFile="$([MSBuild]::NormalizePath('$(RepositoryEngineeringDir)', 'Version.Details.xml'))"
+      SourceBuildIntermediateNupkgPrefix="$(SourceBuildIntermediateNupkgPrefix)"
+      SourceBuildIntermediateNupkgRid="$(SourceBuildIntermediateNupkgRid)">
+      <Output TaskParameter="Dependencies" ItemName="SourceBuildIntermediateNupkgReference" />
+    </ReadSourceBuildIntermediateNupkgDependencies>
+
+    <ItemGroup>
+      <PackageReference Include="@(SourceBuildIntermediateNupkgReference)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="SetUpSourceBuildIntermediateNupkgCache"
+          Condition="
+            ('$(ArcadeBuildFromSource)' == 'true' and
+              '$(ArcadeInnerBuildFromSource)' == 'true' and
+              '@(SourceBuildIntermediateNupkgReference)' != '') or
+            '$(SetUpSourceBuildIntermediateNupkgCache)' == 'true'"
+          AfterTargets="Restore">
+    <PropertyGroup>
+      <SourceBuiltNupkgCacheDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsObjDir)', 'source-built-upstream-cache'))</SourceBuiltNupkgCacheDir>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <IntermediateNupkgSourceDir Include="$([MSBuild]::NormalizeDirectory(
+        '$(NuGetPackageRoot)',
+        '$([System.String]::new(`%(SourceBuildIntermediateNupkgReference.Identity)`).ToLowerInvariant())',
+        '$([System.String]::new(`%(SourceBuildIntermediateNupkgReference.ExactVersion)`).ToLowerInvariant())',
+        'artifacts'))" />
+
+      <SourceBuiltNupkgFile Include="%(IntermediateNupkgSourceDir.Identity)**\*.nupkg" />
+    </ItemGroup>
+
+    <Copy
+      SourceFiles="@(SourceBuiltNupkgFile)"
+      DestinationFiles="@(SourceBuiltNupkgFile -> '$(SourceBuiltNupkgCacheDir)%(Filename)%(Extension)')" />
+
+    <AddSourceToNuGetConfig
+      NuGetConfigFile="$(RestoreConfigFile)"
+      SourceName="source-build-int-nupkg-cache"
+      SourcePath="$(SourceBuiltNupkgCacheDir)" />
+  </Target>
+
+</Project>

--- a/src/SourceBuild/tarball/content/repos/Directory.Build.targets
+++ b/src/SourceBuild/tarball/content/repos/Directory.Build.targets
@@ -621,12 +621,6 @@
       Condition=" '%(_ToolPackage.Id)' == 'Microsoft.DotNet.Arcade.Sdk' "
       WorkingDirectory="$(ToolPackageExtractDir)%(_ToolPackage.Id)/tools/SourceBuild/" />
 
-    <ReplaceTextInFile
-      Condition=" '%(_ToolPackage.Id)' == 'Microsoft.DotNet.Arcade.Sdk' "
-      InputFile="$(ToolPackageExtractDir)%(_ToolPackage.Id)/tools/SourceBuild/SourceBuildArcadeTools.targets"
-      OldText="%3CReadSourceBuildIntermediateNupkgDependencies"
-      NewText="%3CReadSourceBuildIntermediateNupkgDependencies Condition=&quot;'%24%28DotNetBuildOffline%29' != 'true'&quot;" />
-
     <!-- Allow overriding of Arcade targets for SourceBuild to enable quicker
          dev turnaround for Preview 6 -->
     <PropertyGroup>

--- a/src/SourceBuild/tarball/content/repos/package-source-build.proj
+++ b/src/SourceBuild/tarball/content/repos/package-source-build.proj
@@ -50,7 +50,8 @@
       <SourceBuiltTarballName>$(OutputPath)$(SourceBuiltArtifactsTarballName).$(installerOutputPackageVersion).tar.gz</SourceBuiltTarballName>
     </PropertyGroup>
 
-    <Exec Command="tar --numeric-owner --exclude='$(SBRPIntermediateWildcard)' -czf $(SourceBuiltTarballName) *.nupkg *.props SourceBuildReferencePackages/" WorkingDirectory="$(SourceBuiltPackagesPath)" />
+    <Exec Command="tar --numeric-owner --exclude='Microsoft.SourceBuild.Intermediate.*.nupkg' --exclude='runtime.$(TargetRid).*.nupkg' -czf $(SourceBuiltTarballName) *.nupkg *.props SourceBuildReferencePackages/"
+          WorkingDirectory="$(SourceBuiltPackagesPath)" />
 
     <Message Importance="High" Text="Packaged source-built artifacts to $(SourceBuiltTarballName)" />
   </Target>


### PR DESCRIPTION
Fixes #https://github.com/dotnet/source-build/issues/2472

This reduces the artifacts tarball from 5630540852 to 1671079678.

Please look at the individual commits to get a good diff of the changes made to the SourceBuildArcadeTools.targets

cc @oleksandr-didyk 
