### PR TITLE
Fix threading issue in source build smoke tests

### DIFF
--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/ExecuteHelper.cs
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/ExecuteHelper.cs
@@ -75,16 +75,30 @@ internal static class ExecuteHelper
             process.WaitForExit();
         }
 
-        string output = stdOutput.ToString().Trim();
-        if (logOutput && !string.IsNullOrWhiteSpace(output))
+        string output;
+        string error;
+
+        lock (stdOutput)
         {
-            outputHelper.WriteLine(output);
+            output = stdOutput.ToString().Trim();
         }
 
-        string error = stdError.ToString().Trim();
-        if (logOutput && !string.IsNullOrWhiteSpace(error))
+        lock (stdError)
         {
-            outputHelper.WriteLine(error);
+            error = stdError.ToString().Trim();
+        }
+
+        if (logOutput)
+        {
+            if (!string.IsNullOrWhiteSpace(output))
+            {
+                outputHelper.WriteLine(output);
+            }
+
+            if (string.IsNullOrWhiteSpace(error))
+            {
+                outputHelper.WriteLine(error);
+            }
         }
 
         return (process, output, error);


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/2823

The underlying issue I believe is that the DataReceivedEventHandlers can still be running by time the process exits so we must access the StringBuilder instances they write to after the process has exited in a thread safe way.

We should backport this to the servicing branches once proven in main.
