### PR TITLE
Fix Download MSFT sdk Tarball pattern

### DIFF
--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-build-tarball.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-build-tarball.yml
@@ -68,7 +68,7 @@ jobs:
   - ${{ if ne(parameters.excludeSdkContentTests, 'true') }}:
     - download: ${{ parameters.installerBuildResourceId }}
       artifact: BlobArtifacts
-      patterns: '**/dotnet-sdk-+([0-9]).+([0-9]).+([0-9])?(-preview*|-rc*|-rtm)-linux-${{ parameters.architecture }}.tar.gz'
+      patterns: '**/dotnet-sdk-+([0-9]).+([0-9]).+([0-9])?(-@(preview|rc|rtm)*)-linux-${{ parameters.architecture }}.tar.gz'
       displayName: Download MSFT sdk Tarball
 
   - ${{ if eq(parameters.usePreviousArtifacts, 'true') }}:


### PR DESCRIPTION
Previous fix in https://github.com/dotnet/installer/pull/14558 was not sufficient.   @lbussell's [sugestion](https://github.com/dotnet/installer/pull/14558#discussion_r975872150) was correct, the `*` is needed for the version # after the pre-release moniker.  I misinterpreted what the `*` was allowing, I thought it was for the moniker itself as in `rtm2`.  I refactored the pattern to make this a little more apparent.

Here is an internal build testing the change - https://dev.azure.com/dnceng/internal/_build/results?buildId=2000961&view=results (Microsoft internal link)
