### PR TITLE
[release/6.0.1xx] GetRuntimeInformation.targets: determine PortableProductMonikerRid based on OSName and Architecture. (backports #12516)

### DIFF
--- a/src/redist/targets/GetRuntimeInformation.targets
+++ b/src/redist/targets/GetRuntimeInformation.targets
@@ -28,6 +28,8 @@
                                    '$(Rid)' == 'linux-musl-x64' ">$(Rid)</ProductMonikerRid>
       <ProductMonikerRid Condition=" '$(ProductMonikerRid)' == '' ">$(OSName)-$(Architecture)</ProductMonikerRid>
 
+      <PortableProductMonikerRid Condition=" '$(PortableProductMonikerRid)' == '' ">$(HostOSName)-$(Architecture)</PortableProductMonikerRid>
+
       <ArtifactNameSdk>dotnet-sdk-internal$(PgoTerm)</ArtifactNameSdk>
       <ArtifactNameCombinedHostHostFxrFrameworkSdk>dotnet-sdk$(PgoTerm)</ArtifactNameCombinedHostHostFxrFrameworkSdk>
 


### PR DESCRIPTION
## Description
Backports https://github.com/dotnet/installer/pull/12516 to release/6.0.1xx.

## Customer Impact
Without this, the portable RID will be incorrect in some source-built versions.  This causes failures in partners' test suites and could lead to future issues with N-1 builds.

## Fix
Determines PortableProductMonikerRid based on OSName and Architecture.

## Regression?
- [ ] Yes
- [x] No

## Risk
- [ ] High
- [ ] Medium
- [x] Low

## Verification
- [ ] Manuel (required)
- [x] Automated

