### PR TITLE
[release/7.0.1xx] Add RID argument to llvm-project repo.proj.

### DIFF
--- a/src/SourceBuild/tarball/content/repos/llvm-project.proj
+++ b/src/SourceBuild/tarball/content/repos/llvm-project.proj
@@ -2,7 +2,10 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <BuildCommand>$(ProjectDirectory)build$(ShellExtension) $(StandardSourceBuildArgs)</BuildCommand>
+    <BuildCommandArgs/>
+    <!-- llvm-project always builds x64 unless told otherwisse -->
+    <BuildCommandArgs>$(BuildCommandArgs) /p:OutputRid=$(PortableRid)</BuildCommandArgs>
+    <BuildCommand>$(ProjectDirectory)build$(ShellExtension) $(StandardSourceBuildArgs) $(BuildCommandArgs)</BuildCommand>
 
     <GlobalJsonFile>$(ProjectDirectory)global.json</GlobalJsonFile>
     <NuGetConfigFile>$(ProjectDirectory)NuGet.config</NuGetConfigFile>


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/3029.  llvm-project always builds for linux-x64 unless another RID is specified, so we just specify the relevant portable RID here.