### PR TITLE
#6828 moving latest channel declaration to Version.props

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -236,5 +236,8 @@
     -->
     <DotNetDeploymentReleasesPackageVersion>1.0.0-preview5.1.22263.1</DotNetDeploymentReleasesPackageVersion>
   </PropertyGroup>
+  <PropertyGroup>
+    <Channel>master</Channel>
+  </PropertyGroup>
   <Import Project="$(RepositoryEngineeringDir)ManualVersions.props" />
 </Project>


### PR DESCRIPTION
#6828 

Located value at https://github.com/dotnet/installer/blob/bf8d55dcc671543e923b4661ea0b3425bb54739c/src/CopyToLatest/targets/BranchInfo.props#L1-L5

and place declaration to the bottom of the XML file.

