### PR TITLE
removed workarounds for `console` and `classlib` in template tests

### DIFF
--- a/src/redist/targets/BundledTemplates.targets
+++ b/src/redist/targets/BundledTemplates.targets
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <Bundled80Templates Include="Microsoft.DotNet.Common.ItemTemplates" PackageVersion="$(MicrosoftDotNetCommonItemTemplates80PackageVersion)" />
+    <Bundled80Templates Include="Microsoft.DotNet.Common.ProjectTemplates.8.0" PackageVersion="$(MicrosoftDotNetCommonItemTemplates80PackageVersion)" />
     <Bundled80Templates Include="Microsoft.DotNet.Web.ItemTemplates.8.0" PackageVersion="$(AspNetCorePackageVersionFor80Templates)" />
     <Bundled80Templates Include="Microsoft.DotNet.Web.ProjectTemplates.8.0" PackageVersion="$(AspNetCorePackageVersionFor80Templates)" UseVersionForTemplateInstallPath="true" />
     <Bundled80Templates Include="Microsoft.DotNet.Web.Spa.ProjectTemplates.8.0" PackageVersion="$(AspNetCorePackageVersionFor80Templates)" />
@@ -30,10 +31,6 @@
     <Bundled80Templates Include="Microsoft.Dotnet.WinForms.ProjectTemplates" PackageVersion="$(MicrosoftDotnetWinFormsProjectTemplates80PackageVersion)" Condition="'$(DotNetBuildFromSource)' != 'true'" />
     
     <Bundled80Templates Include="Microsoft.DotNet.Test.ProjectTemplates.8.0" PackageVersion="$(MicrosoftDotNetTestProjectTemplates80PackageVersion)" />
-    
-    <!-- NUnit templates are shipped in Test.ProjectTemplates -->
-    <!-- Not available yet for 8.0 -->
-    <Bundled80Templates Include="Microsoft.DotNet.Common.ProjectTemplates.7.0" PackageVersion="$(MicrosoftDotNetCommonItemTemplates70PackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/EndToEnd/ProjectBuildTests.cs
+++ b/test/EndToEnd/ProjectBuildTests.cs
@@ -21,7 +21,7 @@ namespace EndToEnd.Tests
             var directory = TestAssets.CreateTestDirectory();
             string projectDirectory = directory.FullName;
 
-            string newArgs = "console --debug:ephemeral-hive --no-restore";
+            string newArgs = "console --no-restore";
             new NewCommandShim()
                 .WithWorkingDirectory(projectDirectory)
                 .Execute(newArgs)
@@ -59,7 +59,7 @@ namespace EndToEnd.Tests
             var directory = TestAssets.CreateTestDirectory();
             string projectDirectory = directory.FullName;
 
-            string newArgs = "console --debug:ephemeral-hive --no-restore";
+            string newArgs = "console --no-restore";
             new NewCommandShim()
                 .WithWorkingDirectory(projectDirectory)
                 .Execute(newArgs)
@@ -224,7 +224,7 @@ namespace EndToEnd.Tests
             DirectoryInfo directory = TestAssets.CreateTestDirectory(identifier: templateName);
             string projectDirectory = directory.FullName;
 
-            string newArgs = $"{templateName} --debug:ephemeral-hive";
+            string newArgs = $"{templateName}";
 
             new NewCommandShim()
                 .WithWorkingDirectory(projectDirectory)
@@ -406,7 +406,7 @@ namespace EndToEnd.Tests
             DirectoryInfo directory = TestAssets.CreateTestDirectory(identifier: string.IsNullOrWhiteSpace(language) ? templateName : $"{templateName}[{language}]");
             string projectDirectory = directory.FullName;
 
-            string newArgs = $"{templateName} --debug:ephemeral-hive --no-restore";
+            string newArgs = $"{templateName} --no-restore";
             if (!string.IsNullOrWhiteSpace(language))
             {
                 newArgs += $" --language {language}";

--- a/test/EndToEnd/ProjectBuildTests.cs
+++ b/test/EndToEnd/ProjectBuildTests.cs
@@ -15,8 +15,6 @@ namespace EndToEnd.Tests
 {
     public class ProjectBuildTests : TestBase
     {
-        private static readonly string currentTfm = "net8.0";
-
         [Fact]
         public void ItCanNewRestoreBuildRunCleanMSBuildProject()
         {
@@ -28,13 +26,6 @@ namespace EndToEnd.Tests
                 .WithWorkingDirectory(projectDirectory)
                 .Execute(newArgs)
                 .Should().Pass();
-
-            string projectPath = Path.Combine(projectDirectory, directory.Name + ".csproj");
-            var project = XDocument.Load(projectPath);
-            var ns = project.Root.Name.Namespace;
-            project.Root.Element(ns + "PropertyGroup")
-                .Element(ns + "TargetFramework").Value = currentTfm;
-            project.Save(projectPath);
 
             new RestoreCommand()
                 .WithWorkingDirectory(projectDirectory)
@@ -80,9 +71,6 @@ namespace EndToEnd.Tests
             var ns = project.Root.Name.Namespace;
 
             project.Root.Attribute("Sdk").Value = "Microsoft.NET.Sdk.Web";
-            project.Root.Element(ns + "PropertyGroup")
-                .Element(ns + "TargetFramework").Value = currentTfm;
-
             project.Save(projectPath);
 
             new BuildCommand()
@@ -397,8 +385,6 @@ namespace EndToEnd.Tests
                 // Return net7.0 for templates that don't support
                 // net8.0 yet.
                 if (template.StartsWith("blazor")
-                    || template.StartsWith("classlib")
-                    || template.StartsWith("console")
                     || template.StartsWith("mvc")
                     || template.StartsWith("web")
                     || template.StartsWith("worker")


### PR DESCRIPTION
removed workarounds for `console` and `classlib` in template tests, now that these templates are updated for `net8.0`