### PR TITLE
Add dotnet root to the env script 

### DIFF
--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -29,6 +29,8 @@ set DOTNET_MULTILEVEL_LOOKUP=0
 
 set PATH=$env:DOTNET_INSTALL_DIR;%PATH%
 set NUGET_PACKAGES=$env:NUGET_PACKAGES
+
+set DOTNET_ROOT=$env:DOTNET_INSTALL_DIR
 "@
 
   Out-File -FilePath $scriptPath -InputObject $scriptContents -Encoding ASCII


### PR DESCRIPTION
Add dotnet root to the env script as tests we're running correctly in the IDE otherwise. I found the IDE was unable to find the runtime. Once I added this, it started working.


