### PR TITLE
[7.0.1xx] Use mktemp to correctly use temp files

### DIFF
--- a/src/redist/targets/packaging/deb/postinst
+++ b/src/redist/targets/packaging/deb/postinst
@@ -4,6 +4,5 @@ first_run() {
     /usr/share/dotnet/dotnet exec /usr/share/dotnet/sdk/%SDK_VERSION%/dotnet.dll internal-reportinstallsuccess "debianpackage" > /dev/null 2>&1 || true
 }
 
-INSTALL_TEMP_HOME=/tmp/dotnet-installer
-[ -d $INSTALL_TEMP_HOME ] || mkdir $INSTALL_TEMP_HOME
+INSTALL_TEMP_HOME=$(mktemp -d) # mktemp should set 700 perm automatically
 HOME=$INSTALL_TEMP_HOME first_run

--- a/src/redist/targets/packaging/osx/clisdk/scripts/postinstall
+++ b/src/redist/targets/packaging/osx/clisdk/scripts/postinstall
@@ -12,7 +12,7 @@ first_run() {
     $INSTALL_DESTINATION/dotnet exec $INSTALL_DESTINATION/sdk/%SDK_VERSION%/dotnet.dll internal-reportinstallsuccess "$1" > /dev/null 2>&1 || true
 }
 
-[ -d $INSTALL_TEMP_HOME ] || mkdir $INSTALL_TEMP_HOME
+INSTALL_TEMP_HOME=$(mktemp -d) # mktemp should set 700 perm automatically
 HOME=$INSTALL_TEMP_HOME first_run
 
 exit 0


### PR DESCRIPTION
Port of Security Fix from Internal Mirror 