### PR TITLE
BundledVersions: update portable rid logic.

### DIFF
--- a/src/SourceBuild/tarball/content/repos/installer.proj
+++ b/src/SourceBuild/tarball/content/repos/installer.proj
@@ -10,6 +10,10 @@
     <OverrideTargetRid Condition="'$(TargetOS)' == 'OSX'">osx-x64</OverrideTargetRid>
     <OSNameOverride>$(OverrideTargetRid.Substring(0, $(OverrideTargetRid.IndexOf("-"))))</OSNameOverride>
 
+    <!-- Determine target portable rid based on bootstrap SDK's portable rid -->
+    <_platformIndex>$(NETCoreSdkPortableRuntimeIdentifier.LastIndexOf('-'))</_platformIndex>
+    <PortableOS>$(NETCoreSdkPortableRuntimeIdentifier.Substring(0, $(_platformIndex)))</PortableOS>
+
     <RuntimeArg>--runtime-id $(OverrideTargetRid)</RuntimeArg>
     <RuntimeArg Condition="'$(TargetOS)' == 'Linux'">--runtime-id $(TargetRid)</RuntimeArg>
 
@@ -22,6 +26,7 @@
     -->
     <BuildCommandArgs>$(BuildCommandArgs) /p:NETCoreAppMaximumVersion=99.9</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:OSName=$(OSNameOverride)</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) /p:PortableOSName=$(PortableOS)</BuildCommandArgs>
     <BuildCommandArgs Condition="'$(TargetOS)' == 'Linux'">$(BuildCommandArgs) /p:Rid=$(TargetRid)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:DOTNET_INSTALL_DIR=$(DotNetCliToolDir)</BuildCommandArgs>
 

--- a/src/redist/targets/GetRuntimeInformation.targets
+++ b/src/redist/targets/GetRuntimeInformation.targets
@@ -9,10 +9,15 @@
       <HostOSName Condition=" '$(HostOSName)' == '' AND $([MSBuild]::IsOSPlatform('OSX')) ">osx</HostOSName>
       <HostOSName Condition=" '$(HostOSName)' == '' AND $([MSBuild]::IsOSPlatform('FREEBSD')) ">freebsd</HostOSName>
       <HostOSName Condition=" '$(HostOSName)' == '' AND '$(IsLinux)' == 'True' ">linux</HostOSName>
-      
+
+      <OSName Condition=" '$(OSName)' == '' AND $(Rid) != '' ">$(Rid.Substring(0, $(Rid.LastIndexOf('-'))))</OSName>
       <OSName Condition=" '$(OSName)' == '' ">$(HostOSName)</OSName>
 
-      <Rid Condition=" '$(Rid)' == '' ">$(OSName)-$(Architecture)</Rid>
+      <PortableOSName Condition=" '$(PortableOSName)' == '' ">$(OSName)</PortableOSName>
+
+      <Rid>$(OSName)-$(Architecture)</Rid>
+
+      <PortableRid>$(PortableOSName)-$(Architecture)</PortableRid>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -24,12 +29,9 @@
     </PropertyGroup>
 
     <PropertyGroup>
-      <ProductMonikerRid Condition=" '$(Rid)' == 'ubuntu.16.04-x64' OR
-                                   '$(Rid)' == 'rhel.6-x64' OR
-                                   '$(Rid)' == 'linux-musl-x64' ">$(Rid)</ProductMonikerRid>
-      <ProductMonikerRid Condition=" '$(ProductMonikerRid)' == '' ">$(OSName)-$(Architecture)</ProductMonikerRid>
+      <ProductMonikerRid Condition=" '$(ProductMonikerRid)' == '' ">$(Rid)</ProductMonikerRid>
 
-      <PortableProductMonikerRid Condition=" '$(PortableProductMonikerRid)' == '' ">$(HostOSName)-$(Architecture)</PortableProductMonikerRid>
+      <PortableProductMonikerRid Condition=" '$(PortableProductMonikerRid)' == '' ">$(PortableRid)</PortableProductMonikerRid>
 
       <ArtifactNameSdk>dotnet-sdk-internal$(PgoTerm)</ArtifactNameSdk>
       <ArtifactNameCombinedHostHostFxrFrameworkSdk>dotnet-sdk$(PgoTerm)</ArtifactNameCombinedHostHostFxrFrameworkSdk>


### PR DESCRIPTION
Defaults the portable rid to match the rid.
This works for portable builds.

For non-portable builds, the portable rid can be
controlled using PortableOSName.

For source-build, we set PortableOSName based
on the bootstrap SDK's portable rid.
