### PR TITLE
Set `product-construction` as code owners for `src/VirtualMonoRepo`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,7 @@
 # Users referenced in this file will automatically be requested as reviewers for PRs that modify the given paths.
 # See https://help.github.com/articles/about-code-owners/
 
-# Snaps
-
 /.devcontainer/ @dotnet/source-build-internal
 /src/snaps/ @rbhanda
 /src/SourceBuild/ @dotnet/source-build-internal
+/src/VirtualMonoRepo/ @dotnet/product-construction


### PR DESCRIPTION
I expect to put there more infrastructure like pipeline templates for the VMR legs