### PR TITLE
Ensure finalizer only runs when no matching SDK feature bands are installed

### DIFF
--- a/src/finalizer/finalizer.cpp
+++ b/src/finalizer/finalizer.cpp
@@ -396,7 +396,17 @@ extern "C" HRESULT DetectSdk(LPWSTR sczSdkFeatureBandVersion, LPWSTR sczArchitec
     LogStringLine(REPORT_STANDARD, "Scanning %ls", sczInstalledSdkVersionsKeyName);
 
     hr = RegOpen(HKEY_LOCAL_MACHINE, sczInstalledSdkVersionsKeyName, KEY_READ, &hkInstalledSdkVersionsKey);
-    ExitOnFailure(hr, "Failed to read installed versions key.");
+
+    // When the last SDK is removed the registry key should no longer exist so we can just exit
+    if (E_FILENOTFOUND == hr)
+    {
+        LogStringLine(REPORT_STANDARD, "Registry key not found: %ls.", sczInstalledSdkVersionsKeyName);
+        hr = S_OK;
+        *pbInstalled = FALSE;
+        goto LExit;
+    }
+
+    ExitOnFailure(hr, "Failed to open registry key: %ls.", sczInstalledSdkVersionsKeyName);
 
     for (DWORD dwSdkVersionsValueIndex = 0;; ++dwSdkVersionsValueIndex)
     {
@@ -460,9 +470,10 @@ int wmain(int argc, wchar_t* argv[])
     hr = ::DetectSdk(sczFeatureBandVersion, argv[3], &bSdkFeatureBandInstalled);
     ExitOnFailure(hr, "Failed to detect installed SDKs.");
 
-    if (!bSdkFeatureBandInstalled)
+    // If the feature band is still present, do not remove workloads.
+    if (bSdkFeatureBandInstalled)
     {
-        LogStringLine(REPORT_STANDARD, "SDK with feature band %ls could not be found.", sczFeatureBandVersion);
+        LogStringLine(REPORT_STANDARD, "Detected SDK with feature band %ls.", sczFeatureBandVersion);
         goto LExit;
     }
 

--- a/src/redist/targets/packaging/windows/clisdk/bundle.wxs
+++ b/src/redist/targets/packaging/windows/clisdk/bundle.wxs
@@ -151,7 +151,31 @@
     <Variable Name="WINFORMSANDWPFVERSION" Type="string" Value="$(var.WinFormsAndWpfVersion)" bal:Overridable="no" />
     <Variable Name="DOTNETHOMESIMILARITYCHECKOVERRIDE" Type="string" Value="" bal:Overridable="yes" />
       
-      <Chain DisableSystemRestore="yes" ParallelCache="yes">
+    <Chain DisableSystemRestore="yes" ParallelCache="yes">
+      
+      <!-- 
+        The finalizer is not an actual installation package. We "detect" the EXE
+        based on the action the bundle is performing to ensure that it runs the uninstall
+        command only when the bundle is being removed. The package is always installable because the bundle
+        will remove the package (execute its UninstallCommand) if it is not installable when then bundle is 
+        being installed.
+
+        The finalizer is first in the chain to ensure it executes last during an uninstall. When the 
+        SDK is upgraded, the old SDK will be removed before the finalizer executes. This ensures that the
+        finalizer detects the new SDK and does nothing because the feature band matches.
+
+        For an install+uninstall scenario, because the SDK MSI is removed prior to the finalizer, it will
+        detect that there are no matching feature bands and then clean up workloads associated with
+        the feature band.
+      -->
+      <ExePackage SourceFile="$(var.FinalizerExeSourcePath)"
+                  Cache="always"
+                  DetectCondition="WixBundleAction >= 3"
+                  Id="Finalizer"
+                  InstallCondition="WixBundleAction >= 4"
+                  UninstallCommand="&quot;[WixBundleLog_Finalizer]&quot; $(var.NugetVersion) $(var.Platform)"
+                  Vital="no" />
+
       <MsiPackage SourceFile="$(var.SharedFXMsiSourcePath)">
         <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
       </MsiPackage>
@@ -208,20 +232,7 @@
         <PackageGroupRef Id="PG_AspNetCoreSharedFramework_arm64"/>
       <?endif?>
 
-      <!-- 
-        The finalizer is not an actual installation package. We "detect" the EXE
-        based on the action the bundle is performing to ensure that it runs the uninstall
-        command only when the bundle is being removed. The package is always installable because the bundle
-        will remove (execute the uninstall command) the package if it is not installable when then bundle is 
-        being installed.
-      -->
-      <ExePackage SourceFile="$(var.FinalizerExeSourcePath)"
-                  Cache="always"
-                  DetectCondition="WixBundleAction >= 3"
-                  Id="Finalizer"
-                  InstallCondition="WixBundleAction >= 4"
-                  UninstallCommand="&quot;[WixBundleLog_Finalizer]&quot; $(var.NugetVersion) $(var.Platform)"
-                  Vital="no" />
+      
     </Chain>
   </Bundle>
 


### PR DESCRIPTION
## Description

When a user updates an SDK after installing a workload, the workload is expected to remain installed. 

#### Repro Steps

1. Install the 6.0.400 SDK
2. Install an optional workload, e.g., `dotnet workload install wasm-tools`
3. Install the 6.0.401 SDK
4. Execute `dotnet workload list`

Expected: wasm-tools should be listed as installed
Actual: No installed workloads are reported.

## Fix

The finalizer in the SDK bundle is used to remove optional workloads installed through the CLI when the SDK is removed. When an SDK bundle is upgraded, the new SDK is installed before the previous bundle is removed. No properties are available to distinguish between an uninstall and an uninstall due to a major upgrade and the finalizer ends up removing workloads.
 
The package chain in the bundle is executed in reverse order when it is uninstalled. During an install, the finalizer will be first in the chain, but skipped due to its install condition. When the bundle is removed, the old SDK toolset MSI is removedbefore the finalizer runs. This allows the finalizer to detect the absence of matching SDK feature bands and remove any remaining workloads.

During an upgrade, the new SDK toolset MSI is present then the finalizer executes, allowing it to detect the presence of an SDK with a feature band matching the SDK being removed. In this case the finalizer will terminate and leave the previously installed workloads installed.

## Testing

Manual testing required since we need a build with the fix and another build of the SDK bundle that can be upgraded.