### PR TITLE
[release/7.0.1xx] Fix incorrect Microsoft.CodeAnalysis package versions in arcade and razor-compiler during bootstrap

### DIFF
--- a/src/SourceBuild/tarball/content/repos/arcade.proj
+++ b/src/SourceBuild/tarball/content/repos/arcade.proj
@@ -17,6 +17,13 @@
     <!-- we need to use a prebuilt Arcade to build Arcade -->
     <UseBootstrapArcade>true</UseBootstrapArcade>
     <IsToolingProject>true</IsToolingProject>
+    
+    <!-- NU1605: Package downgrade warning. During a bootstrap, arcade needs to
+                 reference the newly-built version of Microsoft.CodeAnalysis but
+                 we no longer have access to its N-1 dependencies from before
+                 the stage 1 build, so we manually reference the current version
+                 of M.CA's dependencies, causing NU1605. -->
+    <RepoNoWarns>NU1605</RepoNoWarns>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SourceBuild/tarball/content/repos/razor-compiler.proj
+++ b/src/SourceBuild/tarball/content/repos/razor-compiler.proj
@@ -9,8 +9,13 @@
     <OutputPlacementRepoApiImplemented>false</OutputPlacementRepoApiImplemented>
 
     <!-- NU1507 - https://github.com/dotnet/razor-compiler/issues/242
-                  Occurs when using NuGet central package management without defining any Package Source Mappings. -->
-    <RepoNoWarns>NU1507</RepoNoWarns>
+                  Occurs when using NuGet central package management without defining any Package Source Mappings.
+         NU1605 - Package downgrade warning. During a bootstrap, arcade needs to
+                  reference the newly-built version of Microsoft.CodeAnalysis but
+                  we no longer have access to its N-1 dependencies from before
+                  the stage 1 build, so we manually reference the current version
+                  of M.CA's dependencies, causing NU1605. -->
+    <RepoNoWarns>NU1507;NU1605</RepoNoWarns>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SourceBuild/tarball/patches/arcade/0001-Bump-more-versions-of-Microsoft.CodeAnalysis-depende.patch
+++ b/src/SourceBuild/tarball/patches/arcade/0001-Bump-more-versions-of-Microsoft.CodeAnalysis-depende.patch
@@ -1,0 +1,55 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Logan Bussell <loganbussell@microsoft.com>
+Date: Wed, 9 Nov 2022 10:50:17 -0800
+Subject: [PATCH] Bump more versions of Microsoft.CodeAnalysis dependencies
+
+---
+ .../Microsoft.DotNet.CodeAnalysis.csproj                   | 1 +
+ .../Microsoft.DotNet.GenFacades.csproj                     | 2 ++
+ .../Microsoft.DotNet.PackageTesting.csproj                 | 7 +++++++
+ 3 files changed, 10 insertions(+)
+
+diff --git a/src/Microsoft.DotNet.CodeAnalysis/Microsoft.DotNet.CodeAnalysis.csproj b/src/Microsoft.DotNet.CodeAnalysis/Microsoft.DotNet.CodeAnalysis.csproj
+index d1ac5ccbb..ce3136ca4 100644
+--- a/src/Microsoft.DotNet.CodeAnalysis/Microsoft.DotNet.CodeAnalysis.csproj
++++ b/src/Microsoft.DotNet.CodeAnalysis/Microsoft.DotNet.CodeAnalysis.csproj
+@@ -20,6 +20,7 @@
+   <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
+     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
+     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
++    <PackageReference Include="System.Text.Encoding.CodePages" Version="$(SystemTextEncodingCodePagesVersion)" />
+   </ItemGroup>
+ 
+   <ItemGroup>
+diff --git a/src/Microsoft.DotNet.GenFacades/Microsoft.DotNet.GenFacades.csproj b/src/Microsoft.DotNet.GenFacades/Microsoft.DotNet.GenFacades.csproj
+index d73f6abd2..9381a9a13 100644
+--- a/src/Microsoft.DotNet.GenFacades/Microsoft.DotNet.GenFacades.csproj
++++ b/src/Microsoft.DotNet.GenFacades/Microsoft.DotNet.GenFacades.csproj
+@@ -16,7 +16,9 @@
+ 
+   <!-- When building offline we need to bump the version of System.Reflection.Metadata that CodeAnalysis package depends on to match what the source build tarball expects. -->
+   <ItemGroup Condition="'$(DotNetBuildOffline)' == 'true'">
++    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
+     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
++    <PackageReference Include="System.Text.Encoding.CodePages" Version="$(SystemTextEncodingCodePagesVersion)" />
+   </ItemGroup>
+ 
+   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+diff --git a/src/Microsoft.DotNet.PackageTesting/Microsoft.DotNet.PackageTesting.csproj b/src/Microsoft.DotNet.PackageTesting/Microsoft.DotNet.PackageTesting.csproj
+index a9d9ad295..db4b3c879 100644
+--- a/src/Microsoft.DotNet.PackageTesting/Microsoft.DotNet.PackageTesting.csproj
++++ b/src/Microsoft.DotNet.PackageTesting/Microsoft.DotNet.PackageTesting.csproj
+@@ -18,6 +18,13 @@
+     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+   </ItemGroup>
+ 
++  <!-- When building offline we need to bump the version of System.Reflection.Metadata that CodeAnalysis package depends on to match what the source build tarball expects. -->
++  <ItemGroup Condition="'$(DotNetBuildOffline)' == 'true'">
++    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
++    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
++    <PackageReference Include="System.Text.Encoding.CodePages" Version="$(SystemTextEncodingCodePagesVersion)" />
++  </ItemGroup>
++
+   <ItemGroup>
+     <Compile Include="..\Common\Internal\BuildTask.cs" />
+   </ItemGroup>

--- a/src/SourceBuild/tarball/patches/razor-compiler/0001-Specify-versions-of-Microsoft.CodeAnalysis-dependenc.patch
+++ b/src/SourceBuild/tarball/patches/razor-compiler/0001-Specify-versions-of-Microsoft.CodeAnalysis-dependenc.patch
@@ -1,0 +1,61 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Logan Bussell <loganbussell@microsoft.com>
+Date: Wed, 9 Nov 2022 14:17:00 -0800
+Subject: [PATCH] Specify versions of Microsoft.CodeAnalysis dependencies
+
+---
+ .../src/Microsoft.CodeAnalysis.Razor.csproj                | 7 +++++++
+ .../Microsoft.NET.Sdk.Razor.SourceGenerators.csproj        | 7 +++++++
+ ...spNetCore.Razor.SourceGenerator.Tooling.Internal.csproj | 7 +++++++
+ 3 files changed, 21 insertions(+)
+
+diff --git a/src/Microsoft.CodeAnalysis.Razor/src/Microsoft.CodeAnalysis.Razor.csproj b/src/Microsoft.CodeAnalysis.Razor/src/Microsoft.CodeAnalysis.Razor.csproj
+index 5eb6ea9f..89f667d5 100644
+--- a/src/Microsoft.CodeAnalysis.Razor/src/Microsoft.CodeAnalysis.Razor.csproj
++++ b/src/Microsoft.CodeAnalysis.Razor/src/Microsoft.CodeAnalysis.Razor.csproj
+@@ -12,4 +12,11 @@
+     <ProjectReference Include="..\..\Microsoft.AspNetCore.Razor.Language\src\Microsoft.AspNetCore.Razor.Language.csproj" />
+     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+   </ItemGroup>
++
++  <!-- When building offline we need to bump the version of System.Reflection.Metadata that CodeAnalysis package depends on to match what the source build tarball expects. -->
++  <ItemGroup Condition="'$(DotNetBuildOffline)' == 'true'">
++    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
++    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
++    <PackageReference Include="System.Text.Encoding.CodePages" Version="$(SystemTextEncodingCodePagesVersion)" />
++  </ItemGroup>
+ </Project>
+diff --git a/src/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.csproj b/src/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.csproj
+index 27c23c27..473ee427 100644
+--- a/src/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.csproj
++++ b/src/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.csproj
+@@ -15,6 +15,13 @@
+     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+   </ItemGroup>
+ 
++  <!-- When building offline we need to bump the version of System.Reflection.Metadata that CodeAnalysis package depends on to match what the source build tarball expects. -->
++  <ItemGroup Condition="'$(DotNetBuildOffline)' == 'true'">
++    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
++    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
++    <PackageReference Include="System.Text.Encoding.CodePages" Version="$(SystemTextEncodingCodePagesVersion)" />
++  </ItemGroup>
++
+   <ItemGroup>
+     <ProjectReference Include="..\Microsoft.AspNetCore.Mvc.Razor.Extensions\src\Microsoft.AspNetCore.Mvc.Razor.Extensions.csproj" />
+     <ProjectReference Include="..\Microsoft.AspNetCore.Razor.Language\src\Microsoft.AspNetCore.Razor.Language.csproj" />
+diff --git a/src/tools/Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal/Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal.csproj b/src/tools/Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal/Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal.csproj
+index e3501517..aba28738 100644
+--- a/src/tools/Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal/Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal.csproj
++++ b/src/tools/Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal/Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal.csproj
+@@ -30,4 +30,11 @@
+     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+   </ItemGroup>
+ 
++  <!-- When building offline we need to bump the version of System.Reflection.Metadata that CodeAnalysis package depends on to match what the source build tarball expects. -->
++  <ItemGroup Condition="'$(DotNetBuildOffline)' == 'true'">
++    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
++    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
++    <PackageReference Include="System.Text.Encoding.CodePages" Version="$(SystemTextEncodingCodePagesVersion)" />
++  </ItemGroup>
++
+ </Project>

--- a/src/SourceBuild/tarball/patches/razor-compiler/0001-Specify-versions-of-Microsoft.CodeAnalysis-dependenc.patch
+++ b/src/SourceBuild/tarball/patches/razor-compiler/0001-Specify-versions-of-Microsoft.CodeAnalysis-dependenc.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Logan Bussell <loganbussell@microsoft.com>
 Date: Wed, 9 Nov 2022 14:17:00 -0800
-Subject: [PATCH] Specify versions of Microsoft.CodeAnalysis dependencies
+Subject: [PATCH 1/2] Specify versions of Microsoft.CodeAnalysis dependencies
 
 ---
  .../src/Microsoft.CodeAnalysis.Razor.csproj                | 7 +++++++
@@ -10,7 +10,7 @@ Subject: [PATCH] Specify versions of Microsoft.CodeAnalysis dependencies
  3 files changed, 21 insertions(+)
 
 diff --git a/src/Microsoft.CodeAnalysis.Razor/src/Microsoft.CodeAnalysis.Razor.csproj b/src/Microsoft.CodeAnalysis.Razor/src/Microsoft.CodeAnalysis.Razor.csproj
-index 5eb6ea9f..89f667d5 100644
+index 5eb6ea9f..0570bc56 100644
 --- a/src/Microsoft.CodeAnalysis.Razor/src/Microsoft.CodeAnalysis.Razor.csproj
 +++ b/src/Microsoft.CodeAnalysis.Razor/src/Microsoft.CodeAnalysis.Razor.csproj
 @@ -12,4 +12,11 @@
@@ -20,13 +20,13 @@ index 5eb6ea9f..89f667d5 100644
 +
 +  <!-- When building offline we need to bump the version of System.Reflection.Metadata that CodeAnalysis package depends on to match what the source build tarball expects. -->
 +  <ItemGroup Condition="'$(DotNetBuildOffline)' == 'true'">
-+    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
-+    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
-+    <PackageReference Include="System.Text.Encoding.CodePages" Version="$(SystemTextEncodingCodePagesVersion)" />
++    <PackageReference Include="System.Collections.Immutable" />
++    <PackageReference Include="System.Reflection.Metadata" />
++    <PackageReference Include="System.Text.Encoding.CodePages" />
 +  </ItemGroup>
  </Project>
 diff --git a/src/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.csproj b/src/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.csproj
-index 27c23c27..473ee427 100644
+index 27c23c27..3cec7922 100644
 --- a/src/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.csproj
 +++ b/src/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.csproj
 @@ -15,6 +15,13 @@
@@ -35,16 +35,16 @@ index 27c23c27..473ee427 100644
  
 +  <!-- When building offline we need to bump the version of System.Reflection.Metadata that CodeAnalysis package depends on to match what the source build tarball expects. -->
 +  <ItemGroup Condition="'$(DotNetBuildOffline)' == 'true'">
-+    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
-+    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
-+    <PackageReference Include="System.Text.Encoding.CodePages" Version="$(SystemTextEncodingCodePagesVersion)" />
++    <PackageReference Include="System.Collections.Immutable" />
++    <PackageReference Include="System.Reflection.Metadata" />
++    <PackageReference Include="System.Text.Encoding.CodePages" />
 +  </ItemGroup>
 +
    <ItemGroup>
      <ProjectReference Include="..\Microsoft.AspNetCore.Mvc.Razor.Extensions\src\Microsoft.AspNetCore.Mvc.Razor.Extensions.csproj" />
      <ProjectReference Include="..\Microsoft.AspNetCore.Razor.Language\src\Microsoft.AspNetCore.Razor.Language.csproj" />
 diff --git a/src/tools/Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal/Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal.csproj b/src/tools/Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal/Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal.csproj
-index e3501517..aba28738 100644
+index e3501517..1f7263ea 100644
 --- a/src/tools/Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal/Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal.csproj
 +++ b/src/tools/Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal/Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal.csproj
 @@ -30,4 +30,11 @@
@@ -53,9 +53,9 @@ index e3501517..aba28738 100644
  
 +  <!-- When building offline we need to bump the version of System.Reflection.Metadata that CodeAnalysis package depends on to match what the source build tarball expects. -->
 +  <ItemGroup Condition="'$(DotNetBuildOffline)' == 'true'">
-+    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
-+    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
-+    <PackageReference Include="System.Text.Encoding.CodePages" Version="$(SystemTextEncodingCodePagesVersion)" />
++    <PackageReference Include="System.Collections.Immutable" />
++    <PackageReference Include="System.Reflection.Metadata" />
++    <PackageReference Include="System.Text.Encoding.CodePages" />
 +  </ItemGroup>
 +
  </Project>

--- a/src/SourceBuild/tarball/patches/razor-compiler/0002-Add-Microsoft.CodeAnalysis-deps-to-central-package-m.patch
+++ b/src/SourceBuild/tarball/patches/razor-compiler/0002-Add-Microsoft.CodeAnalysis-deps-to-central-package-m.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Logan Bussell <loganbussell@microsoft.com>
+Date: Wed, 9 Nov 2022 16:01:01 -0800
+Subject: [PATCH 2/2] Add Microsoft.CodeAnalysis deps to central package
+ management
+
+---
+ Directory.Packages.props | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/Directory.Packages.props b/Directory.Packages.props
+index 6bb9c542..67e8603c 100644
+--- a/Directory.Packages.props
++++ b/Directory.Packages.props
+@@ -20,4 +20,9 @@
+     <PackageVersion Include="xunit.assert" Version="$(XunitAssertVersion)" />
+     <PackageVersion Include="xunit.extensibility.execution" Version="$(XunitExtensibilityExecutionVersion)" />
+   </ItemGroup>
++  <!-- When building offline we need to bump the version of System.Reflection.Metadata that CodeAnalysis package depends on to match what the source build tarball expects. -->
++  <ItemGroup Condition="'$(DotNetBuildOffline)' == 'true'">
++    <PackageVersion Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
++    <PackageVersion Include="System.Text.Encoding.CodePages" Version="$(SystemTextEncodingCodePagesVersion)" />
++  </ItemGroup>
+ </Project>


### PR DESCRIPTION
There was a bootstrap build failure after updating repos to 7.0 GA: https://dev.azure.com/dnceng/internal/_build/results?buildId=2040527&view=logs&j=474d5763-7d9f-5893-39b2-65ff9c24ec20&t=cfff399e-7ec3-573b-d32e-566ce7d1652a (internal Microsoft link)

This change should take care of the missing package errors in arcade, by fully specifying the dependencies everywhere Microsoft.CodeAnalysis is referenced in arcade.