### PR TITLE
Fix emsdk hash

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -168,7 +168,7 @@
     </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-6.0.300" Version="6.0.4">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>3f6c45a2580cd9387b643163de8136a9691764c8</Sha>
+      <Sha>52e9452f82e26f9fcae791e84c082ae22f1ef66f</Sha>
     </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build" Version="0.1.0-alpha.1.21519.2" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/source-build</Uri>


### PR DESCRIPTION
I noticed in the codeflow from 3xx to 4xx that the hash got messed up in the process and set to the 6.0.9 one. We don't believe the version needs to be updated but the hashes should match so reverting this.

