### PR TITLE
remove unnecessary nowarn from source-build SBRP project

### DIFF
--- a/src/SourceBuild/tarball/content/repos/source-build-reference-packages.proj
+++ b/src/SourceBuild/tarball/content/repos/source-build-reference-packages.proj
@@ -16,8 +16,6 @@
 
     <!-- SBRP builds before Arcade so it also needs the bootstrap Arcade version -->
     <UseBootstrapArcade>true</UseBootstrapArcade>
-
-    <RepoNoWarns>NU1504</RepoNoWarns>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is cleanup from https://github.com/dotnet/installer/pull/15251.  At one point SBRP was set back to an older version where this nowarn was needed.  This underlying issue was fixed and is not needed with the current SBRP version.
