### PR TITLE
[release/7.0.1xx] repos/sdk.proj: set NativeAotSupported=false on arm platform

### DIFF
--- a/src/SourceBuild/tarball/content/repos/sdk.proj
+++ b/src/SourceBuild/tarball/content/repos/sdk.proj
@@ -7,6 +7,9 @@
     <BuildCommandArgs>$(BuildCommandArgs) /p:PackageProjectUrl=https://github.com/dotnet/sdk</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:PublishCompressedFilesPathPrefix=$(SourceBuiltToolsetDir)</BuildCommandArgs>
 
+    <!-- Just like mono, arm does not support NativeAot -->
+    <BuildCommandArgs Condition="'$(BuildArchitecture)' == 'arm'">$(BuildCommandArgs) /p:NativeAotSupported=false</BuildCommandArgs>
+
     <LogVerbosityOptOut>true</LogVerbosityOptOut>
     <BuildCommandArgs>$(BuildCommandArgs) -v $(LogVerbosity)</BuildCommandArgs>
 


### PR DESCRIPTION
Just like on mono-flavored runtime, `arm` does not support NativeAot. Thus, when building on that platform, the build fails when building on itself as `sdk` looks for `Microsoft.DotNet.ILCompiler` when it is never produced by runtime. 

Piggy-backing off of https://github.com/dotnet/sdk/pull/28674, fix by setting `NativeAotSupported=false` when building source-build on `arm`.