### PR TITLE
[7.0.1xx] Revert roslyn CodeAnalysis patch removal

### DIFF
--- a/src/SourceBuild/tarball/content/repos/roslyn.proj
+++ b/src/SourceBuild/tarball/content/repos/roslyn.proj
@@ -32,6 +32,10 @@
       need to support VS.
     -->
     <ExtraPackageVersionPropsPackageInfo Include="SourceGeneratorMicrosoftCodeAnalysisVersion" Version="%24(MicrosoftCodeAnalysisCommonVersion)" />
+    <ExtraPackageVersionPropsPackageInfo Include="SourceBuildLiftedSystemCollectionsImmutableVersion" Version="%24(SystemCollectionsImmutableVersion)" />
+    <ExtraPackageVersionPropsPackageInfo Include="SourceBuildLiftedSystemReflectionMetadataVersion" Version="%24(SystemReflectionMetadataVersion)" />
+    <ExtraPackageVersionPropsPackageInfo Include="SourceBuildLiftedSystemRuntimeCompilerServicesUnsafeVersion" Version="%24(SystemRuntimeCompilerServicesUnsafeVersion)" />
+    <ExtraPackageVersionPropsPackageInfo Include="SourceBuildLiftedSystemTextEncodingCodePagesVersion" Version="%24(SystemTextEncodingCodePagesVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SourceBuild/tarball/patches/roslyn/0001-lift-version-of-Microsoft.CodeAnalysis.Common-depend.patch
+++ b/src/SourceBuild/tarball/patches/roslyn/0001-lift-version-of-Microsoft.CodeAnalysis.Common-depend.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Logan Bussell <36081148+lbussell@users.noreply.github.com>
+Date: Thu, 21 Oct 2021 23:15:23 +0000
+Subject: [PATCH 1/2] lift version of Microsoft.CodeAnalysis.Common
+ dependencies to previously source built versions
+
+Requires https://github.com/dotnet/source-build/issues/2482 in order to eliminate this patch
+---
+ .../Source/CSharpSyntaxGenerator/CSharpSyntaxGenerator.csproj | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/CSharpSyntaxGenerator.csproj b/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/CSharpSyntaxGenerator.csproj
+index 7eae8afa275..a50822a6aeb 100644
+--- a/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/CSharpSyntaxGenerator.csproj
++++ b/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/CSharpSyntaxGenerator.csproj
+@@ -27,5 +27,9 @@
+     <Compile Include="..\..\..\..\..\Compilers\CSharp\Portable\Syntax\SyntaxKindFacts.cs" Link="Grammar\SyntaxKindFacts.cs" Condition="'$(TargetFramework)' != 'netstandard2.0'" />
+ 
+     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(SourceGeneratorMicrosoftCodeAnalysisVersion)" PrivateAssets="all" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
++    <PackageReference Include="System.Collections.Immutable" Version="$(SourceBuildLiftedSystemCollectionsImmutableVersion)" PrivateAssets="all" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
++    <PackageReference Include="System.Reflection.Metadata" Version="$(SourceBuildLiftedSystemReflectionMetadataVersion)" PrivateAssets="all" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
++    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SourceBuildLiftedSystemRuntimeCompilerServicesUnsafeVersion)" PrivateAssets="all" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
++    <PackageReference Include="System.Text.Encoding.CodePages" Version="$(SourceBuildLiftedSystemTextEncodingCodePagesVersion)" PrivateAssets="all" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+   </ItemGroup>
+ </Project>
+\ No newline at end of file


### PR DESCRIPTION

https://github.com/dotnet/installer/pull/14484 introduced some prebuilts:

```
<Usage Id="System.Collections.Immutable" Version="7.0.0-rc.1.22403.8" File="src/roslyn/artifacts/source-build/self/src/artifacts/obj/CSharpSyntaxGenerator/project.assets.json" />
<Usage Id="System.Reflection.Metadata" Version="7.0.0-rc.1.22403.8" File="src/roslyn/artifacts/source-build/self/src/artifacts/obj/CSharpSyntaxGenerator/project.assets.json" />
<Usage Id="System.Text.Encoding.CodePages" Version="7.0.0-rc.1.22403.8" File="src/roslyn/artifacts/source-build/self/src/artifacts/obj/CSharpSyntaxGenerator/project.assets.json" />
```

We should research these, but the change needs to be reverted to unblock ongoing work.

Also see See https://github.com/dotnet/source-build/issues/2971