### PR TITLE
Update source-build artifacts

### DIFF
--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -68,7 +68,7 @@ stages:
         name: ${{ variables.defaultPoolName }}
         demands: ${{ variables.defaultPoolDemands }}
       container: ${{ parameters.centOSStream8Container }}
-      bootstrapPrep: false               # 🚫
+      bootstrapPrep: true                # ✅
       buildFromArchive: false            # 🚫
       enablePoison: false                # 🚫
       excludeOmniSharpTests: true        # ✅
@@ -87,7 +87,7 @@ stages:
           name: ${{ variables.defaultPoolName }}
           demands: ${{ variables.defaultPoolDemands }}
         container: ${{ parameters.centOSStream8Container }}
-        bootstrapPrep: false               # 🚫
+        bootstrapPrep: true                # ✅
         buildFromArchive: true             # ✅
         enablePoison: false                # 🚫
         excludeOmniSharpTests: true        # ✅
@@ -105,7 +105,7 @@ stages:
           name: ${{ variables.defaultPoolName }}
           demands: ${{ variables.defaultPoolDemands }}
         container: ${{ parameters.centOSStream9Container }}
-        bootstrapPrep: false              # 🚫
+        bootstrapPrep: true               # ✅
         buildFromArchive: true            # ✅
         enablePoison: false               # 🚫
         excludeOmniSharpTests: false      # 🚫
@@ -123,7 +123,7 @@ stages:
           name: ${{ variables.defaultPoolName }}
           demands: ${{ variables.defaultPoolDemands }}
         container: ${{ parameters.fedora36Container }}
-        bootstrapPrep: false               # 🚫
+        bootstrapPrep: true                # 🚫
         buildFromArchive: true             # ✅
         enablePoison: true                 # ✅
         excludeOmniSharpTests: false       # 🚫
@@ -141,7 +141,7 @@ stages:
           name: ${{ variables.defaultPoolName }}
           demands: ${{ variables.defaultPoolDemands }}
         container: ${{ parameters.ubuntu2004Container }}
-        bootstrapPrep: false               # 🚫
+        bootstrapPrep: true                # ✅
         buildFromArchive: false            # 🚫
         enablePoison: false                # 🚫
         excludeOmniSharpTests: false       # 🚫
@@ -175,7 +175,7 @@ stages:
           name: ${{ variables.defaultPoolName }}
           demands: ${{ variables.defaultPoolDemands }}
         container: ${{ parameters.fedora36Container }}
-        bootstrapPrep: false               # 🚫
+        bootstrapPrep: true                # 🚫
         buildFromArchive: false            # 🚫
         enablePoison: false                # 🚫
         excludeOmniSharpTests: false       # 🚫

--- a/src/SourceBuild/content/Directory.Build.props
+++ b/src/SourceBuild/content/Directory.Build.props
@@ -229,6 +229,10 @@
     <!-- if MicrosoftSourceLinkCommonPackageVersion is non-empty, then we've already built SourceLink, regardless of whether
          this is the production or offline build, so we should use that version.  -->
     <ExtraPackageVersionPropsPackageInfo Include="MicrosoftSourceLinkVersion" Version="%24(MicrosoftSourceLinkCommonPackageVersion)" />
+
+    <!-- non-rid-specific versions of RID-specific version variables to use for bootstrapping -->
+    <ExtraPackageVersionPropsPackageInfo Include="MicrosoftAspNetCoreAppRuntimeVersion" Version="%24(MicrosoftAspNetCoreAppRuntimeCentos8X64PackageVersion)" />
+    <ExtraPackageVersionPropsPackageInfo Include="MicrosoftNETCoreAppCrossgen2Version" Version="%24(MicrosoftNETCoreAppCrossgen2Centos8X64PackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/SourceBuild/content/eng/Versions.props
+++ b/src/SourceBuild/content/eng/Versions.props
@@ -24,6 +24,6 @@
       or minor release, prebuilts may be needed. When the release is mature, prebuilts are not
       necessary, and this property is removed from the file.
     -->
-    <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-8.0.100-2</PrivateSourceBuiltArtifactsPackageVersion>
+    <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-8.0.100-3</PrivateSourceBuiltArtifactsPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/SourceBuild/content/eng/Versions.props
+++ b/src/SourceBuild/content/eng/Versions.props
@@ -24,6 +24,6 @@
       or minor release, prebuilts may be needed. When the release is mature, prebuilts are not
       necessary, and this property is removed from the file.
     -->
-    <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-8.0.100-3</PrivateSourceBuiltArtifactsPackageVersion>
+    <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-8.0.100-4.centos.8-x64</PrivateSourceBuiltArtifactsPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/SourceBuild/content/eng/bootstrap/buildBootstrapPreviouslySB.csproj
+++ b/src/SourceBuild/content/eng/bootstrap/buildBootstrapPreviouslySB.csproj
@@ -13,36 +13,40 @@
   </PropertyGroup>
 
   <ItemGroup>
-        <!-- These packages will be replaced with ms-built packages downloaded from official package feeds-->
+    <!-- These packages will be replaced with ms-built packages downloaded from official package feeds-->
+    <PackageDownload Include="Microsoft.Aspnetcore.App.Runtime.linux-x64" Version="[$(MicrosoftAspNetCoreAppRuntimeVersion)]" />
+    <PackageDownload Include="Microsoft.NETCore.App.Crossgen2.linux-x64" Version="[$(MicrosoftNETCoreAppCrossgen2Version)]" />
+    <PackageDownload Include="Microsoft.NETCore.App.Host.linux-x64" Version="[$(MicrosoftNETCoreAppHostPackageVersion)]" />
+    <PackageDownload Include="Microsoft.NETCore.App.Runtime.linux-x64" Version="[$(MicrosoftNETCoreAppRuntimeVersion)]" />
     <PackageDownload Include="Microsoft.NET.HostModel" Version="[$(MicrosoftNETHostModelVersion)]" />
     <PackageDownload Include="Microsoft.NET.Sdk.IL" Version="[$(MicrosoftNETSdkILVersion)]" />
     <PackageDownload Include="Microsoft.NETCore.ILAsm" Version="[$(MicrosoftNETCoreILAsmVersion)]" />
     <PackageDownload Include="Microsoft.NETCore.ILDAsm" Version="[$(MicrosoftNETCoreILDAsmVersion)]" />
     <PackageDownload Include="Microsoft.NETCore.TestHost" Version="[$(MicrosoftNETCoreTestHostVersion)]" />
-    <PackageDownload Include="runtime.linux-x64.Microsoft.NETCore.ILAsm" Version="[$(RuntimeLinuxX64MicrosoftNETCoreILAsmVersion)]" />
-    <PackageDownload Include="runtime.linux-x64.Microsoft.NETCore.ILDAsm" Version="[$(RuntimeLinuxX64MicrosoftNETCoreILDAsmVersion)]" />
-    <PackageDownload Include="runtime.linux-x64.Microsoft.NETCore.TestHost" Version="[$(RuntimeLinuxX64MicrosoftNETCoreTestHostVersion)]" />
-    <PackageDownload Include="runtime.linux-x64.runtime.native.System.IO.Ports" Version="[$(RuntimeLinuxX64RuntimeNativeSystemIOPortsVersion)]" />
-    <PackageDownload Include="runtime.linux-musl-x64.Microsoft.NETCore.ILAsm" Version="[$(RuntimeLinuxX64MicrosoftNETCoreILAsmVersion)]" />
-    <PackageDownload Include="runtime.linux-musl-x64.Microsoft.NETCore.ILDAsm" Version="[$(RuntimeLinuxX64MicrosoftNETCoreILDAsmVersion)]" />
-    <PackageDownload Include="runtime.linux-musl-x64.Microsoft.NETCore.TestHost" Version="[$(RuntimeLinuxX64MicrosoftNETCoreTestHostVersion)]" />
+    <PackageDownload Include="runtime.linux-x64.Microsoft.NETCore.ILAsm" Version="[$(MicrosoftNETCoreILAsmVersion)]" />
+    <PackageDownload Include="runtime.linux-x64.Microsoft.NETCore.ILDAsm" Version="[$(MicrosoftNETCoreILDAsmVersion)]" />
+    <PackageDownload Include="runtime.linux-x64.Microsoft.NETCore.TestHost" Version="[$(MicrosoftNETCoreTestHostVersion)]" />
+    <PackageDownload Include="runtime.linux-x64.runtime.native.System.IO.Ports" Version="[$(SystemIOPortsVersion)]" />
+    <PackageDownload Include="runtime.linux-musl-x64.Microsoft.NETCore.ILAsm" Version="[$(MicrosoftNETCoreILAsmVersion)]" />
+    <PackageDownload Include="runtime.linux-musl-x64.Microsoft.NETCore.ILDAsm" Version="[$(MicrosoftNETCoreILDAsmVersion)]" />
+    <PackageDownload Include="runtime.linux-musl-x64.Microsoft.NETCore.TestHost" Version="[$(MicrosoftNETCoreTestHostVersion)]" />
     <!-- There's no nuget package for runtime.linux-musl-x64.runtime.native.System.IO.Ports
     <PackageReference Include="runtime.linux-musl-x64.runtime.native.System.IO.Ports" Version="$(RuntimeLinuxX64RuntimeNativeSystemIOPortsVersion)" />
     -->
     <!-- Packages needed to bootstrap arm64 -->
-    <PackageDownload Include="Microsoft.Aspnetcore.App.Runtime.linux-arm64" Version="[$(MicrosoftAspNetCoreAppRuntimeLinuxx64Version)]" />
-    <PackageDownload Include="Microsoft.NETCore.App.Crossgen2.linux-arm64" Version="[$(MicrosoftNETCoreAppCrossgen2LinuxX64Version)]" />
-    <PackageDownload Include="Microsoft.NETCore.App.Host.linux-arm64" Version="[$(MicrosoftNETCoreAppHostLinuxX64Version)]" />
-    <PackageDownload Include="Microsoft.NETCore.App.Runtime.linux-arm64" Version="[$(MicrosoftNETCoreAppRuntimeLinuxX64Version)]" />
-    <PackageDownload Include="runtime.linux-arm64.Microsoft.DotNet.IlCompiler" Version="[$(RuntimeLinuxX64MicrosoftDotNetIlCompilerVersion)]" />
-    <PackageDownload Include="runtime.linux-arm64.Microsoft.NETCore.DotNetAppHost" Version="[$(RuntimeLinuxX64MicrosoftNETCoreDotNetAppHostVersion)]" />
-    <PackageDownload Include="runtime.linux-arm64.Microsoft.NETCore.DotNetHost" Version="[$(RuntimeLinuxX64MicrosoftNETCoreDotNetHostVersion)]" />
-    <PackageDownload Include="runtime.linux-arm64.Microsoft.NETCore.DotNetHostPolicy" Version="[$(RuntimeLinuxX64MicrosoftNETCoreDotNetHostPolicyVersion)]" />
-    <PackageDownload Include="runtime.linux-arm64.Microsoft.NETCore.DotNetHostResolver" Version="[$(RuntimeLinuxX64MicrosoftNETCoreDotNetHostResolverVersion)]" />
-    <PackageDownload Include="runtime.linux-arm64.Microsoft.NETCore.ILAsm" Version="[$(RuntimeLinuxX64MicrosoftNETCoreILAsmVersion)]" />
-    <PackageDownload Include="runtime.linux-arm64.Microsoft.NETCore.ILDAsm" Version="[$(RuntimeLinuxX64MicrosoftNETCoreILDAsmVersion)]" />
-    <PackageDownload Include="runtime.linux-arm64.Microsoft.NETCore.TestHost" Version="[$(RuntimeLinuxX64MicrosoftNETCoreTestHostVersion)]" />
-    <PackageDownload Include="runtime.linux-arm64.runtime.native.System.IO.Ports" Version="[$(RuntimeLinuxX64RuntimeNativeSystemIOPortsVersion)]" />
+    <PackageDownload Include="Microsoft.Aspnetcore.App.Runtime.linux-arm64" Version="[$(MicrosoftAspNetCoreAppRuntimeVersion)]" />
+    <PackageDownload Include="Microsoft.NETCore.App.Crossgen2.linux-arm64" Version="[$(MicrosoftNETCoreAppCrossgen2Version)]" />
+    <PackageDownload Include="Microsoft.NETCore.App.Host.linux-arm64" Version="[$(MicrosoftNETCoreAppHostPackageVersion)]" />
+    <PackageDownload Include="Microsoft.NETCore.App.Runtime.linux-arm64" Version="[$(MicrosoftNETCoreAppRuntimeVersion)]" />
+    <PackageDownload Include="runtime.linux-arm64.Microsoft.DotNet.IlCompiler" Version="[$(MicrosoftDotNetIlCompilerVersion)]" />
+    <PackageDownload Include="runtime.linux-arm64.Microsoft.NETCore.DotNetAppHost" Version="[$(MicrosoftNETCoreDotNetAppHostVersion)]" />
+    <PackageDownload Include="runtime.linux-arm64.Microsoft.NETCore.DotNetHost" Version="[$(MicrosoftNETCoreDotNetHostVersion)]" />
+    <PackageDownload Include="runtime.linux-arm64.Microsoft.NETCore.DotNetHostPolicy" Version="[$(MicrosoftNETCoreDotNetHostPolicyVersion)]" />
+    <PackageDownload Include="runtime.linux-arm64.Microsoft.NETCore.DotNetHostResolver" Version="[$(MicrosoftNETCoreDotNetHostResolverVersion)]" />
+    <PackageDownload Include="runtime.linux-arm64.Microsoft.NETCore.ILAsm" Version="[$(MicrosoftNETCoreILAsmVersion)]" />
+    <PackageDownload Include="runtime.linux-arm64.Microsoft.NETCore.ILDAsm" Version="[$(MicrosoftNETCoreILDAsmVersion)]" />
+    <PackageDownload Include="runtime.linux-arm64.Microsoft.NETCore.TestHost" Version="[$(MicrosoftNETCoreTestHostVersion)]" />
+    <PackageDownload Include="runtime.linux-arm64.runtime.native.System.IO.Ports" Version="[$(RuntimeNativeSystemIOPortsVersion)]" />
   </ItemGroup>
 
   <Target Name="BuildBoostrapPreviouslySourceBuilt" AfterTargets="Restore">
@@ -72,6 +76,29 @@
     <MSBuild Projects="$(MSBuildProjectFile)"
       Targets="CopyDownloadedPackage"
       Properties="SourcePath=$(RestorePackagesPath);DestinationPath=$(UnpackedTarPath);PackageName=%(PackageDownload.Identity);PackageVersion=%(PackageDownload.Version)" />
+
+    <!-- override PVP with bootstrap-override package versions -->
+    <Message Text="  Overriding previously-source-built package versions with $(BootstrapOverrideVersionsProps)" Importance="High" />
+    <ReadLinesFromFile File="$(UnpackedTarPath)/PackageVersions.props">
+      <Output TaskParameter="Lines" ItemName="OriginalPackageVersionLines" />
+    </ReadLinesFromFile>
+    <ReadLinesFromFile File="$(BootstrapOverrideVersionsProps)">
+      <Output TaskParameter="Lines" ItemName="BootstrapPackageVersionLines" />
+    </ReadLinesFromFile>
+
+    <ItemGroup>
+      <OriginalPackageVersionLines Remove="&lt;/Project&gt;" />
+      <BootstrapPackageVersionLines Remove="&lt;Project&gt;" />
+    </ItemGroup>
+
+    <WriteLinesToFile File="$(UnpackedTarPath)/PackageVersions.props"
+                      Lines="@(OriginalPackageVersionLines)"
+                      Overwrite="true"
+    />
+    <WriteLinesToFile File="$(UnpackedTarPath)/PackageVersions.props"
+                      Lines="@(BootstrapPackageVersionLines)"
+                      Overwrite="false"
+    />
 
     <!-- Repack tarball with new bootstrap name -->
     <Message Text="  Repacking tarball to $(NewTarballName)" Importance="High" />

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -111,12 +111,10 @@
     <!-- Update the BuildToolFramework for repos that have not adopted the current version of Arcade-->
     <ReplaceTextInFile InputFile="$(EngCommonToolsShFile)"
                        OldText="_InitializeBuildToolFramework=&quot;netcoreapp3.1&quot;"
-                       NewText="_InitializeBuildToolFramework=&quot;$(NetCurrent)&quot;"
-                       Condition="'$(UseBootstrapArcade)' != 'true'" />
+                       NewText="_InitializeBuildToolFramework=&quot;$(NetCurrent)&quot;" />
     <ReplaceTextInFile InputFile="$(EngCommonToolsShFile)"
                        OldText="_InitializeBuildToolFramework=&quot;net7.0&quot;"
-                       NewText="_InitializeBuildToolFramework=&quot;$(NetCurrent)&quot;"
-                       Condition="'$(UseBootstrapArcade)' != 'true'" />
+                       NewText="_InitializeBuildToolFramework=&quot;$(NetCurrent)&quot;" />
 
     <!-- Temporary workaround for when the ci option is specified, non-zero exit are swallowed which prevents builds from failing within 
          the build process.  https://github.com/dotnet/source-build/issues/2307 -->

--- a/src/SourceBuild/patches/sourcelink/0001-command-line-api-updates.patch
+++ b/src/SourceBuild/patches/sourcelink/0001-command-line-api-updates.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michael Simons <msimons@microsoft.com>
+Date: Fri, 27 Jan 2023 17:50:38 +0000
+Subject: [PATCH] command-line-api updates
+
+Updates necessary to build with the command-line-api version included in source-build.
+
+Backport: https://github.com/dotnet/sourcelink/issues/945
+---
+ src/dotnet-sourcelink/Program.cs | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/dotnet-sourcelink/Program.cs b/src/dotnet-sourcelink/Program.cs
+index 0803734..9affcf5 100644
+--- a/src/dotnet-sourcelink/Program.cs
++++ b/src/dotnet-sourcelink/Program.cs
+@@ -64,7 +64,7 @@ private static string GetSourceLinkVersion()
+ 
+         private static RootCommand GetRootCommand()
+         {
+-            var authArg = new Option<string>(new[] { "--auth", "-a" }, "Authentication method").FromAmong(AuthenticationMethod.Basic);
++            var authArg = new Option<string>(new[] { "--auth", "-a" }, "Authentication method").AcceptOnlyFromAmong(AuthenticationMethod.Basic);
+             var userArg = new Option<string>(new[] { "--user", "-u" }, "Username to use to authenticate") { Arity = ArgumentArity.ExactlyOne };
+             var passwordArg = new Option<string>(new[] { "--password", "-p" }, "Password to use to authenticate") { Arity = ArgumentArity.ExactlyOne };
+ 


### PR DESCRIPTION
In order to update the artifacts I needed to merge in https://github.com/dotnet/installer/pull/15251 from 7.0.1xx.  A sourcelink patch was also needed to build with the version included in source-build.

Fixes https://github.com/dotnet/source-build/issues/3215
