### PR TITLE
Scan the VMR for binaries and cloaked files

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "microsoft.dotnet.darc": {
-      "version": "1.1.0-beta.23063.1",
+      "version": "1.1.0-beta.23068.1",
       "commands": [
         "darc"
       ]

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -205,13 +205,13 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>e52b885a6ec2fc87c9e94b80d9ff7a862786390b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Darc" Version="1.1.0-beta.23063.1">
+    <Dependency Name="Microsoft.DotNet.Darc" Version="1.1.0-beta.23068.1">
       <Uri>https://github.com/dotnet/arcade-services</Uri>
-      <Sha>ad564790607031479f7c74b4211f53930d0f6ca8</Sha>
+      <Sha>fbfe3ef4178f3e5ca05ee32ebd4a20599e72f115</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.DarcLib" Version="1.1.0-beta.23063.1">
+    <Dependency Name="Microsoft.DotNet.DarcLib" Version="1.1.0-beta.23068.1">
       <Uri>https://github.com/dotnet/arcade-services</Uri>
-      <Sha>ad564790607031479f7c74b4211f53930d0f6ca8</Sha>
+      <Sha>fbfe3ef4178f3e5ca05ee32ebd4a20599e72f115</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging.Console" Version="8.0.0-alpha.1.22557.12">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,7 +30,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/arcade-services -->
-    <MicrosoftDotNetDarcLibVersion>1.1.0-beta.23063.1</MicrosoftDotNetDarcLibVersion>
+    <MicrosoftDotNetDarcLibVersion>1.1.0-beta.23068.1</MicrosoftDotNetDarcLibVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/winforms -->

--- a/src/SourceBuild/content/eng/pipelines/ci.yml
+++ b/src/SourceBuild/content/eng/pipelines/ci.yml
@@ -18,16 +18,6 @@ pr:
 stages:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: templates/stages/vmr-scan.yml
-    parameters:
-      name: binaries
-      type: binaries
-      command: scan-binary-files
-
-  - template: templates/stages/vmr-scan.yml
-    parameters:
-      name: cloaked files
-      type: cloaked_files
-      command: scan-cloaked-files
 
 # For rolling builds we want to build the MSFT SDK first so that we can
 # compare the contents with the source-built one later.

--- a/src/SourceBuild/content/eng/pipelines/ci.yml
+++ b/src/SourceBuild/content/eng/pipelines/ci.yml
@@ -16,6 +16,19 @@ pr:
     - internal/release/*
 
 stages:
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - template: templates/stages/vmr-scan.yml
+    parameters:
+      name: binaries
+      type: binaries
+      command: scan-binary-files
+
+  - template: templates/stages/vmr-scan.yml
+    parameters:
+      name: cloaked files
+      type: cloaked_files
+      command: scan-cloaked-files
+
 # For rolling builds we want to build the MSFT SDK first so that we can
 # compare the contents with the source-built one later.
 # This only works because we don't run this test in PRs. If we decided

--- a/src/SourceBuild/content/eng/pipelines/templates/stages/vmr-scan.yml
+++ b/src/SourceBuild/content/eng/pipelines/templates/stages/vmr-scan.yml
@@ -1,22 +1,18 @@
-parameters:
-- name: name
-  type: string
-
-- name: type
-  type: string
-
-- name: command
-  type: string
-
 stages:
-- stage: VMR_Scan_${{ parameters.type }}
-  displayName: Scan ${{ parameters.name }}
+- stage: VMR_Scan
+  displayName: VMR Scan
   dependsOn: []
   jobs:
   - job: Scan
-    displayName: Scan ${{ parameters.name }}
+    displayName: VMR Scan
     pool:
-      vmImage: 'ubuntu-latest'
+      ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        name: $(DncEngPublicBuildPool)
+        demands: ImageOverride -equals Build.Ubuntu.2004.Amd64.Open
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        name: $(DncEngInternalBuildPool)
+        demands: ImageOverride -equals Build.Ubuntu.2004.Amd64
+
     steps:
     - checkout: self
 
@@ -29,10 +25,19 @@ stages:
       workingDirectory: $(Build.SourcesDirectory)/src/installer
 
     - script: >
-        ./.dotnet/dotnet darc vmr ${{ parameters.command }}
+        ./.dotnet/dotnet darc vmr scan-binary-files
         --vmr "$(Build.SourcesDirectory)"
         --tmp "$(Agent.TempDirectory)"
-        || (echo '##[error]Found ${{ parameters.name }} in the VMR' && exit 1)
-      displayName: Scan ${{ parameters.name }}
+        || (echo '##[error]Found binaries in the VMR' && exit 1)
+      displayName: Scan for binaries
+      workingDirectory: $(Build.SourcesDirectory)/src/installer
+      continueOnError: true
+
+    - script: >
+        ./.dotnet/dotnet darc vmr scan-cloaked-files
+        --vmr "$(Build.SourcesDirectory)"
+        --tmp "$(Agent.TempDirectory)"
+        || (echo '##[error]Found cloaked files in the VMR' && exit 1)
+      displayName: Scan for cloaked files
       workingDirectory: $(Build.SourcesDirectory)/src/installer
       continueOnError: true

--- a/src/SourceBuild/content/eng/pipelines/templates/stages/vmr-scan.yml
+++ b/src/SourceBuild/content/eng/pipelines/templates/stages/vmr-scan.yml
@@ -2,6 +2,8 @@ stages:
 - stage: VMR_Scan
   displayName: VMR Scan
   dependsOn: []
+  variables:
+  - template: /eng/common/templates/variables/pool-providers.yml
   jobs:
   - job: Scan
     displayName: VMR Scan

--- a/src/SourceBuild/content/eng/pipelines/templates/stages/vmr-scan.yml
+++ b/src/SourceBuild/content/eng/pipelines/templates/stages/vmr-scan.yml
@@ -1,0 +1,38 @@
+parameters:
+- name: name
+  type: string
+
+- name: type
+  type: string
+
+- name: command
+  type: string
+
+stages:
+- stage: VMR_Scan_${{ parameters.type }}
+  displayName: Scan ${{ parameters.name }}
+  dependsOn: []
+  jobs:
+  - job: Scan
+    displayName: Scan ${{ parameters.name }}
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+    - checkout: self
+
+    - script: |
+        source ./eng/common/tools.sh
+        InitializeDotNetCli true
+        dotnet='./.dotnet/dotnet'
+        "$dotnet" tool restore
+      displayName: Initialize tooling
+      workingDirectory: $(Build.SourcesDirectory)/src/installer
+
+    - script: >
+        ./.dotnet/dotnet darc vmr ${{ parameters.command }}
+        --vmr "$(Build.SourcesDirectory)"
+        --tmp "$(Agent.TempDirectory)"
+        || (echo '##[error]Found ${{ parameters.name }} in the VMR' && exit 1)
+      displayName: Scan ${{ parameters.name }}
+      workingDirectory: $(Build.SourcesDirectory)/src/installer
+      continueOnError: true


### PR DESCRIPTION
Adds 2 stages in the rolling build that will scan for any cloaked files that are still inside of the VMR and for any binaries.

Example run: https://dev.azure.com/dnceng-public/public/_build/results?buildId=141246&view=results

https://github.com/dotnet/arcade/issues/11985
https://github.com/dotnet/arcade/issues/11267