### PR TITLE
[main] Add support for arm platform

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <BuildArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</BuildArchitecture>
-    <Architecture Condition="'$(Architecture)' == '' AND '$(BuildArchitecture)' == 'arm64'">$(BuildArchitecture)</Architecture>
+    <Architecture Condition="'$(Architecture)' == '' AND ('$(BuildArchitecture)' == 'arm64' OR '$(BuildArchitecture)' == 'arm')">$(BuildArchitecture)</Architecture>
     <Architecture Condition="'$(Architecture)' == '' AND '$(BuildArchitecture)' == 's390x'">$(BuildArchitecture)</Architecture>
     <Architecture Condition="'$(Architecture)' == '' AND '$(BuildArchitecture)' == 'ppc64le'">$(BuildArchitecture)</Architecture>
     <Architecture Condition="'$(Architecture)' == ''">x64</Architecture>

--- a/Native.sln
+++ b/Native.sln
@@ -12,9 +12,11 @@ Global
 		Debug|x86 = Debug|x86
 		Debug|x64 = Debug|x64
 		Debug|arm64 = Debug|arm64
+		Debug|arm = Debug|arm
 		Release|x86 = Release|x86
 		Release|x64 = Release|x64
 		Release|arm64 = Release|arm64
+		Release|arm = Release|arm
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{688E2883-C5A9-4D66-A207-772C9160989C}.Debug|x86.ActiveCfg = Debug|x86
@@ -23,12 +25,16 @@ Global
 		{688E2883-C5A9-4D66-A207-772C9160989C}.Debug|x64.Build.0 = Debug|x64
 		{688E2883-C5A9-4D66-A207-772C9160989C}.Debug|arm64.ActiveCfg = Debug|arm64
 		{688E2883-C5A9-4D66-A207-772C9160989C}.Debug|arm64.Build.0 = Debug|arm64
+		{688E2883-C5A9-4D66-A207-772C9160989C}.Debug|arm.ActiveCfg = Debug|arm
+		{688E2883-C5A9-4D66-A207-772C9160989C}.Debug|arm.Build.0 = Debug|arm
 		{688E2883-C5A9-4D66-A207-772C9160989C}.Release|x86.ActiveCfg = Release|x86
 		{688E2883-C5A9-4D66-A207-772C9160989C}.Release|x86.Build.0 = Release|x86
 		{688E2883-C5A9-4D66-A207-772C9160989C}.Release|x64.ActiveCfg = Release|x64
 		{688E2883-C5A9-4D66-A207-772C9160989C}.Release|x64.Build.0 = Release|x64
 		{688E2883-C5A9-4D66-A207-772C9160989C}.Release|arm64.ActiveCfg = Release|arm64
 		{688E2883-C5A9-4D66-A207-772C9160989C}.Release|arm64.Build.0 = Release|arm64
+		{688E2883-C5A9-4D66-A207-772C9160989C}.Release|arm.ActiveCfg = Release|arm
+		{688E2883-C5A9-4D66-A207-772C9160989C}.Release|arm.Build.0 = Release|arm
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -21,7 +21,7 @@
         <!-- Regular build -->
         <ItemGroup>
           <ProjectToBuild Include="$(RepoRoot)Microsoft.DotNet.Cli.sln" />
-          <ProjectToBuild Condition="'$(OS)' == 'Windows_NT' And ('$(Architecture)' == 'x86' Or '$(Architecture)' == 'x64' Or '$(Architecture)' == 'arm64')" 
+          <ProjectToBuild Condition="'$(OS)' == 'Windows_NT' And ('$(Architecture)' == 'x86' Or '$(Architecture)' == 'x64' Or '$(Architecture)' == 'arm64' Or '$(Architecture)' == 'arm')"
                           Include="$(RepoRoot)eng\version.csproj;
                                    $(RepoRoot)eng\native.proj" />
         </ItemGroup>

--- a/src/SourceBuild/tarball/content/Directory.Build.props
+++ b/src/SourceBuild/tarball/content/Directory.Build.props
@@ -17,7 +17,7 @@
   <PropertyGroup>
     <Platform Condition="'$(Platform)' == 'AnyCPU'"></Platform>
     <BuildArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</BuildArchitecture>
-    <Platform Condition="'$(Platform)' == '' AND '$(BuildArchitecture)' == 'arm64'">$(BuildArchitecture)</Platform>
+    <Platform Condition="'$(Platform)' == '' AND ('$(BuildArchitecture)' == 'arm64' OR '$(BuildArchitecture)' == 'arm')">$(BuildArchitecture)</Platform>
     <Platform Condition="'$(Platform)' == '' AND '$(BuildArchitecture)' == 's390x'">$(BuildArchitecture)</Platform>
     <Platform Condition="'$(Platform)' == '' AND '$(BuildArchitecture)' == 'ppc64le'">$(BuildArchitecture)</Platform>
     <Platform Condition="'$(Platform)' == ''">x64</Platform>

--- a/src/SourceBuild/tarball/content/repos/known-good.proj
+++ b/src/SourceBuild/tarball/content/repos/known-good.proj
@@ -18,7 +18,8 @@
         <RepositoryReference Include="runtime" />
       </ItemGroup>
     </When>
-    <When Condition="$(Platform.Contains('arm')) AND '$(BuildArchitecture)' != 'arm64'">
+    <!-- Originally used to capture arm platforms. Now with support, left as an extension point for bringing up new architectures in the future. -->
+    <When Condition="'true' == 'false'">
       <ItemGroup>
         <RepositoryReference Include="runtime" />
       </ItemGroup>

--- a/src/SourceBuild/tarball/content/tools-local/init-build.proj
+++ b/src/SourceBuild/tarball/content/tools-local/init-build.proj
@@ -138,7 +138,7 @@
   </Target>
 
   <Target Name="GenerateRootFs" Condition="'$(OS)' != 'Windows_NT'">
-     <Exec Condition="$(Platform.Contains('arm')) AND '$(Platform)' != 'armel' AND '$(BuildArchitecture)' != 'arm64'" Command="$(ArmEnvironmentVariables) $(ProjectDir)cross/build-rootfs.sh" />
+     <Exec Condition="$(Platform.Contains('arm')) AND '$(Platform)' != 'armel' AND '$(BuildArchitecture)' != 'arm64' AND '$(BuildArchitecture)' != 'arm'" Command="$(ArmEnvironmentVariables) $(ProjectDir)cross/build-rootfs.sh" />
      <Exec Condition="'$(Platform)' == 'armel'" Command="$(ArmEnvironmentVariables) $(ProjectDir)cross/armel/tizen-build-rootfs.sh" />
   </Target>
 


### PR DESCRIPTION
## Expected behavior
As prebuilt SDKs are provided for arm by Microsoft, source-build should support ARM build.

## Actual behavior
Per https://github.com/dotnet/source-build/issues/2781, source-build does not support arm. 

## Proposed modifications
This pull request modifies existing `Platform` and `Architecture` logics to parse arch information correctly when `BuildArchitecture=arm`

## Varia
release/6.0.1xx version: https://github.com/dotnet/installer/pull/13378

Made as part of Alpine Linux dotnet6 packaging project, see https://github.com/dotnet/source-build/issues/2782