### PR TITLE
Fix source-build CI to not run tarball build when tarball creation fails

### DIFF
--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build.yml
@@ -1,9 +1,6 @@
 # Builds a source-build tarball
 
 parameters:
-  # Custom condition to apply to the job
-  condition: true
-
   # Dependent jobs that must be completed before this job will run
   dependsOn:
 
@@ -30,7 +27,6 @@ jobs:
 - template: /src/SourceBuild/Arcade/eng/common/templates/job/source-build-build-tarball.yml
   parameters:
     architecture: x64
-    condition: ${{ parameters.condition }}
     dependsOn: ${{ parameters.dependsOn }}
     ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
       excludeSdkContentTests: true
@@ -78,7 +74,6 @@ jobs:
   - template: /src/SourceBuild/Arcade/eng/common/templates/job/source-build-build-tarball.yml
     parameters:
       architecture: arm64
-      condition: ${{ parameters.condition }}
       dependsOn: ${{ parameters.dependsOn }}
       ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
         excludeSdkContentTests: true
@@ -100,7 +95,7 @@ jobs:
       architecture: x64
       # Always attempt to run the bootstrap leg (e.g. even when stage 1 tests fail) in order to get a complete accessment of the build status.
       # The bootstrap build will shortcut if the stage 1 build failed.
-      condition: and(${{ parameters.condition }}, succeededOrFailed())
+      condition: succeededOrFailed()
       dependsOn: Build_Tarball_x64
       excludeSdkContentTests: true
       installerBuildResourceId: ${{ parameters.installerBuildResourceId }}

--- a/src/SourceBuild/tarball/patches/runtime/0001-PR-76471.patch
+++ b/src/SourceBuild/tarball/patches/runtime/0001-PR-76471.patch
@@ -24,7 +24,7 @@ index c55ee607da773..4e1246b481b10 100644
 +++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.CoreCLR.cs
 @@ -316,7 +316,9 @@ public override MethodImplAttributes GetMethodImplementationFlags()
                  Span<ParameterCopyBackAction> shouldCopyBackParameters = new(ref argStorage._copyBack0, 1);
-Bad Patch change to test CI
+ 
                  StackAllocatedByRefs byrefStorage = default;
 +#pragma warning disable 8500
                  IntPtr* pByRefStorage = (IntPtr*)&byrefStorage;

--- a/src/SourceBuild/tarball/patches/runtime/0001-PR-76471.patch
+++ b/src/SourceBuild/tarball/patches/runtime/0001-PR-76471.patch
@@ -24,7 +24,7 @@ index c55ee607da773..4e1246b481b10 100644
 +++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.CoreCLR.cs
 @@ -316,7 +316,9 @@ public override MethodImplAttributes GetMethodImplementationFlags()
                  Span<ParameterCopyBackAction> shouldCopyBackParameters = new(ref argStorage._copyBack0, 1);
- 
+Bad Patch change to test CI
                  StackAllocatedByRefs byrefStorage = default;
 +#pragma warning disable 8500
                  IntPtr* pByRefStorage = (IntPtr*)&byrefStorage;


### PR DESCRIPTION
The changes in https://github.com/dotnet/installer/pull/14620 regressed the tarball build CI.  It was getting run even when tarball creation failed.  This can be seen by looking at the checks run for the first commit of https://github.com/dotnet/installer/pull/14670.