### PR TITLE
Separate vmr sync from installer build

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -372,23 +372,25 @@ stages:
 
   - template: /eng/common/templates/jobs/source-build.yml
 
-# You can temporarily disable the VMR Build stage by setting the disableVmrBuild variable on the installer pipeline
-- ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), not(parameters.disableVmrBuild)) }}:
-  - template: eng/pipelines/templates/stages/vmr-build.yml
-    parameters:
-      vmrBranch: ${{ variables.VmrBranch }}
-      isBuiltFromVmr: false
+- ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
 
-# In case the VMR Build stage is temporarily disabled, the VMR synchronization step is run to validate
-# that the PR can be merged and later synchronized into the VMR without problems.
-- ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), parameters.disableVmrBuild) }}:
-  - stage: Synchronize_VMR
-    displayName: Synchronize VMR
-    dependsOn: []
-    jobs:
-    - template: eng/pipelines/templates/jobs/vmr-synchronization.yml
+  # You can temporarily disable the VMR Build stage by setting the disableVmrBuild variable on the installer pipeline
+  - ${{ if not(parameters.disableVmrBuild) }}:
+    - template: eng/pipelines/templates/stages/vmr-build.yml
       parameters:
         vmrBranch: ${{ variables.VmrBranch }}
+        isBuiltFromVmr: false
+  
+  # In case the VMR Build stage is temporarily disabled, the VMR synchronization step is run to validate
+  # that the PR can be merged and later synchronized into the VMR without problems.
+  - ${{ else }}:
+    - stage: Synchronize_VMR
+      displayName: Synchronize VMR
+      dependsOn: []
+      jobs:
+      - template: eng/pipelines/templates/jobs/vmr-synchronization.yml
+        parameters:
+          vmrBranch: ${{ variables.VmrBranch }}
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - stage: Publish

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -10,13 +10,6 @@ trigger:
     - internal/release/6.*
     - internal/release/7.*
 
-resources:
-  repositories:
-  - repository: vmr
-    type: github
-    name: dotnet/dotnet
-    endpoint: dotnet
-
 parameters:
 - name: vmrBranch
   displayName: dotnet/dotnet branch to push to
@@ -378,17 +371,6 @@ stages:
     parameters:
       vmrBranch: ${{ variables.VmrBranch }}
       isBuiltFromVmr: false
-
-# In case the VMR Build stage is temporarily disabled, the VMR synchronization step is run to validate
-# that the PR can be merged and later synchronized into the VMR without problems.
-- ${{ else }}:
-  - stage: Synchronize_VMR
-    displayName: Synchronize VMR
-    dependsOn: []
-    jobs:
-    - template: eng/pipelines/templates/jobs/vmr-synchronization.yml
-      parameters:
-        vmrBranch: ${{ variables.VmrBranch }}
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - stage: Publish

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -10,6 +10,13 @@ trigger:
     - internal/release/6.*
     - internal/release/7.*
 
+resources:
+  repositories:
+    - repository: vmr
+      type: github
+      name: dotnet/dotnet
+      endpoint: dotnet
+
 parameters:
 - name: vmrBranch
   displayName: dotnet/dotnet branch to push to
@@ -371,6 +378,17 @@ stages:
     parameters:
       vmrBranch: ${{ variables.VmrBranch }}
       isBuiltFromVmr: false
+
+# In case the VMR Build stage is temporarily disabled, the VMR synchronization step is run to validate
+# that the PR can be merged and later synchronized into the VMR without problems.
+- ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), parameters.disableVmrBuild) }}:
+  - stage: Synchronize_VMR
+    displayName: Synchronize VMR
+    dependsOn: []
+    jobs:
+    - template: eng/pipelines/templates/jobs/vmr-synchronization.yml
+      parameters:
+        vmrBranch: ${{ variables.VmrBranch }}
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - stage: Publish

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -12,10 +12,10 @@ trigger:
 
 resources:
   repositories:
-    - repository: vmr
-      type: github
-      name: dotnet/dotnet
-      endpoint: dotnet
+  - repository: vmr
+    type: github
+    name: dotnet/dotnet
+    endpoint: dotnet
 
 parameters:
 - name: vmrBranch

--- a/eng/pipelines/vmr-sync.yml
+++ b/eng/pipelines/vmr-sync.yml
@@ -1,0 +1,38 @@
+trigger:
+  batch: true
+  branches:
+    include:
+    - main
+    - master
+    - release/*
+
+resources:
+  repositories:
+  - repository: vmr
+    type: github
+    name: dotnet/dotnet
+    endpoint: dotnet
+
+parameters:
+- name: vmrBranch
+  displayName: dotnet/dotnet branch to push to
+  type: string
+  default: ''
+
+variables: 
+  - ${{ if ne(parameters.vmrBranch, '') }}:
+    - name: VmrBranch
+      value: ${{ parameters.vmrBranch }}
+  - ${{ else }}:
+    - name: VmrBranch
+      value: ${{ replace(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), 'refs/pull/', '') }}
+    
+stages:
+- stage: Synchronize_VMR
+  displayName: Synchronize VMR
+  dependsOn: []
+  jobs:
+  - template: /eng/pipelines/templates/jobs/vmr-synchronization.yml
+    parameters:
+      vmrBranch: ${{ variables.VmrBranch }}
+    

--- a/eng/pipelines/vmr-sync.yml
+++ b/eng/pipelines/vmr-sync.yml
@@ -1,9 +1,10 @@
+pr: none
+
 trigger:
   batch: true
   branches:
     include:
     - main
-    - master
     - release/*
 
 resources:

--- a/eng/pipelines/vmr-sync.yml
+++ b/eng/pipelines/vmr-sync.yml
@@ -20,12 +20,12 @@ parameters:
   default: ''
 
 variables: 
-  - ${{ if ne(parameters.vmrBranch, '') }}:
-    - name: VmrBranch
-      value: ${{ parameters.vmrBranch }}
-  - ${{ else }}:
-    - name: VmrBranch
-      value: ${{ replace(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), 'refs/pull/', '') }}
+- ${{ if ne(parameters.vmrBranch, '') }}:
+  - name: VmrBranch
+    value: ${{ parameters.vmrBranch }}
+- ${{ else }}:
+  - name: VmrBranch
+    value: ${{ replace(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), 'refs/pull/', '') }}
     
 stages:
 - stage: Synchronize_VMR

--- a/eng/pipelines/vmr-sync.yml
+++ b/eng/pipelines/vmr-sync.yml
@@ -28,12 +28,9 @@ variables:
   - name: VmrBranch
     value: ${{ replace(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), 'refs/pull/', '') }}
     
-stages:
-- stage: Synchronize_VMR
-  displayName: Synchronize VMR
-  dependsOn: []
-  jobs:
+jobs:
   - template: /eng/pipelines/templates/jobs/vmr-synchronization.yml
     parameters:
       vmrBranch: ${{ variables.VmrBranch }}
+  
     


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/12323

This is the first step of creating 2 separate pipelines that will synchronize the VMR - one for internal branches and one for main and release - in order to make sure we are pushing the right changes to the right VMR (public or internal) 
