### PR TITLE
Refactor source-build archives infra

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -190,28 +190,6 @@
     <MicrosoftNETTestSdkVersion>17.5.0-preview-20221209-03</MicrosoftNETTestSdkVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>8.0.0-alpha.1.22557.12</MicrosoftExtensionsLoggingConsoleVersion>
   </PropertyGroup>
-  <!-- dependencies for source-build tarball -->
-  <PropertyGroup>
-    <!-- These two MicrosoftBuild versions are required to build tarball tasks
-         These tasks will eventually move to Arcade and then these can be
-         removed.  See https://github.com/dotnet/source-build/issues/2295 -->
-    <MicrosoftBuildFrameworkVersion>15.7.179</MicrosoftBuildFrameworkVersion>
-    <MicrosoftBuildUtilitiesCoreVersion>15.7.179</MicrosoftBuildUtilitiesCoreVersion>
-    <!--
-      Building .NET from source depends on one or two tar.gz files depending on the branch's current
-      source-buildability status.
-
-      PrivateSourceBuiltArtifactsPackageVersion is a tar.gz of .NET build outputs from a previous
-      build needed to build the current version of .NET. This is always defined, because .NET needs
-      to be bootstrappable at any point in time.
-
-      PrivateSourceBuiltPrebuiltsPackageVersion is a tar.gz of assets downloaded from the internet
-      that are needed to build the current version of .NET. Early in the lifecycle of a .NET major
-      or minor release, prebuilts may be needed. When the release is mature, prebuilts are not
-      necessary, and this property is removed from the file.
-    -->
-    <PrivateSourceBuiltArtifactsPackageVersion>7.0.100</PrivateSourceBuiltArtifactsPackageVersion>
-  </PropertyGroup>
   <!-- Workload manifest package versions -->
   <PropertyGroup>
     <MauiFeatureBand>7.0.100</MauiFeatureBand>

--- a/src/SourceBuild/tarball/content/eng/Versions.props
+++ b/src/SourceBuild/tarball/content/eng/Versions.props
@@ -9,4 +9,21 @@
   <PropertyGroup>
     <HumanizerCorePackageVersion>2.2.0</HumanizerCorePackageVersion>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <!--
+      Building .NET from source depends on one or two tar.gz files depending on the branch's current
+      source-buildability status.
+
+      PrivateSourceBuiltArtifactsPackageVersion is a tar.gz of .NET build outputs from a previous
+      build needed to build the current version of .NET. This is always defined, because .NET needs
+      to be bootstrappable at any point in time.
+
+      PrivateSourceBuiltPrebuiltsPackageVersion is a tar.gz of assets downloaded from the internet
+      that are needed to build the current version of .NET. Early in the lifecycle of a .NET major
+      or minor release, prebuilts may be needed. When the release is mature, prebuilts are not
+      necessary, and this property is removed from the file.
+    -->
+    <PrivateSourceBuiltArtifactsPackageVersion>7.0.100</PrivateSourceBuiltArtifactsPackageVersion>
+  </PropertyGroup>
 </Project>

--- a/src/SourceBuild/tarball/content/prep.sh
+++ b/src/SourceBuild/tarball/content/prep.sh
@@ -39,12 +39,6 @@ while :; do
     shift
 done
 
-# Check for the archive text file which describes the location of the archive files to download
-if [ ! -f $SCRIPT_ROOT/packages/archive/archiveArtifacts.txt ]; then
-    echo "  ERROR: $SCRIPT_ROOT/packages/archive/archiveArtifacts.txt does not exist.  Cannot determine which archives to download.  Exiting..."
-    exit -1
-fi
-
 downloadArtifacts=true
 downloadPrebuilts=true
 installDotnet=true
@@ -57,13 +51,15 @@ then
 fi
 
 # Check if Private.SourceBuilt artifacts archive exists
-if [ -f $SCRIPT_ROOT/packages/archive/Private.SourceBuilt.Artifacts.*.tar.gz ]; then
+artifactsBaseFileName="Private.SourceBuilt.Artifacts"
+if [ -f $SCRIPT_ROOT/packages/archive/$artifactsBaseFileName.*.tar.gz ]; then
     echo "  Private.SourceBuilt.Artifacts.*.tar.gz exists...it will not be downloaded"
     downloadArtifacts=false
 fi
 
 # Check if Private.SourceBuilt prebuilts archive exists
-if [ -f $SCRIPT_ROOT/packages/archive/Private.SourceBuilt.Prebuilts.*.tar.gz ]; then
+prebuiltsBaseFileName="Private.SourceBuilt.Prebuilts"
+if [ -f $SCRIPT_ROOT/packages/archive/$prebuiltsBaseFileName.*.tar.gz ]; then
     echo "  Private.SourceBuilt.Prebuilts.*.tar.gz exists...it will not be downloaded"
     downloadPrebuilts=false
 fi
@@ -75,20 +71,35 @@ if [ -d $SCRIPT_ROOT/.dotnet ]; then
 fi
 
 # Read the archive text file to get the archives to download and download them
-while read -r line; do
-    if [[ $line == *"Private.SourceBuilt.Artifacts"* ]]; then
-        if [ "$downloadArtifacts" == "true" ]; then
-            echo "  Downloading source-built artifacts from $line..."
-            (cd $SCRIPT_ROOT/packages/archive/ && curl --retry 5 -O $line)
-        fi
+sourceBuiltArtifactsTarballUrl="https://dotnetcli.azureedge.net/source-built-artifacts/assets/"
+packageVersionsPath="$SCRIPT_ROOT/eng/Versions.props"
+
+if [ "$downloadArtifacts" == "true" ]; then
+    echo "  Looking for source-built artifacts to download..."
+    artifactsVersionLine=`grep -m 1 '<PrivateSourceBuiltArtifactsPackageVersion>' "$packageVersionsPath" || :`
+    versionPattern="<PrivateSourceBuiltArtifactsPackageVersion>(.*)</PrivateSourceBuiltArtifactsPackageVersion>"
+    if [[ $artifactsVersionLine =~ $versionPattern ]]; then
+        artifactsUrl="${sourceBuiltArtifactsTarballUrl}${artifactsBaseFileName}.${BASH_REMATCH[1]}.tar.gz"
+        echo "  Downloading source-built artifacts from $artifactsUrl..."
+        (cd $SCRIPT_ROOT/packages/archive/ && curl --retry 5 -O $artifactsUrl)
+    else
+      echo "  ERROR: No source-built artifacts found to download..."
+      exit -1
     fi
-    if [[ $line == *"Private.SourceBuilt.Prebuilts"* ]]; then
-        if [ "$downloadPrebuilts" == "true" ]; then
-            echo "  Downloading source-built prebuilts from $line..."
-            (cd $SCRIPT_ROOT/packages/archive/ && curl --retry 5 -O $line)
-        fi
+fi
+
+if [ "$downloadPrebuilts" == "true" ]; then
+    echo "  Looking for source-built prebuilts to download..."
+    prebuiltsVersionLine=`grep -m 1 '<PrivateSourceBuiltPrebuiltsPackageVersion>' "$packageVersionsPath" || :`
+    versionPattern="<PrivateSourceBuiltPrebuiltsPackageVersion>(.*)</PrivateSourceBuiltPrebuiltsPackageVersion>"
+    if [[ $prebuiltsVersionLine =~ $versionPattern ]]; then
+        prebuiltsUrl="${sourceBuiltArtifactsTarballUrl}${prebuiltsBaseFileName}.${BASH_REMATCH[1]}.tar.gz"
+        echo "  Downloading source-built prebuilts from $prebuiltsUrl..."
+        (cd $SCRIPT_ROOT/packages/archive/ && curl --retry 5 -O $prebuiltsUrl)
+    else
+      echo "  No source-built prebuilts found to download..."
     fi
-done < $SCRIPT_ROOT/packages/archive/archiveArtifacts.txt
+fi
 
 # Check for the version of dotnet to install
 if [ "$installDotnet" == "true" ]; then


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/3167

This PR refactors the archives infra.  The dependency on the installer's eng/versions.props was moved to the vmr's eng/versions.props thus eliminating the need for the archiveArtifacts.txt file.  The prep script needed updates to construct the archive urls to download.
