### PR TITLE
Fix branch filters for the VMR synchronization

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-synchronization.yml
+++ b/eng/pipelines/templates/jobs/vmr-synchronization.yml
@@ -53,7 +53,7 @@ jobs:
 
   # For official builds, push the changes to the VMR
   # Push only main and release branches
-  - ${{ if and(not(parameters.noPush), or(eq(parameters.vmrBranch, 'main'), eq(parameters.vmrBranch, 'refs/heads/main'), startswith(parameters.vmrBranch, 'refs/heads/release/'), startswith(parameters.vmrBranch, 'release/')), not(in(variables['Build.Reason'], 'PullRequest')), eq(variables['System.TeamProject'], 'internal')) }}:
+  - ${{ if and(not(parameters.noPush), or(eq(parameters.vmrBranch, 'main'), startsWith(parameters.vmrBranch, 'release/')), not(in(variables['Build.Reason'], 'PullRequest')), eq(variables['System.TeamProject'], 'internal')) }}:
     - script: |
         set -x
         git config --global user.email 'dotnet-maestro[bot]@users.noreply.github.com' && git config --global user.name 'dotnet-maestro[bot]'


### PR DESCRIPTION
I think it was the `startsWith` vs `startswith`? Otherwise I don't see any problem