### PR TITLE
[release/6.0.3xx] Update Windows SDK Versions

### DIFF
--- a/eng/ManualVersions.props
+++ b/eng/ManualVersions.props
@@ -9,11 +9,11 @@
      Basically: In this file, choose the highest version when resolving merge conflicts.
  -->
   <PropertyGroup>
-    <MicrosoftWindowsSDKNETRef10_0_17763PackageVersion>10.0.17763.26</MicrosoftWindowsSDKNETRef10_0_17763PackageVersion>
-    <MicrosoftWindowsSDKNETRef10_0_18362PackageVersion>10.0.18362.26</MicrosoftWindowsSDKNETRef10_0_18362PackageVersion>
-    <MicrosoftWindowsSDKNETRef10_0_19041PackageVersion>10.0.19041.26</MicrosoftWindowsSDKNETRef10_0_19041PackageVersion>
-    <MicrosoftWindowsSDKNETRef10_0_20348PackageVersion>10.0.20348.26</MicrosoftWindowsSDKNETRef10_0_20348PackageVersion>
-    <MicrosoftWindowsSDKNETRef10_0_22000PackageVersion>10.0.22000.26</MicrosoftWindowsSDKNETRef10_0_22000PackageVersion>
-    <MicrosoftWindowsSDKNETRef10_0_22621PackageVersion>10.0.22621.26</MicrosoftWindowsSDKNETRef10_0_22621PackageVersion>
+    <MicrosoftWindowsSDKNETRef10_0_17763PackageVersion>10.0.17763.27</MicrosoftWindowsSDKNETRef10_0_17763PackageVersion>
+    <MicrosoftWindowsSDKNETRef10_0_18362PackageVersion>10.0.18362.27</MicrosoftWindowsSDKNETRef10_0_18362PackageVersion>
+    <MicrosoftWindowsSDKNETRef10_0_19041PackageVersion>10.0.19041.27</MicrosoftWindowsSDKNETRef10_0_19041PackageVersion>
+    <MicrosoftWindowsSDKNETRef10_0_20348PackageVersion>10.0.20348.27</MicrosoftWindowsSDKNETRef10_0_20348PackageVersion>
+    <MicrosoftWindowsSDKNETRef10_0_22000PackageVersion>10.0.22000.27</MicrosoftWindowsSDKNETRef10_0_22000PackageVersion>
+    <MicrosoftWindowsSDKNETRef10_0_22621PackageVersion>10.0.22621.27</MicrosoftWindowsSDKNETRef10_0_22621PackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -674,11 +674,18 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Supported Windows versions -->
     <WindowsSdkSupportedTargetPlatformVersion Include="10.0.22621.0" WindowsSdkPackageVersion="$(MicrosoftWindowsSDKNETRef10_0_22621PackageVersion)" MinimumNETVersion="6.0" />
-    <WindowsSdkSupportedTargetPlatformVersion Include="10.0.22000.0" WindowsSdkPackageVersion="$(MicrosoftWindowsSDKNETRef10_0_22000PackageVersion)" MinimumNETVersion="5.0" />
-    <WindowsSdkSupportedTargetPlatformVersion Include="10.0.20348.0" WindowsSdkPackageVersion="$(MicrosoftWindowsSDKNETRef10_0_20348PackageVersion)" MinimumNETVersion="5.0" />
-    <WindowsSdkSupportedTargetPlatformVersion Include="10.0.19041.0" WindowsSdkPackageVersion="$(MicrosoftWindowsSDKNETRef10_0_19041PackageVersion)" MinimumNETVersion="5.0" />
-    <WindowsSdkSupportedTargetPlatformVersion Include="10.0.18362.0" WindowsSdkPackageVersion="$(MicrosoftWindowsSDKNETRef10_0_18362PackageVersion)" MinimumNETVersion="5.0" />
-    <WindowsSdkSupportedTargetPlatformVersion Include="10.0.17763.0" WindowsSdkPackageVersion="$(MicrosoftWindowsSDKNETRef10_0_17763PackageVersion)" MinimumNETVersion="5.0" />
+    <WindowsSdkSupportedTargetPlatformVersion Include="10.0.22000.0" WindowsSdkPackageVersion="$(MicrosoftWindowsSDKNETRef10_0_22000PackageVersion)" MinimumNETVersion="6.0" />
+    <WindowsSdkSupportedTargetPlatformVersion Include="10.0.20348.0" WindowsSdkPackageVersion="$(MicrosoftWindowsSDKNETRef10_0_20348PackageVersion)" MinimumNETVersion="6.0" />
+    <WindowsSdkSupportedTargetPlatformVersion Include="10.0.19041.0" WindowsSdkPackageVersion="$(MicrosoftWindowsSDKNETRef10_0_19041PackageVersion)" MinimumNETVersion="6.0" />
+    <WindowsSdkSupportedTargetPlatformVersion Include="10.0.18362.0" WindowsSdkPackageVersion="$(MicrosoftWindowsSDKNETRef10_0_18362PackageVersion)" MinimumNETVersion="6.0" />
+    <WindowsSdkSupportedTargetPlatformVersion Include="10.0.17763.0" WindowsSdkPackageVersion="$(MicrosoftWindowsSDKNETRef10_0_17763PackageVersion)" MinimumNETVersion="6.0" />
+    
+    <WindowsSdkSupportedTargetPlatformVersion Include="10.0.22000.0" WindowsSdkPackageVersion="10.0.22000.26" MinimumNETVersion="5.0" />
+    <WindowsSdkSupportedTargetPlatformVersion Include="10.0.20348.0" WindowsSdkPackageVersion="10.0.20348.26" MinimumNETVersion="5.0" />
+    <WindowsSdkSupportedTargetPlatformVersion Include="10.0.19041.0" WindowsSdkPackageVersion="10.0.19041.26" MinimumNETVersion="5.0" />
+    <WindowsSdkSupportedTargetPlatformVersion Include="10.0.18362.0" WindowsSdkPackageVersion="10.0.18362.26" MinimumNETVersion="5.0" />
+    <WindowsSdkSupportedTargetPlatformVersion Include="10.0.17763.0" WindowsSdkPackageVersion="10.0.17763.26" MinimumNETVersion="5.0" />
+    
     <WindowsSdkSupportedTargetPlatformVersion Include="8.0" />
     <WindowsSdkSupportedTargetPlatformVersion Include="7.0" />
 


### PR DESCRIPTION
This PR adds locked versions of the Windows SDK projections for .NET 5. This is needed as part of https://github.com/dotnet/sdk/pull/27199.

The Windows SDK projections for .NET 6 will continue to update, but given .NET 5 is EOL we need to lock the versions to the last known good.