### PR TITLE
Add root `.gitignore` for the VMR

### DIFF
--- a/src/SourceBuild/tarball/content/.gitignore
+++ b/src/SourceBuild/tarball/content/.gitignore
@@ -1,0 +1,8 @@
+/.dotnet
+/Tools
+/artifacts
+/packages
+/tools-local/**/bin
+/tools-local/**/obj
+/src/linker/src/ILLink.Tasks/ILLink.Tasks.nuspec
+/src/nuget-client/NuGet.config


### PR DESCRIPTION
- These are all additions after building the VMR
- `/src/nuget-client/NuGet.config` is a rename from `/src/nuget-client/NuGet.Config` (capital C)
- Modifications cannot be covered because files are already checked in

https://github.com/dotnet/arcade/issues/11598