### PR TITLE
[release/6.0] Disable secure supply chain check.

### DIFF
--- a/src/SourceBuild/tarball/content/eng/pipelines/security-partners-dotnet.yml
+++ b/src/SourceBuild/tarball/content/eng/pipelines/security-partners-dotnet.yml
@@ -1,5 +1,18 @@
 trigger: none
 
+variables:
+- name: cfsNPMWarnLevel
+  value: none
+
+- name: cfsNugetWarnLevel
+  value: none
+
+- name: myGetWarnLevel
+  value: none
+
+- name: NuGetSecurityAnalysisWarningLevel
+  value: none
+
 jobs:
 - template: ../../src/installer/src/SourceBuild/Arcade/eng/common/templates/job/source-build-build-tarball.yml
   parameters:


### PR DESCRIPTION
These issues are checked for in the individual repos - by the time source-build is building the tarball they have already been processed and approved.
