### PR TITLE
Update README.md in installer 

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ Sources for dotnet-install.sh and dotnet-install.ps1 are in the [install-scripts
 Questions & Comments
 --------------------
 
-For all feedback, use the Issues on the [.NET CLI](https://github.com/dotnet/cli) repository.
+For all feedback, use the Issues on the [.NET SDK](https://github.com/dotnet/sdk) repository.
 
 License
 -------


### PR DESCRIPTION
In the bottom of the README a URL points to dotnet/cli for issues, when you reach that page it points you to dotnet SDK repo.

That has been updated to the respective links.

https://github.com/dotnet/cli
https://github.com/dotnet/sdk

#7940