### PR TITLE
Split the VMR Build into a separate pipeline

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -10,24 +10,6 @@ trigger:
     - internal/release/6.*
     - internal/release/7.*
 
-resources:
-  repositories:
-  - repository: vmr
-    type: github
-    name: dotnet/dotnet
-    endpoint: dotnet
-
-parameters:
-- name: vmrBranch
-  displayName: dotnet/dotnet branch to push to
-  type: string
-  default: ''
-
-- name: disableVmrBuild
-  displayName: Skip source-building the VMR
-  type: boolean
-  default: false
-
 variables:
 - name: _PublishUsingPipelines
   value: false
@@ -47,13 +29,6 @@ variables:
 
 - name: _InternalRuntimeDownloadArgs
   value: ''
-
-- ${{ if ne(parameters.vmrBranch, '') }}:
-  - name: VmrBranch
-    value: ${{ parameters.vmrBranch }}
-- ${{ else }}:
-  - name: VmrBranch
-    value: ${{ replace(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), 'refs/pull/', '') }}
 
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNetBuilds storage account read tokens
@@ -371,26 +346,6 @@ stages:
         runTests: false
 
   - template: /eng/common/templates/jobs/source-build.yml
-
-- ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-
-  # You can temporarily disable the VMR Build stage by setting the disableVmrBuild variable on the installer pipeline
-  - ${{ if not(parameters.disableVmrBuild) }}:
-    - template: eng/pipelines/templates/stages/vmr-build.yml
-      parameters:
-        vmrBranch: ${{ variables.VmrBranch }}
-        isBuiltFromVmr: false
-  
-  # In case the VMR Build stage is temporarily disabled, the VMR synchronization step is run to validate
-  # that the PR can be merged and later synchronized into the VMR without problems.
-  - ${{ else }}:
-    - stage: Synchronize_VMR
-      displayName: Synchronize VMR
-      dependsOn: []
-      jobs:
-      - template: eng/pipelines/templates/jobs/vmr-synchronization.yml
-        parameters:
-          vmrBranch: ${{ variables.VmrBranch }}
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - stage: Publish

--- a/eng/pipelines/vmr-build.yml
+++ b/eng/pipelines/vmr-build.yml
@@ -1,0 +1,51 @@
+trigger: none
+pr:
+  branches:
+    include:
+    - main
+    - release/*
+
+resources:
+  repositories:
+  - repository: vmr
+    type: github
+    name: dotnet/dotnet
+    endpoint: dotnet
+
+parameters:
+- name: vmrBranch
+  displayName: dotnet/dotnet branch to push to
+  type: string
+  default: ''
+
+- name: disableVmrBuild
+  displayName: Skip source-building the VMR
+  type: boolean
+  default: false
+
+variables:
+- ${{ if ne(parameters.vmrBranch, '') }}:
+  - name: VmrBranch
+    value: ${{ parameters.vmrBranch }}
+- ${{ else }}:
+  - name: VmrBranch
+    value: ${{ replace(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), 'refs/pull/', '') }}
+
+stages:
+# You can temporarily disable the VMR Build stage by setting the disableVmrBuild variable on the installer pipeline
+- ${{ if not(parameters.disableVmrBuild) }}:
+  - template: eng/pipelines/templates/stages/vmr-build.yml
+    parameters:
+      vmrBranch: ${{ variables.VmrBranch }}
+      isBuiltFromVmr: false
+
+# In case the VMR Build stage is temporarily disabled, the VMR synchronization step is run to validate
+# that the PR can be merged and later synchronized into the VMR without problems.
+- ${{ else }}:
+  - stage: Synchronize_VMR
+    displayName: Synchronize VMR
+    dependsOn: []
+    jobs:
+    - template: eng/pipelines/templates/jobs/vmr-synchronization.yml
+      parameters:
+        vmrBranch: ${{ variables.VmrBranch }}

--- a/eng/pipelines/vmr-build.yml
+++ b/eng/pipelines/vmr-build.yml
@@ -34,7 +34,7 @@ variables:
 stages:
 # You can temporarily disable the VMR Build stage by setting the disableVmrBuild variable on the installer pipeline
 - ${{ if not(parameters.disableVmrBuild) }}:
-  - template: eng/pipelines/templates/stages/vmr-build.yml
+  - template: templates/stages/vmr-build.yml
     parameters:
       vmrBranch: ${{ variables.VmrBranch }}
       isBuiltFromVmr: false
@@ -46,6 +46,6 @@ stages:
     displayName: Synchronize VMR
     dependsOn: []
     jobs:
-    - template: eng/pipelines/templates/jobs/vmr-synchronization.yml
+    - template: templates/jobs/vmr-synchronization.yml
       parameters:
         vmrBranch: ${{ variables.VmrBranch }}

--- a/eng/pipelines/vmr-build.yml
+++ b/eng/pipelines/vmr-build.yml
@@ -5,13 +5,6 @@ pr:
     - main
     - release/*
 
-resources:
-  repositories:
-  - repository: vmr
-    type: github
-    name: dotnet/dotnet
-    endpoint: dotnet
-
 parameters:
 - name: vmrBranch
   displayName: dotnet/dotnet branch to push to
@@ -29,7 +22,15 @@ variables:
     value: ${{ parameters.vmrBranch }}
 - ${{ else }}:
   - name: VmrBranch
-    value: ${{ replace(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), 'refs/pull/', '') }}
+    value: ${{ replace(replace(variables['System.PullRequest.TargetBranch'], 'refs/heads/', ''), 'refs/pull/', '') }}
+
+resources:
+  repositories:
+  - repository: vmr
+    type: github
+    name: dotnet/dotnet
+    endpoint: dotnet
+    ref: ${{ variables.VmrBranch }}
 
 stages:
 # You can temporarily disable the VMR Build stage by setting the disableVmrBuild variable on the installer pipeline

--- a/eng/pipelines/vmr-build.yml
+++ b/eng/pipelines/vmr-build.yml
@@ -33,7 +33,7 @@ resources:
     ref: ${{ variables.VmrBranch }}
 
 stages:
-# You can temporarily disable the VMR Build stage by setting the disableVmrBuild variable on the installer pipeline
+# You can temporarily disable the VMR Build stage by setting the disableVmrBuild variable
 - ${{ if not(parameters.disableVmrBuild) }}:
   - template: templates/stages/vmr-build.yml
     parameters:


### PR DESCRIPTION
Moving the "VMR Build" stage from the installer pipeline into its own pipeline. This will separate concerns better, give us more flexibility in setting up security and possibly even improve cases when we'd like to turn the build off.

We should discuss the name of the pipeline in this PR.