### PR TITLE
Update to .NET 7 GA MAUI manifests

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -197,13 +197,13 @@
   </PropertyGroup>
   <!-- Workload manifest package versions -->
   <PropertyGroup>
-    <MauiFeatureBand>7.0.100-rc.1</MauiFeatureBand>
-    <MauiWorkloadManifestVersion>7.0.0-rc.1.6430</MauiWorkloadManifestVersion>
-    <XamarinAndroidWorkloadManifestVersion>33.0.0-rc.1.136</XamarinAndroidWorkloadManifestVersion>
-    <XamarinIOSWorkloadManifestVersion>15.4.1006-rc.1</XamarinIOSWorkloadManifestVersion>
-    <XamarinMacCatalystWorkloadManifestVersion>15.4.1006-rc.1</XamarinMacCatalystWorkloadManifestVersion>
-    <XamarinMacOSWorkloadManifestVersion>12.3.1006-rc.1</XamarinMacOSWorkloadManifestVersion>
-    <XamarinTvOSWorkloadManifestVersion>15.4.1006-rc.1</XamarinTvOSWorkloadManifestVersion>
+    <MauiFeatureBand>7.0.100</MauiFeatureBand>
+    <MauiWorkloadManifestVersion>7.0.49</MauiWorkloadManifestVersion>
+    <XamarinAndroidWorkloadManifestVersion>33.0.4</XamarinAndroidWorkloadManifestVersion>
+    <XamarinIOSWorkloadManifestVersion>16.0.1478</XamarinIOSWorkloadManifestVersion>
+    <XamarinMacCatalystWorkloadManifestVersion>15.4.2372</XamarinMacCatalystWorkloadManifestVersion>
+    <XamarinMacOSWorkloadManifestVersion>12.3.2372</XamarinMacOSWorkloadManifestVersion>
+    <XamarinTvOSWorkloadManifestVersion>16.0.1478</XamarinTvOSWorkloadManifestVersion>
     <MonoWorkloadManifestVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MonoWorkloadManifestVersion>
     <MicrosoftNETWorkloadEmscriptennet6Manifest70100Version>7.0.0-rtm.22504.3</MicrosoftNETWorkloadEmscriptennet6Manifest70100Version>
     <MicrosoftNETWorkloadEmscriptennet7Manifest70100Version>7.0.0-rtm.22504.3</MicrosoftNETWorkloadEmscriptennet7Manifest70100Version>


### PR DESCRIPTION
These are the set of .NET 7 GA builds.

After `.\build.cmd -pack -publish`, manually tested the workloads:

    > $env:DOTNET_MULTILEVEL_LOOKUP=0
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install android --skip-manifest-update
    Installing pack Microsoft.Android.Sdk.Windows version 33.0.4...
    ...
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install ios --skip-manifest-update
    Installing pack Microsoft.iOS.Sdk version 16.0.1478..
    ...
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install macos --skip-manifest-update
    Installing pack Microsoft.macOS.Sdk version 12.3.2372...
    ...
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install maccatalyst --skip-manifest-update
    Installing pack Microsoft.MacCatalyst.Sdk version 15.4.2372...
    ...
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install tvos --skip-manifest-update
    Installing pack Microsoft.tvOS.Sdk version 16.0.1478...
    ...
    > .\artifacts\bin\redist\Debug\dotnet\dotnet.exe workload install maui --skip-manifest-update
    Installing pack Microsoft.Maui.Core.Ref.android version 7.0.49...

/cc @Redth @dalexsoto to check my version numbers