### PR TITLE
Fix annotated prebuilt report again

### DIFF
--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/UsageReport/WriteUsageReports.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/UsageReport/WriteUsageReports.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
     public class WriteUsageReports : Task
     {
         private const string SnapshotPrefix = "PackageVersions.";
-        private const string SnapshotSuffix = ".Current.props";
+        private const string SnapshotSuffix = ".Snapshot.props";
 
         /// <summary>
         /// Source usage data JSON file.
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
         public string DataFile { get; set; }
 
         /// <summary>
-        /// A set of "PackageVersions.{repo}.Current.props" files. They are analyzed to find
+        /// A set of "PackageVersions.{repo}.Snapshot.props" files. They are analyzed to find
         /// packages built during source-build, and which repo built them. This info is added to the
         /// report. New packages are associated to a repo by going through each PVP in ascending
         /// file modification order.

--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -27,6 +27,7 @@
     <!-- Paths to the version props files -->
     <CurrentSourceBuiltPackageVersionPropsPath>$(IntermediatePath)PackageVersions.$(RepositoryName).Current.props</CurrentSourceBuiltPackageVersionPropsPath>
     <PreviouslySourceBuiltPackageVersionPropsPath>$(IntermediatePath)PackageVersions.$(RepositoryName).Previous.props</PreviouslySourceBuiltPackageVersionPropsPath>
+    <SnapshotPackageVersionPropsPath>$(IntermediatePath)PackageVersions.$(RepositoryName).Snapshot.props</SnapshotPackageVersionPropsPath>
     <PackageVersionPropsPath>$(IntermediatePath)PackageVersions.$(RepositoryName).props</PackageVersionPropsPath>
     <PackageVersionPropsFlowType>AllPackages</PackageVersionPropsFlowType>
   </PropertyGroup>

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -225,17 +225,30 @@
 
     <!-- Write the build input properties, then save off a copy that will be used for generating usage reports later -->
     <WritePackageVersionsProps NuGetPackages="@(_CurrentSourceBuiltPackages)"
-                           ExtraProperties="@(ExtraPackageVersionPropsPackageInfo)"
-                           VersionPropsFlowType="$(PackageVersionPropsFlowType)"
-                           VersionDetails="$(_VersionDetailsXml)"
-                           AdditionalAssetDirs="@(_CurrentAdditionalAssetDirs)"
-                           OutputPath="$(CurrentSourceBuiltPackageVersionPropsPath)" />
+                               ExtraProperties="@(ExtraPackageVersionPropsPackageInfo)"
+                               VersionPropsFlowType="$(PackageVersionPropsFlowType)"
+                               VersionDetails="$(_VersionDetailsXml)"
+                               AdditionalAssetDirs="@(_CurrentAdditionalAssetDirs)"
+                               OutputPath="$(CurrentSourceBuiltPackageVersionPropsPath)" />
 
     <!-- Create previously source-built inputs info -->
     <WritePackageVersionsProps NuGetPackages="@(_PreviouslyBuiltSourceBuiltPackages)"
-                          VersionPropsFlowType="$(PackageVersionPropsFlowType)"
-                          VersionDetails="$(_VersionDetailsXml)"
-                          OutputPath="$(PreviouslySourceBuiltPackageVersionPropsPath)" />
+                               VersionPropsFlowType="$(PackageVersionPropsFlowType)"
+                               VersionDetails="$(_VersionDetailsXml)"
+                               OutputPath="$(PreviouslySourceBuiltPackageVersionPropsPath)" />
+
+    <!-- Write a full package version props (unfiltered) that will be used to track which repo creates a package.
+         Because not all repos implement the repo API (e.g. some are external), it's difficult to consistently gather
+         a list of packages from the output of each repo. This may be an area for improvement later.
+
+         Instead, we rely on the package version props file that is built up
+         before each build. If the full list of packages grows by package A, B and C between repo Y and Z, then Y produced
+         A B and C.
+
+         A key element of this algorith is that we must write the full package version props and not the filtered version. -->
+    <WritePackageVersionsProps NuGetPackages="@(_CurrentSourceBuiltPackages)"
+                               VersionPropsFlowType="AllPackages"
+                               OutputPath="$(SnapshotPackageVersionPropsPath)" />
 
     <!-- Write a single file that contains imports for both the current and previously built packages -->
     <PropertyGroup>
@@ -601,7 +614,7 @@
           Outputs="$(RepoCompletedSemaphorePath)WritePrebuiltUsageData.complete">
     <!-- Save the PVP snapshot of each build step to be evaluated while building the report. -->
     <ItemGroup>
-      <PackageVersionPropsSnapshotFiles Include="$(IntermediatePath)PackageVersions.*.Current.props" />
+      <PackageVersionPropsSnapshotFiles Include="$(IntermediatePath)PackageVersions.*.Snapshot.props" />
     </ItemGroup>
     <Copy SourceFiles="@(PackageVersionPropsSnapshotFiles)" DestinationFolder="$(PackageReportDir)snapshots/" />
 
@@ -687,7 +700,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageVersionPropsSavedSnapshotFiles Include="$(PackageReportDir)snapshots/PackageVersions.*.Current.props" />
+      <PackageVersionPropsSavedSnapshotFiles Include="$(PackageReportDir)snapshots/PackageVersions.*.Snapshot.props" />
     </ItemGroup>
 
     <WriteUsageReports DataFile="$(PackageReportDataFile)"


### PR DESCRIPTION
Because roslyn-analyzers started to use PVP flow, it lists only a few entries in its input Version.props. This was confusing the annotated usage report, which was interpreting this as roslyn-analyzers producing a large number of packages. This is because the report looks for new entries, then looks at the previous repo and assumes it created them. This problem isn't super easy to solve elegantly in the current infra, so I just went back to supporting the way things were calculated before by saving off a "full" version props file as a snapshot.
