### PR TITLE
[release/7.0.1xx] Update source-build tarball CI to utilize faster build agents

### DIFF
--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build.yml
@@ -15,12 +15,12 @@ parameters:
   fedora36Container: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-36-20220818134137-a09384f
   ubuntu2004Container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-20220813234344-4c008dd
   poolInternalAmd64:
-    name: NetCore1ESPool-Svc-Internal
+    name: NetCore1ESPool-Internal-XL
     demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
   poolInternalArm64:
     name: Docker-Linux-Arm-Internal
   poolPublicAmd64:
-    name: NetCore-Svc-Public
+    name: NetCore-Public-XL
     demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
 
 jobs:


### PR DESCRIPTION
These new build agents are not to be used for other builds outside of source-build PR validation.
