### PR TITLE
[main] Adds alternative musl version of MicrosoftAspNetCoreAppRuntimePackageVersion

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -54,6 +54,7 @@
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
     <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>8.0.0-alpha.1.22479.18</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftAspNetCoreAppRuntimemuslx64PackageVersion>$(MicrosoftAspNetCoreAppRuntimewinx64PackageVersion)</MicrosoftAspNetCoreAppRuntimemuslx64PackageVersion>
     <MicrosoftAspNetCoreAppRefPackageVersion>8.0.0-alpha.1.22479.18</MicrosoftAspNetCoreAppRefPackageVersion>
     <MicrosoftAspNetCoreAppRefInternalPackageVersion>8.0.0-alpha.1.22479.18</MicrosoftAspNetCoreAppRefInternalPackageVersion>
     <VSRedistCommonAspNetCoreSharedFrameworkx6480PackageVersion>8.0.0-alpha.1.22479.18</VSRedistCommonAspNetCoreSharedFrameworkx6480PackageVersion>

--- a/src/SourceBuild/tarball/content/Directory.Build.props
+++ b/src/SourceBuild/tarball/content/Directory.Build.props
@@ -236,6 +236,7 @@
     <!-- OSX needs the OSX version instead of Linux.  We don't have a lot of flexibility in how we output these properties so we're relying on the previous one being blank if the Linux version of the package is missing.  -->
     <ExtraPackageVersionPropsPackageInfo Include="MicrosoftAspNetCoreAppRuntimePackageVersion" Version="%24(MicrosoftAspNetCoreAppRuntimeOsxX64PackageVersion)" DoNotOverwrite="true" />
     <ExtraPackageVersionPropsPackageInfo Include="MicrosoftAspNetCoreAppRuntimePackageVersion" Version="%24(MicrosoftAspNetCoreAppRuntimewinx64PackageVersion)" DoNotOverwrite="true" />
+    <ExtraPackageVersionPropsPackageInfo Include="MicrosoftAspNetCoreAppRuntimePackageVersion" Version="%24(MicrosoftAspNetCoreAppRuntimemuslx64PackageVersion)" DoNotOverwrite="true" />
 
     <!-- Used by installer to determine sdk version -->
     <ExtraPackageVersionPropsPackageInfo Include="MicrosoftDotnetToolsetInternalPackageVersion" Version="%24(MicrosoftNETSdkPackageVersion)" />


### PR DESCRIPTION
Wrong version of `aspnetcore-runtime-internal-$(MicrosoftAspNetCoreAppRuntimePackageVersion)-$(AspNetCoreArchiveRid)$(ArchiveExtension)` is pulled by installer when building source-build on Alpine Linux. Version `7.0.0-rc.1.22404` is expected, but aspnetcore builds `7.0.0-rc.2.22452.11`.

This attempts to fix by adding an alternative musl version of this, similar to how an alternative is provided to osx64 and win64 builds.

Fixes https://github.com/dotnet/installer/issues/14492