### PR TITLE
Fix branch name in VMR CI

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -21,7 +21,7 @@ parameters:
 - name: vmrBranch
   displayName: dotnet/dotnet branch to push to
   type: string
-  default: $(Build.SourceBranch)
+  default: ${{ variables['Build.SourceBranch'] }}
 
 - name: disableVmrBuild
   displayName: Skip source-building the VMR

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -21,7 +21,7 @@ parameters:
 - name: vmrBranch
   displayName: dotnet/dotnet branch to push to
   type: string
-  default: ${{ variables['Build.SourceBranch'] }}
+  default: ''
 
 - name: disableVmrBuild
   displayName: Skip source-building the VMR
@@ -48,8 +48,12 @@ variables:
 - name: _InternalRuntimeDownloadArgs
   value: ''
 
-- name: VmrBranch
-  value: ${{ replace(replace(parameters.vmrBranch, 'refs/heads/', ''), 'refs/pull/', '') }}
+- ${{ if eq(parameters.vmrBranch, '') }}:
+  - name: VmrBranch
+    value: ${{ parameters.vmrBranch }}
+- ${{ else }}:
+  - name: VmrBranch
+    value: ${{ replace(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), 'refs/pull/', '') }}
 
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNetBuilds storage account read tokens

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -48,6 +48,9 @@ variables:
 - name: _InternalRuntimeDownloadArgs
   value: ''
 
+- name: VmrBranch
+  value: ${{ replace(parameters.vmrBranch, 'refs/heads/', '') }}
+
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNetBuilds storage account read tokens
   - name: _InternalRuntimeDownloadArgs
@@ -369,7 +372,7 @@ stages:
 - ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), not(parameters.disableVmrBuild)) }}:
   - template: eng/pipelines/templates/stages/vmr-build.yml
     parameters:
-      vmrBranch: ${{ parameters.vmrBranch }}
+      vmrBranch: ${{ variables.VmrBranch }}
       isBuiltFromVmr: false
 
 # In case the VMR Build stage is temporarily disabled, the VMR synchronization step is run to validate
@@ -381,7 +384,7 @@ stages:
     jobs:
     - template: eng/pipelines/templates/jobs/vmr-synchronization.yml
       parameters:
-        vmrBranch: ${{ parameters.vmrBranch }}
+        vmrBranch: ${{ variables.VmrBranch }}
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - stage: Publish

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -49,7 +49,7 @@ variables:
   value: ''
 
 - name: VmrBranch
-  value: ${{ replace(parameters.vmrBranch, 'refs/heads/', '') }}
+  value: ${{ replace(replace(parameters.vmrBranch, 'refs/heads/', ''), 'refs/pull/', '') }}
 
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNetBuilds storage account read tokens

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -48,7 +48,7 @@ variables:
 - name: _InternalRuntimeDownloadArgs
   value: ''
 
-- ${{ if eq(parameters.vmrBranch, '') }}:
+- ${{ if ne(parameters.vmrBranch, '') }}:
   - name: VmrBranch
     value: ${{ parameters.vmrBranch }}
 - ${{ else }}:

--- a/eng/pipelines/templates/jobs/vmr-synchronization.yml
+++ b/eng/pipelines/templates/jobs/vmr-synchronization.yml
@@ -25,8 +25,6 @@ jobs:
   - template: /eng/common/templates/variables/pool-providers.yml
   - name: vmrPath
     value: $(Agent.BuildDirectory)/vmr
-  - name: vmrBranchName
-    value: ${{ replace(parameters.vmrBranch, 'refs/heads/', '') }}
   - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
     - group: DotNetBot-GitHub
   - ${{ else }}:
@@ -61,9 +59,9 @@ jobs:
         git config --global user.email 'dotnet-maestro[bot]@users.noreply.github.com' && git config --global user.name 'dotnet-maestro[bot]'
         git remote add dotnet 'https://$(BotAccount-dotnet-bot-repo-PAT)@github.com/dotnet/dotnet.git'
         git fetch dotnet
-        git branch $(vmrBranchName)
-        git branch --set-upstream-to=dotnet/$(vmrBranchName) $(vmrBranchName) || echo 'Branch $(vmrBranchName) not found in remote'
-        git push dotnet $(vmrBranchName)
+        git branch ${{ parameters.vmrBranch }}
+        git branch --set-upstream-to=dotnet/${{ parameters.vmrBranch }} ${{ parameters.vmrBranch }} || echo 'Branch ${{ parameters.vmrBranch }} not found in remote'
+        git push dotnet ${{ parameters.vmrBranch }}
       displayName: Push changes to dotnet/dotnet
       workingDirectory: $(vmrPath)
-      condition: and(succeeded(), or(eq(variables['vmrBranchName'], 'main'), startsWith(variables['vmrBranchName'], 'release/')))
+      condition: and(succeeded(), or(eq(variables['vmrBranch'], 'main'), startsWith(variables['vmrBranch'], 'release/')))

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -57,12 +57,19 @@ stages:
       - name: defaultPoolDemands
         value: ${{ parameters.poolInternalAmd64.demands }}
 
+  - ${{ if ne(parameters.vmrBranch, '') }}:
+    - name: VmrBranch
+      value: ${{ parameters.vmrBranch }}
+  - ${{ else }}:
+    - name: VmrBranch
+      value: ${{ replace(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), 'refs/pull/', '') }}
+
   jobs:
   - template: ../jobs/vmr-build.yml
     parameters:
       buildName: CentOSStream8_Online
       isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-      vmrBranch: ${{ parameters.vmrBranch }}
+      vmrBranch: ${{ variables.VmrBranch }}
       architecture: x64
       pool:
         name: ${{ variables.defaultPoolName }}
@@ -81,7 +88,7 @@ stages:
       parameters:
         buildName: CentOSStream8_Offline
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        vmrBranch: ${{ parameters.vmrBranch }}
+        vmrBranch: ${{ variables.VmrBranch }}
         architecture: x64
         pool:
           name: ${{ variables.defaultPoolName }}
@@ -99,7 +106,7 @@ stages:
       parameters:
         buildName: CentOSStream9_Offline
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        vmrBranch: ${{ parameters.vmrBranch }}
+        vmrBranch: ${{ variables.VmrBranch }}
         architecture: x64
         pool:
           name: ${{ variables.defaultPoolName }}
@@ -117,7 +124,7 @@ stages:
       parameters:
         buildName: Fedora36_Offline
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        vmrBranch: ${{ parameters.vmrBranch }}
+        vmrBranch: ${{ variables.VmrBranch }}
         architecture: x64
         pool:
           name: ${{ variables.defaultPoolName }}
@@ -135,7 +142,7 @@ stages:
       parameters:
         buildName: Ubuntu2004_Offline
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        vmrBranch: ${{ parameters.vmrBranch }}
+        vmrBranch: ${{ variables.VmrBranch }}
         architecture: x64
         pool:
           name: ${{ variables.defaultPoolName }}
@@ -153,7 +160,7 @@ stages:
       parameters:
         buildName: Debian11_Offline
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        vmrBranch: ${{ parameters.vmrBranch }}
+        vmrBranch: ${{ variables.VmrBranch }}
         architecture: arm64
         pool: ${{ parameters.poolInternalArm64 }}
         container: ${{ parameters.debian11Arm64Container }}
@@ -169,7 +176,7 @@ stages:
       parameters:
         buildName: Fedora36_Offline_Using_Previous
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        vmrBranch: ${{ parameters.vmrBranch }}
+        vmrBranch: ${{ variables.VmrBranch }}
         architecture: x64
         pool:
           name: ${{ variables.defaultPoolName }}

--- a/eng/pipelines/templates/steps/vmr-prepare.yml
+++ b/eng/pipelines/templates/steps/vmr-prepare.yml
@@ -30,8 +30,7 @@ steps:
 
 - ${{ if or(not(parameters.isBuiltFromVmr), eq(variables['System.TeamProject'], 'internal')) }}:
   - script: |
-      branch_name=$(echo '${{ parameters.vmrBranch }}' | sed -e "s#^/refs/heads/##")
-      git switch -c "$branch_name"
+      git switch -c ${{ parameters.vmrBranch }}
     displayName: Checkout ${{ parameters.vmrBranch }}
     workingDirectory: $(Agent.BuildDirectory)/vmr
 

--- a/eng/pipelines/templates/steps/vmr-pull-updates.yml
+++ b/eng/pipelines/templates/steps/vmr-pull-updates.yml
@@ -23,9 +23,8 @@ steps:
   path: installer
 
 - script: |
-    branch_name=$(echo '${{ parameters.vmrBranch }}' | sed -e "s#^/refs/heads/##")
-    git checkout -B "$branch_name"
-    echo "##vso[task.setvariable variable=vmrBranch]$branch_name"
+    git checkout -B ${{ parameters.vmrBranch }}
+    echo "##vso[task.setvariable variable=vmrBranch]${{ parameters.vmrBranch }}"
   displayName: Prepare branch ${{ parameters.vmrBranch }}
   workingDirectory: ${{ parameters.vmrPath }}
 
@@ -33,7 +32,7 @@ steps:
     ./eng/vmr-sync.sh
     --vmr ${{ parameters.vmrPath }}
     --tmp $(Agent.TempDirectory)
-    --branch $(echo '${{ parameters.vmrBranch }}' | sed -e "s#^/refs/heads/##")
+    --branch ${{ parameters.vmrBranch }}
     --target-ref ${{ parameters.targetRef }}
   displayName: Synchronize dotnet/dotnet
   workingDirectory: $(Agent.BuildDirectory)/installer


### PR DESCRIPTION
This is a fix of a fix introduced in https://github.com/dotnet/installer/commit/83406a8660e499c0b800dade81406f80a747b5cf

Trying compile-time variable and simplifying the branch name we're using as soon as possible so that we don't have to deal with the `refs/heads/` prefix any longer
