### PR TITLE
Pin the emsdk and mono workloads so that the baseline manifest doesn't update each month

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -163,11 +163,11 @@
       <Uri>https://github.com/Microsoft/ApplicationInsights-dotnet</Uri>
       <Sha>53b80940842204f78708a538628288ff5d741a1d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.net6.Manifest-7.0.100" Version="7.0.2" CoherentParentDependency="VS.Redist.Common.NetCore.SharedFramework.x64.7.0">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.net6.Manifest-7.0.100" Version="7.0.2" Pinned="true">
       <Uri>https://github.com/dotnet/emsdk</Uri>
       <Sha>d71ea7cbed84152a921c7b7b4b4439c306bf9130</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.net7.Manifest-7.0.100" Version="7.0.2" CoherentParentDependency="VS.Redist.Common.NetCore.SharedFramework.x64.7.0">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.net7.Manifest-7.0.100" Version="7.0.2" Pinned="true">
       <Uri>https://github.com/dotnet/emsdk</Uri>
       <Sha>d71ea7cbed84152a921c7b7b4b4439c306bf9130</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -204,7 +204,7 @@
     <XamarinMacCatalystWorkloadManifestVersion>15.4.2372</XamarinMacCatalystWorkloadManifestVersion>
     <XamarinMacOSWorkloadManifestVersion>12.3.2372</XamarinMacOSWorkloadManifestVersion>
     <XamarinTvOSWorkloadManifestVersion>16.0.1478</XamarinTvOSWorkloadManifestVersion>
-    <MonoWorkloadManifestVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MonoWorkloadManifestVersion>
+    <MonoWorkloadManifestVersion>7.0.2</MonoWorkloadManifestVersion>
     <MicrosoftNETWorkloadEmscriptennet6Manifest70100Version>7.0.2</MicrosoftNETWorkloadEmscriptennet6Manifest70100Version>
     <MicrosoftNETWorkloadEmscriptennet7Manifest70100Version>7.0.2</MicrosoftNETWorkloadEmscriptennet7Manifest70100Version>
     <EmscriptenWorkloadManifestVersion>$(MicrosoftNETWorkloadEmscriptennet7Manifest70100Version)</EmscriptenWorkloadManifestVersion>


### PR DESCRIPTION
If we don't do this, updating your local SDk will update your manifest and force a workload update. With this, we'll pin to a specific baseline. Specific workload commands like install/update will still float to the latest and VS will still include the latest so it's only on manual and MU updates that this is an issue.

This change should not flow into 7.0.3xx.