### PR TITLE
[release/8.0.1xx-preview1] Use the 8.0 VMR branch during sync

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -16,6 +16,7 @@ resources:
     type: github
     name: dotnet/dotnet
     endpoint: dotnet
+    ref: refs/heads/release/8.0.1xx-preview1
 
 parameters:
 - name: vmrBranch


### PR DESCRIPTION
The VMR synchronization is broken as the resource is cloning main and then we are not fast-forward pushing.

This is a workaround for the preview1 branch to unblock synchronization but we will have a better fix in main soon and will backport it here.