### PR TITLE
Revert "Update dependencies from SBRP"

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -201,9 +201,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>f36ea231c234560514ede4c2747897a737ced28f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="7.0.0-alpha.1.22570.1">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="7.0.0-alpha.1.22531.3">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>2aa8a10cf23402f91c49b832f20773ac3d1506bb</Sha>
+      <Sha>4f5672e90b7f908d96aad61a40b0e9b352518b1c</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceLink.GitHub" Version="1.2.0-beta-22429-01" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">


### PR DESCRIPTION
This reverts commit 769d0524d73ba66d256168d00661d96fb86a9903 from https://github.com/dotnet/installer/pull/15023.  This requires corresponding changes from runtime before it can be submitted.

