### PR TITLE
[release/6.0.1xx] Update Application Insights to 2.19.0, Update SBRP and SB externals

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -156,9 +156,9 @@
       <Sha>75551652b352f860ea0b29095b64fa63715dd672</Sha>
       <SourceBuildTarball RepoName="nuget-client" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.ApplicationInsights" Version="2.0.0">
+    <Dependency Name="Microsoft.ApplicationInsights" Version="2.19.0">
       <Uri>https://github.com/Microsoft/ApplicationInsights-dotnet</Uri>
-      <Sha>53b80940842204f78708a538628288ff5d741a1d</Sha>
+      <Sha>93f745cfef8541f09862aae9bc8c04554bca38c7</Sha>
     </Dependency>
     <!-- Temporarily pinning Microsoft.Web.Xdt until strict coherency is enabled by default -->
     <Dependency Name="Microsoft.Web.Xdt" Version="5.0.0-preview.21431.1" CoherentParentDependency="Microsoft.NET.Sdk" Pinned="true">
@@ -172,7 +172,7 @@
     </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build" Version="6.0.0-servicing.22320.1">
       <Uri>https://github.com/dotnet/source-build</Uri>
-      <Sha>126aed9b11b5aece8ebcf7bdbb82d0654206d5a4</Sha>
+      <Sha>7649ca7106e7e91ac06f169626bf01a77c2258eb</Sha>
       <SourceBuild RepoName="source-build" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Cli.CommandLine" Version="1.0.0-preview.21310.2">
@@ -213,7 +213,7 @@
     </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="6.0.0-servicing.22314.1">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>bc3b0a4c27b23d08ef00a6c4150fc73ebe80140b</Sha>
+      <Sha>fdbbfadcaa5804038ad0a3f67c33f489cbeda65c</Sha>
       <SourceBuildTarball RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceLink.GitHub" Version="1.1.0-beta-21480-02" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -170,7 +170,7 @@
       <Uri>https://github.com/dotnet/emsdk</Uri>
       <Sha>52e9452f82e26f9fcae791e84c082ae22f1ef66f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build" Version="6.0.0-servicing.22320.1">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build" Version="6.0.0-servicing.22419.2">
       <Uri>https://github.com/dotnet/source-build</Uri>
       <Sha>7649ca7106e7e91ac06f169626bf01a77c2258eb</Sha>
       <SourceBuild RepoName="source-build" ManagedOnly="true" />
@@ -211,7 +211,7 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>41323ecb0b2312980381bfdbb75afd2dae2b266b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="6.0.0-servicing.22314.1">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="6.0.0-servicing.22419.2">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
       <Sha>fdbbfadcaa5804038ad0a3f67c33f489cbeda65c</Sha>
       <SourceBuildTarball RepoName="source-build-reference-packages" ManagedOnly="true" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/2994

I checked a previous online build and verified that the only prebuilt was system.diagnostics.diagnosticsource 5.0.0, which was addressed by https://github.com/dotnet/source-build-reference-packages/pull/430