### PR TITLE
[release/7.0.1xx] Remove PrivateSourceBuiltPrebuiltsPackageVersion since all prebuilts have been removed

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -194,7 +194,6 @@
       necessary, and this property is removed from the file.
     -->
     <PrivateSourceBuiltArtifactsPackageVersion>7.0.100-rc.1</PrivateSourceBuiltArtifactsPackageVersion>
-    <PrivateSourceBuiltPrebuiltsPackageVersion>0.1.0-7.0.100-9</PrivateSourceBuiltPrebuiltsPackageVersion>
   </PropertyGroup>
   <!-- Workload manifest package versions -->
   <PropertyGroup>


### PR DESCRIPTION
Port of https://github.com/dotnet/installer/pull/14532 to release/7.0.1xx
