### PR TITLE
#14522 adjusting width to avoid cropping.

### DIFF
--- a/src/redist/targets/packaging/windows/clisdk/bundle.thm
+++ b/src/redist/targets/packaging/windows/clisdk/bundle.thm
@@ -75,7 +75,7 @@
         <Text Name="SuccessRepairHeader" X="160" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessRepairHeader)</Text>
         <Text Name="SuccessUninstallHeader" X="160" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessUninstallHeader)</Text>
         <Button Name="LaunchButton" X="-133" Y="-11" Width="99" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.SuccessLaunchButton)</Button>
-        <Text Name="SuccessRestartText" X="-11" Y="-40" Width="400" Height="23" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessRestartText)</Text>
+        <Text Name="SuccessRestartText" X="-11" Y="-40" Width="425" Height="23" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessRestartText)</Text>
         <Button Name="SuccessRestartButton" X="-133" Y="-11" Width="99" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.SuccessRestartButton)</Button>
         <Button Name="SuccessCancelButton" X="-32" Y="-11" Width="99" Height="23" TabStop="yes" FontId="0">#(loc.SuccessCloseButton)</Button>
     </Page>


### PR DESCRIPTION
#14522 This image is a little off with the text coloring as I made it appear by default when the installer finished instead of going through the edge case of being asked to restart. The cropping was due to a rather simple width adjustment. 

![image](https://user-images.githubusercontent.com/114699222/196833344-0b7ce561-77e2-45eb-869d-3e01f76fcb53.png)