### PR TITLE
Set default Codespaces path to `/workspaces`

### DIFF
--- a/.devcontainer/vmr-source-build/devcontainer.json
+++ b/.devcontainer/vmr-source-build/devcontainer.json
@@ -16,7 +16,7 @@
         },
         "codespaces": {
             "openFiles": [
-                "/workspaces/installer/.devcontainer/vmr-source-build/README.md"
+                "installer/.devcontainer/vmr-source-build/README.md"
             ]
         }
     },

--- a/.devcontainer/vmr-source-build/devcontainer.json
+++ b/.devcontainer/vmr-source-build/devcontainer.json
@@ -16,10 +16,10 @@
         },
         "codespaces": {
             "openFiles": [
-                ".devcontainer/vmr-source-build/README.md"
+                "/workspaces/installer/.devcontainer/vmr-source-build/README.md"
             ]
         }
     },
-    "onCreateCommand": "${containerWorkspaceFolder}/.devcontainer/vmr-source-build/init.sh",
+    "onCreateCommand": "${containerWorkspaceFolder}/installer/.devcontainer/vmr-source-build/init.sh",
     "workspaceFolder": "/workspaces"
 }

--- a/.devcontainer/vmr-source-build/devcontainer.json
+++ b/.devcontainer/vmr-source-build/devcontainer.json
@@ -20,5 +20,6 @@
             ]
         }
     },
-    "onCreateCommand": "${containerWorkspaceFolder}/.devcontainer/vmr-source-build/init.sh"
+    "onCreateCommand": "${containerWorkspaceFolder}/.devcontainer/vmr-source-build/init.sh",
+    "workspaceFolder": "/workspaces"
 }

--- a/.devcontainer/vmr-source-build/init.sh
+++ b/.devcontainer/vmr-source-build/init.sh
@@ -19,11 +19,13 @@ git -C "$installer_dir" fetch --all --unshallow
 # We need this to figure out, which VMR branch to use
 vmr_branch=$(git log --pretty=format:'%D' HEAD^ | grep 'origin/' | head -n1 | sed 's@origin/@@' | sed 's@,.*@@')
 
-"$installer_dir/eng/vmr-sync.sh" \
-    --vmr "$vmr_dir"             \
-    --tmp "$tmp_dir"             \
-    --branch "$vmr_branch"       \
+pushd "$installer_dir"
+  "./eng/vmr-sync.sh"      \
+    --vmr "$vmr_dir"       \
+    --tmp "$tmp_dir"       \
+    --branch "$vmr_branch" \
     --debug
+popd
 
 # Run prep.sh
 unset RepositoryName


### PR DESCRIPTION
This PR sets the default working directory to `/workspaces` instead of the default `/workspaces/installer`.

https://github.com/dotnet/arcade/issues/12101