### PR TITLE
Enable online and offline source-build tarball build in all PRs

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -332,10 +332,10 @@ stages:
 
   - template: /src/SourceBuild/Arcade/eng/common/templates/job/source-build-create-tarball.yml
 
-  - template: /src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build.yml
-    parameters:
-      dependsOn: Source_Build_Create_Tarball
-      condition: eq(dependencies.Source_Build_Create_Tarball.outputs['Tarball_Build_Check._includeTarballBuild'], 'true')
+  - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
+    - template: /src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build.yml
+      parameters:
+        dependsOn: Source_Build_Create_Tarball
 
   # https://github.com/dotnet/core-sdk/issues/248
   # - template: /eng/build.yml

--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-create-tarball.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-create-tarball.yml
@@ -74,15 +74,3 @@ jobs:
     displayName: Publish BuildLogs
     continueOnError: true
     condition: succeededOrFailed()
-
-  - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-    # Check if the tarball should be built now so the result can be used in the build tarball job condition.
-    # This prevents allocation of additional agents if the tarball build legs should be skipped.
-    # Only build the tarball if the PR touches source-build source.
-    - script: |
-        if curl "https://api.github.com/repos/dotnet/installer/pulls/$(System.PullRequest.PullRequestNumber)/files" | grep '"filename": "src/SourceBuild/*'
-        then
-          echo "##vso[task.setvariable variable=_includeTarballBuild;isoutput=true]true"
-        fi
-      displayName: Tarball Build Check
-      name: Tarball_Build_Check

--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build.yml
@@ -42,13 +42,13 @@ jobs:
         _EnablePoison: false
         _ExcludeOmniSharpTests: true
         _RunOnline: true
+      CentOSStream8-Offline:
+        _BootstrapPrep: false
+        _Container: ${{ parameters.centOSStream8Container }}
+        _EnablePoison: false
+        _ExcludeOmniSharpTests: true
+        _RunOnline: false
       ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-        CentOSStream8-Offline:
-          _BootstrapPrep: false
-          _Container: ${{ parameters.centOSStream8Container }}
-          _EnablePoison: false
-          _ExcludeOmniSharpTests: true
-          _RunOnline: false
         CentOSStream9-Offline:
           _BootstrapPrep: false
           _Container: ${{ parameters.centOSStream9Container }}


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/2842, https://github.com/dotnet/source-build/issues/3037.

This may not be popular but we need to ensure source build is not regressing for GA.  This change should not get backported in its current for to main.  I am still working with engineering services to get faster machines to speed up the legs.  If expediency is necessary for non-dependency flows, admin merges ahead of the tarball legs will be necessary.
