### PR TITLE
Pull in razor fix to address prebuilts

### DIFF
--- a/src/SourceBuild/patches/razor/0001-Add-some-projects-to-Razor.Slim.slnf.patch
+++ b/src/SourceBuild/patches/razor/0001-Add-some-projects-to-Razor.Slim.slnf.patch
@@ -5,8 +5,9 @@ Subject: [PATCH] Add some projects to Razor.Slim.slnf
 
 Backport: https://github.com/dotnet/razor/pull/8188
 ---
- Razor.Slim.slnf | 3 +++
- 1 file changed, 3 insertions(+)
+ Razor.Slim.slnf                                                | 3 +++
+ .../Microsoft.NET.Sdk.Razor.SourceGenerators.Transport.csproj  | 2 ++
+ 2 files changed, 5 insertions(+)
 
 diff --git a/Razor.Slim.slnf b/Razor.Slim.slnf
 index 6e76d40f1..8328075c4 100644
@@ -22,3 +23,16 @@ index 6e76d40f1..8328075c4 100644
        "src\\Shared\\Microsoft.AspNetCore.Razor.LanguageSupport\\Microsoft.AspNetCore.Razor.LanguageSupport.csproj",
        "src\\Razor\\src\\Microsoft.AspNetCore.Razor.Common\\Microsoft.AspNetCore.Razor.Common.csproj",
        "src\\Razor\\src\\Microsoft.CodeAnalysis.Razor.Workspaces\\Microsoft.CodeAnalysis.Razor.Workspaces.csproj",
+diff --git a/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators.Transport/Microsoft.NET.Sdk.Razor.SourceGenerators.Transport.csproj b/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators.Transport/Microsoft.NET.Sdk.Razor.SourceGenerators.Transport.csproj
+index 278e35a42..745645fc9 100644
+--- a/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators.Transport/Microsoft.NET.Sdk.Razor.SourceGenerators.Transport.csproj
++++ b/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators.Transport/Microsoft.NET.Sdk.Razor.SourceGenerators.Transport.csproj
+@@ -8,6 +8,8 @@
+     <NoPackageAnalysis>true</NoPackageAnalysis>
+     <GenerateDependencyFile>false</GenerateDependencyFile>
+     <IsPackable>true</IsPackable>
++    <!-- Need to build this project in source build -->
++    <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
+   </PropertyGroup>
+ 
+   <ItemGroup>

--- a/src/SourceBuild/patches/razor/0001-Add-some-projects-to-Razor.Slim.slnf.patch
+++ b/src/SourceBuild/patches/razor/0001-Add-some-projects-to-Razor.Slim.slnf.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: davidwengier
+Date: Mon, 30 Jan 2023 15:40:22 +0000
+Subject: [PATCH] Add some projects to Razor.Slim.slnf
+
+Backport: https://github.com/dotnet/razor/pull/8188
+---
+ Razor.Slim.slnf | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/Razor.Slim.slnf b/Razor.Slim.slnf
+index 6e76d40f1..8328075c4 100644
+--- a/Razor.Slim.slnf
++++ b/Razor.Slim.slnf
+@@ -6,6 +6,9 @@
+       "src\\Compiler\\Microsoft.AspNetCore.Mvc.Razor.Extensions\\src\\Microsoft.AspNetCore.Mvc.Razor.Extensions.csproj",
+       "src\\Compiler\\Microsoft.AspNetCore.Razor.Language\\src\\Microsoft.AspNetCore.Razor.Language.csproj",
+       "src\\Compiler\\Microsoft.CodeAnalysis.Razor\\src\\Microsoft.CodeAnalysis.Razor.csproj",
++      "src\\Compiler\\Microsoft.NET.Sdk.Razor.SourceGenerators.Transport\\Microsoft.NET.Sdk.Razor.SourceGenerators.Transport.csproj",
++      "src\\Compiler\\tools\\Microsoft.AspNetCore.Mvc.Razor.Extensions.Tooling.Internal\\Microsoft.AspNetCore.Mvc.Razor.Extensions.Tooling.Internal.csproj",
++      "src\\Compiler\\tools\\Microsoft.CodeAnalysis.Razor.Tooling.Internal\\Microsoft.CodeAnalysis.Razor.Tooling.Internal.csproj",
+       "src\\Shared\\Microsoft.AspNetCore.Razor.LanguageSupport\\Microsoft.AspNetCore.Razor.LanguageSupport.csproj",
+       "src\\Razor\\src\\Microsoft.AspNetCore.Razor.Common\\Microsoft.AspNetCore.Razor.Common.csproj",
+       "src\\Razor\\src\\Microsoft.CodeAnalysis.Razor.Workspaces\\Microsoft.CodeAnalysis.Razor.Workspaces.csproj",


### PR DESCRIPTION
Pull in https://github.com/dotnet/razor/pull/8188 to address sdk prebuilts.

Related to https://github.com/dotnet/razor/issues/8186 and https://github.com/dotnet/source-build/issues/3163
