### PR TITLE
Reflect move of templating dependencies to sdk repo

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -105,7 +105,6 @@
     <Dependency Name="Microsoft.TemplateEngine.Cli" Version="7.0.100-rc.1.22409.4">
       <Uri>https://github.com/dotnet/sdk</Uri>
       <Sha>215b2c8c993c2a5ca47f5e76d52122853a29c4ce</Sha>
-      <SourceBuild RepoName="sdk" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.NET.Sdk" Version="7.0.100-rc.1.22404.18">
       <Uri>https://github.com/dotnet/sdk</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -98,7 +98,7 @@
       <Sha>0385265f4d0b6413d64aea0223172366a9b9858c</Sha>
       <SourceBuild RepoName="test-templates" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="7.0.100-dev">
+    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="7.0.100-rc.1.22409.4">
       <Uri>https://github.com/dotnet/sdk</Uri>
       <Sha>215b2c8c993c2a5ca47f5e76d52122853a29c4ce</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -98,14 +98,14 @@
       <Sha>0385265f4d0b6413d64aea0223172366a9b9858c</Sha>
       <SourceBuild RepoName="test-templates" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="7.0.100-rc.1.22404.7" CoherentParentDependency="Microsoft.NET.Sdk">
-      <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>225ce682f0578db2db5644df5e7024276b39785e</Sha>
+    <Dependency Name="Microsoft.DotNet.Common.ItemTemplates" Version="7.0.100-dev">
+      <Uri>https://github.com/dotnet/sdk</Uri>
+      <Sha>215b2c8c993c2a5ca47f5e76d52122853a29c4ce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Cli" Version="7.0.100-rc.1.22404.7" CoherentParentDependency="Microsoft.NET.Sdk">
-      <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>225ce682f0578db2db5644df5e7024276b39785e</Sha>
-      <SourceBuild RepoName="templating" ManagedOnly="true" />
+    <Dependency Name="Microsoft.TemplateEngine.Cli" Version="7.0.100-rc.1.22409.4">
+      <Uri>https://github.com/dotnet/sdk</Uri>
+      <Sha>215b2c8c993c2a5ca47f5e76d52122853a29c4ce</Sha>
+      <SourceBuild RepoName="sdk" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.NET.Sdk" Version="7.0.100-rc.1.22404.18">
       <Uri>https://github.com/dotnet/sdk</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -37,10 +37,6 @@
     <MicrosoftDotNetWpfProjectTemplatesPackageVersion>7.0.0-rc.1.22379.2</MicrosoftDotNetWpfProjectTemplatesPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Dependency from https://github.com/dotnet/templating -->
-    <MicrosoftDotNetCommonItemTemplatesPackageVersion>7.0.100-rc.1.22404.7</MicrosoftDotNetCommonItemTemplatesPackageVersion>
-  </PropertyGroup>
-  <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/test-templates -->
     <MicrosoftDotNetTestProjectTemplates50PackageVersion>1.0.2-beta4.22406.1</MicrosoftDotNetTestProjectTemplates50PackageVersion>
     <MicrosoftDotNetTestProjectTemplates60PackageVersion>1.0.2-beta4.22406.1</MicrosoftDotNetTestProjectTemplates60PackageVersion>
@@ -65,6 +61,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
+	<MicrosoftDotNetCommonItemTemplatesPackageVersion>7.0.100-dev</MicrosoftDotNetCommonItemTemplatesPackageVersion>
     <MicrosoftNETSdkPackageVersion>7.0.100-rc.1.22404.18</MicrosoftNETSdkPackageVersion>
     <MicrosoftDotNetMSBuildSdkResolverPackageVersion>7.0.100-rc.1.22404.18</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -61,7 +61,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
-	<MicrosoftDotNetCommonItemTemplatesPackageVersion>7.0.100-dev</MicrosoftDotNetCommonItemTemplatesPackageVersion>
+    <MicrosoftDotNetCommonItemTemplatesPackageVersion>7.0.100-rc.1.22409.4</MicrosoftDotNetCommonItemTemplatesPackageVersion>
     <MicrosoftNETSdkPackageVersion>7.0.100-rc.1.22404.18</MicrosoftNETSdkPackageVersion>
     <MicrosoftDotNetMSBuildSdkResolverPackageVersion>7.0.100-rc.1.22404.18</MicrosoftDotNetMSBuildSdkResolverPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>


### PR DESCRIPTION
Templating code was moved to sdk repo, packages are still in the same channel, but the repo reference should change.

This is just a draft, as we need to first address the ItemTemplate package not being published properly (it shows only with 'dev' version now) - https://github.com/dotnet/installer/pull/14281#discussion_r941339859
