### PR TITLE
Update the 3.1 and 6.0 implicit versions for GA

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -61,9 +61,9 @@
 
   <PropertyGroup>
       <VersionFeature21>30</VersionFeature21>
-      <VersionFeature31>30</VersionFeature31>
+      <VersionFeature31>$([MSBuild]::Add($(VersionFeature), 31))</VersionFeature31>
       <VersionFeature50>17</VersionFeature50>
-      <VersionFeature60>10</VersionFeature60>
+      <VersionFeature60>$([MSBuild]::Add($(VersionFeature), 11))</VersionFeature60>
   </PropertyGroup>
 
   <Target Name="GenerateBundledVersionsProps" DependsOnTargets="SetupBundledComponents">


### PR DESCRIPTION
The November release should be 3.1.31 and 6.0.11

