### PR TITLE
[release/7.0.1xx] Fix bootstrap build with SDK patch

### DIFF
--- a/src/SourceBuild/tarball/patches/sdk/0003-Check-RIDs-in-asserts.patch
+++ b/src/SourceBuild/tarball/patches/sdk/0003-Check-RIDs-in-asserts.patch
@@ -1,0 +1,38 @@
+From 43f51a115a8f20b0c1374afa180c2a67db2e357e Mon Sep 17 00:00:00 2001
+From: Noah Gilson <noahgilson@microsoft.com>
+Date: Mon, 19 Sep 2022 09:24:07 -0700
+Subject: [PATCH] Also check runtime identifiers in asserts
+
+Backport: https://github.com/dotnet/sdk/pull/28120/files
+---
+ .../Microsoft.NET.RuntimeIdentifierInference.targets      | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+index e7f3be936b4..84b21ee0dd8 100644
+--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
++++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets
+@@ -162,19 +162,19 @@ Copyright (c) .NET Foundation. All rights reserved.
+           Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(HasRuntimeOutput)' == 'true'">
+ 
+     <!-- The following RID errors are asserts, and we don't expect them to ever occur. The error message is added as a safeguard.-->
+-    <NETSdkError Condition="'$(SelfContained)' == 'true' and '$(RuntimeIdentifier)' == ''"
++    <NETSdkError Condition="'$(SelfContained)' == 'true' and '$(RuntimeIdentifier)' == '' and '$(RuntimeIdentifiers)' == ''"
+                  ResourceName="ImplicitRuntimeIdentifierResolutionForPublishPropertyFailed"
+                  FormatArguments="SelfContained"/>
+ 
+-    <NETSdkError Condition="'$(PublishReadyToRun)' == 'true' and '$(RuntimeIdentifier)' == ''"
++    <NETSdkError Condition="'$(PublishReadyToRun)' == 'true' and '$(RuntimeIdentifier)' == '' and '$(RuntimeIdentifiers)' == ''"
+                  ResourceName="ImplicitRuntimeIdentifierResolutionForPublishPropertyFailed"
+                  FormatArguments="PublishReadyToRun"/>
+ 
+-    <NETSdkError Condition="'$(PublishSingleFile)' == 'true' and '$(RuntimeIdentifier)' == ''"
++    <NETSdkError Condition="'$(PublishSingleFile)' == 'true' and '$(RuntimeIdentifier)' == '' and '$(RuntimeIdentifiers)' == ''"
+                 ResourceName="ImplicitRuntimeIdentifierResolutionForPublishPropertyFailed"
+                 FormatArguments="PublishSingleFile"/>
+ 
+-    <NETSdkError Condition="'$(PublishAot)' == 'true' and '$(RuntimeIdentifier)' == ''"
++    <NETSdkError Condition="'$(PublishAot)' == 'true' and '$(RuntimeIdentifier)' == '' and '$(RuntimeIdentifiers)' == ''"
+                 ResourceName="ImplicitRuntimeIdentifierResolutionForPublishPropertyFailed"
+                 FormatArguments="PublishAot"/>
+ 


### PR DESCRIPTION
Backporting https://github.com/dotnet/sdk/pull/28120 to unblock the bootstrap build ahead of sdk -> installer code flow. I will run a bootstrap build to verify.

(Internal MS link only) [Bootstrap tarball CI run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2005431&view=results)