### PR TITLE
Add .NET 8 nuget feed to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,16 @@ You can download the .NET Core SDK as either an installer (MSI, PKG) or a zip (z
 want to install the latest released versions, check out the [preceding section](#looking-for-released-versions-of-the-net-core-tooling).
 With development builds, internal NuGet feeds are necessary for some scenarios (for example, to acquire the runtime pack for self-contained apps). You can use the following NuGet.config to configure these feeds. See the following document [Configuring NuGet behavior](https://docs.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior) for more information on where to modify your NuGet.config to apply the changes.
 
+**For .NET 8 builds**
+
+```
+<configuration>
+  <packageSources>
+    <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
+  </packageSources>
+</configuration>
+```
+
 **For .NET 7 builds**
 
 ```


### PR DESCRIPTION
This is required to make current [dotnet/sdk](https://github.com/dotnet/sdk) local builds from `main` branch to work.

Error before including this sample nuget.config:
```bash
error NU1102: Unable to find package Microsoft.NETCore.App.Ref with version (= 8.0.0-alpha.1.22467.6)
```