### PR TITLE
[release/7.0] Disable secure supply chain check and always bootstrap

### DIFF
--- a/src/SourceBuild/tarball/content/eng/pipelines/security-partners-dotnet.yml
+++ b/src/SourceBuild/tarball/content/eng/pipelines/security-partners-dotnet.yml
@@ -20,7 +20,7 @@ jobs:
     excludeSdkContentTests: true
     matrix:
       Ubuntu2004-Offline:
-        _BootstrapPrep: false
+        _BootstrapPrep: true
         _Container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-20220813234344-4c008dd
         _EnablePoison: false
         _ExcludeOmniSharpTests: false

--- a/src/SourceBuild/tarball/content/eng/pipelines/security-partners-dotnet.yml
+++ b/src/SourceBuild/tarball/content/eng/pipelines/security-partners-dotnet.yml
@@ -1,5 +1,18 @@
 trigger: none
 
+variables:
+- name: cfsNPMWarnLevel
+  value: none
+
+- name: cfsNugetWarnLevel
+  value: none
+
+- name: myGetWarnLevel
+  value: none
+
+- name: NuGetSecurityAnalysisWarningLevel
+  value: none
+
 jobs:
 - template: ../../src/installer/src/SourceBuild/Arcade/eng/common/templates/job/source-build-build-tarball.yml
   parameters:


### PR DESCRIPTION
- Secure supply chain issues are checked for in the individual repos - by the time source-build is building the tarball they have already been processed and approved.
- We now expect all builds using the Microsoft-built SDK as the bootstrap SDK to use the bootstrapping previously-source-built artifacts as well.  Mixing RID-ness between the bootstrap SDK and PSB is not supported.