### PR TITLE
Add Codespaces container definitions for the VMR

### DIFF
--- a/src/SourceBuild/content/.devcontainer/default/devcontainer.json
+++ b/src/SourceBuild/content/.devcontainer/default/devcontainer.json
@@ -1,0 +1,17 @@
+// Container contains checked-out source code only
+{
+    "name": "Default",
+    "image": "mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-36",
+    "hostRequirements": {
+        // A completely built .NET source-tarball is >64 GB
+        "storage": "128gb"
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-dotnettools.csharp",
+                "eamodio.gitlens"
+            ]
+        }
+    }
+}

--- a/src/SourceBuild/content/.devcontainer/devcontainer.json
+++ b/src/SourceBuild/content/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+// Container contains a pre-built SDK
+{
+    "name": "Pre-built .NET SDK",
+    "image": "mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-36",
+    "hostRequirements": {
+        // A completely built .NET source-tarball is >64 GB
+        "storage": "128gb"
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-dotnettools.csharp",
+                "eamodio.gitlens"
+            ]
+        }
+    },
+    "onCreateCommand": "${containerWorkspaceFolder}/.devcontainer/prebuilt-sdk/build.sh"
+}

--- a/src/SourceBuild/content/.devcontainer/prebuilt-sdk/build.sh
+++ b/src/SourceBuild/content/.devcontainer/prebuilt-sdk/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+./prep.sh
+
+# GitHub Codespaces automatically sets RepositoryName, which conflicts with source-build scripts.
+unset RepositoryName
+
+./build.sh --online --clean-while-building || true

--- a/src/SourceBuild/content/.devcontainer/prebuilt-sdk/devcontainer.json
+++ b/src/SourceBuild/content/.devcontainer/prebuilt-sdk/devcontainer.json
@@ -1,0 +1,18 @@
+// Container contains a pre-built SDK
+{
+    "name": "Pre-built .NET SDK",
+    "image": "mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-36",
+    "hostRequirements": {
+        // A completely built .NET source-tarball is >64 GB
+        "storage": "128gb"
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-dotnettools.csharp",
+                "eamodio.gitlens"
+            ]
+        }
+    },
+    "onCreateCommand": "${containerWorkspaceFolder}/.devcontainer/prebuilt-sdk/build.sh"
+}


### PR DESCRIPTION
Bringing back devcontainers that were originally in installer and were removed in https://github.com/dotnet/installer/pull/15114/files

Resolves https://github.com/dotnet/arcade/issues/11902