### PR TITLE
Prebuilt report fix

### DIFF
--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/UsageReport/WriteUsageReports.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/UsageReport/WriteUsageReports.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Xml;
 using System.Xml.Linq;
 
 namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport

--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/UsageReport/WriteUsageReports.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/UsageReport/WriteUsageReports.cs
@@ -192,24 +192,15 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
                 })
                 .OrderBy(snapshot =>
                 {
-                    // Get the embedded creation time if possible: the file's original metadata may
-                    // have been destroyed by copying, zipping, etc.
-                    string creationTime = snapshot.Xml
-                        // Get the second PropertyGroup.
-                        .Elements().Skip(1).FirstOrDefault()
-                        // Get the creation time element.
-                        ?.Element(snapshot.Xml
-                            .GetDefaultNamespace()
-                            .GetName(WritePackageVersionsProps.CreationTimePropertyName))
-                        ?.Value;
+                    XmlNodeList creationtimePropertyNodes = snapshot.Xml.SelectNodes($"//{WritePackageVersionsProps.CreationTimePropertyName}");
 
-                    if (string.IsNullOrEmpty(creationTime))
+                    if (creationtimePropertyNodes.Count() != 1 || string.IsNullOrEmpty(creationtimePropertyNodes.Single().Value))
                     {
                         Log.LogError($"No creation time property found in snapshot {snapshot.Path}");
                         return default(DateTime);
                     }
 
-                    return new DateTime(long.Parse(creationTime));
+                    return new DateTime(long.Parse(creationtimePropertyNodes.Single().Value));
                 })
                 .Select(snapshot =>
                 {

--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/UsageReport/WriteUsageReports.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/UsageReport/WriteUsageReports.cs
@@ -200,7 +200,7 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
                         // Select all the subelements
                         .SelectMany(e => e.Elements())
                         // Find all that match the creation time property name
-                        .Where(e => e.Name == xml.GetDefaultNamespace().GetName(WritePackageVersionsProps.CreationTimePropertyName))
+                        .Where(e => e.Name == snapshot.Xml.GetDefaultNamespace().GetName(WritePackageVersionsProps.CreationTimePropertyName))
                         // There should be only one or zero
                         .SingleOrDefault()?.Value;
 

--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/WritePackageVersionProps.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/WritePackageVersionProps.cs
@@ -62,13 +62,6 @@ namespace Microsoft.DotNet.Build.Tasks
         public string OutputPath { get; set; }
 
         /// <summary>
-        /// Adds a second PropertyGroup to the output XML containing a property with the time of
-        /// creation in UTC DateTime Ticks. This can be used to track creation time in situations
-        /// where file metadata isn't reliable or preserved.
-        /// </summary>
-        public bool IncludeCreationTimeProperty { get; set; }
-
-        /// <summary>
         /// Properties to add to the build output props, which may not exist as nupkgs.
         /// FOr example, this is used to pass the version of the CLI toolset archives.
         /// 
@@ -242,12 +235,9 @@ namespace Microsoft.DotNet.Build.Tasks
                 WriteExtraProperties(sw);
                 WriteVersionEntries(sw, additionalAssetElementsToWrite, "additional assets");
 
-                if (IncludeCreationTimeProperty)
-                {
-                    sw.WriteLine(@"  <PropertyGroup>");
-                    sw.WriteLine($@"    <{CreationTimePropertyName}>{DateTime.UtcNow.Ticks}</{CreationTimePropertyName}>");
-                    sw.WriteLine(@"  </PropertyGroup>");
-                }
+                sw.WriteLine(@"  <PropertyGroup>");
+                sw.WriteLine($@"    <{CreationTimePropertyName}>{DateTime.UtcNow.Ticks}</{CreationTimePropertyName}>");
+                sw.WriteLine(@"  </PropertyGroup>");
 
                 sw.WriteLine(@"</Project>");
             }

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -602,7 +602,7 @@
           Outputs="$(RepoCompletedSemaphorePath)WritePrebuiltUsageData.complete">
     <!-- Save the PVP snapshot of each build step to be evaluated while building the report. -->
     <ItemGroup>
-      <PackageVersionPropsSnapshotFiles Include="$(IntermediatePath)PackageVersions.props.pre.*.xml" />
+      <PackageVersionPropsSnapshotFiles Include="$(IntermediatePath)PackageVersions.*.Current.props" />
     </ItemGroup>
     <Copy SourceFiles="@(PackageVersionPropsSnapshotFiles)" DestinationFolder="$(PackageReportDir)snapshots/" />
 
@@ -688,7 +688,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageVersionPropsSavedSnapshotFiles Include="$(PackageReportDir)snapshots/PackageVersions.props.pre.*.xml" />
+      <PackageVersionPropsSavedSnapshotFiles Include="$(PackageReportDir)snapshots/PackageVersions.*.Current.props" />
     </ItemGroup>
 
     <WriteUsageReports DataFile="$(PackageReportDataFile)"


### PR DESCRIPTION
PVP flow change the pattern for the input package version props files, and broke some annotations. See https://github.com/dotnet/source-build/issues/3218. Fixes the pattern.
