### PR TITLE
[release/7.0.1xx] Fix spelling error in msbuild property reference

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -206,9 +206,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>a8b74560cd0ad9a01f0356369bb9dfc031a9a6b0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="7.0.0-alpha.1.22465.1">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="7.0.0-alpha.1.22466.3">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>f1ca87cd81e6081e827f25150088fca734da8f5c</Sha>
+      <Sha>6d1119ce3caac7e29f7e44c6be80494345f9de2a</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceLink.GitHub" Version="1.2.0-beta-22429-01" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">

--- a/src/SourceBuild/tarball/patches/roslyn/0001-Use-the-source-built-version-of-ref-packs-and-don-t-.patch
+++ b/src/SourceBuild/tarball/patches/roslyn/0001-Use-the-source-built-version-of-ref-packs-and-don-t-.patch
@@ -18,7 +18,7 @@ index 8f38a48cd95..dfb4fd33c9a 100644
  <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
  <Project>
 +  <!-- use the source-built version of the reference packs if building in source-build -->
-+  <ItemGroup Condition="'$(DotNetBuidlFromSource)' == 'true'">
++  <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
 +    <KnownFrameworkReference Update="Microsoft.NETCore.App">
 +      <TargetingPackVersion Condition="'%(TargetFramework)' == 'net6.0'">6.0.0</TargetingPackVersion>
 +    </KnownFrameworkReference>


### PR DESCRIPTION
Porting https://github.com/dotnet/installer/pull/14530 to release/7.0.1xx
