### PR TITLE
Move RemoveVersions logic of SdkContentTests to before the file diff

### DIFF
--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SdkContentTests.cs
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SdkContentTests.cs
@@ -31,7 +31,6 @@ public class SdkContentTests : SmokeTests
         WriteTarballFileList(Config.SdkTarballPath, sbFileListingFileName, isPortable: false);
 
         string diff = BaselineHelper.DiffFiles(msftFileListingFileName, sbFileListingFileName, OutputHelper);
-        diff = BaselineHelper.RemoveVersions(diff);
         diff = RemoveDiffMarkers(diff);
         BaselineHelper.CompareContents("MsftToSbSdk.diff", diff, OutputHelper, Config.WarnOnSdkContentDiffs);
     }
@@ -45,6 +44,7 @@ public class SdkContentTests : SmokeTests
 
         string fileListing = ExecuteHelper.ExecuteProcessValidateExitCode("tar", $"tf {tarballPath}", OutputHelper);
         fileListing = BaselineHelper.RemoveRids(fileListing, isPortable);
+        fileListing = BaselineHelper.RemoveVersions(fileListing);
         IEnumerable<string> files = fileListing.Split(Environment.NewLine).OrderBy(path => path);
 
         File.WriteAllLines(outputFileName, files);


### PR DESCRIPTION
This is needed for scenarios when the sdk build numbers are different.

Related to https://github.com/dotnet/source-build/issues/2965
