### PR TITLE
Add selective unzipping to avoid ASP.NET clobbering NetCore.App

### DIFF
--- a/src/core-sdk-tasks/ExtractArchiveToDirectory.cs
+++ b/src/core-sdk-tasks/ExtractArchiveToDirectory.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DotNet.Build.Tasks
         /// <summary>
         /// A list of directories, semicolon deliminated, relative to the root of the archive to include. If empty all directories will be copied.
         /// </summary>
-        public string DirectoriesToCopy { get; set; }
+        public ITaskItem[] DirectoriesToCopy { get; set; }
 
         protected override bool ValidateParameters()
         {
@@ -84,19 +84,15 @@ namespace Microsoft.DotNet.Build.Tasks
                         string loc = DestinationDirectory;
                         foreach (var entry in zip.Entries)
                         {
-                            foreach (var directory in DirectoriesToCopy.Split(';'))
+                            foreach (var directory in DirectoriesToCopy)
                             {
-                                if (entry.FullName.Contains(directory))
+                                if (entry.FullName.StartsWith(directory.ItemSpec))
                                 {
-                                    string dirBuilder = loc;
-                                    foreach (var pathPart in Path.GetDirectoryName(entry.FullName).Split('/'))
+                                    if (!Directory.Exists(Path.Combine(DestinationDirectory, Path.GetDirectoryName(entry.FullName))))
                                     {
-                                        if (!Directory.Exists(Path.Combine(dirBuilder, pathPart)))
-                                        {
-                                            Directory.CreateDirectory(Path.Combine(dirBuilder, pathPart));
-                                        }
-                                        dirBuilder = Path.Combine(dirBuilder, pathPart);
+                                        Directory.CreateDirectory(Path.Combine(DestinationDirectory, Path.GetDirectoryName(entry.FullName)));
                                     }
+
                                     Log.LogMessage(Path.GetDirectoryName(entry.FullName));
                                     entry.ExtractToFile(Path.Combine(loc, entry.FullName));
                                 }

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -129,13 +129,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <BundledLayoutComponent Include="CombinedSharedHostAndFrameworkArchive">
-        <BaseUrl>$(CoreSetupRootUrl)$(CoreSetupBlobVersion)</BaseUrl>
-        <BaseUrl Condition=" '$(DotNetBuildFromSource)' == 'true' AND '$(DotNetBuildFromSourceFlavor)' == 'Product' ">$(CoreSetupRootUrl)</BaseUrl>
-        <DownloadFileName>$(CombinedFrameworkHostArchiveFileName)</DownloadFileName>
-        <RelativeLayoutPath></RelativeLayoutPath>
-      </BundledLayoutComponent>
-
       <BundledLayoutPackage Include="MicrosoftNetCoreAppTargetingPackNupkg">
         <PackageName>Microsoft.NETCore.App.Ref</PackageName>
         <PackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</PackageVersion>
@@ -334,6 +327,13 @@
       <BundledLayoutComponent Include="WinFormsAndWpfSharedFxArchiveFile">
         <BaseUrl>$(WinFormsAndWpfSharedFxRootUrl)$(WindowsDesktopBlobVersion)</BaseUrl>
         <DownloadFileName>$(WinFormsAndWpfSharedFxArchiveFileName)</DownloadFileName>
+      </BundledLayoutComponent>
+
+      <BundledLayoutComponent Include="CombinedSharedHostAndFrameworkArchive">
+        <BaseUrl>$(CoreSetupRootUrl)$(CoreSetupBlobVersion)</BaseUrl>
+        <BaseUrl Condition=" '$(DotNetBuildFromSource)' == 'true' AND '$(DotNetBuildFromSourceFlavor)' == 'Product' ">$(CoreSetupRootUrl)</BaseUrl>
+        <DownloadFileName>$(CombinedFrameworkHostArchiveFileName)</DownloadFileName>
+        <RelativeLayoutPath></RelativeLayoutPath>
       </BundledLayoutComponent>
 
       <BundledInstallerComponent Include="DownloadedWinFormsAndWpfSharedFrameworkInstallerFile"

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -129,6 +129,13 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <BundledLayoutComponent Include="CombinedSharedHostAndFrameworkArchive">
+        <BaseUrl>$(CoreSetupRootUrl)$(CoreSetupBlobVersion)</BaseUrl>
+        <BaseUrl Condition=" '$(DotNetBuildFromSource)' == 'true' AND '$(DotNetBuildFromSourceFlavor)' == 'Product' ">$(CoreSetupRootUrl)</BaseUrl>
+        <DownloadFileName>$(CombinedFrameworkHostArchiveFileName)</DownloadFileName>
+        <RelativeLayoutPath></RelativeLayoutPath>
+      </BundledLayoutComponent>
+
       <BundledLayoutPackage Include="MicrosoftNetCoreAppTargetingPackNupkg">
         <PackageName>Microsoft.NETCore.App.Ref</PackageName>
         <PackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</PackageVersion>
@@ -323,6 +330,7 @@
         <PackageVersion>$(MicrosoftWindowsDesktopAppRefPackageVersion)</PackageVersion>
         <TargetFramework>$(TargetFramework)</TargetFramework>
         <RelativeLayoutPath>packs/%(PackageName)/%(PackageVersion)</RelativeLayoutPath>
+        <DirectoriesToCopy>shared/Microsoft.WindowsDesktop.App</DirectoriesToCopy>
       </BundledLayoutPackage>
 
       <BundledLayoutComponent Include="WinFormsAndWpfSharedFxArchiveFile">
@@ -335,15 +343,6 @@
         <BaseUrl>$(WinFormsAndWpfSharedFxRootUrl)$(WindowsDesktopBlobVersion)</BaseUrl>
         <DownloadFileName>$(DownloadedWinFormsAndWpfSharedFrameworkInstallerFileName)</DownloadFileName>
       </BundledInstallerComponent>
-    </ItemGroup>
-
-    <ItemGroup>
-      <BundledLayoutComponent Include="CombinedSharedHostAndFrameworkArchive">
-        <BaseUrl>$(CoreSetupRootUrl)$(CoreSetupBlobVersion)</BaseUrl>
-        <BaseUrl Condition=" '$(DotNetBuildFromSource)' == 'true' AND '$(DotNetBuildFromSourceFlavor)' == 'Product' ">$(CoreSetupRootUrl)</BaseUrl>
-        <DownloadFileName>$(CombinedFrameworkHostArchiveFileName)</DownloadFileName>
-        <RelativeLayoutPath></RelativeLayoutPath>
-      </BundledLayoutComponent>
     </ItemGroup>
 
   </Target>

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -343,7 +343,7 @@
         <DownloadFileName>$(CombinedFrameworkHostArchiveFileName)</DownloadFileName>
         <RelativeLayoutPath></RelativeLayoutPath>
       </BundledLayoutComponent>
-    </itemGroup>
+    </ItemGroup>
 
   </Target>
 

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -330,12 +330,12 @@
         <PackageVersion>$(MicrosoftWindowsDesktopAppRefPackageVersion)</PackageVersion>
         <TargetFramework>$(TargetFramework)</TargetFramework>
         <RelativeLayoutPath>packs/%(PackageName)/%(PackageVersion)</RelativeLayoutPath>
-        <DirectoriesToCopy>shared/Microsoft.WindowsDesktop.App</DirectoriesToCopy>
       </BundledLayoutPackage>
 
       <BundledLayoutComponent Include="WinFormsAndWpfSharedFxArchiveFile">
         <BaseUrl>$(WinFormsAndWpfSharedFxRootUrl)$(WindowsDesktopBlobVersion)</BaseUrl>
         <DownloadFileName>$(WinFormsAndWpfSharedFxArchiveFileName)</DownloadFileName>
+        <DirectoriesToCopy>shared/Microsoft.WindowsDesktop.App</DirectoriesToCopy>
       </BundledLayoutComponent>
 
       <BundledInstallerComponent Include="DownloadedWinFormsAndWpfSharedFrameworkInstallerFile"

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -267,6 +267,7 @@
         <BaseUrl Condition=" '$(DotNetBuildFromSource)' == 'true' AND '$(DotNetBuildFromSourceFlavor)' == 'Product' ">$(AspNetCoreSharedFxRootUrl)</BaseUrl>
         <DownloadFileName>$(AspNetCoreSharedFxArchiveFileName)</DownloadFileName>
         <RelativeLayoutPath></RelativeLayoutPath>
+        <DirectoriesToCopy>shared/Microsoft.AspNetCore.App</DirectoriesToCopy>
       </BundledLayoutComponent>
 
       <!-- The AspNet does not provide native MacOS PKG installers at this time; we use AspNet archives.
@@ -449,7 +450,8 @@
 
   <Target Name="LayoutBundledComponents">
     <ExtractArchiveToDirectory SourceArchive="%(BundledLayoutComponent.DownloadDestination)"
-                               DestinationDirectory="$(RedistLayoutPath)/%(BundledLayoutComponent.RelativeLayoutPath)" />
+                               DestinationDirectory="$(RedistLayoutPath)/%(BundledLayoutComponent.RelativeLayoutPath)"
+                               DirectoriesToCopy="%(BundledLayoutComponent.DirectoriesToCopy)"/>
 
     <Copy SourceFiles="@(BundledLayoutPackageDownloadFilesWithDestination)"
           DestinationFiles="@(BundledLayoutPackageDownloadFilesWithDestination->'%(DestinationPath)')"

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -329,19 +329,21 @@
         <DownloadFileName>$(WinFormsAndWpfSharedFxArchiveFileName)</DownloadFileName>
       </BundledLayoutComponent>
 
-      <BundledLayoutComponent Include="CombinedSharedHostAndFrameworkArchive">
-        <BaseUrl>$(CoreSetupRootUrl)$(CoreSetupBlobVersion)</BaseUrl>
-        <BaseUrl Condition=" '$(DotNetBuildFromSource)' == 'true' AND '$(DotNetBuildFromSourceFlavor)' == 'Product' ">$(CoreSetupRootUrl)</BaseUrl>
-        <DownloadFileName>$(CombinedFrameworkHostArchiveFileName)</DownloadFileName>
-        <RelativeLayoutPath></RelativeLayoutPath>
-      </BundledLayoutComponent>
-
       <BundledInstallerComponent Include="DownloadedWinFormsAndWpfSharedFrameworkInstallerFile"
                                  Condition="'$(SkipBuildingInstallers)' != 'true' And '$(InstallerExtension)' != '' And (!$(Architecture.StartsWith('arm')) or '$(Rid)' == 'win-arm64' or '$(Rid)' == 'osx-arm64')">
         <BaseUrl>$(WinFormsAndWpfSharedFxRootUrl)$(WindowsDesktopBlobVersion)</BaseUrl>
         <DownloadFileName>$(DownloadedWinFormsAndWpfSharedFrameworkInstallerFileName)</DownloadFileName>
       </BundledInstallerComponent>
     </ItemGroup>
+
+    <ItemGroup>
+      <BundledLayoutComponent Include="CombinedSharedHostAndFrameworkArchive">
+        <BaseUrl>$(CoreSetupRootUrl)$(CoreSetupBlobVersion)</BaseUrl>
+        <BaseUrl Condition=" '$(DotNetBuildFromSource)' == 'true' AND '$(DotNetBuildFromSourceFlavor)' == 'Product' ">$(CoreSetupRootUrl)</BaseUrl>
+        <DownloadFileName>$(CombinedFrameworkHostArchiveFileName)</DownloadFileName>
+        <RelativeLayoutPath></RelativeLayoutPath>
+      </BundledLayoutComponent>
+    </itemGroup>
 
   </Target>
 


### PR DESCRIPTION
When building the shared framework folder because we no longer use the internal packages the ASP.NET package contains a version of NetCore.App. Previously we would copy the NetCore.App package first then the ASP.NET package, but for PGO instrumented builds this would clobber the instrumented build and cause PGO count generation failures.

This change moves the NetCore.App extract and copy to be the last step to ensure this doesn't happen.
