### PR TITLE
Revert "Remove nuget source-build patch"

### DIFF
--- a/src/SourceBuild/tarball/patches/nuget-client/0001-Remove-non-compliant-feeds-NuGet.configs.patch
+++ b/src/SourceBuild/tarball/patches/nuget-client/0001-Remove-non-compliant-feeds-NuGet.configs.patch
@@ -1,0 +1,88 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Premek Vysoky <premek.vysoky@microsoft.com>
+Date: Wed, 30 Nov 2022 11:08:09 +0100
+Subject: [PATCH] Remove non-compliant feeds/NuGet.configs
+
+---
+ NuGet.Config                       | 14 +++++++-------
+ submodules/Common/NuGet.config     |  7 -------
+ submodules/FileSystem/NuGet.config |  7 -------
+ 3 files changed, 7 insertions(+), 21 deletions(-)
+ delete mode 100644 submodules/Common/NuGet.config
+ delete mode 100644 submodules/FileSystem/NuGet.config
+
+diff --git a/NuGet.Config b/NuGet.Config
+index 0a4c87ea06..7b913598f6 100644
+--- a/NuGet.Config
++++ b/NuGet.Config
+@@ -4,9 +4,9 @@
+     <clear />
+     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
+     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+-    <add key="myget-legacy@Local" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy%40Local/nuget/v3/index.json" />
+     <add key="nuget-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
+-    <add key="vside" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/nuget/v3/index.json" />
++    <add key="vside_vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
++    <add key="vside_vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
+   </packageSources>
+   <packageSourceMapping>
+     <clear />
+@@ -43,16 +43,13 @@
+       <package pattern="nuget.client.endtoend.testdata" />
+       <package pattern="nugetvalidator" />
+     </packageSource>
+-    <packageSource key = "vside">
++    <packageSource key = "vside_vssdk">
+       <package pattern="envdte" />
+       <package pattern="envdte100" />
+       <package pattern="envdte80" />
+       <package pattern="envdte90" />
+       <package pattern="envdte90a" />
+-      <package pattern="microsoft.internal.visualstudio.*" />
+-      <package pattern="microsoft.servicehub.*" />
+-      <package pattern="microsoft.test.apex.visualstudio" />
+-      <package pattern="microsoft.visualstudio.*" />
++      <package pattern="microsoft.*" />
+       <package pattern="stdole" />
+       <package pattern="streamjsonrpc" />
+       <package pattern="vslangproj" />
+@@ -68,6 +65,9 @@
+       <package pattern="vslangproj90" />
+       <package pattern="vswebsite.interop" />
+     </packageSource>
++    <packageSource key = "vside_vs-impl">
++      <package pattern="microsoft.*" />
++    </packageSource>
+     <packageSource key = "myget-legacy@Local">
+       <package pattern="microsoft.*" />
+     </packageSource>
+diff --git a/submodules/Common/NuGet.config b/submodules/Common/NuGet.config
+deleted file mode 100644
+index 09c3488420..0000000000
+--- a/submodules/Common/NuGet.config
++++ /dev/null
+@@ -1,7 +0,0 @@
+-﻿<?xml version="1.0" encoding="utf-8"?>
+-<configuration>
+-  <packageSources>
+-    <add key="AspNetVNext" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
+-    <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
+-  </packageSources>
+-</configuration>
+diff --git a/submodules/FileSystem/NuGet.config b/submodules/FileSystem/NuGet.config
+deleted file mode 100644
+index 1707938c61..0000000000
+--- a/submodules/FileSystem/NuGet.config
++++ /dev/null
+@@ -1,7 +0,0 @@
+-<?xml version="1.0" encoding="utf-8"?>
+-<configuration>
+-  <packageSources>
+-    <add key="AspNetVNext" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
+-    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+-  </packageSources>
+-</configuration>
+\ No newline at end of file
+-- 
+2.30.2.windows.1
+


### PR DESCRIPTION
This doesn't work as we expected. There are 3 separate scans - NuGet analysis, NPM analysis and Multifeed analysis. The problems in the files we're removing are flagged by the third kind of the scan and there doesn't seem to be any suppression mechanism for that one.

Reverts dotnet/installer#15079

