### PR TITLE
Add Roslyn patch to use source-built versions of ref packs and not use app host 

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -206,9 +206,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>a8b74560cd0ad9a01f0356369bb9dfc031a9a6b0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="7.0.0-alpha.1.22408.1">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="7.0.0-alpha.1.22465.1">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>ddc5b4880b0bf18783fc6808c4d407214f7bdae1</Sha>
+      <Sha>f1ca87cd81e6081e827f25150088fca734da8f5c</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceLink.GitHub" Version="1.2.0-beta-22429-01" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">

--- a/src/SourceBuild/tarball/patches/roslyn/0001-Use-the-source-built-version-of-ref-packs-and-don-t-.patch
+++ b/src/SourceBuild/tarball/patches/roslyn/0001-Use-the-source-built-version-of-ref-packs-and-don-t-.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Chris Rummel <crummel@microsoft.com>
+Date: Thu, 15 Sep 2022 14:46:53 -0500
+Subject: [PATCH] Use the source-built version of ref packs and don't use app
+ host when building in source-build.
+
+Backport PR: https://github.com/dotnet/roslyn/pull/64055.
+
+---
+ Directory.Build.targets | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/Directory.Build.targets b/Directory.Build.targets
+index 8f38a48cd95..dfb4fd33c9a 100644
+--- a/Directory.Build.targets
++++ b/Directory.Build.targets
+@@ -1,5 +1,20 @@
+ <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+ <Project>
++  <!-- use the source-built version of the reference packs if building in source-build -->
++  <ItemGroup Condition="'$(DotNetBuidlFromSource)' == 'true'">
++    <KnownFrameworkReference Update="Microsoft.NETCore.App">
++      <TargetingPackVersion Condition="'%(TargetFramework)' == 'net6.0'">6.0.0</TargetingPackVersion>
++    </KnownFrameworkReference>
++    <KnownFrameworkReference Update="Microsoft.AspNetCore.App">
++      <TargetingPackVersion Condition="'%(TargetFramework)' == 'net6.0'">6.0.0</TargetingPackVersion>
++    </KnownFrameworkReference>
++  </ItemGroup>
++
++  <!-- do not restore or use the 6.0 app host in source-build -->
++  <PropertyGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
++    <UseAppHost>false</UseAppHost>
++  </PropertyGroup>
++
+   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+   <Import Project="eng\targets\Imports.targets" />
+ </Project>


### PR DESCRIPTION
Cherry picking changes from https://github.com/dotnet/installer/pull/14518 into 7.0.1xx-rc2 branch