### PR TITLE
Do not depend on the Tag'n'Scan stage in the VMR CI

### DIFF
--- a/src/SourceBuild/content/eng/pipelines/ci.yml
+++ b/src/SourceBuild/content/eng/pipelines/ci.yml
@@ -25,6 +25,7 @@ stages:
   # to run this test in PRs, we would need to build the MSFT SDK there too.
   - stage: Build_MSFT_SDK
     displayName: Build MSFT SDK
+    dependsOn: []
     jobs:
     - template: /src/installer/eng/build.yml
       parameters:


### PR DESCRIPTION
We want the first stage to be isolated and not depend on it. We don't want this:
![image](https://user-images.githubusercontent.com/7013027/213669899-00165435-15cf-4f8f-926f-094f03a14460.png)


