### PR TITLE
Update SBRP and address issue in DependencyPackageProjects infra

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -206,9 +206,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>a8b74560cd0ad9a01f0356369bb9dfc031a9a6b0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="7.0.0-alpha.1.22466.3">
-      <Uri>https://github.com/lbussell/source-build-reference-packages</Uri>
-      <Sha>353e91a5f7a9125c7270410a6ac87a8ab68b52f2</Sha>
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="7.0.0-alpha.1.22472.3">
+      <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
+      <Sha>f23834cc527b7b88a3600ab8cd857eab93cca0a6</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceLink.GitHub" Version="1.2.0-beta-22429-01" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -207,8 +207,8 @@
       <Sha>a8b74560cd0ad9a01f0356369bb9dfc031a9a6b0</Sha>
     </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="7.0.0-alpha.1.22466.3">
-      <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>6d1119ce3caac7e29f7e44c6be80494345f9de2a</Sha>
+      <Uri>https://github.com/lbussell/source-build-reference-packages</Uri>
+      <Sha>353e91a5f7a9125c7270410a6ac87a8ab68b52f2</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceLink.GitHub" Version="1.2.0-beta-22429-01" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">

--- a/src/SourceBuild/tarball/content/repos/source-build-reference-packages.proj
+++ b/src/SourceBuild/tarball/content/repos/source-build-reference-packages.proj
@@ -2,7 +2,9 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <BuildCommand>$(StandardSourceBuildCommand) $(StandardSourceBuildArgs)</BuildCommand>
+    <LocalNuGetPackageCacheDirectory>$(BaseIntermediatePath)source-build-reference-package-cache</LocalNuGetPackageCacheDirectory>
+
+    <BuildCommand>$(StandardSourceBuildCommand) $(StandardSourceBuildArgs) /p:NuGetPackageCacheDirectory=$(NuGetPackageCacheDirectory)</BuildCommand>
 
     <NuGetConfigFile>$(ProjectDirectory)NuGet.config</NuGetConfigFile>
     <GlobalJsonFile>$(ProjectDirectory)global.json</GlobalJsonFile>
@@ -15,6 +17,16 @@
   <ItemGroup>
     <UseSourceBuiltSdkOverride Include="@(ArcadeBootstrapSdkOverride)" />
   </ItemGroup>
+
+  <Target Name="AddLocalNuGetPackageCacheDirectory" BeforeTargets="Build">
+    <MakeDir Condition="'$(LocalNuGetPackageCacheDirectory)' != ''"
+             Directories="$(LocalNuGetPackageCacheDirectory)" />
+
+    <AddSourceToNuGetConfig
+      NuGetConfigFile="$(NuGetConfigFile)"
+      SourceName="source-build-reference-package-cache"
+      SourcePath="$(LocalNuGetPackageCacheDirectory)" />
+  </Target>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>


### PR DESCRIPTION
This removes the System.Reflection.Emit 4.7.0 prebuilt in fsharp and addressed an issue with the DependencyPackageProjects SBRP infra.  The Versions.Details.xml reference will need updating once https://github.com/dotnet/source-build-reference-packages/pull/447 is merged.
