### PR TITLE
Fix MS.Extensions versions in dotnet-format

### DIFF
--- a/src/SourceBuild/tarball/patches/format/0001-Fix-MicrosoftExtensionsVersion.patch
+++ b/src/SourceBuild/tarball/patches/format/0001-Fix-MicrosoftExtensionsVersion.patch
@@ -36,8 +36,8 @@ index 6b628c2..9b579ea 100644
 -    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="$(MicrosoftExtensionsVersion)" />
 -    <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsVersion)" />
 +    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
-+    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
-+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
++    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="$(MicrosoftExtensionsFileSystemGlobbingVersion)" />
++    <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
      <PackageVersion Include="NuGet.Common" Version="$(NuGetVersion)" />
      <PackageVersion Include="NuGet.Configuration" Version="$(NuGetVersion)" />
      <PackageVersion Include="NuGet.Frameworks" Version="$(NuGetVersion)" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/3032

Microsoft.Extensions.FileSystemGlobbing and Microsoft.Extensions.DependencyInjection could potentially be different versions, so they shouldn't use the same version number.