### PR TITLE
Use relative paths when referencing YAML templates

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -71,7 +71,7 @@ stages:
     
     ## Windows
 
-    - template: /eng/build.yml
+    - template: eng/build.yml
       parameters:
         agentOs: Windows_NT
         jobName: Build_Debug_x64
@@ -82,7 +82,7 @@ stages:
 
     ## Linux
 
-    - template: /eng/build.yml
+    - template: eng/build.yml
       parameters:
         agentOs: Linux
         jobName: Build_Ubuntu_22_04_Debug_x64
@@ -91,7 +91,7 @@ stages:
         buildArchitecture: x64
         linuxPortable: true
         runTests: true
-    - template: /eng/build.yml
+    - template: eng/build.yml
       parameters:
         agentOs: Linux
         jobName: Build_Fedora_36_Debug_x64
@@ -100,7 +100,7 @@ stages:
         buildArchitecture: x64
         linuxPortable: true
         runTests: true
-    - template: /eng/build.yml
+    - template: eng/build.yml
       parameters:
         agentOs: Linux
         jobName: Build_CentOS_7_Debug_x64
@@ -109,7 +109,7 @@ stages:
         buildArchitecture: x64
         linuxPortable: false
         runTests: true
-    - template: /eng/build.yml
+    - template: eng/build.yml
       parameters:
         agentOs: Linux
         jobName: Build_Debian_Stretch_Debug_x64
@@ -119,7 +119,7 @@ stages:
         additionalBuildParameters: '/p:BuildSdkDeb=true'
         linuxPortable: false
         runTests: true
-    - template: /eng/build.yml
+    - template: eng/build.yml
       parameters:
         agentOs: Linux
         jobName: Build_Arm64_Debug
@@ -129,7 +129,7 @@ stages:
         linuxPortable: true
         # Never run tests on arm64
         runTests: false
-    - template: /eng/build.yml
+    - template: eng/build.yml
       parameters:
         agentOs: Linux
         jobName: Build_Linux_musl_Debug_x64
@@ -141,7 +141,7 @@ stages:
         additionalBuildParameters: '/p:HostOSName="linux-musl"'
         linuxPortable: false
         runTests: true
-    - template: /eng/build.yml
+    - template: eng/build.yml
       parameters:
         agentOs: Linux
         jobName: Build_LinuxPortable_Release_x64
@@ -152,7 +152,7 @@ stages:
 
     # MacOS
 
-    - template: /eng/build.yml
+    - template: eng/build.yml
       parameters:
         agentOs: Darwin
         jobName: Build_Release_x64
@@ -166,7 +166,7 @@ stages:
     
     ## Windows
 
-    - template: /eng/build.yml
+    - template: eng/build.yml
       parameters:
         agentOs: Windows_NT
         jobName: Build_Release_x64
@@ -174,14 +174,14 @@ stages:
         buildArchitecture: x64
         additionalBuildParameters: '/p:PublishInternalAsset=true'
         runTests: false
-    - template: /eng/build.yml
+    - template: eng/build.yml
       parameters:
         agentOs: Windows_NT
         jobName: Build_Release_x86
         buildConfiguration: Release
         buildArchitecture: x86
         runTests: false
-    - template: /eng/build.yml
+    - template: eng/build.yml
       parameters:
         agentOs: Windows_NT
         jobName: Build_Release_arm64
@@ -191,7 +191,7 @@ stages:
 
     ## Linux 
 
-    - template: /eng/build.yml
+    - template: eng/build.yml
       parameters:
         agentOs: Linux
         jobName: Build_Arm_Release
@@ -200,7 +200,7 @@ stages:
         runtimeIdentifier: 'linux-arm'
         linuxPortable: true
         runTests: false
-    - template: /eng/build.yml
+    - template: eng/build.yml
       parameters:
         agentOs: Linux
         jobName: Build_Arm64_Release
@@ -209,7 +209,7 @@ stages:
         runtimeIdentifier: 'linux-arm64'
         linuxPortable: true
         runTests: false
-    - template: /eng/build.yml
+    - template: eng/build.yml
       parameters:
         agentOs: Linux
         jobName: Build_Linux_musl_Release_arm
@@ -220,7 +220,7 @@ stages:
         additionalBuildParameters: '/p:OSName="linux-musl"'
         linuxPortable: false
         runTests: false
-    - template: /eng/build.yml
+    - template: eng/build.yml
       parameters:
         agentOs: Linux
         jobName: Build_Linux_musl_Release_arm64
@@ -230,7 +230,7 @@ stages:
         additionalBuildParameters: '/p:OSName="linux-musl"'
         linuxPortable: false
         runTests: false
-    - template: /eng/build.yml
+    - template: eng/build.yml
       parameters:
         agentOs: Linux
         jobName: Build_Linux_musl_Release_x64
@@ -242,7 +242,7 @@ stages:
         additionalBuildParameters: '/p:HostOSName="linux-musl"'
         linuxPortable: false
         runTests: false
-    - template: /eng/build.yml
+    - template: eng/build.yml
       parameters:
         agentOs: Linux
         jobName: Build_Linux_Portable_Deb_Release_x64
@@ -254,7 +254,7 @@ stages:
         additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:BuildSdkDeb=true'
         linuxPortable: true
         runTests: false
-    - template: /eng/build.yml
+    - template: eng/build.yml
       parameters:
         agentOs: Linux
         jobName: Build_Linux_Portable_Rpm_Release_x64
@@ -266,7 +266,7 @@ stages:
         additionalBuildParameters: '/p:PublishBinariesAndBadge=false'
         linuxPortable: true
         runTests: false
-    - template: /eng/build.yml
+    - template: eng/build.yml
       parameters:
         agentOs: Linux
         jobName: Build_Linux_Portable_Rpm_Release_Arm64
@@ -279,7 +279,7 @@ stages:
         additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:CLIBUILD_SKIP_TESTS=true'
         linuxPortable: true
         runTests: false
-    - template: /eng/build.yml
+    - template: eng/build.yml
       parameters:
         agentOs: Linux
         jobName: Build_LinuxPortable_Release_x64
@@ -290,14 +290,14 @@ stages:
 
     # MacOS
 
-    - template: /eng/build.yml
+    - template: eng/build.yml
       parameters:
         agentOs: Darwin
         jobName: Build_Release_x64
         buildConfiguration: Release
         buildArchitecture: x64
         runTests: false
-    - template: /eng/build.yml
+    - template: eng/build.yml
       parameters:
         agentOs: Darwin
         jobName: Build_Release_arm64
@@ -308,7 +308,7 @@ stages:
 
     ## Windows PGO Instrumentation builds
 
-    - template: /eng/build.yml
+    - template: eng/build.yml
       parameters:
         agentOs: Windows_NT
         pgoInstrument: true
@@ -317,7 +317,7 @@ stages:
         buildArchitecture: x64
         additionalBuildParameters: '/p:PublishInternalAsset=true'
         runTests: false
-    - template: /eng/build.yml
+    - template: eng/build.yml
       parameters:
         agentOs: Windows_NT
         pgoInstrument: true
@@ -325,7 +325,7 @@ stages:
         buildConfiguration: Release
         buildArchitecture: x86
         runTests: false
-    - template: /eng/build.yml
+    - template: eng/build.yml
       parameters:
         agentOs: Windows_NT
         pgoInstrument: true
@@ -336,7 +336,7 @@ stages:
 
     ## Linux PGO Instrumentation builds
 
-    - template: /eng/build.yml
+    - template: eng/build.yml
       parameters:
         agentOs: Linux
         pgoInstrument: true
@@ -346,7 +346,7 @@ stages:
         linuxPortable: true
         runTests: false
 
-    - template: /eng/build.yml
+    - template: eng/build.yml
       parameters:
         agentOs: Linux
         pgoInstrument: true
@@ -363,7 +363,7 @@ stages:
     displayName: Synchronize VMR
     dependsOn: []
     jobs:
-    - template: /eng/pipelines/templates/jobs/vmr-synchronization.yml
+    - template: eng/pipelines/templates/jobs/vmr-synchronization.yml
       parameters:
         vmrBranch: ${{ parameters.vmrBranch }}
 
@@ -372,7 +372,7 @@ stages:
 # synchronized into the VMR without problems.
 # You can do this by allowing the Synchronize_VMR stage from above in PRs.
 - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-  - template: /eng/pipelines/templates/stages/vmr-build.yml
+  - template: eng/pipelines/templates/stages/vmr-build.yml
     parameters:
       vmrBranch: ${{ parameters.vmrBranch }}
       installerBuildResourceId: current

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -64,7 +64,7 @@ parameters:
   default: false
 
 jobs:
-- template: /eng/common/templates/job/job.yml
+- template: common/templates/job/job.yml
   parameters:
     # Set up the name of the job.
     ${{ if parameters.pgoInstrument }}:

--- a/eng/pipelines/vmr-ci.yml
+++ b/eng/pipelines/vmr-ci.yml
@@ -21,6 +21,6 @@ resources:
     endpoint: dotnet
 
 stages:
-- template: /eng/pipelines/templates/stages/vmr-build.yml
+- template: templates/stages/vmr-build.yml
   parameters:
     installerBuildResourceId: installer-build-resource


### PR DESCRIPTION
- This will make the YAML templates work inside the VMR
- Arcade templates use absolute paths too but it doesn't matter as we will have `eng/common` copied over from installer in the VMR too

https://github.com/dotnet/arcade/issues/11820