### PR TITLE
Improve workload manifest flow resolution and bump to preview2

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -167,30 +167,33 @@
       <Uri>https://github.com/Microsoft/ApplicationInsights-dotnet</Uri>
       <Sha>53b80940842204f78708a538628288ff5d741a1d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100-alpha.1" Version="8.0.0-alpha.1.23077.4">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100-preview.1" Version="8.0.0-preview.1.23081.2">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>0fe864fc71191ff4ee18e59ef0af2929ca367a11</Sha>
+      <Sha>75ccb6879a3a4710558b28491f19555eb15fe40f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.net7.Manifest-8.0.100-alpha.1" Version="8.0.0-alpha.1.23077.4">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.net7.Manifest-8.0.100-preview.1" Version="8.0.0-preview.1.23081.2">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>0fe864fc71191ff4ee18e59ef0af2929ca367a11</Sha>
+      <Sha>75ccb6879a3a4710558b28491f19555eb15fe40f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.net6.Manifest-8.0.100-alpha.1" Version="8.0.0-alpha.1.23077.4">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.net6.Manifest-8.0.100-preview.1" Version="8.0.0-preview.1.23081.2">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>0fe864fc71191ff4ee18e59ef0af2929ca367a11</Sha>
+      <Sha>75ccb6879a3a4710558b28491f19555eb15fe40f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest-8.0.100-alpha.1" Version="8.0.0-alpha.1.23078.5" CoherentParentDependency="Microsoft.NET.Sdk">
+    <!-- pulled from Microsoft.NETCore.App.Ref -->
+    <!--
+    <Dependency Name="Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest-8.0.100-preview.1" Version="8.0.0-alpha.1.23078.5" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>dfe1076090adad6990747e6abed8bf6699371877</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest-8.0.100-alpha.1" Version="8.0.0-alpha.1.23078.5" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest-8.0.100-preview.1" Version="8.0.0-alpha.1.23078.5" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>dfe1076090adad6990747e6abed8bf6699371877</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Mono.Toolchain.net6.Manifest-8.0.100-alpha.1" Version="8.0.0-alpha.1.23078.5" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NET.Workload.Mono.Toolchain.net6.Manifest-8.0.100-preview.1" Version="8.0.0-alpha.1.23078.5" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>dfe1076090adad6990747e6abed8bf6699371877</Sha>
     </Dependency>
+    -->
     <Dependency Name="Microsoft.Deployment.DotNet.Releases" Version="1.0.0-preview5.1.22263.1">
       <Uri>https://github.com/dotnet/deployment-tools</Uri>
       <Sha>c3ad00ae84489071080a606f6a8e43c9a91a5cc2</Sha>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -167,33 +167,18 @@
       <Uri>https://github.com/Microsoft/ApplicationInsights-dotnet</Uri>
       <Sha>53b80940842204f78708a538628288ff5d741a1d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100-preview.1" Version="8.0.0-preview.1.23081.2">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100-preview.2" Version="8.0.0-preview.2.23081.3">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>75ccb6879a3a4710558b28491f19555eb15fe40f</Sha>
+      <Sha>1d9df3320ccdb0bbc40a31314641e1100369745b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.net7.Manifest-8.0.100-preview.1" Version="8.0.0-preview.1.23081.2">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.net7.Manifest-8.0.100-preview.2" Version="8.0.0-preview.2.23081.3">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>75ccb6879a3a4710558b28491f19555eb15fe40f</Sha>
+      <Sha>1d9df3320ccdb0bbc40a31314641e1100369745b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.net6.Manifest-8.0.100-preview.1" Version="8.0.0-preview.1.23081.2">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.net6.Manifest-8.0.100-preview.2" Version="8.0.0-preview.2.23081.3">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>75ccb6879a3a4710558b28491f19555eb15fe40f</Sha>
+      <Sha>1d9df3320ccdb0bbc40a31314641e1100369745b</Sha>
     </Dependency>
-    <!-- pulled from Microsoft.NETCore.App.Ref -->
-    <!--
-    <Dependency Name="Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest-8.0.100-preview.1" Version="8.0.0-alpha.1.23078.5" CoherentParentDependency="Microsoft.NET.Sdk">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>dfe1076090adad6990747e6abed8bf6699371877</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest-8.0.100-preview.1" Version="8.0.0-alpha.1.23078.5" CoherentParentDependency="Microsoft.NET.Sdk">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>dfe1076090adad6990747e6abed8bf6699371877</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Mono.Toolchain.net6.Manifest-8.0.100-preview.1" Version="8.0.0-alpha.1.23078.5" CoherentParentDependency="Microsoft.NET.Sdk">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>dfe1076090adad6990747e6abed8bf6699371877</Sha>
-    </Dependency>
-    -->
     <Dependency Name="Microsoft.Deployment.DotNet.Releases" Version="1.0.0-preview5.1.22263.1">
       <Uri>https://github.com/dotnet/deployment-tools</Uri>
       <Sha>c3ad00ae84489071080a606f6a8e43c9a91a5cc2</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -203,7 +203,7 @@
     <MicrosoftNETWorkloadEmscriptenCurrentManifest80100preview2PackageVersion>8.0.0-preview.2.23081.3</MicrosoftNETWorkloadEmscriptenCurrentManifest80100preview2PackageVersion>
     <MicrosoftNETWorkloadEmscriptennet7Manifest80100preview2PackageVersion>8.0.0-preview.2.23081.3</MicrosoftNETWorkloadEmscriptennet7Manifest80100preview2PackageVersion>
     <MicrosoftNETWorkloadEmscriptennet6Manifest80100preview2PackageVersion>8.0.0-preview.2.23081.3</MicrosoftNETWorkloadEmscriptennet6Manifest80100preview2PackageVersion>
-    <EmscriptenWorkloadManifestVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest80100preview1PackageVersion)</EmscriptenWorkloadManifestVersion>
+    <EmscriptenWorkloadManifestVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest80100preview2PackageVersion)</EmscriptenWorkloadManifestVersion>
     <!-- emsdk workload prerelease version band must match the emsdk feature band -->
     <EmscriptenWorkloadFeatureBand>8.0.100$([System.Text.RegularExpressions.Regex]::Match($(EmscriptenWorkloadManifestVersion), `-[A-z]*[\.]*\d*`))</EmscriptenWorkloadFeatureBand>
     <!-- Workloads from dotnet/runtime use MicrosoftNETCoreAppRefPackageVersion because it has a stable name that does not include the full feature band -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -200,15 +200,21 @@
     <XamarinMacOSWorkloadManifestVersion>12.3.2372</XamarinMacOSWorkloadManifestVersion>
     <XamarinTvOSWorkloadManifestVersion>16.0.1478</XamarinTvOSWorkloadManifestVersion>
     <!-- Workloads from dotnet/emsdk -->
-    <MicrosoftNETWorkloadEmscriptenCurrentManifest80100alpha1Version>8.0.0-alpha.1.23077.4</MicrosoftNETWorkloadEmscriptenCurrentManifest80100alpha1Version>
-    <MicrosoftNETWorkloadEmscriptennet7Manifest80100alpha1Version>8.0.0-alpha.1.23077.4</MicrosoftNETWorkloadEmscriptennet7Manifest80100alpha1Version>
-    <MicrosoftNETWorkloadEmscriptennet6Manifest80100alpha1Version>8.0.0-alpha.1.23077.4</MicrosoftNETWorkloadEmscriptennet6Manifest80100alpha1Version>
-    <EmscriptenWorkloadManifestVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest80100alpha1Version)</EmscriptenWorkloadManifestVersion>
-    <!-- Workloads from dotnet/runtime -->
-    <MicrosoftNETWorkloadMonoToolchainCurrentManifest80100alpha1Version>8.0.0-alpha.1.23078.5</MicrosoftNETWorkloadMonoToolchainCurrentManifest80100alpha1Version>
-    <MicrosoftNETWorkloadMonoToolchainnet7Manifest80100alpha1Version>8.0.0-alpha.1.23078.5</MicrosoftNETWorkloadMonoToolchainnet7Manifest80100alpha1Version>
-    <MicrosoftNETWorkloadMonoToolchainnet6Manifest80100alpha1Version>8.0.0-alpha.1.23078.5</MicrosoftNETWorkloadMonoToolchainnet6Manifest80100alpha1Version>
-    <MonoWorkloadManifestVersion>$(MicrosoftNETWorkloadMonoToolchainCurrentManifest80100alpha1Version)</MonoWorkloadManifestVersion>
+    <MicrosoftNETWorkloadEmscriptenCurrentManifest80100preview1PackageVersion>8.0.0-preview.1.23081.2</MicrosoftNETWorkloadEmscriptenCurrentManifest80100preview1PackageVersion>
+    <MicrosoftNETWorkloadEmscriptennet7Manifest80100preview1PackageVersion>8.0.0-preview.1.23081.2</MicrosoftNETWorkloadEmscriptennet7Manifest80100preview1PackageVersion>
+    <MicrosoftNETWorkloadEmscriptennet6Manifest80100preview1PackageVersion>8.0.0-preview.1.23081.2</MicrosoftNETWorkloadEmscriptennet6Manifest80100preview1PackageVersion>
+    <EmscriptenWorkloadManifestVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest80100preview1PackageVersion)</EmscriptenWorkloadManifestVersion>
+    <!-- emsdk workload prerelease version band must match the emsdk feature band -->
+    <EmscriptenWorkloadFeatureBand>$([System.Text.RegularExpressions.Regex]::Match($(EmscriptenWorkloadManifestVersion), `^\d*[\.]\d*[\.]\d*(-[A-z]*[\.]*\d*)?`))</EmscriptenWorkloadFeatureBand>
+    <!-- Workloads from dotnet/runtime use MicrosoftNETCoreAppRefPackageVersion because it has a stable name that does not include the full feature band -->
+    <!--
+    <MicrosoftNETWorkloadMonoToolchainCurrentManifest80100preview1PackageVersion>8.0.0-alpha.1.23078.5</MicrosoftNETWorkloadMonoToolchainCurrentManifest80100preview1PackageVersion>
+    <MicrosoftNETWorkloadMonoToolchainnet7Manifest80100preview1PackageVersion>8.0.0-alpha.1.23078.5</MicrosoftNETWorkloadMonoToolchainnet7Manifest80100preview1PackageVersion>
+    <MicrosoftNETWorkloadMonoToolchainnet6Manifest80100preview1PackageVersion>8.0.0-alpha.1.23078.5</MicrosoftNETWorkloadMonoToolchainnet6Manifest80100preview1PackageVersion>
+    -->
+    <MonoWorkloadManifestVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MonoWorkloadManifestVersion>
+    <!-- mono workload prerelease version band must match the runtime feature band -->
+    <MonoWorkloadFeatureBand>$([System.Text.RegularExpressions.Regex]::Match($(MonoWorkloadManifestVersion), `^\d*[\.]\d*[\.]\d*(-[A-z]*[\.]*\d*)?`))</MonoWorkloadFeatureBand>
   </PropertyGroup>
   <!-- dependencies for VMR initialization -->
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -200,21 +200,16 @@
     <XamarinMacOSWorkloadManifestVersion>12.3.2372</XamarinMacOSWorkloadManifestVersion>
     <XamarinTvOSWorkloadManifestVersion>16.0.1478</XamarinTvOSWorkloadManifestVersion>
     <!-- Workloads from dotnet/emsdk -->
-    <MicrosoftNETWorkloadEmscriptenCurrentManifest80100preview1PackageVersion>8.0.0-preview.1.23081.2</MicrosoftNETWorkloadEmscriptenCurrentManifest80100preview1PackageVersion>
-    <MicrosoftNETWorkloadEmscriptennet7Manifest80100preview1PackageVersion>8.0.0-preview.1.23081.2</MicrosoftNETWorkloadEmscriptennet7Manifest80100preview1PackageVersion>
-    <MicrosoftNETWorkloadEmscriptennet6Manifest80100preview1PackageVersion>8.0.0-preview.1.23081.2</MicrosoftNETWorkloadEmscriptennet6Manifest80100preview1PackageVersion>
+    <MicrosoftNETWorkloadEmscriptenCurrentManifest80100preview2PackageVersion>8.0.0-preview.2.23081.3</MicrosoftNETWorkloadEmscriptenCurrentManifest80100preview2PackageVersion>
+    <MicrosoftNETWorkloadEmscriptennet7Manifest80100preview2PackageVersion>8.0.0-preview.2.23081.3</MicrosoftNETWorkloadEmscriptennet7Manifest80100preview2PackageVersion>
+    <MicrosoftNETWorkloadEmscriptennet6Manifest80100preview2PackageVersion>8.0.0-preview.2.23081.3</MicrosoftNETWorkloadEmscriptennet6Manifest80100preview2PackageVersion>
     <EmscriptenWorkloadManifestVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest80100preview1PackageVersion)</EmscriptenWorkloadManifestVersion>
     <!-- emsdk workload prerelease version band must match the emsdk feature band -->
-    <EmscriptenWorkloadFeatureBand>$([System.Text.RegularExpressions.Regex]::Match($(EmscriptenWorkloadManifestVersion), `^\d*[\.]\d*[\.]\d*(-[A-z]*[\.]*\d*)?`))</EmscriptenWorkloadFeatureBand>
+    <EmscriptenWorkloadFeatureBand>8.0.100$([System.Text.RegularExpressions.Regex]::Match($(EmscriptenWorkloadManifestVersion), `-[A-z]*[\.]*\d*`))</EmscriptenWorkloadFeatureBand>
     <!-- Workloads from dotnet/runtime use MicrosoftNETCoreAppRefPackageVersion because it has a stable name that does not include the full feature band -->
-    <!--
-    <MicrosoftNETWorkloadMonoToolchainCurrentManifest80100preview1PackageVersion>8.0.0-alpha.1.23078.5</MicrosoftNETWorkloadMonoToolchainCurrentManifest80100preview1PackageVersion>
-    <MicrosoftNETWorkloadMonoToolchainnet7Manifest80100preview1PackageVersion>8.0.0-alpha.1.23078.5</MicrosoftNETWorkloadMonoToolchainnet7Manifest80100preview1PackageVersion>
-    <MicrosoftNETWorkloadMonoToolchainnet6Manifest80100preview1PackageVersion>8.0.0-alpha.1.23078.5</MicrosoftNETWorkloadMonoToolchainnet6Manifest80100preview1PackageVersion>
-    -->
     <MonoWorkloadManifestVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MonoWorkloadManifestVersion>
     <!-- mono workload prerelease version band must match the runtime feature band -->
-    <MonoWorkloadFeatureBand>$([System.Text.RegularExpressions.Regex]::Match($(MonoWorkloadManifestVersion), `^\d*[\.]\d*[\.]\d*(-[A-z]*[\.]*\d*)?`))</MonoWorkloadFeatureBand>
+    <MonoWorkloadFeatureBand>8.0.100$([System.Text.RegularExpressions.Regex]::Match($(MonoWorkloadManifestVersion), `-[A-z]*[\.]*\d*`))</MonoWorkloadFeatureBand>
   </PropertyGroup>
   <!-- dependencies for VMR initialization -->
   <PropertyGroup>

--- a/src/redist/targets/BundledManifests.targets
+++ b/src/redist/targets/BundledManifests.targets
@@ -1,6 +1,5 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <NetFeatureBandPrerelease>8.0.100-alpha.1</NetFeatureBandPrerelease>
     <NetFeatureBand>8.0.100</NetFeatureBand>
   </PropertyGroup>
   <ItemGroup>
@@ -11,12 +10,12 @@
     <BundledManifests Include="Microsoft.NET.Sdk.Maui" FeatureBand="$(MauiFeatureBand)" Version="$(MauiWorkloadManifestVersion)" />
     <BundledManifests Include="Microsoft.NET.Sdk.tvOS" FeatureBand="$(MauiFeatureBand)" Version="$(XamarinTvOSWorkloadManifestVersion)" />
     <!-- Bundled Manifests are ordered by the reference here - verify before altering -->
-    <BundledManifests Include="Microsoft.NET.Workload.Mono.ToolChain.Current" FeatureBand="$(NetFeatureBandPrerelease)" Version="$(MonoWorkloadManifestVersion)" />
-    <BundledManifests Include="Microsoft.NET.Workload.Emscripten.Current" FeatureBand="$(NetFeatureBandPrerelease)" Version="$(EmscriptenWorkloadManifestVersion)" />
-    <BundledManifests Include="Microsoft.NET.Workload.Emscripten.net6" FeatureBand="$(NetFeatureBandPrerelease)" Version="$(EmscriptenWorkloadManifestVersion)" />
-    <BundledManifests Include="Microsoft.NET.Workload.Emscripten.net7" FeatureBand="$(NetFeatureBandPrerelease)" Version="$(EmscriptenWorkloadManifestVersion)" />
-    <BundledManifests Include="Microsoft.NET.Workload.Mono.ToolChain.net6" FeatureBand="$(NetFeatureBandPrerelease)" Version="$(MonoWorkloadManifestVersion)" />
-    <BundledManifests Include="Microsoft.NET.Workload.Mono.ToolChain.net7" FeatureBand="$(NetFeatureBandPrerelease)" Version="$(MonoWorkloadManifestVersion)" />
+    <BundledManifests Include="Microsoft.NET.Workload.Mono.ToolChain.Current" FeatureBand="$(MonoWorkloadFeatureBand)" Version="$(MonoWorkloadManifestVersion)" />
+    <BundledManifests Include="Microsoft.NET.Workload.Emscripten.Current" FeatureBand="$(EmscriptenWorkloadFeatureBand)" Version="$(EmscriptenWorkloadManifestVersion)" />
+    <BundledManifests Include="Microsoft.NET.Workload.Emscripten.net6" FeatureBand="$(EmscriptenWorkloadFeatureBand)" Version="$(EmscriptenWorkloadManifestVersion)" />
+    <BundledManifests Include="Microsoft.NET.Workload.Emscripten.net7" FeatureBand="$(EmscriptenWorkloadFeatureBand)" Version="$(EmscriptenWorkloadManifestVersion)" />
+    <BundledManifests Include="Microsoft.NET.Workload.Mono.ToolChain.net6" FeatureBand="$(MonoWorkloadFeatureBand)" Version="$(MonoWorkloadManifestVersion)" />
+    <BundledManifests Include="Microsoft.NET.Workload.Mono.ToolChain.net7" FeatureBand="$(MonoWorkloadFeatureBand)" Version="$(MonoWorkloadManifestVersion)" />
   </ItemGroup>
 
   <!-- Calculate NuGet package IDs for bundled manifests -->


### PR DESCRIPTION
1. Moves the feature band for mono and emscripten workloads to Versions.props
2. Compute the mono workload package from MicrosoftNETCoreAppRePackageVersion
3. Computes the feature band for mono and emscripten workloads individually from their version string