### PR TITLE
Stop app host downloads for android

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -305,6 +305,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                       AppHostPackNamePattern="Microsoft.NETCore.App.Host.**RID**"
                       AppHostPackVersion="$(_NETCoreAppPackageVersion)"
                       AppHostRuntimeIdentifiers="@(NetCoreAppHostRids, '%3B')"
+                      ExcludedRuntimeIdentifiers="android"
                       />
 
     <KnownCrossgen2Pack Include="Microsoft.NETCore.App.Crossgen2"


### PR DESCRIPTION
## Description
Maui apps by default have various android RIDs configured. In the RID graph, this ends up getting mapped onto linux and we end up searching for an apphost to download when building maui apps. However, these apps do not use apphosts so we should exclude android from the known app host lookup. We already exclude android elsewhere during the processing of known framework references and this is just extending that.

## Customer Impact
Customers building Maui applications will download app hosts they don't need. This is particularly annoying for dogfooders when we are targeting prerelease servicing builds of the runtime as then they need an extra feed all for a set of packs they don't need.

## Fix
Add ExcludedRuntimeIdentifiers="android" to the known app host reference in the generate bundled targets file.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

## Verification

- [x] Manual (required)
- [ ] Automated
