### PR TITLE
Use latest docker containers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.238.0/containers/dotnet
 {
 	"name": "Source-Build w/ Built Tarball",
-	"image": "mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-33",
+	"image": "mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-36",
 	// A completely built .NET source-tarball is >64 GB
 	"hostRequirements": {
 		"storage": "128gb"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.238.0/containers/dotnet
 {
 	"name": "Source-Build w/ Built Tarball",
-	"image": "mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-33-20210222183538-031e7d2",
+	"image": "mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-33",
 	// A completely built .NET source-tarball is >64 GB
 	"hostRequirements": {
 		"storage": "128gb"

--- a/.devcontainer/source-build-tarball/devcontainer.json
+++ b/.devcontainer/source-build-tarball/devcontainer.json
@@ -2,7 +2,7 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.238.0/containers/dotnet
 {
 	"name": "Source-Build w/ Tarball",
-	"image": "mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-33-20210222183538-031e7d2",
+	"image": "mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-33",
 	// A completely built .NET source tarball is >64 GB
 	"hostRequirements": {
 		"storage": "128gb"

--- a/.devcontainer/source-build-tarball/devcontainer.json
+++ b/.devcontainer/source-build-tarball/devcontainer.json
@@ -2,7 +2,7 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.238.0/containers/dotnet
 {
 	"name": "Source-Build w/ Tarball",
-	"image": "mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-33",
+	"image": "mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-36",
 	// A completely built .NET source tarball is >64 GB
 	"hostRequirements": {
 		"storage": "128gb"

--- a/.devcontainer/source-build/devcontainer.json
+++ b/.devcontainer/source-build/devcontainer.json
@@ -1,5 +1,5 @@
 // Use this devcontainer if you don't need the full context of a source-build tarball
 {
 	"name": "Source-Build",
-	"image": "mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-33"
+	"image": "mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-36"
 }

--- a/.devcontainer/source-build/devcontainer.json
+++ b/.devcontainer/source-build/devcontainer.json
@@ -1,5 +1,5 @@
 // Use this devcontainer if you don't need the full context of a source-build tarball
 {
 	"name": "Source-Build",
-	"image": "mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-33-20210222183538-031e7d2"
+	"image": "mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-33"
 }

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -73,7 +73,7 @@ stages:
       parameters:
         agentOs: Linux
         jobName: Build_Ubuntu_18_04_Debug_x64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-20220916154732-3c53da6'
+        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04'
         buildConfiguration: Debug
         buildArchitecture: x64
         linuxPortable: true
@@ -82,7 +82,7 @@ stages:
       parameters:
         agentOs: Linux
         jobName: Build_Fedora_36_Debug_x64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-36-20220912173100-a09384f'
+        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-36'
         buildConfiguration: Debug
         buildArchitecture: x64
         linuxPortable: true
@@ -91,7 +91,7 @@ stages:
       parameters:
         agentOs: Linux
         jobName: Build_CentOS_7_Debug_x64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-20220912172913-d16db59'
+        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7'
         buildConfiguration: Debug
         buildArchitecture: x64
         linuxPortable: false
@@ -100,7 +100,7 @@ stages:
       parameters:
         agentOs: Linux
         jobName: Build_Debian_Stretch_Debug_x64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-20220912173009-94fc78a'
+        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch'
         buildConfiguration: Debug
         buildArchitecture: x64
         additionalBuildParameters: '/p:BuildSdkDeb=true'
@@ -120,7 +120,7 @@ stages:
       parameters:
         agentOs: Linux
         jobName: Build_Linux_musl_Debug_x64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.15-WithNode-20220916182008-f0ea7ba'
+        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.15-WithNode'
         buildConfiguration: Debug
         buildArchitecture: x64
         runtimeIdentifier: 'linux-musl-x64'
@@ -200,7 +200,7 @@ stages:
       parameters:
         agentOs: Linux
         jobName: Build_Linux_musl_Release_arm
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-20220916154619-56ef508'
+        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross'
         buildConfiguration: Release
         buildArchitecture: arm
         runtimeIdentifier: 'linux-musl-arm'
@@ -221,7 +221,7 @@ stages:
       parameters:
         agentOs: Linux
         jobName: Build_Linux_musl_Release_x64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.15-WithNode-20220916182008-f0ea7ba'
+        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.15-WithNode'
         buildConfiguration: Release
         buildArchitecture: x64
         runtimeIdentifier: 'linux-musl-x64'
@@ -233,7 +233,7 @@ stages:
       parameters:
         agentOs: Linux
         jobName: Build_Linux_Portable_Deb_Release_x64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-debpkg-20220916154732-cfdd435'
+        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-debpkg'
         buildConfiguration: Release
         buildArchitecture: x64
         # Do not publish zips and tarballs. The linux-x64 binaries are
@@ -245,7 +245,7 @@ stages:
       parameters:
         agentOs: Linux
         jobName: Build_Linux_Portable_Rpm_Release_x64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-rpmpkg-20220912172913-d0fa36f'
+        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-rpmpkg'
         buildConfiguration: Release
         buildArchitecture: x64
         # Do not publish zips and tarballs. The linux-x64 binaries are
@@ -257,7 +257,7 @@ stages:
       parameters:
         agentOs: Linux
         jobName: Build_Linux_Portable_Rpm_Release_Arm64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-rpmpkg-20220912172913-d0fa36f'
+        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-rpmpkg'
         buildConfiguration: Release
         buildArchitecture: arm64
         runtimeIdentifier: 'linux-arm64'

--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-create-tarball.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-create-tarball.yml
@@ -2,7 +2,7 @@
 
 jobs:
 - job: Source_Build_Create_Tarball
-  container: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-33-20210222183538-031e7d2
+  container: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-33
   displayName: Source-Build Create Tarball
   pool:
     ${{ if eq(variables['System.TeamProject'], 'public') }}:

--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-create-tarball.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-create-tarball.yml
@@ -2,7 +2,7 @@
 
 jobs:
 - job: Source_Build_Create_Tarball
-  container: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-33
+  container: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-36
   displayName: Source-Build Create Tarball
   pool:
     ${{ if eq(variables['System.TeamProject'], 'public') }}:

--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build.yml
@@ -12,11 +12,11 @@ parameters:
 
   # The following parameters aren't expected to be passed in rather they are used for encapsulation
   # -----------------------------------------------------------------------------------------------
-  centOSStream8Container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8-20220809204800-17a4aab
-  centOSStream9Container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9-20220107135047-4cd394c
-  debian11Arm64Container: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-arm64v8-20220812185233-b286fae
-  fedora36Container: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-36-20220818134137-a09384f
-  ubuntu2004Container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-20220813234344-4c008dd
+  centOSStream8Container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8
+  centOSStream9Container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9
+  debian11Arm64Container: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-arm64v8
+  fedora36Container: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-36
+  ubuntu2004Container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04
   poolInternalAmd64:
     name: NetCore1ESPool-Svc-Internal
     demands: ImageOverride -equals Build.Ubuntu.1804.Amd64


### PR DESCRIPTION
This change moves all of the docker images to the latest tag as part of https://github.com/dotnet/arcade/issues/10377.

- Please add description for changes you are making.
- If there is an issue related to this PR, please add the reference.
