### PR TITLE
Use PAT variable group for internal VMR builds

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -66,9 +66,10 @@ jobs:
     dependsOn: ${{ parameters.reuseBuildArtifactsFrom }}_${{ parameters.architecture }}
   variables:
   - template: /eng/common/templates/variables/pool-providers.yml
+  - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+    - group: AzureDevOps-Artifact-Feeds-Pats
   - ${{ if and(not(parameters.isBuiltFromVmr), eq(variables['System.TeamProject'], 'internal')) }}:
     - group: DotNetBot-GitHub
-    - group: AzureDevOps-Artifact-Feeds-Pats
   - ${{ else }}:
     - name: BotAccount-dotnet-bot-repo-PAT
       value: N/A


### PR DESCRIPTION
VMR smoke tests are failing with 401 Unauthorized errors trying to access the internal artifact feeds. This is because the PAT variable that's being set for the NuGet.config file isn't actually resolving to anything.

https://github.com/dotnet/installer/blob/8cc66d4073799b5f7d5e65ecceff37310ddf9cee/eng/pipelines/templates/jobs/vmr-build.yml#L125

It's adding the literal string `$(dn-bot-dnceng-artifact-feeds-rw)` to the NuGet.config file, not the actual PAT value. This is because the variable group that defines the variable isn't configured to be included for the job. I've updated the conditions in the YAML so that it gets added for all internal builds.

Fixes dotnet/source-build#3200