### PR TITLE
Enable source-link in SourceBuild

### DIFF
--- a/src/SourceBuild/tarball/content/ArcadeOverrides/SourceBuildArcadeBuild.targets
+++ b/src/SourceBuild/tarball/content/ArcadeOverrides/SourceBuildArcadeBuild.targets
@@ -86,9 +86,9 @@
       <InnerBuildArgs>$(InnerBuildArgs) /p:SourceBuiltBlobFeedDir=$(SourceBuiltBlobFeedDir)</InnerBuildArgs>
 
       <!-- Work around issue where local clone may cause failure using non-origin remote fallback: https://github.com/dotnet/sourcelink/issues/629 -->
-      <InnerBuildArgs>$(InnerBuildArgs) /p:EnableSourceControlManagerQueries=false</InnerBuildArgs>
-      <InnerBuildArgs>$(InnerBuildArgs) /p:EnableSourceLink=false</InnerBuildArgs>
-      <InnerBuildArgs>$(InnerBuildArgs) /p:DeterministicSourcePaths=false</InnerBuildArgs>
+      <InnerBuildArgs Condition="'$(DisableSourceLink)' == 'true'">$(InnerBuildArgs) /p:EnableSourceControlManagerQueries=false</InnerBuildArgs>
+      <InnerBuildArgs Condition="'$(DisableSourceLink)' == 'true'">$(InnerBuildArgs) /p:EnableSourceLink=false</InnerBuildArgs>
+      <InnerBuildArgs Condition="'$(DisableSourceLink)' == 'true'">$(InnerBuildArgs) /p:DeterministicSourcePaths=false</InnerBuildArgs>
       <InnerBuildArgs >$(InnerBuildArgs) /p:DotNetBuildOffline=true</InnerBuildArgs>
       <InnerBuildArgs Condition=" '$(DotNetPackageVersionPropsPath)' != '' ">$(InnerBuildArgs) /p:DotNetPackageVersionPropsPath=$(DotNetPackageVersionPropsPath)</InnerBuildArgs>
     </PropertyGroup>

--- a/src/SourceBuild/tarball/content/ArcadeOverrides/SourceBuildArcadeBuild.targets
+++ b/src/SourceBuild/tarball/content/ArcadeOverrides/SourceBuildArcadeBuild.targets
@@ -85,10 +85,6 @@
       <InnerBuildArgs>$(InnerBuildArgs) /p:SourceBuildOutputDir=$(SourceBuildOutputDir)</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) /p:SourceBuiltBlobFeedDir=$(SourceBuiltBlobFeedDir)</InnerBuildArgs>
 
-      <!-- Work around issue where local clone may cause failure using non-origin remote fallback: https://github.com/dotnet/sourcelink/issues/629 -->
-      <InnerBuildArgs Condition="'$(DisableSourceLink)' == 'true'">$(InnerBuildArgs) /p:EnableSourceControlManagerQueries=false</InnerBuildArgs>
-      <InnerBuildArgs Condition="'$(DisableSourceLink)' == 'true'">$(InnerBuildArgs) /p:EnableSourceLink=false</InnerBuildArgs>
-      <InnerBuildArgs Condition="'$(DisableSourceLink)' == 'true'">$(InnerBuildArgs) /p:DeterministicSourcePaths=false</InnerBuildArgs>
       <InnerBuildArgs >$(InnerBuildArgs) /p:DotNetBuildOffline=true</InnerBuildArgs>
       <InnerBuildArgs Condition=" '$(DotNetPackageVersionPropsPath)' != '' ">$(InnerBuildArgs) /p:DotNetPackageVersionPropsPath=$(DotNetPackageVersionPropsPath)</InnerBuildArgs>
     </PropertyGroup>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/2883

Follows up on change in dotnet/runtime: https://github.com/dotnet/runtime/pull/76685 which was merged into installer's release/7.0.1xx with https://github.com/dotnet/installer/pull/14692

Related changes in Arcade are also in flight, one of them was merged: https://github.com/dotnet/arcade/pull/11153, the other is in PR: https://github.com/dotnet/arcade/pull/11191. **Note**: changes in Arcade are not needed for this to work e2e, since I'm updating the target override in installer repo (src/SourceBuild/tarball/content/ArcadeOverrides/SourceBuildArcadeBuild.targets).
