### PR TITLE
Update triggers to prevent tarball CI from running on 6.0.3xx and 6.0.4xx

### DIFF
--- a/eng/source-build-tarball-build-official.yml
+++ b/eng/source-build-tarball-build-official.yml
@@ -10,6 +10,11 @@ resources:
         - main
         - release/*
         - internal/release/*
+        exclude:
+        - release/6.0.3xx
+        - internal/release/6.0.3xx
+        - release/6.0.4xx
+        - internal/release/6.0.4xx
       stages:
       - build
 


### PR DESCRIPTION
In https://github.com/dotnet/installer/pull/14896, I mistakenly thought these needed to be checked into 6.0.3xx/6.0.4xx.  They apparently triggers are read from the default branch but utilize the pipeline definition defined in the individual branches.
