### PR TITLE
[release/7.0.1xx] Increase dotnet-watch source-build smoke test timeout

### DIFF
--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetWatchTests.cs
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetWatchTests.cs
@@ -24,7 +24,7 @@ public class DotNetWatchTests : SmokeTests
             workingDirectory: projectDirectory,
             additionalProcessConfigCallback: processConfigCallback,
             expectedExitCode: null, // The exit code does not reflect whether or not dotnet watch is working properly
-            millisecondTimeout: 30000);
+            millisecondTimeout: 60000);
 
         Assert.True(outputChanged);
 

--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/ExecuteHelper.cs
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/ExecuteHelper.cs
@@ -70,7 +70,7 @@ internal static class ExecuteHelper
 
         if (!process.HasExited)
         {
-            outputHelper.WriteLine($"Killing: {fileName} {args}");
+            outputHelper.WriteLine($"Process did not exit. Killing {fileName} {args} after waiting {millisecondTimeout} milliseconds.");
             process.Kill(true);
             process.WaitForExit();
         }


### PR DESCRIPTION
I also added a more descriptive timeout message.