### PR TITLE
Add sdk patch to address templating prebuilts

### DIFF
--- a/src/SourceBuild/tarball/patches/sdk/0003-Add-templates-to-source-build.slnf.patch
+++ b/src/SourceBuild/tarball/patches/sdk/0003-Add-templates-to-source-build.slnf.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michael Simons <msimons@microsoft.com>
+Date: Wed, 10 Aug 2022 16:57:32 -0500
+Subject: [PATCH] Add templates to source-build.slnf
+
+Backport: https://github.com/dotnet/sdk/issues/27089
+---
+ source-build.slnf | 14 +++++++++-----
+ 1 file changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/source-build.slnf b/source-build.slnf
+index 4bd6e994b4..0cce0088c1 100644
+--- a/source-build.slnf
++++ b/source-build.slnf
+@@ -2,6 +2,10 @@
+   "solution": {
+     "path": "sdk.sln",
+     "projects": [
++      "src\\ApiCompat\\Microsoft.DotNet.ApiCompat.Shared\\Microsoft.DotNet.ApiCompat.Shared.shproj",
++      "src\\ApiCompat\\Microsoft.DotNet.ApiCompat.Task\\Microsoft.DotNet.ApiCompat.Task.csproj",
++      "src\\ApiCompat\\Microsoft.DotNet.ApiCompatibility\\Microsoft.DotNet.ApiCompatibility.csproj",
++      "src\\ApiCompat\\Microsoft.DotNet.PackageValidation\\Microsoft.DotNet.PackageValidation.csproj",
+       "src\\BlazorWasmSdk\\Tasks\\Microsoft.NET.Sdk.BlazorWebAssembly.Tasks.csproj",
+       "src\\BlazorWasmSdk\\Tool\\Microsoft.NET.Sdk.BlazorWebAssembly.Tool.csproj",
+       "src\\BuiltInTools\\BrowserRefresh\\Microsoft.AspNetCore.Watch.BrowserRefresh.csproj",
+@@ -12,11 +16,9 @@
+       "src\\Cli\\Microsoft.DotNet.Cli.Utils\\Microsoft.DotNet.Cli.Utils.csproj",
+       "src\\Cli\\Microsoft.DotNet.Configurer\\Microsoft.DotNet.Configurer.csproj",
+       "src\\Cli\\Microsoft.DotNet.InternalAbstractions\\Microsoft.DotNet.InternalAbstractions.csproj",
++      "src\\Cli\\Microsoft.TemplateEngine.Cli\\Microsoft.TemplateEngine.Cli.csproj",
++      "src\\Cli\\dotnet-new3\\dotnet-new3.csproj",
+       "src\\Cli\\dotnet\\dotnet.csproj",
+-      "src\\ApiCompat\\Microsoft.DotNet.ApiCompat.Shared\\Microsoft.DotNet.ApiCompat.Shared.shproj",
+-      "src\\ApiCompat\\Microsoft.DotNet.ApiCompat.Task\\Microsoft.DotNet.ApiCompat.Task.csproj",
+-      "src\\ApiCompat\\Microsoft.DotNet.ApiCompatibility\\Microsoft.DotNet.ApiCompatibility.csproj",
+-      "src\\ApiCompat\\Microsoft.DotNet.PackageValidation\\Microsoft.DotNet.PackageValidation.csproj",
+       "src\\Layout\\redist\\redist.csproj",
+       "src\\Layout\\tool_fsharp\\tool_fsc.csproj",
+       "src\\Layout\\tool_msbuild\\tool_msbuild.csproj",
+@@ -37,7 +39,9 @@
+       "src\\WebSdk\\ProjectSystem\\Tasks\\Microsoft.NET.Sdk.Web.ProjectSystem.Tasks.csproj",
+       "src\\WebSdk\\Publish\\Tasks\\Microsoft.NET.Sdk.Publish.Tasks.csproj",
+       "src\\WebSdk\\Web\\Tasks\\Microsoft.NET.Sdk.Web.Tasks.csproj",
+-      "src\\WebSdk\\Worker\\Tasks\\Microsoft.NET.Sdk.Worker.Tasks.csproj"
++      "src\\WebSdk\\Worker\\Tasks\\Microsoft.NET.Sdk.Worker.Tasks.csproj",
++      "template_feed\\Microsoft.DotNet.Common.ItemTemplates\\Microsoft.DotNet.Common.ItemTemplates.csproj",
++      "template_feed\\Microsoft.DotNet.Common.ProjectTemplates.7.0\\Microsoft.DotNet.Common.ProjectTemplates.7.0.csproj"
+     ]
+   }
+ }
+\ No newline at end of file


### PR DESCRIPTION
Related to: https://github.com/dotnet/sdk/issues/27089
