### PR TITLE
[main] Accommodate alpha sdk naming scheme for msft-to-source-build comparison test

### DIFF
--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-build-tarball.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-build-tarball.yml
@@ -68,7 +68,7 @@ jobs:
   - ${{ if ne(parameters.excludeSdkContentTests, 'true') }}:
     - download: ${{ parameters.installerBuildResourceId }}
       artifact: BlobArtifacts
-      patterns: '**/dotnet-sdk-+([0-9]).+([0-9]).+([0-9])?(-@(preview|rc|rtm)*)-linux-${{ parameters.architecture }}.tar.gz'
+      patterns: '**/dotnet-sdk-+([0-9]).+([0-9]).+([0-9])?(-@(alpha|preview|rc|rtm)*)-linux-${{ parameters.architecture }}.tar.gz'
       displayName: Download MSFT sdk Tarball
 
   - ${{ if eq(parameters.usePreviousArtifacts, 'true') }}:


### PR DESCRIPTION
Internal tarball build CI is failing because our regex won't download a pattern like `dotnet-sdk-8.0.100-alpha.1.22527.5-linux-x64.tar.gz`