### PR TITLE
Apply RID override behaviour from runtime to aspnetcore/installer

### DIFF
--- a/src/SourceBuild/tarball/content/repo-projects/aspnetcore.proj
+++ b/src/SourceBuild/tarball/content/repo-projects/aspnetcore.proj
@@ -2,6 +2,11 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
+    <OverrideTargetRid>$(TargetRid)</OverrideTargetRid>
+    <OverrideTargetRid Condition="'$(TargetOS)' == 'OSX'">osx-x64</OverrideTargetRid>
+    <OverrideTargetRid Condition="'$(TargetOS)' == 'FreeBSD'">freebsd-x64</OverrideTargetRid>
+    <OverrideTargetRid Condition="'$(TargetOS)' == 'Windows_NT'">win-x64</OverrideTargetRid>
+
     <!-- StandardSourceBuildArgs include -publish which is not supported by the aspnetcore build script. -->
     <BuildCommandArgs>$(StandardSourceBuildArgs.Replace('--publish', ''))</BuildCommandArgs>
     <!-- The arch flag (defaults to x64) overrides any value of TargetArchitecture that we might set -->
@@ -9,7 +14,7 @@
     <BuildCommandArgs>$(BuildCommandArgs) --no-build-repo-tasks</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) --no-build-nodejs</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:PublishCompressedFilesPathPrefix=$(SourceBuiltAspNetCoreRuntime)</BuildCommandArgs>
-    <BuildCommandArgs>$(BuildCommandArgs) /p:PortableBuild=false /p:TargetRuntimeIdentifier=$(TargetRid)</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) /p:PortableBuild=false /p:TargetRuntimeIdentifier=$(OverrideTargetRid)</BuildCommandArgs>
     <!-- Update to 1.0.0 version of reference assemblies which are built in SBRP instead of the preview.2 version
          included by Arcade -->
     <BuildCommandArgs>$(BuildCommandArgs) /p:MicrosoftNetFrameworkReferenceAssembliesVersion=1.0.0</BuildCommandArgs>

--- a/src/SourceBuild/tarball/content/repo-projects/installer.proj
+++ b/src/SourceBuild/tarball/content/repo-projects/installer.proj
@@ -8,6 +8,8 @@
   <PropertyGroup>
     <OverrideTargetRid>$(TargetRid)</OverrideTargetRid>
     <OverrideTargetRid Condition="'$(TargetOS)' == 'OSX'">osx-x64</OverrideTargetRid>
+    <OverrideTargetRid Condition="'$(TargetOS)' == 'FreeBSD'">freebsd-x64</OverrideTargetRid>
+    <OverrideTargetRid Condition="'$(TargetOS)' == 'Windows_NT'">win-x64</OverrideTargetRid>
     <OSNameOverride>$(OverrideTargetRid.Substring(0, $(OverrideTargetRid.IndexOf("-"))))</OSNameOverride>
 
     <!-- Determine target portable rid based on bootstrap SDK's portable rid -->
@@ -15,7 +17,6 @@
     <PortableOS>$(NETCoreSdkPortableRuntimeIdentifier.Substring(0, $(_platformIndex)))</PortableOS>
 
     <RuntimeArg>--runtime-id $(OverrideTargetRid)</RuntimeArg>
-    <RuntimeArg Condition="'$(TargetOS)' == 'Linux'">--runtime-id $(TargetRid)</RuntimeArg>
 
     <BuildCommandArgs>$(StandardSourceBuildArgs)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) $(RuntimeArg)</BuildCommandArgs>
@@ -27,14 +28,13 @@
     <BuildCommandArgs>$(BuildCommandArgs) /p:NETCoreAppMaximumVersion=99.9</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:OSName=$(OSNameOverride)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:PortableOSName=$(PortableOS)</BuildCommandArgs>
-    <BuildCommandArgs Condition="'$(TargetOS)' == 'Linux'">$(BuildCommandArgs) /p:Rid=$(TargetRid)</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) /p:Rid=$(OverrideTargetRid)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:DOTNET_INSTALL_DIR=$(DotNetCliToolDir)</BuildCommandArgs>
 
-    <BuildCommandArgs Condition="'$(TargetOS)' == 'Linux'">$(BuildCommandArgs) /p:AspNetCoreInstallerRid=$(TargetRid)</BuildCommandArgs>
+    <BuildCommandArgs Condition="'$(TargetOS)' != 'Windows_NT'">$(BuildCommandArgs) /p:AspNetCoreInstallerRid=$(OverrideTargetRid)</BuildCommandArgs>
     <!-- core-sdk always wants to build portable on OSX and FreeBSD -->
-    <BuildCommandArgs Condition="'$(TargetOS)' == 'FreeBSD'">$(BuildCommandArgs) /p:CoreSetupRid=freebsd-x64 /p:PortableBuild=true</BuildCommandArgs>
-    <BuildCommandArgs Condition="'$(TargetOS)' == 'OSX'">$(BuildCommandArgs) /p:CoreSetupRid=osx-x64</BuildCommandArgs>
-    <BuildCommandArgs Condition="'$(TargetOS)' == 'Linux'">$(BuildCommandArgs) /p:CoreSetupRid=$(TargetRid)</BuildCommandArgs>
+    <BuildCommandArgs Condition="'$(TargetOS)' == 'FreeBSD'">$(BuildCommandArgs) /p:PortableBuild=true</BuildCommandArgs>
+    <BuildCommandArgs Condition="'$(TargetOS)' != 'Windows_NT'">$(BuildCommandArgs) /p:CoreSetupRid=$(OverrideTargetRid)</BuildCommandArgs>
 
     <!-- Consume the source-built Core-Setup and toolset. This line must be removed to source-build CLI without source-building Core-Setup first. -->
     <BuildCommandArgs>$(BuildCommandArgs) /p:PublicBaseURL=file:%2F%2F$(SourceBuiltAssetsDir)</BuildCommandArgs>


### PR DESCRIPTION
Running `./build.sh` on a Mac creates a runtime pack with a RID of `osx-x64` due to an OS override in the proj file. Later, aspnetcore tries to restore a runtime but does not override the RID - it searches for osx.12-x64 and fails.

This PR attempts to unify RID override behaviour around how it's done in runtime. The Windows and FreeBSD overrides are not tested, but should be consistent (I expect they currently fail in the same way macOS does)

Closes: https://github.com/dotnet/source-build/issues/3151