### PR TITLE
Update source-build prebuilts

### DIFF
--- a/src/SourceBuild/content/eng/Versions.props
+++ b/src/SourceBuild/content/eng/Versions.props
@@ -25,6 +25,6 @@
       necessary, and this property is removed from the file.
     -->
     <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-8.0.100-5.centos.8-x64</PrivateSourceBuiltArtifactsPackageVersion>
-    <PrivateSourceBuiltPrebuiltsPackageVersion>0.1.0-8.0.100-3.centos.8-x64</PrivateSourceBuiltPrebuiltsPackageVersion>
+    <PrivateSourceBuiltPrebuiltsPackageVersion>0.1.0-8.0.100-4.centos.8-x64</PrivateSourceBuiltPrebuiltsPackageVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Removing workload manifest prebuilts from prebuilts tarball.

```
microsoft.net.sdk.android.manifest-7.0.100.33.0.4.nupkg
microsoft.net.sdk.ios.manifest-7.0.100.16.0.1478.nupkg
microsoft.net.sdk.maccatalyst.manifest-7.0.100.15.4.2372.nupkg
microsoft.net.sdk.macos.manifest-7.0.100.12.3.2372.nupkg
microsoft.net.sdk.maui.manifest-7.0.100.7.0.49.nupkg
microsoft.net.sdk.tvos.manifest-7.0.100.16.0.1478.nupkg
microsoft.net.workload.mono.toolchain.current.manifest-8.0.100-preview.1.8.0.0-preview.1.23106.5.nupkg
microsoft.net.workload.mono.toolchain.net6.manifest-8.0.100-preview.1.8.0.0-preview.1.23106.5.nupkg
microsoft.net.workload.mono.toolchain.net7.manifest-8.0.100-preview.1.8.0.0-preview.1.23106.5.nupkg
```

These are being removed with the following PRs:
- https://github.com/dotnet/installer/pull/15501
- https://github.com/dotnet/runtime/pull/81889

This isn't strictly required, but I think it is preferred that we ship the minimum set of required prebuilts.
