### PR TITLE
Shutdown build servers for each SB repo project

### DIFF
--- a/src/SourceBuild/content/build.sh
+++ b/src/SourceBuild/content/build.sh
@@ -37,8 +37,7 @@ while :; do
     lowerI="$(echo $1 | awk '{print tolower($0)}')"
     case $lowerI in
         --clean-while-building)
-            # TODO: Reenable with https://github.com/dotnet/source-build/issues/3233
-            # MSBUILD_ARGUMENTS+=( "-p:CleanWhileBuilding=true")
+            MSBUILD_ARGUMENTS+=( "-p:CleanWhileBuilding=true")
             ;;
         --online)
             MSBUILD_ARGUMENTS+=( "-p:BuildWithOnlineSources=true")

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -268,6 +268,9 @@
           DependsOnTargets="BuildRepoReferences"
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(RepoCompletedSemaphorePath)Build.complete">
+
+    <Exec Command="$(DOTNET_HOST_PATH) build-server shutdown" />
+
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Building $(ProjectBuildReason)" />
     <Message Importance="High" Text="Running command:" />
     <Message Importance="High" Text="  $(BuildCommand) $(RepoApiArgs)" Condition="'$(BuildCommand)' != ''" />


### PR DESCRIPTION
Ports the changes from https://github.com/dotnet/installer/pull/15488 to release/8.0.1xx-preview1 branch.

(cherry picked from commit 6b841b4b660324c4a33458310270a8569a84d0ac)