### PR TITLE
Fix emsdk build when RID is autodetected as linux-x64

### DIFF
--- a/src/SourceBuild/content/repo-projects/emsdk.proj
+++ b/src/SourceBuild/content/repo-projects/emsdk.proj
@@ -8,8 +8,8 @@
     <OverrideTargetRid Condition="'$(TargetOS)' == 'Windows_NT'">win-$(Platform)</OverrideTargetRid>
 
     <_platformIndex>$(OverrideTargetRid.LastIndexOf('-'))</_platformIndex>
-    <TargetOS>$(NETCoreSdkRuntimeIdentifier.Substring(0, $(_platformIndex)))</TargetOS>
-    <TargetArch>$(NETCoreSdkPortableRuntimeIdentifier.Substring($(_platformIndex)))</TargetArch>
+    <TargetOS>$(OverrideTargetRid.Substring(0, $(_platformIndex)))</TargetOS>
+    <TargetArch>$(OverrideTargetRid.Substring($(_platformIndex)))</TargetArch>
 
     <BuildCommandArgs>$(StandardSourceBuildArgs)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:PackageRid=$(OverrideTargetRid)</BuildCommandArgs>


### PR DESCRIPTION
It seems I made a copy-paste error in this earlier, so it only worked on Mac/Windows, specific detected Linux systems with non-portable RIDs, or any case where the RID is explicitly overridden from the default.

```
/home/directhex/Projects/dotnet/repo-projects/emsdk.proj(11,5): error MSB4184: The expression ""linux-x64".Substring(0, 12)" cannot be evaluated. Index and length must refer to a location within the string. (Parameter 'length')
```