### PR TITLE
Update `XamarinAndroidWorkloadManifestVersion` to a version on NuGet.org

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -214,7 +214,7 @@
   <PropertyGroup>
     <MauiFeatureBand>7.0.100-rc.1</MauiFeatureBand>
     <MauiWorkloadManifestVersion>7.0.0-rc.1.6430</MauiWorkloadManifestVersion>
-    <XamarinAndroidWorkloadManifestVersion>33.0.0-rc.1.136</XamarinAndroidWorkloadManifestVersion>
+    <XamarinAndroidWorkloadManifestVersion>33.0.0-rc.1.151</XamarinAndroidWorkloadManifestVersion>
     <XamarinIOSWorkloadManifestVersion>15.4.1006-rc.1</XamarinIOSWorkloadManifestVersion>
     <XamarinMacCatalystWorkloadManifestVersion>15.4.1006-rc.1</XamarinMacCatalystWorkloadManifestVersion>
     <XamarinMacOSWorkloadManifestVersion>12.3.1006-rc.1</XamarinMacOSWorkloadManifestVersion>


### PR DESCRIPTION
Closes #14775

This version is on NuGet.