### PR TITLE
Add pipeline parameter for disabling the VMR build during PRs

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -23,6 +23,11 @@ parameters:
   type: string
   default: $(Build.SourceBranchName)
 
+- name: disableVmrBuild
+  displayName: Skip source-building the VMR
+  type: boolean
+  default: false
+
 variables:
 - name: _PublishUsingPipelines
   value: false
@@ -361,7 +366,7 @@ stages:
   - template: /eng/common/templates/jobs/source-build.yml
 
 # You can temporarily disable the VMR Build stage by setting the disableVmrBuild variable on the installer pipeline
-- ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), not(variables['disableVmrBuild'])) }}:
+- ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), not(parameters.disableVmrBuild)) }}:
   - template: eng/pipelines/templates/stages/vmr-build.yml
     parameters:
       vmrBranch: ${{ parameters.vmrBranch }}


### PR DESCRIPTION
UI variables are unfortunately not available during YAML compilation: https://stackoverflow.com/questions/71402496/how-can-i-condition-an-azure-pipelines-stage-on-the-value-of-a-ui-variable
This means, we have to utilize a pipeline parameter in the YAML.

https://github.com/dotnet/arcade/issues/12283