### PR TITLE
Fix incorrect build property name in source-build

### DIFF
--- a/src/SourceBuild/tarball/content/repos/source-build-reference-packages.proj
+++ b/src/SourceBuild/tarball/content/repos/source-build-reference-packages.proj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <LocalNuGetPackageCacheDirectory>$(BaseIntermediatePath)source-build-reference-package-cache</LocalNuGetPackageCacheDirectory>
 
-    <BuildCommand>$(StandardSourceBuildCommand) $(StandardSourceBuildArgs) /p:NuGetPackageCacheDirectory=$(NuGetPackageCacheDirectory)</BuildCommand>
+    <BuildCommand>$(StandardSourceBuildCommand) $(StandardSourceBuildArgs) /p:LocalNuGetPackageCacheDirectory=$(LocalNuGetPackageCacheDirectory)</BuildCommand>
 
     <NuGetConfigFile>$(ProjectDirectory)NuGet.config</NuGetConfigFile>
     <GlobalJsonFile>$(ProjectDirectory)global.json</GlobalJsonFile>


### PR DESCRIPTION
Fix a invalid property name reference introduced in https://github.com/dotnet/installer/pull/14571.
