### PR TITLE
Update the implicit versions to match the December release

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -63,7 +63,7 @@
       <VersionFeature21>30</VersionFeature21>
       <VersionFeature31>32</VersionFeature31>
       <VersionFeature50>17</VersionFeature50>
-      <VersionFeature60>$([MSBuild]::Add($(VersionFeature), 10))</VersionFeature60>
+      <VersionFeature60>12</VersionFeature60>
   </PropertyGroup>
 
   <Target Name="GenerateBundledVersionsProps" DependsOnTargets="SetupBundledComponents">


### PR DESCRIPTION
We're going to miss 17.5-preview2 so the plan is to update to the December version, rebuild, update the PR with the December runtimes, and then push into main to get internal dogfooding.