### PR TITLE
Don't run CG in public builds

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -14,6 +14,9 @@ variables:
   value: false
 - name: PostBuildSign
   value: true
+- ${{ if eq(variables['System.TeamProject'], 'public') }}:
+   - name: "skipComponentGovernanceDetection"
+   value: "true"
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - group: DotNet-DotNetCli-Storage
   - group: DotNet-Installer-SDLValidation-Params

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -16,7 +16,7 @@ variables:
   value: true
 - ${{ if eq(variables['System.TeamProject'], 'public') }}:
    - name: "skipComponentGovernanceDetection"
-   value: "true"
+     value: "true"
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - group: DotNet-DotNetCli-Storage
   - group: DotNet-Installer-SDLValidation-Params


### PR DESCRIPTION
This is so that CG stops tracking our public branches as we already track in our internal branche