### PR TITLE
Let VMR CLI handle recursive initialization

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -207,9 +207,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>4f864b2841b3317bdfc516ead0ba6e7856fab575</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.DarcLib" Version="1.1.0-beta.20074.1">
+    <Dependency Name="Microsoft.DotNet.DarcLib" Version="1.1.0-beta.22462.2">
       <Uri>https://github.com/dotnet/arcade-services</Uri>
-      <Sha>cd705029f2675970b42f9273ae359d0926c5e815</Sha>
+      <Sha>1031000fad67fa8e3f8dc67ef73611b556eb33a5</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging.Console" Version="7.0.0-preview.7.22375.6">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -207,9 +207,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>4f864b2841b3317bdfc516ead0ba6e7856fab575</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.DarcLib" Version="1.1.0-beta.22429.1">
+    <Dependency Name="Microsoft.DotNet.DarcLib" Version="1.1.0-beta.20074.1">
       <Uri>https://github.com/dotnet/arcade-services</Uri>
-      <Sha>f169af20efd542ef8aba38154efb9ccd22eba2c4</Sha>
+      <Sha>cd705029f2675970b42f9273ae359d0926c5e815</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging.Console" Version="7.0.0-preview.7.22375.6">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,7 +30,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/arcade-services -->
-    <MicrosoftDotNetDarcLibVersion>1.1.0-beta.20074.1</MicrosoftDotNetDarcLibVersion>
+    <MicrosoftDotNetDarcLibVersion>1.1.0-beta.22462.2</MicrosoftDotNetDarcLibVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/winforms -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,7 +30,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/arcade-services -->
-    <MicrosoftDotNetDarcLibVersion>1.1.0-beta.22429.1</MicrosoftDotNetDarcLibVersion>
+    <MicrosoftDotNetDarcLibVersion>1.1.0-beta.20074.1</MicrosoftDotNetDarcLibVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/winforms -->

--- a/src/VirtualMonoRepo/InitializeVMR.proj
+++ b/src/VirtualMonoRepo/InitializeVMR.proj
@@ -35,9 +35,7 @@
                                                  InitializeCleanVmr;
                                                  CopyTarballContent;
                                                  CommitInitialContent;
-                                                 SetupSelfGithubInfo;
                                                  InitializeRepoAndDependentsRecursive;
-                                                 CommitGitInfoFiles;
                                                  CopyTextOnlyPackages;
                                                  CommitTextOnlyPackages">
     <Message Text="VMR was successfully initialized in '$(VmrDir)'" Importance="High" />
@@ -60,57 +58,30 @@
   <Target Name="InitializeRepoAndDependentsRecursive"
     DependsOnTargets="GetSourceBuildIntermediateNupkgNameConvention">
 
-    <Message Text="--> Initializing repo $(SourceBuildRepoName)" Importance="High" />
     <PropertyGroup>
-      <SourceDir>$(SourceBuildRepoName)/</SourceDir>
-      <IndividualRepoSourceDir>$(VmrSourceDir)$(SourceDir)</IndividualRepoSourceDir>
-      <IndividualRepoSourceEngDir>$(IndividualRepoSourceDir)eng/</IndividualRepoSourceEngDir>
-      <IndividualRepoVersionDetailsFile>$(IndividualRepoSourceEngDir)Version.Details.xml</IndividualRepoVersionDetailsFile>
+      <RootRepoName>$([System.IO.Path]::GetFileName("$(RepoRoot.TrimEnd('/').TrimEnd('\\'))"))</RootRepoName>
     </PropertyGroup>
 
+    <!-- Get installer's sha -->
+    <Exec Command="git rev-parse HEAD" ConsoleToMSBuild="true" WorkingDirectory="$(RepoRoot)">
+      <Output TaskParameter="ConsoleOutput" ItemName="RootRepoCommitSha" />
+    </Exec>
+
+    <Message Text="--> Initializing individual repos recursively. Starting from $(RootRepoName) / @(RootRepoCommitSha)" Importance="High" />
+
+    <!-- We are hardcoding the package version for the root repo (installer), since there
+         isn't a Version.Details.xml file to read it from.
+         See https://github.com/dotnet/source-build/issues/2250 -->
     <VirtualMonoRepo_Initialize
-      Repository="$(SourceBuildRepoName)"
-      Revision="$(RepoSha)"
+      Repository="$(RootRepoName)"
+      Revision="@(RootRepoCommitSha)"
+      PackageVersion="8.0.100"
+      Recursive="true"
       VmrPath="$(VmrDir)"
       TmpPath="$(TmpDir)" />
 
-    <Message Text=" -> Done initializing repo $(SourceBuildRepoName)" Importance="High" />
+    <Message Text=" -> Done initializing individual repositories recursively" Importance="High" />
 
-    <Tarball_ReadSourceBuildIntermediateNupkgDependencies
-      VersionDetailsXmlFile="$([MSBuild]::NormalizePath($(IndividualRepoVersionDetailsFile)))"
-      SourceBuildIntermediateNupkgPrefix="$(SourceBuildIntermediateNupkgPrefix)"
-      SourceBuildIntermediateNupkgRid="$(SourceBuildIntermediateNupkgRid)"
-      ConvertInternalRepos="$(ConvertInternalRepos)">
-      <Output TaskParameter="Dependencies" ItemName="SourceBuildRepos" />
-    </Tarball_ReadSourceBuildIntermediateNupkgDependencies>
-
-    <!-- Remove repo if it has already be cloned at any sha.  This results in
-         The commit sha for the cloned repo in the tarball being the one that
-         was first encountered. -->
-    <ItemGroup>
-      <SourceBuildRepos Remove="@(SourceBuildRepos)" Condition=" EXISTS('$(VmrGitInfoDir)%(SourceBuildRepoName).props')" />
-    </ItemGroup>
-
-    <Tarball_WriteSourceRepoProperties
-      SourceBuildMetadataDir="$(VmrGitInfoDir)"
-      Dependencies="@(SourceBuildRepos)" />
-
-    <Message Text="--> Dependencies for $(IndividualRepoVersionDetailsFile):" Importance="High" Condition=" '@(SourceBuildRepos)' != '' " />
-    <Message Text="-->     %(SourceBuildRepos.SourceBuildRepoName) / %(SourceBuildRepos.Sha)" Importance="High" Condition=" '@(SourceBuildRepos)' != '' " />
-    <MSBuild Projects="$(MSBuildProjectFile)"
-      Condition=" '@(SourceBuildRepos)' != '' "
-      Targets="InitializeRepoAndDependentsRecursive"
-      Properties="SourceBuildRepoName=%(SourceBuildRepos.SourceBuildRepoName);RepoSha=%(SourceBuildRepos.Sha)" />
-
-  </Target>
-
-  <Target Name="CommitGitInfoFiles">
-    <Copy
-      SourceFiles="$(VmrGitInfoDir)runtime.props"
-      DestinationFiles="$(VmrGitInfoDir)runtime-portable.props" />
-
-    <Exec Command="git add git-info" WorkingDirectory="$(VmrDir)" />
-    <Exec Command="git commit -m 'Initialized git-info files'" WorkingDirectory="$(VmrDir)" />
   </Target>
 
   <Target Name="CommitTextOnlyPackages">

--- a/src/VirtualMonoRepo/Tasks/RemoteFactory.cs
+++ b/src/VirtualMonoRepo/Tasks/RemoteFactory.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.DotNet.DarcLib;
 using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.VirtualMonoRepo.Tasks;
 
@@ -21,12 +22,12 @@ internal class RemoteFactory : IRemoteFactory
         _tmpPath = tmpPath;
     }
 
-    public Task<IRemote> GetBarOnlyRemoteAsync(Extensions.Logging.ILogger logger)
+    public Task<IRemote> GetBarOnlyRemoteAsync(ILogger logger)
     {
         throw new NotImplementedException();
     }
 
-    public Task<IRemote> GetRemoteAsync(string repoUrl, Extensions.Logging.ILogger logger)
+    public Task<IRemote> GetRemoteAsync(string repoUrl, ILogger logger)
     {
         var githubClient = new DarcLib.GitHubClient(
             _processManager.GitExecutable,
@@ -36,6 +37,6 @@ internal class RemoteFactory : IRemoteFactory
             cache: null);
 
         IRemote remote = new Remote(githubClient, barClient: null, _versionDetailsParser, logger);
-        return System.Threading.Tasks.Task.FromResult(remote);
+        return Task.FromResult(remote);
     }
 }

--- a/src/VirtualMonoRepo/Tasks/RemoteFactory.cs
+++ b/src/VirtualMonoRepo/Tasks/RemoteFactory.cs
@@ -11,11 +11,13 @@ namespace Microsoft.DotNet.VirtualMonoRepo.Tasks;
 internal class RemoteFactory : IRemoteFactory
 {
     private readonly IProcessManager _processManager;
+    private readonly IVersionDetailsParser _versionDetailsParser;
     private readonly string _tmpPath;
 
-    public RemoteFactory(IProcessManager processManager, string tmpPath)
+    public RemoteFactory(IProcessManager processManager, IVersionDetailsParser versionDetailsParser, string tmpPath)
     {
         _processManager = processManager;
+        _versionDetailsParser = versionDetailsParser;
         _tmpPath = tmpPath;
     }
 
@@ -33,6 +35,7 @@ internal class RemoteFactory : IRemoteFactory
             _tmpPath,
             cache: null);
 
-        return System.Threading.Tasks.Task.FromResult<IRemote>(new Remote(githubClient, barClient: null, logger));
+        IRemote remote = new Remote(githubClient, barClient: null, _versionDetailsParser, logger);
+        return System.Threading.Tasks.Task.FromResult(remote);
     }
 }

--- a/src/VirtualMonoRepo/Tasks/VirtualMonoRepo_Initialize.cs
+++ b/src/VirtualMonoRepo/Tasks/VirtualMonoRepo_Initialize.cs
@@ -14,6 +14,11 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.VirtualMonoRepo.Tasks;
 
+/// <summary>
+/// This tasks equals calling the "darc vmr initialize" command.
+/// This command pulls an individual repository into the VMR for the first time.
+/// It can also recursively pull all of its dependencies based on Version.Details.xml.
+/// </summary>
 public class VirtualMonoRepo_Initialize : Build.Utilities.Task, ICancelableTask
 {
     private readonly Lazy<IServiceProvider> _serviceProvider;

--- a/src/VirtualMonoRepo/Tasks/VirtualMonoRepo_Initialize.cs
+++ b/src/VirtualMonoRepo/Tasks/VirtualMonoRepo_Initialize.cs
@@ -30,6 +30,10 @@ public class VirtualMonoRepo_Initialize : Build.Utilities.Task, ICancelableTask
 
     public string Revision { get; set; }
 
+    public string PackageVersion { get; set; }
+
+    public bool Recursive { get; set; }
+
     public VirtualMonoRepo_Initialize()
     {
         _serviceProvider = new(CreateServiceProvider);
@@ -40,7 +44,7 @@ public class VirtualMonoRepo_Initialize : Build.Utilities.Task, ICancelableTask
     private async Task<bool> ExecuteAsync()
     {
         var vmrInitializer = _serviceProvider.Value.GetRequiredService<IVmrInitializer>();
-        await vmrInitializer.InitializeVmr(Repository, Revision, _cancellationToken.Token);
+        await vmrInitializer.InitializeRepository(Repository, Revision, PackageVersion, Recursive, _cancellationToken.Token);
         return true;
     }
 


### PR DESCRIPTION
Previously, the recursive clone of all the product repos based on `Version.Details.xml` files was done inside MSBuild but the VMR tooling can now do that (https://github.com/dotnet/arcade-services/pull/2004).
This replaces the need for the Source-Build tasks (Read/Write, recursive clone).

Secondly, `git-info` props files are now created by the CLI too (https://github.com/dotnet/arcade-services/pull/2014).

https://github.com/dotnet/arcade/issues/10264