### PR TITLE
Remove Mono.Cecil dependency from poison infra

### DIFF
--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection.csproj
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection.csproj
@@ -13,12 +13,6 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core">
       <Version>15.7.179</Version>
     </PackageReference>
-    <ProjectReference Include="$(SubmoduleDirectory)linker/external/cecil/Mono.Cecil.csproj">
-      <SetConfiguration Condition=" '$(Configuration)' == 'Debug' ">Configuration=netstandard_Debug</SetConfiguration>
-      <SetConfiguration Condition=" '$(Configuration)' == 'Release' ">Configuration=netstandard_Release</SetConfiguration>
-      <Project>{D68133BD-1E63-496E-9EDE-4FBDBF77B486}</Project>
-      <Name>Mono.Cecil</Name>
-    </ProjectReference>
     <ProjectReference Include="../Microsoft.DotNet.SourceBuild.Tasks.XPlat/Microsoft.DotNet.SourceBuild.Tasks.XPlat.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/3201

This removes the dependency on Mono.Cecil projects and libraries. We will simply append a string marker to the end of the assembly binary.

Tested with the same build process, produced the same results and took slightly less time than the old model.