### PR TITLE
Update delete files with questionable licenses logic

### DIFF
--- a/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
+++ b/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
@@ -269,10 +269,10 @@
          Remove them. -->
     <ItemGroup>
       <TarballSrcNonOpenSourceFiles Include="$(TarballSourceDir)**\humanizer\samples\**\*.js" />
-      <TarballSrcNonOpenSourceFiles Include="$(TarballSourceDir)**\*nuget-client.*\**\EndToEnd\**\jquery-validation-unobtrusive\*.js" />
-      <TarballSrcNonOpenSourceFiles Include="$(TarballSourceDir)**\*nuget-client.*\**\EndToEnd\**\jquery-validation-unobtrusive\.bower.json" />
-      <TarballSrcNonOpenSourceFiles Include="$(TarballSourceDir)**\*aspnetcore.*\**\samples\**\jquery-validation-unobtrusive\.bower.json" />
-      <TarballSrcNonOpenSourceFiles Include="$(TarballSourceDir)**\*aspnetcore.*\**\samples\**\jquery-validation-unobtrusive\*.js" />
+      <TarballSrcNonOpenSourceFiles Include="$(TarballSourceDir)**\*nuget-client\**\EndToEnd\**\jquery-validation-unobtrusive\*.js" />
+      <TarballSrcNonOpenSourceFiles Include="$(TarballSourceDir)**\*nuget-client\**\EndToEnd\**\jquery-validation-unobtrusive\.bower.json" />
+      <TarballSrcNonOpenSourceFiles Include="$(TarballSourceDir)**\*aspnetcore\**\samples\**\jquery-validation-unobtrusive\.bower.json" />
+      <TarballSrcNonOpenSourceFiles Include="$(TarballSourceDir)**\*aspnetcore\**\samples\**\jquery-validation-unobtrusive\*.js" />
     </ItemGroup>
 
     <Message Importance="High" Text="Deleting files with questionable licenses: @(TarballSrcNonOpenSourceFiles, ' ')" />


### PR DESCRIPTION
The logic to delete files with questionable licenses logic regressed with the changes to support the VMR where the commit digest was removed from the repo names in the tarball.

Related to https://github.com/dotnet/installer/pull/14264
