### PR TITLE
Add the full nuget version into the .version file

### DIFF
--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -469,7 +469,7 @@
   <Target Name="GenerateVersionFile"
           DependsOnTargets="SetupBundledComponents;GetCommitHash;GenerateFullNuGetVersion">
     <WriteLinesToFile File="$(SdkOutputDirectory).version"
-                      Lines="$(GitCommitHash);$(Version);$(Rid)"
+                      Lines="$(GitCommitHash);$(Version);$(Rid);$(FullNugetVersion)"
                       Overwrite="true" />
 
     <!-- This is a hack to make the full nuget version available during the publishing step -->


### PR DESCRIPTION
## Description
For remote machine ios installation, today the Maui tooling reads the .version file to get the version of the SDK to install. This version gets passed to the install script. This works great for post-release customer usage but doesn't work for prerelease builds. That's because the install scripts don't correctly handle stable branded, secure installs.

## Customer Impact
Without this, the maui team cannot test prerelease versions of the SDK for the remote Mac scenario.

## Fix
Add the specific version number to the sdk .version file that gets dropped on this. In addition to this, Maui testers would need a specific feed and a token but they are planning on implementing that as an environment variable. This reduces the pain of finding the build which is not otherwise available easily without cracking open the binaries themselves.

## Regression?

- [ ] Yes
- [x] No

## Risk
The risk would be if someone were depending on the format of the .version file. That's why I put this version last.

- [ ] High
- [ ] Medium
- [x] Low

## Verification

- [x] Manual (required)
- [ ] Automated
