### PR TITLE
Update triggers to prevent tarball CI from running on 6.0.3xx and 6.0.4xx

### DIFF
--- a/eng/source-build-tarball-build-official.yml
+++ b/eng/source-build-tarball-build-official.yml
@@ -4,7 +4,19 @@ resources:
   pipelines:
   - pipeline: installer-build-resource
     source: dotnet-installer-official-ci
-    trigger: true
+    trigger:
+      branches:
+        include:
+        - main
+        - release/*
+        - internal/release/*
+        exclude:
+        - release/6.0.3xx
+        - internal/release/6.0.3xx
+        - release/6.0.4xx
+        - internal/release/6.0.4xx
+      stages:
+      - build
 
 stages:
 - stage: build


### PR DESCRIPTION
The goal is to prevent tarball CI from running on branches that are [not supported by source-build](https://github.com/dotnet/source-build/#support) to prevent wasting compute.

According to the [AzDO documentation](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/triggers?view=azure-devops#branch-consideration-for-triggers-in-yaml-pipelines) the triggers are read from the branch being run in CI so this must be changed in 6.0.3xx and 6.0.4xx.

