### PR TITLE
[release/6.0.1xx] Re-write dotnet-watch smoke test

### DIFF
--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetHelper.cs
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetHelper.cs
@@ -78,7 +78,7 @@ internal class DotNetHelper
         }
     }
 
-    public void ExecuteCmd(string args, string? workingDirectory = null, Action<Process>? additionalProcessConfigCallback = null, int expectedExitCode = 0, int millisecondTimeout = -1)
+    public void ExecuteCmd(string args, string? workingDirectory = null, Action<Process>? additionalProcessConfigCallback = null, int? expectedExitCode = 0, int millisecondTimeout = -1)
     {
         (Process Process, string StdOut, string StdErr) executeResult = ExecuteHelper.ExecuteProcess(
             DotNetPath,
@@ -87,7 +87,9 @@ internal class DotNetHelper
             configure: (process) => configureProcess(process, workingDirectory),
             millisecondTimeout: millisecondTimeout);
         
-        ExecuteHelper.ValidateExitCode(executeResult, expectedExitCode);
+        if (expectedExitCode != null) {
+            ExecuteHelper.ValidateExitCode(executeResult, (int) expectedExitCode);
+        }
 
         void configureProcess(Process process, string? workingDirectory)
         {


### PR DESCRIPTION
Our `dotnet watch` smoke tests are flaky. We keep getting test failures even when dotnet watch is functioning as expected. It seems that the exit code when sending a `kill` command is not a good indicator of whether or not dotnet watch was functioning properly.

Currently we check that the correct text is output after editing a file that is being watched, and then kill the program and check the exit code. I'm attempting to change the test so that we succeed if and only if the expected text is output by the program, and disregarding the exit code. We should fail the test if we never see the expected output and then timeout.

At the moment I'm not sure if we will fail a test when we timeout. I'm submitting early as a draft to get feedback.