### PR TITLE
Disable CheckEolTargetFramework for all projects

### DIFF
--- a/src/SourceBuild/tarball/content/repos/Directory.Build.props
+++ b/src/SourceBuild/tarball/content/repos/Directory.Build.props
@@ -98,6 +98,9 @@
     <EnvironmentVariables Include="DeterministicSourcePaths=false" Condition="'$(DeterministicBuildOptOut)' == 'true'" />
 
     <EnvironmentVariables Include="SourceRoot=$(ProjectDirectory)" />
+
+    <!-- https://github.com/dotnet/source-build/issues/3081 -->
+    <EnvironmentVariables Include="CheckEolTargetFramework=false" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(EnableExtraDebugging)' == 'true'">

--- a/src/SourceBuild/tarball/content/repos/fsharp.proj
+++ b/src/SourceBuild/tarball/content/repos/fsharp.proj
@@ -27,7 +27,6 @@
 
   <ItemGroup>
     <UseSourceBuiltSdkOverride Include="@(ArcadeSdkOverride)" />
-    <EnvironmentVariables Include="CheckEolTargetFramework=false" />
   </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />

--- a/src/SourceBuild/tarball/content/repos/xliff-tasks.proj
+++ b/src/SourceBuild/tarball/content/repos/xliff-tasks.proj
@@ -3,8 +3,6 @@
 
   <PropertyGroup>
     <BuildCommandArgs>$(StandardSourceBuildArgs)</BuildCommandArgs>
-    <!-- Repo has netcoreapp2.1 projects: https://github.com/dotnet/xliff-tasks/issues/508 -->
-    <BuildCommandArgs>$(BuildCommandArgs) /p:CheckEolTargetFramework=false</BuildCommandArgs>
     <BuildCommand>$(StandardSourceBuildCommand) $(BuildCommandArgs)</BuildCommand>
 
     <RepoApiImplemented>false</RepoApiImplemented>


### PR DESCRIPTION
This fixes the issue described in https://github.com/dotnet/source-build/issues/3081 where source-build can encounter EOL TFMs during its build. This generates a warning which can then produce an error if warnings are treated as errors. We need to avoid having source-build be blocked by this situation.

So these changes disable the `CheckEolTargetFramework` MSBuild property globally for all projects. It also removes some the disabling of that property that was targeted for a couple specific projects.

Fixes https://github.com/dotnet/source-build/issues/3081