### PR TITLE
Add additional supported RIDs to ILCompiler package

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -249,8 +249,8 @@
 
       <Crossgen2SupportedRids Include="@(Net60Crossgen2SupportedRids)" />
 
-      <!-- Match the ILCompilerRIDs.props at https://github.com/dotnet/runtime/blob/main/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/ILCompilerRIDs.props -->
-      <ILCompilerSupportedRids Include="linux-arm;linux-musl-arm64;linux-arm64;linux-musl-x64;linux-x64;osx-x64;win-arm64;win-x64" />
+      <!-- Match the Crossgen2 RIDs although some are currently not supported in NativeAOT. Its better for the SDK not to block on the RIDs and let NativeAOT manage the experience -->
+      <ILCompilerSupportedRids Include="@(Net60Crossgen2SupportedRids)" />
 
       <AspNetCore31RuntimePackRids Include="@(AspNetCore30RuntimePackRids)" />
       <AspNetCore50RuntimePackRids Include="@(AspNetCore31RuntimePackRids);linux-musl-arm;win-arm64" />

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -249,7 +249,8 @@
 
       <Crossgen2SupportedRids Include="@(Net60Crossgen2SupportedRids)" />
 
-      <ILCompilerSupportedRids Include="linux-musl-x64;linux-x64;linux-arm64;win-x64;win-arm64" />
+      <!-- Match the ILCompilerRIDs.props at https://github.com/dotnet/runtime/blob/main/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/ILCompilerRIDs.props -->
+      <ILCompilerSupportedRids Include="linux-arm;linux-musl-arm64;linux-arm64;linux-musl-x64;linux-x64;osx-x64;win-arm64;win-x64" />
 
       <AspNetCore31RuntimePackRids Include="@(AspNetCore30RuntimePackRids)" />
       <AspNetCore50RuntimePackRids Include="@(AspNetCore31RuntimePackRids);linux-musl-arm;win-arm64" />


### PR DESCRIPTION
SDK currently only uses a subset of supported RIDs and that will prevent some supported RIDs (ex. osx-x64) from working in the default PublishAOT mode. Adding the missing RIDs.
