### PR TITLE
[release/7.0.1xx-rc2] Fix spelling error in msbuild property reference

### DIFF
--- a/src/SourceBuild/tarball/patches/roslyn/0001-Use-the-source-built-version-of-ref-packs-and-don-t-.patch
+++ b/src/SourceBuild/tarball/patches/roslyn/0001-Use-the-source-built-version-of-ref-packs-and-don-t-.patch
@@ -18,7 +18,7 @@ index 8f38a48cd95..dfb4fd33c9a 100644
  <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
  <Project>
 +  <!-- use the source-built version of the reference packs if building in source-build -->
-+  <ItemGroup Condition="'$(DotNetBuidlFromSource)' == 'true'">
++  <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
 +    <KnownFrameworkReference Update="Microsoft.NETCore.App">
 +      <TargetingPackVersion Condition="'%(TargetFramework)' == 'net6.0'">6.0.0</TargetingPackVersion>
 +    </KnownFrameworkReference>


### PR DESCRIPTION
This is related to https://github.com/dotnet/installer/pull/14518
