### PR TITLE
Add support for using --with-packages with smoke-tests. (#14387)

### DIFF
--- a/src/SourceBuild/tarball/content/build.proj
+++ b/src/SourceBuild/tarball/content/build.proj
@@ -107,6 +107,7 @@
             SMOKE_TESTS_SDK_TARBALL_PATH=$(SdkTarballPath);
             SMOKE_TESTS_TARGET_RID=$(TargetRid);
             SMOKE_TESTS_PORTABLE_RID=$(PortableRid);
+            SMOKE_TESTS_CUSTOM_PACKAGES_PATH=$(CustomSourceBuiltPackagesPath);
             $(CustomTestEnvVars)" />
   </Target>
 

--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/Config.cs
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/Config.cs
@@ -15,6 +15,7 @@ internal static class Config
     public const string PoisonReportPathEnv = "SMOKE_TESTS_POISON_REPORT_PATH";
     public const string PortableRidEnv = "SMOKE_TESTS_PORTABLE_RID";
     public const string PrereqsPathEnv = "SMOKE_TESTS_PREREQS_PATH";
+    public const string CustomPackagesPathEnv = "SMOKE_TESTS_CUSTOM_PACKAGES_PATH";
     public const string SdkTarballPathEnv = "SMOKE_TESTS_SDK_TARBALL_PATH";
     public const string TargetRidEnv = "SMOKE_TESTS_TARGET_RID";
     public const string WarnPoisonDiffsEnv = "SMOKE_TESTS_WARN_POISON_DIFFS";
@@ -27,6 +28,7 @@ internal static class Config
     public static string PortableRid { get; } = Environment.GetEnvironmentVariable(PortableRidEnv) ??
         throw new InvalidOperationException($"'{Config.PortableRidEnv}' must be specified");
     public static string? PrereqsPath { get; } = Environment.GetEnvironmentVariable(PrereqsPathEnv);
+    public static string? CustomPackagesPath { get; } = Environment.GetEnvironmentVariable(CustomPackagesPathEnv);
     public static string? SdkTarballPath { get; } = Environment.GetEnvironmentVariable(SdkTarballPathEnv);
     public static string TargetRid { get; } = Environment.GetEnvironmentVariable(TargetRidEnv) ??
         throw new InvalidOperationException($"'{Config.TargetRidEnv}' must be specified");

--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetHelper.cs
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetHelper.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.SourceBuild.SmokeTests;
@@ -66,6 +67,8 @@ internal class DotNetHelper
 
         if (useLocalPackages)
         {
+            // When using local packages this feed is always required.  It contains packages that are
+            // not produced by source-build but are required by the various project templates.
             if (!Directory.Exists(Config.PrereqsPath))
             {
                 throw new InvalidOperationException(
@@ -74,6 +77,21 @@ internal class DotNetHelper
 
             string nugetConfig = File.ReadAllText(nugetConfigPath);
             nugetConfig = nugetConfig.Replace("SMOKE_TEST_PACKAGE_FEED", Config.PrereqsPath);
+
+            // This package feed is optional.  You can use an additional feed of source-built packages to run the
+            // smoke-tests as offline as possible.
+            if (Config.CustomPackagesPath != null)
+            {
+                if (!Directory.Exists(Config.CustomPackagesPath))
+                {
+                    throw new ArgumentException($"Specified --with-packages {Config.CustomPackagesPath} does not exist.");
+                }
+                nugetConfig = nugetConfig.Replace("CUSTOM_PACKAGE_FEED", Config.CustomPackagesPath);
+            }
+            else
+            {
+                nugetConfig = string.Join(Environment.NewLine, nugetConfig.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).Where(s => !s.Contains("CUSTOM_PACKAGE_FEED")).ToArray());
+            }
             File.WriteAllText(nugetConfigPath, nugetConfig);
         }
     }

--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/local.NuGet.Config
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/local.NuGet.Config
@@ -3,5 +3,6 @@
   <packageSources>
     <clear />
     <add key="smoke-test-prereqs" value="SMOKE_TEST_PACKAGE_FEED" />
+    <add key="custom-packages" value="CUSTOM_PACKAGE_FEED" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Backport of https://github.com/dotnet/installer/pull/14387 to 6.0 to support Linux partners.