### PR TITLE
Enable SHA1 signing for CentOS Stream 9

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -55,6 +55,10 @@ parameters:
 - name: buildFromArchive
   type: boolean
 
+- name: enableSha1Signing
+  type: boolean
+  default: false
+
 jobs:
 - job: ${{ parameters.buildName }}_${{ parameters.architecture }}
   timeoutInMinutes: 150
@@ -165,19 +169,24 @@ jobs:
       set -x
       df -h
 
-      networkArgs=
+      customRunArgs=
       customBuildArgs=
       if [[ '${{ parameters.runOnline }}' == 'True' ]]; then
         customBuildArgs='--online'
       else
-        networkArgs='--network none'
+        customRunArgs='--network none'
+      fi
+
+      # See https://github.com/dotnet/source-build/issues/3202
+      if [[ '${{ parameters.enableSha1Signing }}' == 'True' ]]; then
+        customRunArgs="$customRunArgs -e OPENSSL_ENABLE_SHA1_SIGNATURES=1"
       fi
 
       if [[ '${{ parameters.enablePoison }}' == 'True' ]]; then
         customBuildArgs="$customBuildArgs --poison"
       fi
 
-      docker run --rm -v "$(sourcesPath):/vmr" -w /vmr ${networkArgs} ${{ parameters.container }} ./build.sh --clean-while-building $(additionalBuildArgs) ${customBuildArgs}
+      docker run --rm -v "$(sourcesPath):/vmr" -w /vmr ${customRunArgs} ${{ parameters.container }} ./build.sh --clean-while-building $(additionalBuildArgs) ${customBuildArgs}
     displayName: Build
 
   - script: |

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -55,7 +55,9 @@ parameters:
 - name: buildFromArchive
   type: boolean
 
-- name: enableSha1Signing
+# Some distros like CentOS Stream 9 use OpenSSL 3.0 which disables SHA1 signing.
+# This option overrides that default configuration and enables it. See https://github.com/dotnet/installer/pull/15289
+- name: overrideDistroDisablingSha1
   type: boolean
   default: false
 
@@ -178,7 +180,7 @@ jobs:
       fi
 
       # See https://github.com/dotnet/source-build/issues/3202
-      if [[ '${{ parameters.enableSha1Signing }}' == 'True' ]]; then
+      if [[ '${{ parameters.overrideDistroDisablingSha1 }}' == 'True' ]]; then
         customRunArgs="$customRunArgs -e OPENSSL_ENABLE_SHA1_SIGNATURES=1"
       fi
 

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -69,12 +69,12 @@ stages:
         demands: ${{ variables.defaultPoolDemands }}
       container: ${{ parameters.centOSStream8Container }}
       bootstrapPrep: false               # 🚫
-      enablePoison: false                # 🚫
-      excludeSdkContentTests: true       # ✅
-      excludeOmniSharpTests: true        # ✅
-      runOnline: true                    # ✅
       buildFromArchive: false            # 🚫
+      enablePoison: false                # 🚫
+      excludeOmniSharpTests: true        # ✅
+      excludeSdkContentTests: true       # ✅
       overrideDistroDisablingSha1: false # 🚫
+      runOnline: true                    # ✅
 
   - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
     - template: ../jobs/vmr-build.yml
@@ -88,12 +88,12 @@ stages:
           demands: ${{ variables.defaultPoolDemands }}
         container: ${{ parameters.centOSStream8Container }}
         bootstrapPrep: false               # 🚫
-        enablePoison: false                # 🚫
-        excludeSdkContentTests: false      # 🚫
-        excludeOmniSharpTests: true        # ✅
-        runOnline: false                   # 🚫
         buildFromArchive: true             # ✅
+        enablePoison: false                # 🚫
+        excludeOmniSharpTests: true        # ✅
+        excludeSdkContentTests: false      # 🚫
         overrideDistroDisablingSha1: false # 🚫
+        runOnline: false                   # 🚫
 
     - template: ../jobs/vmr-build.yml
       parameters:
@@ -106,12 +106,12 @@ stages:
           demands: ${{ variables.defaultPoolDemands }}
         container: ${{ parameters.centOSStream9Container }}
         bootstrapPrep: false              # 🚫
-        enablePoison: false               # 🚫
-        excludeSdkContentTests: false     # 🚫
-        excludeOmniSharpTests: false      # 🚫
-        runOnline: false                  # 🚫
         buildFromArchive: true            # ✅
+        enablePoison: false               # 🚫
+        excludeOmniSharpTests: false      # 🚫
+        excludeSdkContentTests: false     # 🚫
         overrideDistroDisablingSha1: true # ✅
+        runOnline: false                  # 🚫
 
     - template: ../jobs/vmr-build.yml
       parameters:
@@ -124,12 +124,12 @@ stages:
           demands: ${{ variables.defaultPoolDemands }}
         container: ${{ parameters.fedora36Container }}
         bootstrapPrep: false               # 🚫
-        enablePoison: true                 # ✅
-        excludeSdkContentTests: false      # 🚫
-        excludeOmniSharpTests: false       # 🚫
-        runOnline: false                   # 🚫
         buildFromArchive: true             # ✅
+        enablePoison: true                 # ✅
+        excludeOmniSharpTests: false       # 🚫
+        excludeSdkContentTests: false      # 🚫
         overrideDistroDisablingSha1: false # 🚫
+        runOnline: false                   # 🚫
 
     - template: ../jobs/vmr-build.yml
       parameters:
@@ -142,12 +142,12 @@ stages:
           demands: ${{ variables.defaultPoolDemands }}
         container: ${{ parameters.ubuntu2004Container }}
         bootstrapPrep: false               # 🚫
-        enablePoison: false                # 🚫
-        excludeSdkContentTests: false      # 🚫
-        excludeOmniSharpTests: false       # 🚫
-        runOnline: false                   # 🚫
         buildFromArchive: false            # 🚫
+        enablePoison: false                # 🚫
+        excludeOmniSharpTests: false       # 🚫
+        excludeSdkContentTests: false      # 🚫
         overrideDistroDisablingSha1: false # 🚫
+        runOnline: false                   # 🚫
 
     - template: ../jobs/vmr-build.yml
       parameters:
@@ -158,12 +158,12 @@ stages:
         pool: ${{ parameters.poolInternalArm64 }}
         container: ${{ parameters.debian11Arm64Container }}
         bootstrapPrep: true                # ✅
-        enablePoison: false                # 🚫
-        excludeSdkContentTests: false      # 🚫
-        excludeOmniSharpTests: false       # 🚫
-        runOnline: false                   # 🚫
         buildFromArchive: false            # 🚫
+        enablePoison: false                # 🚫
+        excludeOmniSharpTests: false       # 🚫
+        excludeSdkContentTests: false      # 🚫
         overrideDistroDisablingSha1: false # 🚫
+        runOnline: false                   # 🚫
 
     - template: ../jobs/vmr-build.yml
       parameters:
@@ -176,10 +176,10 @@ stages:
           demands: ${{ variables.defaultPoolDemands }}
         container: ${{ parameters.fedora36Container }}
         bootstrapPrep: false               # 🚫
-        enablePoison: false                # 🚫
-        excludeSdkContentTests: true       # ✅
-        excludeOmniSharpTests: false       # 🚫
-        runOnline: false                   # 🚫
         buildFromArchive: false            # 🚫
+        enablePoison: false                # 🚫
+        excludeOmniSharpTests: false       # 🚫
+        excludeSdkContentTests: true       # ✅
         overrideDistroDisablingSha1: false # 🚫
+        runOnline: false                   # 🚫
         reuseBuildArtifactsFrom: Fedora36_Offline

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -68,12 +68,13 @@ stages:
         name: ${{ variables.defaultPoolName }}
         demands: ${{ variables.defaultPoolDemands }}
       container: ${{ parameters.centOSStream8Container }}
-      bootstrapPrep: false          # 🚫
-      enablePoison: false           # 🚫
-      excludeSdkContentTests: true  # ✅
-      excludeOmniSharpTests: true   # ✅
-      runOnline: true               # ✅
-      buildFromArchive: false       # 🚫
+      bootstrapPrep: false               # 🚫
+      enablePoison: false                # 🚫
+      excludeSdkContentTests: true       # ✅
+      excludeOmniSharpTests: true        # ✅
+      runOnline: true                    # ✅
+      buildFromArchive: false            # 🚫
+      overrideDistroDisablingSha1: false # 🚫
 
   - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
     - template: ../jobs/vmr-build.yml
@@ -86,12 +87,13 @@ stages:
           name: ${{ variables.defaultPoolName }}
           demands: ${{ variables.defaultPoolDemands }}
         container: ${{ parameters.centOSStream8Container }}
-        bootstrapPrep: false          # 🚫
-        enablePoison: false           # 🚫
-        excludeSdkContentTests: false # 🚫
-        excludeOmniSharpTests: true   # ✅
-        runOnline: false              # 🚫
-        buildFromArchive: true        # ✅
+        bootstrapPrep: false               # 🚫
+        enablePoison: false                # 🚫
+        excludeSdkContentTests: false      # 🚫
+        excludeOmniSharpTests: true        # ✅
+        runOnline: false                   # 🚫
+        buildFromArchive: true             # ✅
+        overrideDistroDisablingSha1: false # 🚫
 
     - template: ../jobs/vmr-build.yml
       parameters:
@@ -103,13 +105,13 @@ stages:
           name: ${{ variables.defaultPoolName }}
           demands: ${{ variables.defaultPoolDemands }}
         container: ${{ parameters.centOSStream9Container }}
-        bootstrapPrep: false          # 🚫
-        enablePoison: false           # 🚫
-        enableSha1Signing: true       # ✅
-        excludeSdkContentTests: false # 🚫
-        excludeOmniSharpTests: false  # 🚫
-        runOnline: false              # 🚫
-        buildFromArchive: true        # ✅
+        bootstrapPrep: false              # 🚫
+        enablePoison: false               # 🚫
+        excludeSdkContentTests: false     # 🚫
+        excludeOmniSharpTests: false      # 🚫
+        runOnline: false                  # 🚫
+        buildFromArchive: true            # ✅
+        overrideDistroDisablingSha1: true # ✅
 
     - template: ../jobs/vmr-build.yml
       parameters:
@@ -121,12 +123,13 @@ stages:
           name: ${{ variables.defaultPoolName }}
           demands: ${{ variables.defaultPoolDemands }}
         container: ${{ parameters.fedora36Container }}
-        bootstrapPrep: false          # 🚫
-        enablePoison: true            # ✅
-        excludeSdkContentTests: false # 🚫
-        excludeOmniSharpTests: false  # 🚫
-        runOnline: false              # 🚫
-        buildFromArchive: true        # ✅
+        bootstrapPrep: false               # 🚫
+        enablePoison: true                 # ✅
+        excludeSdkContentTests: false      # 🚫
+        excludeOmniSharpTests: false       # 🚫
+        runOnline: false                   # 🚫
+        buildFromArchive: true             # ✅
+        overrideDistroDisablingSha1: false # 🚫
 
     - template: ../jobs/vmr-build.yml
       parameters:
@@ -138,12 +141,13 @@ stages:
           name: ${{ variables.defaultPoolName }}
           demands: ${{ variables.defaultPoolDemands }}
         container: ${{ parameters.ubuntu2004Container }}
-        bootstrapPrep: false          # 🚫
-        enablePoison: false           # 🚫
-        excludeSdkContentTests: false # 🚫
-        excludeOmniSharpTests: false  # 🚫
-        runOnline: false              # 🚫
-        buildFromArchive: false       # 🚫
+        bootstrapPrep: false               # 🚫
+        enablePoison: false                # 🚫
+        excludeSdkContentTests: false      # 🚫
+        excludeOmniSharpTests: false       # 🚫
+        runOnline: false                   # 🚫
+        buildFromArchive: false            # 🚫
+        overrideDistroDisablingSha1: false # 🚫
 
     - template: ../jobs/vmr-build.yml
       parameters:
@@ -153,12 +157,13 @@ stages:
         architecture: arm64
         pool: ${{ parameters.poolInternalArm64 }}
         container: ${{ parameters.debian11Arm64Container }}
-        bootstrapPrep: true           # ✅
-        enablePoison: false           # 🚫
-        excludeSdkContentTests: false # 🚫
-        excludeOmniSharpTests: false  # 🚫
-        runOnline: false              # 🚫
-        buildFromArchive: false       # 🚫
+        bootstrapPrep: true                # ✅
+        enablePoison: false                # 🚫
+        excludeSdkContentTests: false      # 🚫
+        excludeOmniSharpTests: false       # 🚫
+        runOnline: false                   # 🚫
+        buildFromArchive: false            # 🚫
+        overrideDistroDisablingSha1: false # 🚫
 
     - template: ../jobs/vmr-build.yml
       parameters:
@@ -170,10 +175,11 @@ stages:
           name: ${{ variables.defaultPoolName }}
           demands: ${{ variables.defaultPoolDemands }}
         container: ${{ parameters.fedora36Container }}
-        bootstrapPrep: false          # 🚫
-        enablePoison: false           # 🚫
-        excludeSdkContentTests: true  # ✅
-        excludeOmniSharpTests: false  # 🚫
-        runOnline: false              # 🚫
-        buildFromArchive: false       # 🚫
+        bootstrapPrep: false               # 🚫
+        enablePoison: false                # 🚫
+        excludeSdkContentTests: true       # ✅
+        excludeOmniSharpTests: false       # 🚫
+        runOnline: false                   # 🚫
+        buildFromArchive: false            # 🚫
+        overrideDistroDisablingSha1: false # 🚫
         reuseBuildArtifactsFrom: Fedora36_Offline

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -105,6 +105,7 @@ stages:
         container: ${{ parameters.centOSStream9Container }}
         bootstrapPrep: false          # 🚫
         enablePoison: false           # 🚫
+        enableSha1Signing: true       # ✅
         excludeSdkContentTests: false # 🚫
         excludeOmniSharpTests: false  # 🚫
         runOnline: false              # 🚫


### PR DESCRIPTION
The VMR CI build for CentOS Stream 9 is failing with a cryptographic exception:

```
Interop+Crypto+OpenSslCryptographicException: error:03000098:digital envelope routines::invalid digest [/vmr/src/source-build-reference-packages/artifacts/source-build/self/src/src/referencePackages/src/system.drawing.common/4.7.2/System.Drawing.Common.4.7.2.csproj::TargetFramework=net461]
```

This is caused by the use of OpenSSL 3.0 in CentOS Stream 9 which has SHA1 disabled by default. Since strong naming is being used in the build, it requires SHA1. Ideally we'd be able to use public signing which avoid the need for SHA1 but that work is still pending (https://github.com/dotnet/source-build/issues/2907).

This error does not occur in the release/7.0.1xx branch because it's referencing an older version of CentOS Stream 9 that hadn't yet updated to use this version of OpenSSL.

For now, we can explicitly enable SHA1 by setting `OPENSSL_ENABLE_SHA1_SIGNATURES=1`.

Fixes dotnet/source-build#3202

cc @omajid