### PR TITLE
Disable some tests that are failing because of a nuget issue on linux

### DIFF
--- a/test/EndToEnd/EndToEnd.Tests.csproj
+++ b/test/EndToEnd/EndToEnd.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <TargetFramework>$(CoreSdkTargetFramework)</TargetFramework>
+    <DefineConstants Condition="'$(IslinuxPortable)' == 'true'">$(DefineConstants);LINUX_PORTABLE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/EndToEnd/GivenFrameworkDependentApps.cs
+++ b/test/EndToEnd/GivenFrameworkDependentApps.cs
@@ -47,6 +47,11 @@ namespace EndToEnd
 
         internal void ItDoesNotRollForwardToTheLatestVersion(string packageName, string minorVersion)
         {
+            // https://github.com/NuGet/Home/issues/8571
+            #if LINUX_PORTABLE
+                return;
+            #endif
+
             var testProjectCreator = new TestProjectCreator()
             {
                 PackageName = packageName,


### PR DESCRIPTION
There's been a longstanding issue on linux portable in nuget affecting some set of tests. We disable those tests on that leg to workaround the issue. https://github.com/NuGet/Home/issues/8571