### PR TITLE
Add razor-compiler and runtime patches to unblock prebuilt elimination

### DIFF
--- a/src/SourceBuild/tarball/patches/razor-compiler/0002-Exclude-the-razor-syntax-generator-from-source-build.patch
+++ b/src/SourceBuild/tarball/patches/razor-compiler/0002-Exclude-the-razor-syntax-generator-from-source-build.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Fred Silberberg <frsilb@microsoft.com>
+Date: Thu, 21 Jul 2022 10:02:32 -0700
+Subject: [PATCH] Exclude the razor syntax generator from source build (#305)
+
+This is a manually-run tool to update syntax nodes and doesn't need to be built by source-build. Fixes https://github.com/dotnet/razor-compiler/issues/304.
+
+Backport: https://github.com/dotnet/razor-compiler/pull/305
+---
+ src/tools/RazorSyntaxGenerator/RazorSyntaxGenerator.csproj | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/tools/RazorSyntaxGenerator/RazorSyntaxGenerator.csproj b/src/tools/RazorSyntaxGenerator/RazorSyntaxGenerator.csproj
+index 924379ac..f213af41 100644
+--- a/src/tools/RazorSyntaxGenerator/RazorSyntaxGenerator.csproj
++++ b/src/tools/RazorSyntaxGenerator/RazorSyntaxGenerator.csproj
+@@ -9,6 +9,7 @@
+     <IsPackable>false</IsPackable>
+     <!-- No need to track public APIs of this tool. -->
+     <AddPublicApiAnalyzers>false</AddPublicApiAnalyzers>
++    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+   </PropertyGroup>
+ 
+ </Project>

--- a/src/SourceBuild/tarball/patches/runtime/0004-workaround-invalid-warning-message.patch
+++ b/src/SourceBuild/tarball/patches/runtime/0004-workaround-invalid-warning-message.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MichaelSimons <msimons@microsoft.com>
+Date: Fri, 5 Aug 2022 15:26:42 +0000
+Subject: [PATCH] workaround invalid warning message
+
+Temporary fix to unblock work until runtime provides a fix.
+
+Backport: https://github.com/dotnet/runtime/issues/73463
+---
+ eng/packaging.targets | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/eng/packaging.targets b/eng/packaging.targets
+index ac639efe49c..1929f2f1251 100644
+--- a/eng/packaging.targets
++++ b/eng/packaging.targets
+@@ -200,7 +200,7 @@
+ <![CDATA[<Project InitialTargets="$(_NETStandardCompatErrorFileTarget)">
+   <Target Name="$(_NETStandardCompatErrorFileTarget)"
+           Condition="'%24(SuppressTfmSupportBuildWarnings)' == ''">
+-    <Warning Text="$(PackageId) $(PackageVersion) doesn't support %24(TargetFramework) and has not been tested with it. Consider upgrading your TargetFramework to %(NETStandardCompatError.Supported) or later. You may also set &lt;SuppressTfmSupportBuildWarnings&gt;true&lt;/SuppressTfmSupportBuildWarnings&gt; in the project file to ignore this warning and attempt to run in this unsupported configuration at your own risk." />
++    <Warning Text="$(PackageId) $(PackageVersion) doesn't support %24(TargetFramework) and has not been tested with it." />
+   </Target>
+ </Project>]]>
+       </_NETStandardCompatErrorFileContent>


### PR DESCRIPTION
* The razor-compiler fix was checked in a while ago but hasn't flown in
* The runtime workaround is needed to unblock https://github.com/dotnet/installer/pull/14242.

We can't wait for these fixes to flow in if we are going to hit the rc1 timeline.
