### PR TITLE
[release/7.0.1xx-rc2] Remove PrivateSourceBuiltPrebuiltsPackageVersion since all prebuilts have been removed

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -193,7 +193,6 @@
       necessary, and this property is removed from the file.
     -->
     <PrivateSourceBuiltArtifactsPackageVersion>7.0.100-rc.1</PrivateSourceBuiltArtifactsPackageVersion>
-    <PrivateSourceBuiltPrebuiltsPackageVersion>0.1.0-7.0.100-9</PrivateSourceBuiltPrebuiltsPackageVersion>
   </PropertyGroup>
   <!-- Workload manifest package versions -->
   <PropertyGroup>


### PR DESCRIPTION
This PR depends on https://github.com/dotnet/installer/pull/14530
