### PR TITLE
Tag the official VMR build with installer SHA

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "microsoft.dotnet.darc": {
-      "version": "1.1.0-beta.23068.1",
+      "version": "1.1.0-beta.23068.2",
       "commands": [
         "darc"
       ]

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -205,13 +205,13 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>3600aa80a01e90f38a7b86b9d7c1264e091aa5a8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Darc" Version="1.1.0-beta.23068.1">
+    <Dependency Name="Microsoft.DotNet.Darc" Version="1.1.0-beta.23068.2">
       <Uri>https://github.com/dotnet/arcade-services</Uri>
-      <Sha>fbfe3ef4178f3e5ca05ee32ebd4a20599e72f115</Sha>
+      <Sha>f1d9bcb8317ed06f04276a60e4d0e3b46e2a9ce4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.DarcLib" Version="1.1.0-beta.23068.1">
+    <Dependency Name="Microsoft.DotNet.DarcLib" Version="1.1.0-beta.23068.2">
       <Uri>https://github.com/dotnet/arcade-services</Uri>
-      <Sha>fbfe3ef4178f3e5ca05ee32ebd4a20599e72f115</Sha>
+      <Sha>f1d9bcb8317ed06f04276a60e4d0e3b46e2a9ce4</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging.Console" Version="8.0.0-alpha.1.22557.12">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,7 +30,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/arcade-services -->
-    <MicrosoftDotNetDarcLibVersion>1.1.0-beta.23068.1</MicrosoftDotNetDarcLibVersion>
+    <MicrosoftDotNetDarcLibVersion>1.1.0-beta.23068.2</MicrosoftDotNetDarcLibVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/winforms -->

--- a/src/SourceBuild/content/eng/pipelines/ci.yml
+++ b/src/SourceBuild/content/eng/pipelines/ci.yml
@@ -19,11 +19,10 @@ stages:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: templates/stages/vmr-scan.yml
 
-# For rolling builds we want to build the MSFT SDK first so that we can
-# compare the contents with the source-built one later.
-# This only works because we don't run this test in PRs. If we decided
-# to run this test in PRs, we would need to build the MSFT SDK there too.
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  # For rolling builds we want to build the MSFT SDK first so that we can
+  # compare the contents with the source-built one later.
+  # This only works because we don't run this test in PRs. If we decided
+  # to run this test in PRs, we would need to build the MSFT SDK there too.
   - stage: Build_MSFT_SDK
     displayName: Build MSFT SDK
     jobs:

--- a/src/SourceBuild/content/eng/pipelines/templates/stages/vmr-scan.yml
+++ b/src/SourceBuild/content/eng/pipelines/templates/stages/vmr-scan.yml
@@ -1,12 +1,12 @@
 stages:
-- stage: VMR_Scan
-  displayName: VMR Scan
+- stage: Tag_n_Scan
+  displayName: Tag & Scan
   dependsOn: []
   variables:
   - template: /eng/common/templates/variables/pool-providers.yml
   jobs:
-  - job: Scan
-    displayName: VMR Scan
+  - job: Tag_n_Scan
+    displayName: Tag & Scan
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
         name: $(DncEngPublicBuildPool)
@@ -21,9 +21,15 @@ stages:
     - script: |
         source ./eng/common/tools.sh
         InitializeDotNetCli true
-        dotnet='./.dotnet/dotnet'
-        "$dotnet" tool restore
+        ./.dotnet/dotnet tool restore
       displayName: Initialize tooling
+      workingDirectory: $(Build.SourcesDirectory)/src/installer
+
+    - script: |
+        set -e
+        sha=`./.dotnet/dotnet darc vmr get-version --vmr "$(Build.SourcesDirectory)" installer`
+        echo "##vso[build.addbuildtag]installer-$sha"
+      displayName: Tag the build
       workingDirectory: $(Build.SourcesDirectory)/src/installer
 
     - script: >


### PR DESCRIPTION
We will use this tag to find the build during SB release.

Example build: https://dev.azure.com/dnceng-public/public/_build/results?buildId=142163&view=results

https://github.com/dotnet/arcade/issues/12258