### PR TITLE
Fix to final 3.1 build

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -26,7 +26,7 @@
 
   <PropertyGroup>
       <VersionFeature21>30</VersionFeature21>
-      <VersionFeature31>$([MSBuild]::Add($(VersionFeature), 20))</VersionFeature31>
+      <VersionFeature31>32</VersionFeature31>
       <VersionFeature50>17</VersionFeature50>
   </PropertyGroup>
 


### PR DESCRIPTION
We expect 3.1.32 to be the final 3.1 build shipped to preparing the PR to pin to that version.