### PR TITLE
Remove questionable license cleanup logic

### DIFF
--- a/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
+++ b/src/SourceBuild/Arcade/tools/SourceBuildArcadeTarball.targets
@@ -262,19 +262,8 @@
         $(TarballSourceDir)runtime*\src\installer\pkg\**\*%(TarballSrcBinaryExtension.Identity)" />
     </ItemGroup>
 
+    <Message Importance="Normal" Text="Deleting checked in binary files: @(TarballSrcBinaryToRemove, ' ')" />
     <Delete Files="@(TarballSrcBinaryToRemove)" />
-
-    <!-- We have some not-strictly-required files that are under non-open source licenses.
-         See https://github.com/dotnet/source-build/issues/2359.
-         Remove them. -->
-    <ItemGroup>
-      <TarballSrcNonOpenSourceFiles Include="$(TarballSourceDir)**\humanizer\samples\**\*.js" />
-      <TarballSrcNonOpenSourceFiles Include="$(TarballSourceDir)**\*aspnetcore\**\samples\**\jquery-validation-unobtrusive\.bower.json" />
-      <TarballSrcNonOpenSourceFiles Include="$(TarballSourceDir)**\*aspnetcore\**\samples\**\jquery-validation-unobtrusive\*.js" />
-    </ItemGroup>
-
-    <Message Importance="High" Text="Deleting files with questionable licenses: @(TarballSrcNonOpenSourceFiles, ' ')" />
-    <Delete Files="@(TarballSrcNonOpenSourceFiles)" />
   </Target>
 
   <Target Name="RestoreTextOnlyPackages">


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/2359

All questionable license code has been removed from the .NET source included in the tarball.  Because of this, the specialized cleanup logic that existed in the tarball creation is no longer needed.

cc @omajid 
