### PR TITLE
Update the minimum version in the installer UI to 17.4 (which is recommended)

### DIFF
--- a/src/redist/targets/packaging/osx/clisdk/resources/cs.lproj/conclusion.html
+++ b/src/redist/targets/packaging/osx/clisdk/resources/cs.lproj/conclusion.html
@@ -25,7 +25,7 @@
             <ul>
                 <li><a href="https://aka.ms/dotnet-docs">.NET Documentation</a></li>
                 <li><a href="https://aka.ms/dotnet-cli-docs">SDK Documentation</a></li>
-                <li><a href="https://aka.ms/dotnet6-release-notes">Release Notes</a></li>
+                <li><a href="https://aka.ms/dotnet7-release-notes">Release Notes</a></li>
                 <li><a href="https://aka.ms/dotnet-tutorials">Tutorials</a></li>
             </ul>
         </div>

--- a/src/redist/targets/packaging/osx/clisdk/resources/de.lproj/conclusion.html
+++ b/src/redist/targets/packaging/osx/clisdk/resources/de.lproj/conclusion.html
@@ -25,7 +25,7 @@
             <ul>
                 <li><a href="https://aka.ms/dotnet-docs">.NET Documentation</a></li>
                 <li><a href="https://aka.ms/dotnet-cli-docs">SDK Documentation</a></li>
-                <li><a href="https://aka.ms/dotnet6-release-notes">Release Notes</a></li>
+                <li><a href="https://aka.ms/dotnet7-release-notes">Release Notes</a></li>
                 <li><a href="https://aka.ms/dotnet-tutorials">Tutorials</a></li>
             </ul>
         </div>

--- a/src/redist/targets/packaging/osx/clisdk/resources/en.lproj/conclusion.html
+++ b/src/redist/targets/packaging/osx/clisdk/resources/en.lproj/conclusion.html
@@ -25,7 +25,7 @@
             <ul>
                 <li><a href="https://aka.ms/dotnet-docs">.NET Documentation</a></li>
                 <li><a href="https://aka.ms/dotnet-cli-docs">SDK Documentation</a></li>
-                <li><a href="https://aka.ms/dotnet6-release-notes">Release Notes</a></li>
+                <li><a href="https://aka.ms/dotnet7-release-notes">Release Notes</a></li>
                 <li><a href="https://aka.ms/dotnet-tutorials">Tutorials</a></li>
             </ul>
         </div>

--- a/src/redist/targets/packaging/osx/clisdk/resources/es.lproj/conclusion.html
+++ b/src/redist/targets/packaging/osx/clisdk/resources/es.lproj/conclusion.html
@@ -25,7 +25,7 @@
             <ul>
                 <li><a href="https://aka.ms/dotnet-docs">.NET Documentation</a></li>
                 <li><a href="https://aka.ms/dotnet-cli-docs">SDK Documentation</a></li>
-                <li><a href="https://aka.ms/dotnet6-release-notes">Release Notes</a></li>
+                <li><a href="https://aka.ms/dotnet7-release-notes">Release Notes</a></li>
                 <li><a href="https://aka.ms/dotnet-tutorials">Tutorials</a></li>
             </ul>
         </div>

--- a/src/redist/targets/packaging/osx/clisdk/resources/fr.lproj/conclusion.html
+++ b/src/redist/targets/packaging/osx/clisdk/resources/fr.lproj/conclusion.html
@@ -25,7 +25,7 @@
             <ul>
                 <li><a href="https://aka.ms/dotnet-docs">.NET Documentation</a></li>
                 <li><a href="https://aka.ms/dotnet-cli-docs">SDK Documentation</a></li>
-                <li><a href="https://aka.ms/dotnet6-release-notes">Release Notes</a></li>
+                <li><a href="https://aka.ms/dotnet7-release-notes">Release Notes</a></li>
                 <li><a href="https://aka.ms/dotnet-tutorials">Tutorials</a></li>
             </ul>
         </div>

--- a/src/redist/targets/packaging/osx/clisdk/resources/it.lproj/conclusion.html
+++ b/src/redist/targets/packaging/osx/clisdk/resources/it.lproj/conclusion.html
@@ -25,7 +25,7 @@
             <ul>
                 <li><a href="https://aka.ms/dotnet-docs">.NET Documentation</a></li>
                 <li><a href="https://aka.ms/dotnet-cli-docs">SDK Documentation</a></li>
-                <li><a href="https://aka.ms/dotnet6-release-notes">Release Notes</a></li>
+                <li><a href="https://aka.ms/dotnet7-release-notes">Release Notes</a></li>
                 <li><a href="https://aka.ms/dotnet-tutorials">Tutorials</a></li>
             </ul>
         </div>

--- a/src/redist/targets/packaging/osx/clisdk/resources/ja.lproj/conclusion.html
+++ b/src/redist/targets/packaging/osx/clisdk/resources/ja.lproj/conclusion.html
@@ -25,7 +25,7 @@
             <ul>
                 <li><a href="https://aka.ms/dotnet-docs">.NET Documentation</a></li>
                 <li><a href="https://aka.ms/dotnet-cli-docs">SDK Documentation</a></li>
-                <li><a href="https://aka.ms/dotnet6-release-notes">Release Notes</a></li>
+                <li><a href="https://aka.ms/dotnet7-release-notes">Release Notes</a></li>
                 <li><a href="https://aka.ms/dotnet-tutorials">Tutorials</a></li>
             </ul>
         </div>

--- a/src/redist/targets/packaging/osx/clisdk/resources/ko.lproj/conclusion.html
+++ b/src/redist/targets/packaging/osx/clisdk/resources/ko.lproj/conclusion.html
@@ -25,7 +25,7 @@
             <ul>
                 <li><a href="https://aka.ms/dotnet-docs">.NET Documentation</a></li>
                 <li><a href="https://aka.ms/dotnet-cli-docs">SDK Documentation</a></li>
-                <li><a href="https://aka.ms/dotnet6-release-notes">Release Notes</a></li>
+                <li><a href="https://aka.ms/dotnet7-release-notes">Release Notes</a></li>
                 <li><a href="https://aka.ms/dotnet-tutorials">Tutorials</a></li>
             </ul>
         </div>

--- a/src/redist/targets/packaging/osx/clisdk/resources/pl.lproj/conclusion.html
+++ b/src/redist/targets/packaging/osx/clisdk/resources/pl.lproj/conclusion.html
@@ -25,7 +25,7 @@
             <ul>
                 <li><a href="https://aka.ms/dotnet-docs">.NET Documentation</a></li>
                 <li><a href="https://aka.ms/dotnet-cli-docs">SDK Documentation</a></li>
-                <li><a href="https://aka.ms/dotnet6-release-notes">Release Notes</a></li>
+                <li><a href="https://aka.ms/dotnet7-release-notes">Release Notes</a></li>
                 <li><a href="https://aka.ms/dotnet-tutorials">Tutorials</a></li>
             </ul>
         </div>

--- a/src/redist/targets/packaging/osx/clisdk/resources/pt-br.lproj/conclusion.html
+++ b/src/redist/targets/packaging/osx/clisdk/resources/pt-br.lproj/conclusion.html
@@ -25,7 +25,7 @@
             <ul>
                 <li><a href="https://aka.ms/dotnet-docs">.NET Documentation</a></li>
                 <li><a href="https://aka.ms/dotnet-cli-docs">SDK Documentation</a></li>
-                <li><a href="https://aka.ms/dotnet6-release-notes">Release Notes</a></li>
+                <li><a href="https://aka.ms/dotnet7-release-notes">Release Notes</a></li>
                 <li><a href="https://aka.ms/dotnet-tutorials">Tutorials</a></li>
             </ul>
         </div>

--- a/src/redist/targets/packaging/osx/clisdk/resources/ru.lproj/conclusion.html
+++ b/src/redist/targets/packaging/osx/clisdk/resources/ru.lproj/conclusion.html
@@ -25,7 +25,7 @@
             <ul>
                 <li><a href="https://aka.ms/dotnet-docs">.NET Documentation</a></li>
                 <li><a href="https://aka.ms/dotnet-cli-docs">SDK Documentation</a></li>
-                <li><a href="https://aka.ms/dotnet6-release-notes">Release Notes</a></li>
+                <li><a href="https://aka.ms/dotnet7-release-notes">Release Notes</a></li>
                 <li><a href="https://aka.ms/dotnet-tutorials">Tutorials</a></li>
             </ul>
         </div>

--- a/src/redist/targets/packaging/osx/clisdk/resources/tr.lproj/conclusion.html
+++ b/src/redist/targets/packaging/osx/clisdk/resources/tr.lproj/conclusion.html
@@ -25,7 +25,7 @@
             <ul>
                 <li><a href="https://aka.ms/dotnet-docs">.NET Documentation</a></li>
                 <li><a href="https://aka.ms/dotnet-cli-docs">SDK Documentation</a></li>
-                <li><a href="https://aka.ms/dotnet6-release-notes">Release Notes</a></li>
+                <li><a href="https://aka.ms/dotnet7-release-notes">Release Notes</a></li>
                 <li><a href="https://aka.ms/dotnet-tutorials">Tutorials</a></li>
             </ul>
         </div>

--- a/src/redist/targets/packaging/osx/clisdk/resources/zh-hans.lproj/conclusion.html
+++ b/src/redist/targets/packaging/osx/clisdk/resources/zh-hans.lproj/conclusion.html
@@ -25,7 +25,7 @@
             <ul>
                 <li><a href="https://aka.ms/dotnet-docs">.NET Documentation</a></li>
                 <li><a href="https://aka.ms/dotnet-cli-docs">SDK Documentation</a></li>
-                <li><a href="https://aka.ms/dotnet6-release-notes">Release Notes</a></li>
+                <li><a href="https://aka.ms/dotnet7-release-notes">Release Notes</a></li>
                 <li><a href="https://aka.ms/dotnet-tutorials">Tutorials</a></li>
             </ul>
         </div>

--- a/src/redist/targets/packaging/osx/clisdk/resources/zh-hant.lproj/conclusion.html
+++ b/src/redist/targets/packaging/osx/clisdk/resources/zh-hant.lproj/conclusion.html
@@ -25,7 +25,7 @@
             <ul>
                 <li><a href="https://aka.ms/dotnet-docs">.NET Documentation</a></li>
                 <li><a href="https://aka.ms/dotnet-cli-docs">SDK Documentation</a></li>
-                <li><a href="https://aka.ms/dotnet6-release-notes">Release Notes</a></li>
+                <li><a href="https://aka.ms/dotnet7-release-notes">Release Notes</a></li>
                 <li><a href="https://aka.ms/dotnet-tutorials">Tutorials</a></li>
             </ul>
         </div>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1028/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1028/bundle.wxl
@@ -76,7 +76,7 @@
   <String Id="InstallationNoteTitle">安裝附註</String>
   <String Id="InstallationNote">安裝程序期間將會執行命令，加快專案還原速度並啟用離線存取。最多需要一分鐘的時間完成。
   </String>
-  <String Id="VisualStudioWarning">若預計要搭配 Visual Studio 使用 .NET 7.0，需要 Visual Studio 2022 17.0 或更新版本。&lt;A HREF="https://aka.ms/dotnet7-release-notes"&gt;深入了解&lt;/A&gt;.
+  <String Id="VisualStudioWarning">若預計要搭配 Visual Studio 使用 .NET 7.0，需要 Visual Studio 2022 17.4 或更新版本。&lt;A HREF="https://aka.ms/dotnet7-release-notes"&gt;深入了解&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">按一下 [\[]安裝[\[] 即表示您同意下列條款。</String>
   <String Id="InstallPathx64x86">The installation path for x64 SDK installations: &quot;[DOTNETHOME_X64]&quot; cannot be the same as for x86 SDK installations: &quot;[DOTNETHOME_X86]&quot;</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1029/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1029/bundle.wxl
@@ -76,7 +76,7 @@ Zdroje informací
   <String Id="InstallationNoteTitle">Poznámka k instalaci</String>
   <String Id="InstallationNote">Během procesu instalace se spustí příkaz, který zlepší rychlost obnovení projektu a povolí offline přístup. Akce se dokončí přibližně za minutu.
   </String>
-  <String Id="VisualStudioWarning">Pokud se chystáte používat .NET 7.0 se sadou Visual Studio, potřebujete Visual Studio 2022 17.0 nebo novější. &lt;A HREF="https://aka.ms/dotnet7-release-notes"&gt;Další informace&lt;/A&gt;.
+  <String Id="VisualStudioWarning">Pokud se chystáte používat .NET 7.0 se sadou Visual Studio, potřebujete Visual Studio 2022 17.4 nebo novější. &lt;A HREF="https://aka.ms/dotnet7-release-notes"&gt;Další informace&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Kliknutím na Nainstalovat vyjadřujete souhlas s následujícími podmínkami.</String>
   <String Id="InstallPathx64x86">The installation path for x64 SDK installations: &quot;[DOTNETHOME_X64]&quot; cannot be the same as for x86 SDK installations: &quot;[DOTNETHOME_X86]&quot;</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1031/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1031/bundle.wxl
@@ -76,7 +76,7 @@ Ressourcen
   <String Id="InstallationNoteTitle">Installationshinweis</String>
   <String Id="InstallationNote">Während des Installationsvorgangs wird ein Befehl ausgeführt, durch den die Geschwindigkeit der Projektwiederherstellung verbessert und der Offlinezugriff aktiviert wird. Der Vorgang dauert bis zu einer Minute.
   </String>
-  <String Id="VisualStudioWarning">Wenn Sie .NET 7.0 mit Visual Studio verwenden möchten, ist Visual Studio 2022 17.0 oder höher erforderlich. &lt;A HREF="https://aka.ms/dotnet7-release-notes"&gt;Weitere Informationen&lt;/A&gt;
+  <String Id="VisualStudioWarning">Wenn Sie .NET 7.0 mit Visual Studio verwenden möchten, ist Visual Studio 2022 17.4 oder höher erforderlich. &lt;A HREF="https://aka.ms/dotnet7-release-notes"&gt;Weitere Informationen&lt;/A&gt;
   </String>
   <String Id="LicenseAssent">Durch Klicken auf "Installieren" stimmen Sie den nachstehenden Bedingungen zu.</String>
   <String Id="InstallPathx64x86">The installation path for x64 SDK installations: &quot;[DOTNETHOME_X64]&quot; cannot be the same as for x86 SDK installations: &quot;[DOTNETHOME_X86]&quot;</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1033/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1033/bundle.wxl
@@ -76,7 +76,7 @@ Resources
   <String Id="InstallationNoteTitle">Installation note</String>
   <String Id="InstallationNote">A command will be run during the install process that will improve project restore speed and enable offline access. It will take up to a minute to complete.
   </String>
-  <String Id="VisualStudioWarning">If you plan to use .NET 7.0 with Visual Studio, Visual Studio 2022 17.0 or newer is required. &lt;A HREF=&quot;https://aka.ms/dotnet7-release-notes&quot;&gt;Learn more&lt;/A&gt;.
+  <String Id="VisualStudioWarning">If you plan to use .NET 7.0 with Visual Studio, Visual Studio 2022 17.4 or newer is required. &lt;A HREF=&quot;https://aka.ms/dotnet7-release-notes&quot;&gt;Learn more&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">By clicking Install, you agree to the following terms:</String>
   <String Id="InstallPathx64x86">The installation path for x64 SDK installations: &quot;[DOTNETHOME_X64]&quot; cannot be the same as for x86 SDK installations: &quot;[DOTNETHOME_X86]&quot;</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1036/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1036/bundle.wxl
@@ -76,7 +76,7 @@ Ressources
   <String Id="InstallationNoteTitle">Note d'installation</String>
   <String Id="InstallationNote">Une commande va être exécutée pendant le processus d'installation, ce qui va améliorer la vitesse de restauration du projet et permettre l'accès hors connexion. L'opération va prendre environ une minute.
   </String>
-  <String Id="VisualStudioWarning">Si vous comptez utiliser .NET 7.0 avec Visual Studio, Visual Studio 2022 17.0 ou une version ultérieure est nécessaire. &lt;A HREF="https://aka.ms/dotnet7-release-notes"&gt;En savoir plus&lt;/A&gt;.
+  <String Id="VisualStudioWarning">Si vous comptez utiliser .NET 7.0 avec Visual Studio, Visual Studio 2022 17.4 ou une version ultérieure est nécessaire. &lt;A HREF="https://aka.ms/dotnet7-release-notes"&gt;En savoir plus&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">En cliquant sur Installer, vous acceptez les conditions suivantes.</String>
   <String Id="InstallPathx64x86">The installation path for x64 SDK installations: &quot;[DOTNETHOME_X64]&quot; cannot be the same as for x86 SDK installations: &quot;[DOTNETHOME_X86]&quot;</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1040/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1040/bundle.wxl
@@ -76,7 +76,7 @@ Risorse
   <String Id="InstallationNoteTitle">Nota sull'installazione</String>
   <String Id="InstallationNote">Durante il processo di installazione verrà eseguito un comando che migliorerà la velocità di ripristino del progetto e abiliterà l'accesso offline. Il completamento del comando richiederà un minuto.
   </String>
-  <String Id="VisualStudioWarning">Se si intende usare .NET 7.0 con Visual Studio, è richiesto Visual Studio 2022 17.0 o versione successiva. &lt;A HREF="https://aka.ms/dotnet7-release-notes"&gt;Altre informazioni&lt;/A&gt;.
+  <String Id="VisualStudioWarning">Se si intende usare .NET 7.0 con Visual Studio, è richiesto Visual Studio 2022 17.4 o versione successiva. &lt;A HREF="https://aka.ms/dotnet7-release-notes"&gt;Altre informazioni&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Facendo clic su Installa, si accettano le condizioni seguenti.</String>
   <String Id="InstallPathx64x86">The installation path for x64 SDK installations: &quot;[DOTNETHOME_X64]&quot; cannot be the same as for x86 SDK installations: &quot;[DOTNETHOME_X86]&quot;</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1041/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1041/bundle.wxl
@@ -76,7 +76,7 @@
   <String Id="InstallationNoteTitle">インストール メモ</String>
   <String Id="InstallationNote">コマンドはインストール処理中に実行されるので、プロジェクトの復元速度が向上し、オフラインでアクセスできます。完了するまでに最大 1 分かかります。
   </String>
-  <String Id="VisualStudioWarning">.NET 7.0 を Visual Studio で使用する場合は、Visual Studio 2022 17.0 以降が必要です。&lt;A HREF="https://aka.ms/dotnet7-release-notes"&gt;詳細情報&lt;/A&gt;。
+  <String Id="VisualStudioWarning">.NET 7.0 を Visual Studio で使用する場合は、Visual Studio 2022 17.4 以降が必要です。&lt;A HREF="https://aka.ms/dotnet7-release-notes"&gt;詳細情報&lt;/A&gt;。
   </String>
   <String Id="LicenseAssent">[インストール] をクリックすると、次の条項に同意したものと見なされます。</String>
   <String Id="InstallPathx64x86">The installation path for x64 SDK installations: &quot;[DOTNETHOME_X64]&quot; cannot be the same as for x86 SDK installations: &quot;[DOTNETHOME_X86]&quot;</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1042/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1042/bundle.wxl
@@ -76,7 +76,7 @@
   <String Id="InstallationNoteTitle">설치 정보</String>
   <String Id="InstallationNote">프로젝트 복원 속도를 향상하고 오프라인 액세스를 사용할 수 있도록 하는 설치 프로세스 중 명령이 실행됩니다. 완료하는 데 최대 1분이 걸립니다.
   </String>
-  <String Id="VisualStudioWarning">Visual Studio와 함께 .NET 7.0을 사용하려면 Visual Studio 2022 17.0 이상이 필요합니다. &lt;A HREF="https://aka.ms/dotnet7-release-notes"&gt;자세한 정보&lt;/A&gt;.
+  <String Id="VisualStudioWarning">Visual Studio와 함께 .NET 7.0을 사용하려면 Visual Studio 2022 17.4 이상이 필요합니다. &lt;A HREF="https://aka.ms/dotnet7-release-notes"&gt;자세한 정보&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">[설치]를 클릭하면 다음 사용 약관에 동의하는 것입니다.</String>
   <String Id="InstallPathx64x86">The installation path for x64 SDK installations: &quot;[DOTNETHOME_X64]&quot; cannot be the same as for x86 SDK installations: &quot;[DOTNETHOME_X86]&quot;</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1045/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1045/bundle.wxl
@@ -76,7 +76,7 @@ Zasoby
   <String Id="InstallationNoteTitle">Uwaga dotycząca instalacji</String>
   <String Id="InstallationNote">W trakcie procesu instalacji zostanie uruchomione polecenie, które zwiększy szybkość przywracania projektu i umożliwi dostęp do trybu offline. Zajmie to maksymalnie minutę.
   </String>
-  <String Id="VisualStudioWarning">Jeśli planujesz używać platformy .NET 7.0 z programem Visual Studio, wymagany jest program Visual Studio 2022 17.0 lub nowszy. &lt;A HREF="https://aka.ms/dotnet7-release-notes"&gt;Dowiedz się więcej&lt;/A&gt;.
+  <String Id="VisualStudioWarning">Jeśli planujesz używać platformy .NET 7.0 z programem Visual Studio, wymagany jest program Visual Studio 2022 17.4 lub nowszy. &lt;A HREF="https://aka.ms/dotnet7-release-notes"&gt;Dowiedz się więcej&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Klikając pozycję Zainstaluj, wyrażasz zgodę na następujące warunki.</String>
   <String Id="InstallPathx64x86">The installation path for x64 SDK installations: &quot;[DOTNETHOME_X64]&quot; cannot be the same as for x86 SDK installations: &quot;[DOTNETHOME_X86]&quot;</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1046/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1046/bundle.wxl
@@ -76,7 +76,7 @@ Recursos
   <String Id="InstallationNoteTitle">Nota de instalação</String>
   <String Id="InstallationNote">Um comando será executado durante o processo de instalação que melhorará a velocidade de restauração do projeto e habilitará o acesso offline. Isso levará até um minuto para ser concluído.
   </String>
-  <String Id="VisualStudioWarning">Se você planeja usar o .NET 7.0 com o Visual Studio, é necessário usar o Visual Studio 2022 17.0 ou mais recente. &lt;A HREF="https://aka.ms/dotnet7-release-notes"&gt;Saiba mais&lt;/A&gt;.
+  <String Id="VisualStudioWarning">Se você planeja usar o .NET 7.0 com o Visual Studio, é necessário usar o Visual Studio 2022 17.4 ou mais recente. &lt;A HREF="https://aka.ms/dotnet7-release-notes"&gt;Saiba mais&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Ao clicar em instalar, você concorda com os termos a seguir.</String>
   <String Id="InstallPathx64x86">The installation path for x64 SDK installations: &quot;[DOTNETHOME_X64]&quot; cannot be the same as for x86 SDK installations: &quot;[DOTNETHOME_X86]&quot;</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1049/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1049/bundle.wxl
@@ -76,7 +76,7 @@
   <String Id="InstallationNoteTitle">Примечание по установке</String>
   <String Id="InstallationNote">В процессе установки будет выполнена команда, которая увеличит скорость восстановления проекта и обеспечит автономный доступ. Выполнение займет до минуты.
   </String>
-  <String Id="VisualStudioWarning">Если вы планируете использовать .NET 7.0 с Visual Studio, требуется Visual Studio 2022 версии 17.0 или более поздней. &lt;A HREF="https://aka.ms/dotnet7-release-notes"&gt;Дополнительные сведения&lt;/A&gt;.
+  <String Id="VisualStudioWarning">Если вы планируете использовать .NET 7.0 с Visual Studio, требуется Visual Studio 2022 версии 17.4 или более поздней. &lt;A HREF="https://aka.ms/dotnet7-release-notes"&gt;Дополнительные сведения&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Нажимая кнопку "Установить", вы принимаете следующие условия.</String>
   <String Id="InstallPathx64x86">The installation path for x64 SDK installations: &quot;[DOTNETHOME_X64]&quot; cannot be the same as for x86 SDK installations: &quot;[DOTNETHOME_X86]&quot;</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1055/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1055/bundle.wxl
@@ -76,7 +76,7 @@ Kaynaklar
   <String Id="InstallationNoteTitle">Yükleme notu</String>
   <String Id="InstallationNote">Yükleme işlemi sırasında, proje geri yükleme hızını artıran ve çevrimdışı erişimi etkinleştiren bir komut çalıştırılır. Tamamlanması bir dakikanızı alır.
   </String>
-  <String Id="VisualStudioWarning">Visual Studio ile .NET 7.0 kullanmayı planlıyorsanız Visual Studio 2022 17.0 veya üzeri bir sürüm gerekir. &lt;A HREF="https://aka.ms/dotnet7-release-notes"&gt;Daha Fazla Bilgi&lt;/A&gt;.
+  <String Id="VisualStudioWarning">Visual Studio ile .NET 7.0 kullanmayı planlıyorsanız Visual Studio 2022 17.4 veya üzeri bir sürüm gerekir. &lt;A HREF="https://aka.ms/dotnet7-release-notes"&gt;Daha Fazla Bilgi&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Yükle'ye tıklayarak aşağıdaki koşulları kabul etmiş olursunuz.</String>
   <String Id="InstallPathx64x86">The installation path for x64 SDK installations: &quot;[DOTNETHOME_X64]&quot; cannot be the same as for x86 SDK installations: &quot;[DOTNETHOME_X86]&quot;</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/2052/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/2052/bundle.wxl
@@ -76,7 +76,7 @@
   <String Id="InstallationNoteTitle">安装说明</String>
   <String Id="InstallationNote">将在要提升项目还原速度并实现脱机访问的安装进程期间运行命令。此操作最多 1 分钟即可完成。
   </String>
-  <String Id="VisualStudioWarning">如果打算结合使用 .NET 7.0 和 Visual Studio，需要 Visual Studio 2022 17.0 或更高版本。&lt;A HREF="https://aka.ms/dotnet7-release-notes"&gt;了解详细信息&lt;/A&gt;。
+  <String Id="VisualStudioWarning">如果打算结合使用 .NET 7.0 和 Visual Studio，需要 Visual Studio 2022 17.4 或更高版本。&lt;A HREF="https://aka.ms/dotnet7-release-notes"&gt;了解详细信息&lt;/A&gt;。
   </String>
   <String Id="LicenseAssent">单击“安装”即表示你同意以下条款。</String>
   <String Id="InstallPathx64x86">The installation path for x64 SDK installations: &quot;[DOTNETHOME_X64]&quot; cannot be the same as for x86 SDK installations: &quot;[DOTNETHOME_X86]&quot;</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/3082/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/3082/bundle.wxl
@@ -76,7 +76,7 @@ Recursos
   <String Id="InstallationNoteTitle">Nota de instalación</String>
   <String Id="InstallationNote">Se ejecutará un comando durante el proceso de instalación que mejorará la velocidad de restauración del proyecto y permitirá el acceso sin conexión. La operación tardará hasta un minuto en completarse.
   </String>
-  <String Id="VisualStudioWarning">Si tiene previsto usar .NET 7.0 con Visual Studio, se requiere Visual Studio 2022 17.0 o una versión más reciente. &lt;A HREF="https://aka.ms/dotnet7-release-notes"&gt;Obtenga más información&lt;/A&gt;.
+  <String Id="VisualStudioWarning">Si tiene previsto usar .NET 7.0 con Visual Studio, se requiere Visual Studio 2022 17.4 o una versión más reciente. &lt;A HREF="https://aka.ms/dotnet7-release-notes"&gt;Obtenga más información&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Al hacer clic en Instalar, acepta los términos siguientes.</String>
   <String Id="InstallPathx64x86">The installation path for x64 SDK installations: &quot;[DOTNETHOME_X64]&quot; cannot be the same as for x86 SDK installations: &quot;[DOTNETHOME_X86]&quot;</String>


### PR DESCRIPTION
Technically we'll load in 17.3 but that's not supported for targeting net7.0 and that's too complex to put in a dialog.

Also update the osx release notes link