### PR TITLE
Work around the feature band breakage for now

### DIFF
--- a/src/redist/targets/BundledManifests.targets
+++ b/src/redist/targets/BundledManifests.targets
@@ -1,6 +1,6 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <NetFeatureBandPrerelease>8.0.100-$(PreReleaseVersionLabel).$(PreReleaseVersionIteration)</NetFeatureBandPrerelease>
+    <NetFeatureBandPrerelease>8.0.100-alpha.1</NetFeatureBandPrerelease>
     <NetFeatureBand>8.0.100</NetFeatureBand>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
main build is failing, this is needed until runtime can produce a preview branded workload.  The preview 1 branch already has this change