### PR TITLE
Fix emsdk build when RID is autodetected as linux-x64

### DIFF
--- a/src/SourceBuild/content/repo-projects/emsdk.proj
+++ b/src/SourceBuild/content/repo-projects/emsdk.proj
@@ -8,8 +8,8 @@
     <OverrideTargetRid Condition="'$(TargetOS)' == 'Windows_NT'">win-$(Platform)</OverrideTargetRid>
 
     <_platformIndex>$(OverrideTargetRid.LastIndexOf('-'))</_platformIndex>
-    <TargetOS>$(NETCoreSdkRuntimeIdentifier.Substring(0, $(_platformIndex)))</TargetOS>
-    <TargetArch>$(NETCoreSdkPortableRuntimeIdentifier.Substring($(_platformIndex)))</TargetArch>
+    <TargetOS>$(OverrideTargetRid.Substring(0, $(_platformIndex)))</TargetOS>
+    <TargetArch>$(OverrideTargetRid.Substring($(_platformIndex)))</TargetArch>
 
     <BuildCommandArgs>$(StandardSourceBuildArgs)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:PackageRid=$(OverrideTargetRid)</BuildCommandArgs>


### PR DESCRIPTION
Port of https://github.com/dotnet/installer/pull/15393 to 8.0 preview 1

Fixes https://github.com/dotnet/source-build/issues/3238