### PR TITLE
Update Download MSFT sdk Tarball CI step to handle rtm in version #

### DIFF
--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-build-tarball.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-build-tarball.yml
@@ -68,7 +68,7 @@ jobs:
   - ${{ if ne(parameters.excludeSdkContentTests, 'true') }}:
     - download: ${{ parameters.installerBuildResourceId }}
       artifact: BlobArtifacts
-      patterns: '**/dotnet-sdk-+([0-9]).+([0-9]).+([0-9])?(-preview*|-rc*)-linux-${{ parameters.architecture }}.tar.gz'
+      patterns: '**/dotnet-sdk-+([0-9]).+([0-9]).+([0-9])?(-preview*|-rc*|-rtm)-linux-${{ parameters.architecture }}.tar.gz'
       displayName: Download MSFT sdk Tarball
 
   - ${{ if eq(parameters.usePreviousArtifacts, 'true') }}:


### PR DESCRIPTION
The _Download MSFT sdk Tarball_ CI step is failing because to the _rtm_ segment in the version string.

```
Skipped processing item BlobArtifacts/dotnet-sdk-7.0.100-rtm.22468.5-linux-x64.tar.gz
```

This change fixed the download step to handle _rtm_
