### PR TITLE
Hardcode netcoreapp2.1 test templates version

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -81,10 +81,6 @@
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>0438e7ec04808230c67b00caa3d584bd2b991f57</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="1.0.2-beta4.22406.1">
-      <Uri>https://github.com/dotnet/test-templates</Uri>
-      <Sha>0385265f4d0b6413d64aea0223172366a9b9858c</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.DotNet.Test.ProjectTemplates.5.0" Version="1.0.2-beta4.22409.1">
       <Uri>https://github.com/dotnet/test-templates</Uri>
       <Sha>a47740f5f3936da8dcebe9e8868b6311bc4402f8</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -38,7 +38,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/test-templates -->
-    <!-- Version for netcoreapp2.1 is also shipped because it is inserted into VS.Test-templates repository no longer produces that template
+    <!-- Version for netcoreapp2.1 is also shipped because it is inserted into VS. Test-templates repository no longer produces that template
     so we hardcode it below to the latest version that still has that template. -->
     <MicrosoftDotNetTestProjectTemplates50PackageVersion>1.0.2-beta4.22409.1</MicrosoftDotNetTestProjectTemplates50PackageVersion>
     <MicrosoftDotNetTestProjectTemplates60PackageVersion>1.0.2-beta4.22409.1</MicrosoftDotNetTestProjectTemplates60PackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -38,7 +38,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/test-templates -->
-    <MicrosoftDotNetTestProjectTemplates30PackageVersion>1.0.2-beta4.22406.1</MicrosoftDotNetTestProjectTemplates30PackageVersion>
+    <!-- Version for netcoreapp2.1 is also shipped because it is inserted into VS.Test-templates repository no longer produces that template
+    so we hardcode it below to the latest version that still has that template. -->
     <MicrosoftDotNetTestProjectTemplates50PackageVersion>1.0.2-beta4.22409.1</MicrosoftDotNetTestProjectTemplates50PackageVersion>
     <MicrosoftDotNetTestProjectTemplates60PackageVersion>1.0.2-beta4.22409.1</MicrosoftDotNetTestProjectTemplates60PackageVersion>
     <MicrosoftDotNetTestProjectTemplates70PackageVersion>1.0.2-beta4.22409.1</MicrosoftDotNetTestProjectTemplates70PackageVersion>
@@ -157,13 +158,12 @@
     <NUnit3Templates30PackageVersion>1.6.5</NUnit3Templates30PackageVersion>
     <MicrosoftDotNetCommonItemTemplates30PackageVersion>2.0.0-preview8.19373.1</MicrosoftDotNetCommonItemTemplates30PackageVersion>
     <MicrosoftDotNetCommonProjectTemplates30PackageVersion>$(MicrosoftDotNetCommonItemTemplates30PackageVersion)</MicrosoftDotNetCommonProjectTemplates30PackageVersion>
-    <MicrosoftDotNetTestProjectTemplates30PackageVersion>$(MicrosoftDotNetTestProjectTemplates30PackageVersion)</MicrosoftDotNetTestProjectTemplates30PackageVersion>
     <AspNetCorePackageVersionFor30Templates>3.0.1</AspNetCorePackageVersionFor30Templates>
     <!-- 2.1 Template versions -->
     <NUnit3Templates21PackageVersion>1.5.3</NUnit3Templates21PackageVersion>
     <MicrosoftDotNetCommonItemTemplates21PackageVersion>1.0.2-beta3</MicrosoftDotNetCommonItemTemplates21PackageVersion>
     <MicrosoftDotNetCommonProjectTemplates21PackageVersion>$(MicrosoftDotNetCommonItemTemplates21PackageVersion)</MicrosoftDotNetCommonProjectTemplates21PackageVersion>
-    <MicrosoftDotNetTestProjectTemplates21PackageVersion>$(MicrosoftDotNetTestProjectTemplates30PackageVersion)</MicrosoftDotNetTestProjectTemplates21PackageVersion>
+    <MicrosoftDotNetTestProjectTemplates21PackageVersion>1.0.2-beta4.22406.1</MicrosoftDotNetTestProjectTemplates21PackageVersion>
     <AspNetCorePackageVersionFor21Templates>2.1.34</AspNetCorePackageVersionFor21Templates>
   </PropertyGroup>
   <!-- infrastructure and test only dependencies -->


### PR DESCRIPTION
Hardcode netcoreapp2.1 test templates version to the latest version that still ships the templates, we no-longer produce that template in test-templates, but it is still inserted into VS so we need to include it.

Additional cleanup for #14298
