### PR TITLE
Refactor source-build CI triggers and pools

### DIFF
--- a/eng/source-build-tarball-build-official.yml
+++ b/eng/source-build-tarball-build-official.yml
@@ -4,7 +4,14 @@ resources:
   pipelines:
   - pipeline: installer-build-resource
     source: dotnet-installer-official-ci
-    trigger: true
+    trigger:
+      branches:
+        include:
+        - main
+        - release/*
+        - internal/release/*
+      stages:
+      - build
 
 stages:
 - stage: build

--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-create-tarball.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-create-tarball.yml
@@ -6,11 +6,20 @@ jobs:
   displayName: Source-Build Create Tarball
   pool:
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
-      name: NetCore-Svc-Public
-      demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
+      ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
+        name: NetCore-Public-XL
+        demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
+      ${{ else }}:
+        name: NetCore-Svc-Public
+        demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
     ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-      name: NetCore1ESPool-Svc-Internal
-      demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+      ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
+        name: NetCore1ESPool-Internal-XL
+        demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+      ${{ else }}:
+        name: NetCore1ESPool-Svc-Internal
+        demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+
   variables:
   - name: _BuildConfig
     value: Release

--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build.yml
@@ -15,6 +15,9 @@ parameters:
   fedora36Container: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-36-20220818134137-a09384f
   ubuntu2004Container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-20220813234344-4c008dd
   poolInternalAmd64:
+    name: NetCore1ESPool-Svc-Internal
+    demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+  poolInternalAmd64PR:
     name: NetCore1ESPool-Internal-XL
     demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
   poolInternalArm64:
@@ -68,7 +71,10 @@ jobs:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
         ${{ parameters.poolPublicAmd64 }}
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        ${{ parameters.poolInternalAmd64 }}
+        ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
+          ${{ parameters.poolInternalAmd64PR }}
+        ${{ else }}:
+          ${{ parameters.poolInternalAmd64 }}
 
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - template: /src/SourceBuild/Arcade/eng/common/templates/job/source-build-build-tarball.yml


### PR DESCRIPTION
The PR contains the following changes:

1. Refactor the source-build tarball CI trigger to only run on the release branches.  Currently this is triggering on a lot of branches unnecessarily which is wasting compute.  I also added a stage to the trigger so the tarball build will run sooner and won't have to wait for the publish stage to finish.
2. Only use the faster build agents for PR validation.  The faster agents weren't intended to be used for internal builds.
3. Use the faster build agents for the tarball creation leg in PR validation.   I don't know how much this will help but wanted to try it.
