### PR TITLE
Override some versions for nonshipping runtime packages.

### DIFF
--- a/src/SourceBuild/tarball/content/eng/bootstrap/OverrideBootstrapVersions.props
+++ b/src/SourceBuild/tarball/content/eng/bootstrap/OverrideBootstrapVersions.props
@@ -1,0 +1,11 @@
+<Project>
+  <PropertyGroup>
+     <!-- 7.0.0 produced improperly versioned runtime assets because the OfficialBuildId
+          was not set correctly.  This is the actual shipping version that it should have been -->
+     <NonshippingRuntimeVersionFor700>7.0.0-rtm.22518.5</NonshippingRuntimeVersionFor700>
+
+     <MicrosoftNETHostModelVersion>$(NonshippingRuntimeVersionFor700)</MicrosoftNETHostModelVersion>
+     <MicrosoftNETCoreTestHostVersion>$(NonshippingRuntimeVersionFor700)</MicrosoftNETCoreTestHostVersion>
+     <RuntimeLinuxX64MicrosoftNETCoreTestHostVersion>$(NonshippingRuntimeVersionFor700)</RuntimeLinuxX64MicrosoftNETCoreTestHostVersion>
+  </PropertyGroup>
+</Project>

--- a/src/SourceBuild/tarball/content/eng/bootstrap/buildBootstrapPreviouslySB.csproj
+++ b/src/SourceBuild/tarball/content/eng/bootstrap/buildBootstrapPreviouslySB.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="$(MSBuildProjectDirectory)/PackageVersions.props" />
+  <Import Project="$(BootstrapOverrideVersionsProps)" Condition="Exists('$(BootstrapOverrideVersionsProps)')" />
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>

--- a/src/SourceBuild/tarball/content/prep.sh
+++ b/src/SourceBuild/tarball/content/prep.sh
@@ -118,7 +118,7 @@ if [ "$buildBootstrap" == "true" ]; then
     fi
 
     # Run restore on project to initiate download of bootstrap packages
-    $DOTNET_SDK_PATH/dotnet restore $workingDir/buildBootstrapPreviouslySB.csproj /bl:artifacts/prep/bootstrap.binlog /fileLoggerParameters:LogFile=artifacts/prep/bootstrap.log /p:ArchiveDir="$SCRIPT_ROOT/packages/archive/"
+    $DOTNET_SDK_PATH/dotnet restore $workingDir/buildBootstrapPreviouslySB.csproj /bl:artifacts/prep/bootstrap.binlog /fileLoggerParameters:LogFile=artifacts/prep/bootstrap.log /p:ArchiveDir="$SCRIPT_ROOT/packages/archive/" /p:BootstrapOverrideVersionsProps="$SCRIPT_ROOT/eng/bootstrap/OverrideBootstrapVersions.props"
 
     # Remove working directory
     rm -rf $workingDir


### PR DESCRIPTION
Source-build 7.0.0 created these packages with an incorrect version number which is stuckthe previously-source-built PVP for the 7.0.1 release.  This causes a problem if bootstapping because the Microsoft versions of these packages don't actually exist, so trying to download them fails.  This change allows us to override the version read out of PVP and set it to the actual version used by runtime.

Fixes https://github.com/dotnet/source-build/issues/3118.