### PR TITLE
Update logic to delete files with questionable licenses

### DIFF
--- a/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
+++ b/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
@@ -269,10 +269,8 @@
          Remove them. -->
     <ItemGroup>
       <TarballSrcNonOpenSourceFiles Include="$(TarballSourceDir)**\humanizer\samples\**\*.js" />
-      <TarballSrcNonOpenSourceFiles Include="$(TarballSourceDir)**\*nuget-client.*\**\EndToEnd\**\jquery-validation-unobtrusive\*.js" />
-      <TarballSrcNonOpenSourceFiles Include="$(TarballSourceDir)**\*nuget-client.*\**\EndToEnd\**\jquery-validation-unobtrusive\.bower.json" />
-      <TarballSrcNonOpenSourceFiles Include="$(TarballSourceDir)**\*aspnetcore.*\**\samples\**\jquery-validation-unobtrusive\.bower.json" />
-      <TarballSrcNonOpenSourceFiles Include="$(TarballSourceDir)**\*aspnetcore.*\**\samples\**\jquery-validation-unobtrusive\*.js" />
+      <TarballSrcNonOpenSourceFiles Include="$(TarballSourceDir)**\*aspnetcore\**\samples\**\jquery-validation-unobtrusive\.bower.json" />
+      <TarballSrcNonOpenSourceFiles Include="$(TarballSourceDir)**\*aspnetcore\**\samples\**\jquery-validation-unobtrusive\*.js" />
     </ItemGroup>
 
     <Message Importance="High" Text="Deleting files with questionable licenses: @(TarballSrcNonOpenSourceFiles, ' ')" />


### PR DESCRIPTION
NuGet license issues were address in https://github.com/NuGet/Home/issues/11094

The aspnetcore logic is currently broken due to the changes to support the VMR where the commit digest was removed from the directory name.
