### PR TITLE
Update the main table for rc1, rc2, 8.0, and remove 6.0.400

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,20 +151,20 @@ Please do not directly edit the table below. Use https://github.com/dotnet/insta
 
 ### Table
 
-| Platform | main<br>(7.0.x&nbsp;Runtime) | Release/7.0.1xx-preview7<br>(7.0.x&nbsp;Runtime) | Release/6.0.4XX<br>(6.0.x&nbsp;Runtime) |
+| Platform | main<br>(8.0.x&nbsp;Runtime) | Release/7.0.1xx<br>(7.0.x&nbsp;Runtime) | Release/7.0.1xx-rc1<br>(7.0.x&nbsp;Runtime) |
 | :--------- | :----------: | :----------: | :----------: |
-| **Windows x64** | [![][win-x64-badge-main]][win-x64-version-main]<br>[Installer][win-x64-installer-main] - [Checksum][win-x64-installer-checksum-main]<br>[zip][win-x64-zip-main] - [Checksum][win-x64-zip-checksum-main] | [![][win-x64-badge-7.0.1XX-preview7]][win-x64-version-7.0.1XX-preview7]<br>[Installer][win-x64-installer-7.0.1XX-preview7] - [Checksum][win-x64-installer-checksum-7.0.1XX-preview7]<br>[zip][win-x64-zip-7.0.1XX-preview7] - [Checksum][win-x64-zip-checksum-7.0.1XX-preview7] | [![][win-x64-badge-6.0.4XX]][win-x64-version-6.0.4XX]<br>[Installer][win-x64-installer-6.0.4XX] - [Checksum][win-x64-installer-checksum-6.0.4XX]<br>[zip][win-x64-zip-6.0.4XX] - [Checksum][win-x64-zip-checksum-6.0.4XX] |
-| **Windows x86** | [![][win-x86-badge-main]][win-x86-version-main]<br>[Installer][win-x86-installer-main] - [Checksum][win-x86-installer-checksum-main]<br>[zip][win-x86-zip-main] - [Checksum][win-x86-zip-checksum-main] | [![][win-x86-badge-7.0.1XX-preview7]][win-x86-version-7.0.1XX-preview7]<br>[Installer][win-x86-installer-7.0.1XX-preview7] - [Checksum][win-x86-installer-checksum-7.0.1XX-preview7]<br>[zip][win-x86-zip-7.0.1XX-preview7] - [Checksum][win-x86-zip-checksum-7.0.1XX-preview7] | [![][win-x86-badge-6.0.4XX]][win-x86-version-6.0.4XX]<br>[Installer][win-x86-installer-6.0.4XX] - [Checksum][win-x86-installer-checksum-6.0.4XX]<br>[zip][win-x86-zip-6.0.4XX] - [Checksum][win-x86-zip-checksum-6.0.4XX] |
+| **Windows x64** | [![][win-x64-badge-main]][win-x64-version-main]<br>[Installer][win-x64-installer-main] - [Checksum][win-x64-installer-checksum-main]<br>[zip][win-x64-zip-main] - [Checksum][win-x64-zip-checksum-main] | [![][win-x64-badge-7.0.1XX]][win-x64-version-7.0.1XX]<br>[Installer][win-x64-installer-7.0.1XX] - [Checksum][win-x64-installer-checksum-7.0.1XX]<br>[zip][win-x64-zip-7.0.1XX] - [Checksum][win-x64-zip-checksum-7.0.1XX] | [![][win-x64-badge-7.0.1XX-rc1]][win-x64-version-7.0.1XX-rc1]<br>[Installer][win-x64-installer-7.0.1XX-rc1] - [Checksum][win-x64-installer-checksum-7.0.1XX-rc1]<br>[zip][win-x64-zip-7.0.1XX-rc1] - [Checksum][win-x64-zip-checksum-7.0.1XX-rc1] |
+| **Windows x86** | [![][win-x86-badge-main]][win-x86-version-main]<br>[Installer][win-x86-installer-main] - [Checksum][win-x86-installer-checksum-main]<br>[zip][win-x86-zip-main] - [Checksum][win-x86-zip-checksum-main] | [![][win-x86-badge-7.0.1XX]][win-x86-version-7.0.1XX]<br>[Installer][win-x86-installer-7.0.1XX] - [Checksum][win-x86-installer-checksum-7.0.1XX]<br>[zip][win-x86-zip-7.0.1XX] - [Checksum][win-x86-zip-checksum-7.0.1XX] | [![][win-x86-badge-7.0.1XX-rc1]][win-x86-version-7.0.1XX-rc1]<br>[Installer][win-x86-installer-7.0.1XX-rc1] - [Checksum][win-x86-installer-checksum-7.0.1XX-rc1]<br>[zip][win-x86-zip-7.0.1XX-rc1] - [Checksum][win-x86-zip-checksum-7.0.1XX-rc1] |
 | **Windows arm** | **N/A** | **N/A** | **N/A** |
-| **Windows arm64** | [![][win-arm64-badge-main]][win-arm64-version-main]<br>[Installer][win-arm64-installer-main] - [Checksum][win-arm64-installer-checksum-main]<br>[zip][win-arm64-zip-main] | [![][win-arm64-badge-7.0.1XX-preview7]][win-arm64-version-7.0.1XX-preview7]<br>[Installer][win-arm64-installer-7.0.1XX-preview7] - [Checksum][win-arm64-installer-checksum-7.0.1XX-preview7]<br>[zip][win-arm64-zip-7.0.1XX-preview7] | [![][win-arm64-badge-6.0.4XX]][win-arm64-version-6.0.4XX]<br>[Installer][win-arm64-installer-6.0.4XX] - [Checksum][win-arm64-installer-checksum-6.0.4XX]<br>[zip][win-arm64-zip-6.0.4XX] |
-| **macOS x64** | [![][osx-x64-badge-main]][osx-x64-version-main]<br>[Installer][osx-x64-installer-main] - [Checksum][osx-x64-installer-checksum-main]<br>[tar.gz][osx-x64-targz-main] - [Checksum][osx-x64-targz-checksum-main] | [![][osx-x64-badge-7.0.1XX-preview7]][osx-x64-version-7.0.1XX-preview7]<br>[Installer][osx-x64-installer-7.0.1XX-preview7] - [Checksum][osx-x64-installer-checksum-7.0.1XX-preview7]<br>[tar.gz][osx-x64-targz-7.0.1XX-preview7] - [Checksum][osx-x64-targz-checksum-7.0.1XX-preview7] | [![][osx-x64-badge-6.0.4XX]][osx-x64-version-6.0.4XX]<br>[Installer][osx-x64-installer-6.0.4XX] - [Checksum][osx-x64-installer-checksum-6.0.4XX]<br>[tar.gz][osx-x64-targz-6.0.4XX] - [Checksum][osx-x64-targz-checksum-6.0.4XX] |
-| **macOS arm64** | [![][osx-arm64-badge-main]][osx-arm64-version-main]<br>[Installer][osx-arm64-installer-main] - [Checksum][osx-arm64-installer-checksum-main]<br>[tar.gz][osx-arm64-targz-main] - [Checksum][osx-arm64-targz-checksum-main] | [![][osx-arm64-badge-7.0.1XX-preview7]][osx-arm64-version-7.0.1XX-preview7]<br>[Installer][osx-arm64-installer-7.0.1XX-preview7] - [Checksum][osx-arm64-installer-checksum-7.0.1XX-preview7]<br>[tar.gz][osx-arm64-targz-7.0.1XX-preview7] - [Checksum][osx-arm64-targz-checksum-7.0.1XX-preview7] | [![][osx-arm64-badge-6.0.4XX]][osx-arm64-version-6.0.4XX]<br>[Installer][osx-arm64-installer-6.0.4XX] - [Checksum][osx-arm64-installer-checksum-6.0.4XX]<br>[tar.gz][osx-arm64-targz-6.0.4XX] - [Checksum][osx-arm64-targz-checksum-6.0.4XX] |
-| **Linux x64** | [![][linux-badge-main]][linux-version-main]<br>[DEB Installer][linux-DEB-installer-main] - [Checksum][linux-DEB-installer-checksum-main]<br>[RPM Installer][linux-RPM-installer-main] - [Checksum][linux-RPM-installer-checksum-main]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-main] - [Checksum][linux-targz-checksum-main] | [![][linux-badge-7.0.1XX-preview7]][linux-version-7.0.1XX-preview7]<br>[DEB Installer][linux-DEB-installer-7.0.1XX-preview7] - [Checksum][linux-DEB-installer-checksum-7.0.1XX-preview7]<br>[RPM Installer][linux-RPM-installer-7.0.1XX-preview7] - [Checksum][linux-RPM-installer-checksum-7.0.1XX-preview7]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-7.0.1XX-preview7] - [Checksum][linux-targz-checksum-7.0.1XX-preview7] | [![][linux-badge-6.0.4XX]][linux-version-6.0.4XX]<br>[DEB Installer][linux-DEB-installer-6.0.4XX] - [Checksum][linux-DEB-installer-checksum-6.0.4XX]<br>[RPM Installer][linux-RPM-installer-6.0.4XX] - [Checksum][linux-RPM-installer-checksum-6.0.4XX]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-6.0.4XX] - [Checksum][linux-targz-checksum-6.0.4XX] |
-| **Linux arm** | [![][linux-arm-badge-main]][linux-arm-version-main]<br>[tar.gz][linux-arm-targz-main] - [Checksum][linux-arm-targz-checksum-main] | [![][linux-arm-badge-7.0.1XX-preview7]][linux-arm-version-7.0.1XX-preview7]<br>[tar.gz][linux-arm-targz-7.0.1XX-preview7] - [Checksum][linux-arm-targz-checksum-7.0.1XX-preview7] | [![][linux-arm-badge-6.0.4XX]][linux-arm-version-6.0.4XX]<br>[tar.gz][linux-arm-targz-6.0.4XX] - [Checksum][linux-arm-targz-checksum-6.0.4XX] |
-| **Linux arm64** | [![][linux-arm64-badge-main]][linux-arm64-version-main]<br>[tar.gz][linux-arm64-targz-main] - [Checksum][linux-arm64-targz-checksum-main] | [![][linux-arm64-badge-7.0.1XX-preview7]][linux-arm64-version-7.0.1XX-preview7]<br>[tar.gz][linux-arm64-targz-7.0.1XX-preview7] - [Checksum][linux-arm64-targz-checksum-7.0.1XX-preview7] | [![][linux-arm64-badge-6.0.4XX]][linux-arm64-version-6.0.4XX]<br>[tar.gz][linux-arm64-targz-6.0.4XX] - [Checksum][linux-arm64-targz-checksum-6.0.4XX] |
-| **Linux-musl-x64** | [![][linux-musl-x64-badge-main]][linux-musl-x64-version-main]<br>[tar.gz][linux-musl-x64-targz-main] - [Checksum][linux-musl-x64-targz-checksum-main] | [![][linux-musl-x64-badge-7.0.1XX-preview7]][linux-musl-x64-version-7.0.1XX-preview7]<br>[tar.gz][linux-musl-x64-targz-7.0.1XX-preview7] - [Checksum][linux-musl-x64-targz-checksum-7.0.1XX-preview7] | [![][linux-musl-x64-badge-6.0.4XX]][linux-musl-x64-version-6.0.4XX]<br>[tar.gz][linux-musl-x64-targz-6.0.4XX] - [Checksum][linux-musl-x64-targz-checksum-6.0.4XX] |
-| **Linux-musl-arm** | [![][linux-musl-arm-badge-main]][linux-musl-arm-version-main]<br>[tar.gz][linux-musl-arm-targz-main] - [Checksum][linux-musl-arm-targz-checksum-main] | [![][linux-musl-arm-badge-7.0.1XX-preview7]][linux-musl-arm-version-7.0.1XX-preview7]<br>[tar.gz][linux-musl-arm-targz-7.0.1XX-preview7] - [Checksum][linux-musl-arm-targz-checksum-7.0.1XX-preview7] | [![][linux-musl-arm-badge-6.0.4XX]][linux-musl-arm-version-6.0.4XX]<br>[tar.gz][linux-musl-arm-targz-6.0.4XX] - [Checksum][linux-musl-arm-targz-checksum-6.0.4XX] |
-| **Linux-musl-arm64** | [![][linux-musl-arm64-badge-main]][linux-musl-arm64-version-main]<br>[tar.gz][linux-musl-arm64-targz-main] - [Checksum][linux-musl-arm64-targz-checksum-main] | [![][linux-musl-arm64-badge-7.0.1XX-preview7]][linux-musl-arm64-version-7.0.1XX-preview7]<br>[tar.gz][linux-musl-arm64-targz-7.0.1XX-preview7] - [Checksum][linux-musl-arm64-targz-checksum-7.0.1XX-preview7] | [![][linux-musl-arm64-badge-6.0.4XX]][linux-musl-arm64-version-6.0.4XX]<br>[tar.gz][linux-musl-arm64-targz-6.0.4XX] - [Checksum][linux-musl-arm64-targz-checksum-6.0.4XX] |
+| **Windows arm64** | [![][win-arm64-badge-main]][win-arm64-version-main]<br>[Installer][win-arm64-installer-main] - [Checksum][win-arm64-installer-checksum-main]<br>[zip][win-arm64-zip-main] | [![][win-arm64-badge-7.0.1XX]][win-arm64-version-7.0.1XX]<br>[Installer][win-arm64-installer-7.0.1XX] - [Checksum][win-arm64-installer-checksum-7.0.1XX]<br>[zip][win-arm64-zip-7.0.1XX] | [![][win-arm64-badge-7.0.1XX-rc1]][win-arm64-version-7.0.1XX-rc1]<br>[Installer][win-arm64-installer-7.0.1XX-rc1] - [Checksum][win-arm64-installer-checksum-7.0.1XX-rc1]<br>[zip][win-arm64-zip-7.0.1XX-rc1] |
+| **macOS x64** | [![][osx-x64-badge-main]][osx-x64-version-main]<br>[Installer][osx-x64-installer-main] - [Checksum][osx-x64-installer-checksum-main]<br>[tar.gz][osx-x64-targz-main] - [Checksum][osx-x64-targz-checksum-main] | [![][osx-x64-badge-7.0.1XX]][osx-x64-version-7.0.1XX]<br>[Installer][osx-x64-installer-7.0.1XX] - [Checksum][osx-x64-installer-checksum-7.0.1XX]<br>[tar.gz][osx-x64-targz-7.0.1XX] - [Checksum][osx-x64-targz-checksum-7.0.1XX] | [![][osx-x64-badge-7.0.1XX-rc1]][osx-x64-version-7.0.1XX-rc1]<br>[Installer][osx-x64-installer-7.0.1XX-rc1] - [Checksum][osx-x64-installer-checksum-7.0.1XX-rc1]<br>[tar.gz][osx-x64-targz-7.0.1XX-rc1] - [Checksum][osx-x64-targz-checksum-7.0.1XX-rc1] |
+| **macOS arm64** | [![][osx-arm64-badge-main]][osx-arm64-version-main]<br>[Installer][osx-arm64-installer-main] - [Checksum][osx-arm64-installer-checksum-main]<br>[tar.gz][osx-arm64-targz-main] - [Checksum][osx-arm64-targz-checksum-main] | [![][osx-arm64-badge-7.0.1XX]][osx-arm64-version-7.0.1XX]<br>[Installer][osx-arm64-installer-7.0.1XX] - [Checksum][osx-arm64-installer-checksum-7.0.1XX]<br>[tar.gz][osx-arm64-targz-7.0.1XX] - [Checksum][osx-arm64-targz-checksum-7.0.1XX] | [![][osx-arm64-badge-7.0.1XX-rc1]][osx-arm64-version-7.0.1XX-rc1]<br>[Installer][osx-arm64-installer-7.0.1XX-rc1] - [Checksum][osx-arm64-installer-checksum-7.0.1XX-rc1]<br>[tar.gz][osx-arm64-targz-7.0.1XX-rc1] - [Checksum][osx-arm64-targz-checksum-7.0.1XX-rc1] |
+| **Linux x64** | [![][linux-badge-main]][linux-version-main]<br>[DEB Installer][linux-DEB-installer-main] - [Checksum][linux-DEB-installer-checksum-main]<br>[RPM Installer][linux-RPM-installer-main] - [Checksum][linux-RPM-installer-checksum-main]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-main] - [Checksum][linux-targz-checksum-main] | [![][linux-badge-7.0.1XX]][linux-version-7.0.1XX]<br>[DEB Installer][linux-DEB-installer-7.0.1XX] - [Checksum][linux-DEB-installer-checksum-7.0.1XX]<br>[RPM Installer][linux-RPM-installer-7.0.1XX] - [Checksum][linux-RPM-installer-checksum-7.0.1XX]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-7.0.1XX] - [Checksum][linux-targz-checksum-7.0.1XX] | [![][linux-badge-7.0.1XX-rc1]][linux-version-7.0.1XX-rc1]<br>[DEB Installer][linux-DEB-installer-7.0.1XX-rc1] - [Checksum][linux-DEB-installer-checksum-7.0.1XX-rc1]<br>[RPM Installer][linux-RPM-installer-7.0.1XX-rc1] - [Checksum][linux-RPM-installer-checksum-7.0.1XX-rc1]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-7.0.1XX-rc1] - [Checksum][linux-targz-checksum-7.0.1XX-rc1] |
+| **Linux arm** | [![][linux-arm-badge-main]][linux-arm-version-main]<br>[tar.gz][linux-arm-targz-main] - [Checksum][linux-arm-targz-checksum-main] | [![][linux-arm-badge-7.0.1XX]][linux-arm-version-7.0.1XX]<br>[tar.gz][linux-arm-targz-7.0.1XX] - [Checksum][linux-arm-targz-checksum-7.0.1XX] | [![][linux-arm-badge-7.0.1XX-rc1]][linux-arm-version-7.0.1XX-rc1]<br>[tar.gz][linux-arm-targz-7.0.1XX-rc1] - [Checksum][linux-arm-targz-checksum-7.0.1XX-rc1] |
+| **Linux arm64** | [![][linux-arm64-badge-main]][linux-arm64-version-main]<br>[tar.gz][linux-arm64-targz-main] - [Checksum][linux-arm64-targz-checksum-main] | [![][linux-arm64-badge-7.0.1XX]][linux-arm64-version-7.0.1XX]<br>[tar.gz][linux-arm64-targz-7.0.1XX] - [Checksum][linux-arm64-targz-checksum-7.0.1XX] | [![][linux-arm64-badge-7.0.1XX-rc1]][linux-arm64-version-7.0.1XX-rc1]<br>[tar.gz][linux-arm64-targz-7.0.1XX-rc1] - [Checksum][linux-arm64-targz-checksum-7.0.1XX-rc1] |
+| **Linux-musl-x64** | [![][linux-musl-x64-badge-main]][linux-musl-x64-version-main]<br>[tar.gz][linux-musl-x64-targz-main] - [Checksum][linux-musl-x64-targz-checksum-main] | [![][linux-musl-x64-badge-7.0.1XX]][linux-musl-x64-version-7.0.1XX]<br>[tar.gz][linux-musl-x64-targz-7.0.1XX] - [Checksum][linux-musl-x64-targz-checksum-7.0.1XX] | [![][linux-musl-x64-badge-7.0.1XX-rc1]][linux-musl-x64-version-7.0.1XX-rc1]<br>[tar.gz][linux-musl-x64-targz-7.0.1XX-rc1] - [Checksum][linux-musl-x64-targz-checksum-7.0.1XX-rc1] |
+| **Linux-musl-arm** | [![][linux-musl-arm-badge-main]][linux-musl-arm-version-main]<br>[tar.gz][linux-musl-arm-targz-main] - [Checksum][linux-musl-arm-targz-checksum-main] | [![][linux-musl-arm-badge-7.0.1XX]][linux-musl-arm-version-7.0.1XX]<br>[tar.gz][linux-musl-arm-targz-7.0.1XX] - [Checksum][linux-musl-arm-targz-checksum-7.0.1XX] | [![][linux-musl-arm-badge-7.0.1XX-rc1]][linux-musl-arm-version-7.0.1XX-rc1]<br>[tar.gz][linux-musl-arm-targz-7.0.1XX-rc1] - [Checksum][linux-musl-arm-targz-checksum-7.0.1XX-rc1] |
+| **Linux-musl-arm64** | [![][linux-musl-arm64-badge-main]][linux-musl-arm64-version-main]<br>[tar.gz][linux-musl-arm64-targz-main] - [Checksum][linux-musl-arm64-targz-checksum-main] | [![][linux-musl-arm64-badge-7.0.1XX]][linux-musl-arm64-version-7.0.1XX]<br>[tar.gz][linux-musl-arm64-targz-7.0.1XX] - [Checksum][linux-musl-arm64-targz-checksum-7.0.1XX] | [![][linux-musl-arm64-badge-7.0.1XX-rc1]][linux-musl-arm64-version-7.0.1XX-rc1]<br>[tar.gz][linux-musl-arm64-targz-7.0.1XX-rc1] - [Checksum][linux-musl-arm64-targz-checksum-7.0.1XX-rc1] |
 | **RHEL 6** | **N/A** | **N/A** | **N/A** |
 
 Reference notes:
@@ -174,242 +174,242 @@ Reference notes:
 
 .NET Core SDK 2.x downloads can be found here: [.NET Core SDK 2.x Installers and Binaries](Downloads2.x.md)
 
-[win-x64-badge-main]: https://aka.ms/dotnet/7.0.1xx/daily/win_x64_Release_version_badge.svg
-[win-x64-version-main]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-win-x64.txt
-[win-x64-installer-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-win-x64.exe
-[win-x64-installer-checksum-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-win-x64.exe.sha
-[win-x64-zip-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-win-x64.zip
-[win-x64-zip-checksum-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-win-x64.zip.sha
+[win-x64-badge-main]: https://aka.ms/dotnet/8.0.1xx/daily/win_x64_Release_version_badge.svg
+[win-x64-version-main]: https://aka.ms/dotnet/8.0.1xx/daily/productCommit-win-x64.txt
+[win-x64-installer-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-win-x64.exe
+[win-x64-installer-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-win-x64.exe.sha
+[win-x64-zip-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-win-x64.zip
+[win-x64-zip-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-win-x64.zip.sha
 
-[win-x64-badge-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/win_x64_Release_version_badge.svg
-[win-x64-version-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/productCommit-win-x64.txt
-[win-x64-installer-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-win-x64.exe
-[win-x64-installer-checksum-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-win-x64.exe.sha
-[win-x64-zip-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-win-x64.zip
-[win-x64-zip-checksum-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-win-x64.zip.sha
+[win-x64-badge-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/win_x64_Release_version_badge.svg
+[win-x64-version-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-win-x64.txt
+[win-x64-installer-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-win-x64.exe
+[win-x64-installer-checksum-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-win-x64.exe.sha
+[win-x64-zip-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-win-x64.zip
+[win-x64-zip-checksum-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-win-x64.zip.sha
 
-[win-x64-badge-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/win_x64_Release_version_badge.svg
-[win-x64-version-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/productCommit-win-x64.txt
-[win-x64-installer-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-win-x64.exe
-[win-x64-installer-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-win-x64.exe.sha
-[win-x64-zip-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-win-x64.zip
-[win-x64-zip-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-win-x64.zip.sha
+[win-x64-badge-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/win_x64_Release_version_badge.svg
+[win-x64-version-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/productCommit-win-x64.txt
+[win-x64-installer-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-win-x64.exe
+[win-x64-installer-checksum-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-win-x64.exe.sha
+[win-x64-zip-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-win-x64.zip
+[win-x64-zip-checksum-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-win-x64.zip.sha
 
-[win-x86-badge-main]: https://aka.ms/dotnet/7.0.1xx/daily/win_x86_Release_version_badge.svg
-[win-x86-version-main]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-win-x86.txt
-[win-x86-installer-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-win-x86.exe
-[win-x86-installer-checksum-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-win-x86.exe.sha
-[win-x86-zip-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-win-x86.zip
-[win-x86-zip-checksum-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-win-x86.zip.sha
+[win-x86-badge-main]: https://aka.ms/dotnet/8.0.1xx/daily/win_x86_Release_version_badge.svg
+[win-x86-version-main]: https://aka.ms/dotnet/8.0.1xx/daily/productCommit-win-x86.txt
+[win-x86-installer-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-win-x86.exe
+[win-x86-installer-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-win-x86.exe.sha
+[win-x86-zip-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-win-x86.zip
+[win-x86-zip-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-win-x86.zip.sha
 
-[win-x86-badge-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/win_x86_Release_version_badge.svg
-[win-x86-version-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/productCommit-win-x86.txt
-[win-x86-installer-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-win-x86.exe
-[win-x86-installer-checksum-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-win-x86.exe.sha
-[win-x86-zip-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-win-x86.zip
-[win-x86-zip-checksum-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-win-x86.zip.sha
+[win-x86-badge-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/win_x86_Release_version_badge.svg
+[win-x86-version-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-win-x86.txt
+[win-x86-installer-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-win-x86.exe
+[win-x86-installer-checksum-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-win-x86.exe.sha
+[win-x86-zip-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-win-x86.zip
+[win-x86-zip-checksum-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-win-x86.zip.sha
 
-[win-x86-badge-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/win_x86_Release_version_badge.svg
-[win-x86-version-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/productCommit-win-x86.txt
-[win-x86-installer-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-win-x86.exe
-[win-x86-installer-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-win-x86.exe.sha
-[win-x86-zip-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-win-x86.zip
-[win-x86-zip-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-win-x86.zip.sha
+[win-x86-badge-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/win_x86_Release_version_badge.svg
+[win-x86-version-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/productCommit-win-x86.txt
+[win-x86-installer-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-win-x86.exe
+[win-x86-installer-checksum-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-win-x86.exe.sha
+[win-x86-zip-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-win-x86.zip
+[win-x86-zip-checksum-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-win-x86.zip.sha
 
-[osx-x64-badge-main]: https://aka.ms/dotnet/7.0.1xx/daily/osx_x64_Release_version_badge.svg
-[osx-x64-version-main]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-osx-x64.txt
-[osx-x64-installer-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-osx-x64.pkg
-[osx-x64-installer-checksum-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-osx-x64.pkg.sha
-[osx-x64-targz-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-osx-x64.tar.gz
-[osx-x64-targz-checksum-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-osx-x64.pkg.tar.gz.sha
+[osx-x64-badge-main]: https://aka.ms/dotnet/8.0.1xx/daily/osx_x64_Release_version_badge.svg
+[osx-x64-version-main]: https://aka.ms/dotnet/8.0.1xx/daily/productCommit-osx-x64.txt
+[osx-x64-installer-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-osx-x64.pkg
+[osx-x64-installer-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-osx-x64.pkg.sha
+[osx-x64-targz-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-osx-x64.tar.gz
+[osx-x64-targz-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-osx-x64.pkg.tar.gz.sha
 
-[osx-x64-badge-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/osx_x64_Release_version_badge.svg
-[osx-x64-version-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/productCommit-osx-x64.txt
-[osx-x64-installer-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-osx-x64.pkg
-[osx-x64-installer-checksum-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-osx-x64.pkg.sha
-[osx-x64-targz-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-osx-x64.tar.gz
-[osx-x64-targz-checksum-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-osx-x64.pkg.tar.gz.sha
+[osx-x64-badge-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/osx_x64_Release_version_badge.svg
+[osx-x64-version-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-osx-x64.txt
+[osx-x64-installer-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-osx-x64.pkg
+[osx-x64-installer-checksum-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-osx-x64.pkg.sha
+[osx-x64-targz-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-osx-x64.tar.gz
+[osx-x64-targz-checksum-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-osx-x64.pkg.tar.gz.sha
 
-[osx-x64-badge-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/osx_x64_Release_version_badge.svg
-[osx-x64-version-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/productCommit-osx-x64.txt
-[osx-x64-installer-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-osx-x64.pkg
-[osx-x64-installer-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-osx-x64.pkg.sha
-[osx-x64-targz-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-osx-x64.tar.gz
-[osx-x64-targz-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-osx-x64.pkg.tar.gz.sha
+[osx-x64-badge-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/osx_x64_Release_version_badge.svg
+[osx-x64-version-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/productCommit-osx-x64.txt
+[osx-x64-installer-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-osx-x64.pkg
+[osx-x64-installer-checksum-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-osx-x64.pkg.sha
+[osx-x64-targz-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-osx-x64.tar.gz
+[osx-x64-targz-checksum-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-osx-x64.pkg.tar.gz.sha
 
-[osx-arm64-badge-main]: https://aka.ms/dotnet/7.0.1xx/daily/osx_arm64_Release_version_badge.svg
-[osx-arm64-version-main]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-osx-arm64.txt
-[osx-arm64-installer-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-osx-arm64.pkg
-[osx-arm64-installer-checksum-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-osx-arm64.pkg.sha
-[osx-arm64-targz-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-osx-arm64.tar.gz
-[osx-arm64-targz-checksum-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-osx-arm64.pkg.tar.gz.sha
+[osx-arm64-badge-main]: https://aka.ms/dotnet/8.0.1xx/daily/osx_arm64_Release_version_badge.svg
+[osx-arm64-version-main]: https://aka.ms/dotnet/8.0.1xx/daily/productCommit-osx-arm64.txt
+[osx-arm64-installer-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-osx-arm64.pkg
+[osx-arm64-installer-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-osx-arm64.pkg.sha
+[osx-arm64-targz-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-osx-arm64.tar.gz
+[osx-arm64-targz-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-osx-arm64.pkg.tar.gz.sha
 
-[osx-arm64-badge-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/osx_arm64_Release_version_badge.svg
-[osx-arm64-version-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/productCommit-osx-arm64.txt
-[osx-arm64-installer-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-osx-arm64.pkg
-[osx-arm64-installer-checksum-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-osx-arm64.pkg.sha
-[osx-arm64-targz-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-osx-arm64.tar.gz
-[osx-arm64-targz-checksum-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-osx-arm64.pkg.tar.gz.sha
+[osx-arm64-badge-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/osx_arm64_Release_version_badge.svg
+[osx-arm64-version-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-osx-arm64.txt
+[osx-arm64-installer-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-osx-arm64.pkg
+[osx-arm64-installer-checksum-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-osx-arm64.pkg.sha
+[osx-arm64-targz-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-osx-arm64.tar.gz
+[osx-arm64-targz-checksum-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-osx-arm64.pkg.tar.gz.sha
 
-[osx-arm64-badge-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/osx_arm64_Release_version_badge.svg
-[osx-arm64-version-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/productCommit-osx-arm64.txt
-[osx-arm64-installer-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-osx-arm64.pkg
-[osx-arm64-installer-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-osx-arm64.pkg.sha
-[osx-arm64-targz-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-osx-arm64.tar.gz
-[osx-arm64-targz-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-osx-arm64.pkg.tar.gz.sha
+[osx-arm64-badge-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/osx_arm64_Release_version_badge.svg
+[osx-arm64-version-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/productCommit-osx-arm64.txt
+[osx-arm64-installer-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-osx-arm64.pkg
+[osx-arm64-installer-checksum-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-osx-arm64.pkg.sha
+[osx-arm64-targz-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-osx-arm64.tar.gz
+[osx-arm64-targz-checksum-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-osx-arm64.pkg.tar.gz.sha
 
-[linux-badge-main]: https://aka.ms/dotnet/7.0.1xx/daily/linux_x64_Release_version_badge.svg
-[linux-version-main]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-linux-x64.txt
-[linux-DEB-installer-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-x64.deb
-[linux-DEB-installer-checksum-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-x64.deb.sha
-[linux-RPM-installer-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-x64.rpm
-[linux-RPM-installer-checksum-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-x64.rpm.sha
-[linux-targz-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-linux-x64.tar.gz
-[linux-targz-checksum-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-linux-x64.tar.gz.sha
+[linux-badge-main]: https://aka.ms/dotnet/8.0.1xx/daily/linux_x64_Release_version_badge.svg
+[linux-version-main]: https://aka.ms/dotnet/8.0.1xx/daily/productCommit-linux-x64.txt
+[linux-DEB-installer-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-x64.deb
+[linux-DEB-installer-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-x64.deb.sha
+[linux-RPM-installer-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-x64.rpm
+[linux-RPM-installer-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-x64.rpm.sha
+[linux-targz-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-linux-x64.tar.gz
+[linux-targz-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-linux-x64.tar.gz.sha
 
-[linux-badge-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/linux_x64_Release_version_badge.svg
-[linux-version-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/productCommit-linux-x64.txt
-[linux-DEB-installer-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-x64.deb
-[linux-DEB-installer-checksum-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-x64.deb.sha
-[linux-RPM-installer-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-x64.rpm
-[linux-RPM-installer-checksum-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-x64.rpm.sha
-[linux-targz-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-linux-x64.tar.gz
-[linux-targz-checksum-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-linux-x64.tar.gz.sha
+[linux-badge-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/linux_x64_Release_version_badge.svg
+[linux-version-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-linux-x64.txt
+[linux-DEB-installer-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-x64.deb
+[linux-DEB-installer-checksum-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-x64.deb.sha
+[linux-RPM-installer-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-x64.rpm
+[linux-RPM-installer-checksum-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-x64.rpm.sha
+[linux-targz-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-linux-x64.tar.gz
+[linux-targz-checksum-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-linux-x64.tar.gz.sha
 
-[linux-badge-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/linux_x64_Release_version_badge.svg
-[linux-version-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/productCommit-linux-x64.txt
-[linux-DEB-installer-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-x64.deb
-[linux-DEB-installer-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-x64.deb.sha
-[linux-RPM-installer-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-x64.rpm
-[linux-RPM-installer-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-x64.rpm.sha
-[linux-targz-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-linux-x64.tar.gz
-[linux-targz-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-linux-x64.tar.gz.sha
+[linux-badge-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/linux_x64_Release_version_badge.svg
+[linux-version-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/productCommit-linux-x64.txt
+[linux-DEB-installer-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-x64.deb
+[linux-DEB-installer-checksum-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-x64.deb.sha
+[linux-RPM-installer-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-x64.rpm
+[linux-RPM-installer-checksum-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-x64.rpm.sha
+[linux-targz-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-linux-x64.tar.gz
+[linux-targz-checksum-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-linux-x64.tar.gz.sha
 
-[linux-arm-badge-main]: https://aka.ms/dotnet/7.0.1xx/daily/linux_arm_Release_version_badge.svg
-[linux-arm-version-main]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-linux-arm.txt
-[linux-arm-targz-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-linux-arm.tar.gz
-[linux-arm-targz-checksum-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-linux-arm.tar.gz.sha
+[linux-arm-badge-main]: https://aka.ms/dotnet/8.0.1xx/daily/linux_arm_Release_version_badge.svg
+[linux-arm-version-main]: https://aka.ms/dotnet/8.0.1xx/daily/productCommit-linux-arm.txt
+[linux-arm-targz-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-linux-arm.tar.gz
+[linux-arm-targz-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-linux-arm.tar.gz.sha
 
-[linux-arm-badge-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/linux_arm_Release_version_badge.svg
-[linux-arm-version-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/productCommit-linux-arm.txt
-[linux-arm-targz-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-linux-arm.tar.gz
-[linux-arm-targz-checksum-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-linux-arm.tar.gz.sha
+[linux-arm-badge-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/linux_arm_Release_version_badge.svg
+[linux-arm-version-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-linux-arm.txt
+[linux-arm-targz-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-linux-arm.tar.gz
+[linux-arm-targz-checksum-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-linux-arm.tar.gz.sha
 
-[linux-arm-badge-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/linux_arm_Release_version_badge.svg
-[linux-arm-version-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/productCommit-linux-arm.txt
-[linux-arm-targz-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-linux-arm.tar.gz
-[linux-arm-targz-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-linux-arm.tar.gz.sha
+[linux-arm-badge-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/linux_arm_Release_version_badge.svg
+[linux-arm-version-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/productCommit-linux-arm.txt
+[linux-arm-targz-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-linux-arm.tar.gz
+[linux-arm-targz-checksum-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-linux-arm.tar.gz.sha
 
-[linux-arm64-badge-main]: https://aka.ms/dotnet/7.0.1xx/daily/linux_arm64_Release_version_badge.svg
-[linux-arm64-version-main]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-linux-arm64.txt
-[linux-arm64-targz-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-linux-arm64.tar.gz
-[linux-arm64-targz-checksum-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-linux-arm64.tar.gz.sha
+[linux-arm64-badge-main]: https://aka.ms/dotnet/8.0.1xx/daily/linux_arm64_Release_version_badge.svg
+[linux-arm64-version-main]: https://aka.ms/dotnet/8.0.1xx/daily/productCommit-linux-arm64.txt
+[linux-arm64-targz-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-linux-arm64.tar.gz
+[linux-arm64-targz-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-linux-arm64.tar.gz.sha
 
-[linux-arm64-badge-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/linux_arm64_Release_version_badge.svg
-[linux-arm64-version-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/productCommit-linux-arm64.txt
-[linux-arm64-targz-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-linux-arm64.tar.gz
-[linux-arm64-targz-checksum-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-linux-arm64.tar.gz.sha
+[linux-arm64-badge-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/linux_arm64_Release_version_badge.svg
+[linux-arm64-version-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-linux-arm64.txt
+[linux-arm64-targz-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-linux-arm64.tar.gz
+[linux-arm64-targz-checksum-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-linux-arm64.tar.gz.sha
 
-[linux-arm64-badge-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/linux_arm64_Release_version_badge.svg
-[linux-arm64-version-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/productCommit-linux-arm64.txt
-[linux-arm64-targz-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-linux-arm64.tar.gz
-[linux-arm64-targz-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-linux-arm64.tar.gz.sha
+[linux-arm64-badge-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/linux_arm64_Release_version_badge.svg
+[linux-arm64-version-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/productCommit-linux-arm64.txt
+[linux-arm64-targz-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-linux-arm64.tar.gz
+[linux-arm64-targz-checksum-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-linux-arm64.tar.gz.sha
 
-[rhel-6-badge-main]: https://aka.ms/dotnet/7.0.1xx/daily/rhel.6_x64_Release_version_badge.svg
-[rhel-6-version-main]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-rhel.6-x64.txt
-[rhel-6-targz-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-rhel.6-x64.tar.gz
-[rhel-6-targz-checksum-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-rhel.6-x64.tar.gz.sha
+[rhel-6-badge-main]: https://aka.ms/dotnet/8.0.1xx/daily/rhel.6_x64_Release_version_badge.svg
+[rhel-6-version-main]: https://aka.ms/dotnet/8.0.1xx/daily/productCommit-rhel.6-x64.txt
+[rhel-6-targz-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-rhel.6-x64.tar.gz
+[rhel-6-targz-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-rhel.6-x64.tar.gz.sha
 
-[rhel-6-badge-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/rhel.6_x64_Release_version_badge.svg
-[rhel-6-version-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/productCommit-rhel.6-x64.txt
-[rhel-6-targz-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-rhel.6-x64.tar.gz
-[rhel-6-targz-checksum-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-rhel.6-x64.tar.gz.sha
+[rhel-6-badge-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/rhel.6_x64_Release_version_badge.svg
+[rhel-6-version-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-rhel.6-x64.txt
+[rhel-6-targz-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-rhel.6-x64.tar.gz
+[rhel-6-targz-checksum-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-rhel.6-x64.tar.gz.sha
 
-[rhel-6-badge-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/rhel.6_x64_Release_version_badge.svg
-[rhel-6-version-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/productCommit-rhel.6-x64.txt
-[rhel-6-targz-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-rhel.6-x64.tar.gz
-[rhel-6-targz-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-rhel.6-x64.tar.gz.sha
+[rhel-6-badge-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/rhel.6_x64_Release_version_badge.svg
+[rhel-6-version-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/productCommit-rhel.6-x64.txt
+[rhel-6-targz-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-rhel.6-x64.tar.gz
+[rhel-6-targz-checksum-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-rhel.6-x64.tar.gz.sha
 
-[linux-musl-x64-badge-main]: https://aka.ms/dotnet/7.0.1xx/daily/linux_musl_x64_Release_version_badge.svg
-[linux-musl-x64-version-main]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-linux-musl-x64.txt
-[linux-musl-x64-targz-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-linux-musl-x64.tar.gz
-[linux-musl-x64-targz-checksum-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-linux-musl-x64.tar.gz.sha
+[linux-musl-x64-badge-main]: https://aka.ms/dotnet/8.0.1xx/daily/linux_musl_x64_Release_version_badge.svg
+[linux-musl-x64-version-main]: https://aka.ms/dotnet/8.0.1xx/daily/productCommit-linux-musl-x64.txt
+[linux-musl-x64-targz-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-linux-musl-x64.tar.gz
+[linux-musl-x64-targz-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-linux-musl-x64.tar.gz.sha
 
-[linux-musl-x64-badge-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/linux_musl_x64_Release_version_badge.svg
-[linux-musl-x64-version-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/productCommit-linux-musl-x64.txt
-[linux-musl-x64-targz-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-linux-musl-x64.tar.gz
-[linux-musl-x64-targz-checksum-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-linux-musl-x64.tar.gz.sha
+[linux-musl-x64-badge-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/linux_musl_x64_Release_version_badge.svg
+[linux-musl-x64-version-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-linux-musl-x64.txt
+[linux-musl-x64-targz-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-linux-musl-x64.tar.gz
+[linux-musl-x64-targz-checksum-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-linux-musl-x64.tar.gz.sha
 
-[linux-musl-x64-badge-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/linux_musl_x64_Release_version_badge.svg
-[linux-musl-x64-version-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/productCommit-linux-musl-x64.txt
-[linux-musl-x64-targz-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-linux-musl-x64.tar.gz
-[linux-musl-x64-targz-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-linux-musl-x64.tar.gz.sha
+[linux-musl-x64-badge-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/linux_musl_x64_Release_version_badge.svg
+[linux-musl-x64-version-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/productCommit-linux-musl-x64.txt
+[linux-musl-x64-targz-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-linux-musl-x64.tar.gz
+[linux-musl-x64-targz-checksum-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-linux-musl-x64.tar.gz.sha
 
-[linux-musl-arm-badge-main]: https://aka.ms/dotnet/7.0.1xx/daily/linux_musl_arm_Release_version_badge.svg
-[linux-musl-arm-version-main]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-linux-musl-arm.txt
-[linux-musl-arm-targz-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-linux-musl-arm.tar.gz
-[linux-musl-arm-targz-checksum-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-linux-musl-arm.tar.gz.sha
+[linux-musl-arm-badge-main]: https://aka.ms/dotnet/8.0.1xx/daily/linux_musl_arm_Release_version_badge.svg
+[linux-musl-arm-version-main]: https://aka.ms/dotnet/8.0.1xx/daily/productCommit-linux-musl-arm.txt
+[linux-musl-arm-targz-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-linux-musl-arm.tar.gz
+[linux-musl-arm-targz-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-linux-musl-arm.tar.gz.sha
 
-[linux-musl-arm-badge-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/linux_musl_arm_Release_version_badge.svg
-[linux-musl-arm-version-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/productCommit-linux-musl-arm.txt
-[linux-musl-arm-targz-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-linux-musl-arm.tar.gz
-[linux-musl-arm-targz-checksum-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-linux-musl-arm.tar.gz.sha
+[linux-musl-arm-badge-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/linux_musl_arm_Release_version_badge.svg
+[linux-musl-arm-version-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-linux-musl-arm.txt
+[linux-musl-arm-targz-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-linux-musl-arm.tar.gz
+[linux-musl-arm-targz-checksum-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-linux-musl-arm.tar.gz.sha
 
-[linux-musl-arm-badge-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/linux_musl_arm_Release_version_badge.svg
-[linux-musl-arm-version-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/productCommit-linux-musl-arm.txt
-[linux-musl-arm-targz-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-linux-musl-arm.tar.gz
-[linux-musl-arm-targz-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-linux-musl-arm.tar.gz.sha
+[linux-musl-arm-badge-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/linux_musl_arm_Release_version_badge.svg
+[linux-musl-arm-version-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/productCommit-linux-musl-arm.txt
+[linux-musl-arm-targz-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-linux-musl-arm.tar.gz
+[linux-musl-arm-targz-checksum-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-linux-musl-arm.tar.gz.sha
 
-[linux-musl-arm64-badge-main]: https://aka.ms/dotnet/7.0.1xx/daily/linux_musl_arm64_Release_version_badge.svg
-[linux-musl-arm64-version-main]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-linux-musl-arm64.txt
-[linux-musl-arm64-targz-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-linux-musl-arm64.tar.gz
-[linux-musl-arm64-targz-checksum-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-linux-musl-arm64.tar.gz.sha
+[linux-musl-arm64-badge-main]: https://aka.ms/dotnet/8.0.1xx/daily/linux_musl_arm64_Release_version_badge.svg
+[linux-musl-arm64-version-main]: https://aka.ms/dotnet/8.0.1xx/daily/productCommit-linux-musl-arm64.txt
+[linux-musl-arm64-targz-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-linux-musl-arm64.tar.gz
+[linux-musl-arm64-targz-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-linux-musl-arm64.tar.gz.sha
 
-[linux-musl-arm64-badge-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/linux_musl_arm64_Release_version_badge.svg
-[linux-musl-arm64-version-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/productCommit-linux-musl-arm64.txt
-[linux-musl-arm64-targz-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-linux-musl-arm64.tar.gz
-[linux-musl-arm64-targz-checksum-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-linux-musl-arm64.tar.gz.sha
+[linux-musl-arm64-badge-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/linux_musl_arm64_Release_version_badge.svg
+[linux-musl-arm64-version-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-linux-musl-arm64.txt
+[linux-musl-arm64-targz-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-linux-musl-arm64.tar.gz
+[linux-musl-arm64-targz-checksum-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-linux-musl-arm64.tar.gz.sha
 
-[linux-musl-arm64-badge-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/linux_musl_arm64_Release_version_badge.svg
-[linux-musl-arm64-version-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/productCommit-linux-musl-arm64.txt
-[linux-musl-arm64-targz-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-linux-musl-arm64.tar.gz
-[linux-musl-arm64-targz-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-linux-musl-arm64.tar.gz.sha
+[linux-musl-arm64-badge-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/linux_musl_arm64_Release_version_badge.svg
+[linux-musl-arm64-version-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/productCommit-linux-musl-arm64.txt
+[linux-musl-arm64-targz-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-linux-musl-arm64.tar.gz
+[linux-musl-arm64-targz-checksum-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-linux-musl-arm64.tar.gz.sha
 
-[win-arm-badge-main]: https://aka.ms/dotnet/7.0.1xx/daily/win_arm_Release_version_badge.svg
-[win-arm-version-main]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-win-arm.txt
-[win-arm-zip-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-win-arm.zip
-[win-arm-zip-checksum-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-win-arm.zip.sha
+[win-arm-badge-main]: https://aka.ms/dotnet/8.0.1xx/daily/win_arm_Release_version_badge.svg
+[win-arm-version-main]: https://aka.ms/dotnet/8.0.1xx/daily/productCommit-win-arm.txt
+[win-arm-zip-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-win-arm.zip
+[win-arm-zip-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-win-arm.zip.sha
 
-[win-arm-badge-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/win_arm_Release_version_badge.svg
-[win-arm-version-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/productCommit-win-arm.txt
-[win-arm-zip-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-win-arm.zip
-[win-arm-zip-checksum-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-win-arm.zip.sha
+[win-arm-badge-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/win_arm_Release_version_badge.svg
+[win-arm-version-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-win-arm.txt
+[win-arm-zip-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-win-arm.zip
+[win-arm-zip-checksum-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-win-arm.zip.sha
 
-[win-arm-badge-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/win_arm_Release_version_badge.svg
-[win-arm-version-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/productCommit-win-arm.txt
-[win-arm-zip-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-win-arm.zip
-[win-arm-zip-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-win-arm.zip.sha
+[win-arm-badge-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/win_arm_Release_version_badge.svg
+[win-arm-version-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/productCommit-win-arm.txt
+[win-arm-zip-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-win-arm.zip
+[win-arm-zip-checksum-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-win-arm.zip.sha
 
-[win-arm64-badge-main]: https://aka.ms/dotnet/7.0.1xx/daily/win_arm64_Release_version_badge.svg
-[win-arm64-version-main]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-win-arm64.txt
-[win-arm64-installer-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-win-arm64.exe
-[win-arm64-installer-checksum-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-win-arm64.exe.sha
-[win-arm64-zip-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-win-arm64.zip
-[win-arm64-zip-checksum-main]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-win-arm64.zip.sha
+[win-arm64-badge-main]: https://aka.ms/dotnet/8.0.1xx/daily/win_arm64_Release_version_badge.svg
+[win-arm64-version-main]: https://aka.ms/dotnet/8.0.1xx/daily/productCommit-win-arm64.txt
+[win-arm64-installer-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-win-arm64.exe
+[win-arm64-installer-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-win-arm64.exe.sha
+[win-arm64-zip-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-win-arm64.zip
+[win-arm64-zip-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-win-arm64.zip.sha
 
-[win-arm64-badge-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/win_arm64_Release_version_badge.svg
-[win-arm64-version-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/productCommit-win-arm64.txt
-[win-arm64-installer-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-win-arm64.exe
-[win-arm64-installer-checksum-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-win-arm64.exe.sha
-[win-arm64-zip-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-win-arm64.zip
-[win-arm64-zip-checksum-7.0.1XX-preview7]: https://aka.ms/dotnet/7.0.1xx-preview7/daily/dotnet-sdk-win-arm64.zip.sha
+[win-arm64-badge-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/win_arm64_Release_version_badge.svg
+[win-arm64-version-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/productCommit-win-arm64.txt
+[win-arm64-installer-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-win-arm64.exe
+[win-arm64-installer-checksum-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-win-arm64.exe.sha
+[win-arm64-zip-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-win-arm64.zip
+[win-arm64-zip-checksum-7.0.1XX]: https://aka.ms/dotnet/7.0.1xx/daily/dotnet-sdk-win-arm64.zip.sha
 
-[win-arm64-badge-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/win_arm64_Release_version_badge.svg
-[win-arm64-version-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/productCommit-win-arm64.txt
-[win-arm64-installer-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-win-arm64.exe
-[win-arm64-installer-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-win-arm64.exe.sha
-[win-arm64-zip-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-win-arm64.zip
-[win-arm64-zip-checksum-6.0.4XX]: https://aka.ms/dotnet/6.0.4xx/daily/dotnet-sdk-win-arm64.zip.sha
+[win-arm64-badge-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/win_arm64_Release_version_badge.svg
+[win-arm64-version-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/productCommit-win-arm64.txt
+[win-arm64-installer-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-win-arm64.exe
+[win-arm64-installer-checksum-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-win-arm64.exe.sha
+[win-arm64-zip-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-win-arm64.zip
+[win-arm64-zip-checksum-7.0.1XX-rc1]: https://aka.ms/dotnet/7.0.1xx-rc1/daily/dotnet-sdk-win-arm64.zip.sha
 
 [sdk-shas-2.2.1XX]: https://github.com/dotnet/versions/tree/master/build-info/dotnet/product/cli/release/2.2#built-repositories
 

--- a/tools/sdk-readme-table-generator/TableGenerator/Program.fs
+++ b/tools/sdk-readme-table-generator/TableGenerator/Program.fs
@@ -7,14 +7,14 @@ open TableGenerator.Table
 
 let inputBranches =
         [ { GitBranchName = "main"
-            DisplayName = "main<br>(7.0.x&nbsp;Runtime)"
+            DisplayName = "main<br>(8.0.x&nbsp;Runtime)"
+            AkaMsChannel = Some("8.0.1xx/daily") }
+          { GitBranchName = "release/7.0.1xx"
+            DisplayName = "Release/7.0.1xx<br>(7.0.x&nbsp;Runtime)"
             AkaMsChannel = Some("7.0.1xx/daily") }
-          { GitBranchName = "release/7.0.1xx-preview7"
-            DisplayName = "Release/7.0.1xx-preview7<br>(7.0.x&nbsp;Runtime)"
-            AkaMsChannel = Some("7.0.1xx-preview7/daily") }
-          { GitBranchName = "release/6.0.4xx"
-            DisplayName = "Release/6.0.4XX<br>(6.0.x&nbsp;Runtime)"
-            AkaMsChannel = Some("6.0.4xx/daily") }]
+          { GitBranchName = "release/7.0.1xx-rc1"
+            DisplayName = "Release/7.0.1xx-rc1<br>(7.0.x&nbsp;Runtime)"
+            AkaMsChannel = Some("7.0.1xx-rc1/daily") }]
 
 
 let referentNotes = """Reference notes:


### PR DESCRIPTION
Removing the 6.0.400 table as we don't want folks to install daily servicing builds because all the code flow for those is internal (ie the public builds only have changes that went into installer and nowhere else which is confusing).

Added an rc1 column and a column for the 7.0.1xx (rc2) branch.