### PR TITLE
Add KnownILLinkPack to bundled versions

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -411,7 +411,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <KnownILLinkPack Include="Microsoft.NET.ILLink.Tasks"
                      TargetFramework="net8.0"
-                     ILLinkPackVersion="7.0.100-1.22606.1" />
+                     ILLinkPackVersion="8.0.100-1.22619.1" />
 
     <KnownRuntimePack Include="Microsoft.NETCore.App"
                       TargetFramework="net8.0"


### PR DESCRIPTION
Part of https://github.com/dotnet/linker/issues/3029. With https://github.com/dotnet/sdk/pull/29441/files, this will enable the SDK to use a different version of illink depending on the TFM.

The latest 7.0 illink package is used when trimming net7.0 and earlier, which matches the configuration we shipped in the .NET 7 SDK.
- The 7.0 version is taken from the latest 7.0 SDK branch: https://github.com/dotnet/sdk/blob/release/7.0.2xx/eng/Versions.props#L89.
- The 8.0 version is the latest in the SDK's main branch: https://github.com/dotnet/sdk/blob/main/eng/Versions.props#L88

These versions will quickly get out of date and need to be kept updated. For the latest (8.0) version I think it would be possible to set up dependency flow from linker -> installer to automate this, but I would rather wait for the linker move to dotnet/runtime, which will allow us to use `$(MicrosoftNETCoreAppRuntimePackageVersion)` for the latest illink pack. (https://github.com/dotnet/linker/pull/3153 will update this version number to begin with 8).

Unfortunately the 7.0 version will still need manual updates. We might want to consider changing our version numbers to match dotnet/runtime, but AFAIK that will still be a manual process (to update the patch number in the release/7.0 branch of dotnet/linker every SDK servicing release).