### PR TITLE
Suppress already tracked binaries in the VMR scan

### DIFF
--- a/src/VirtualMonoRepo/allowed-binaries.txt
+++ b/src/VirtualMonoRepo/allowed-binaries.txt
@@ -42,9 +42,13 @@ src/msbuild/src/Tasks.UnitTests/*
 src/razor/**/SampleApp/**/fonts/*
 
 src/roslyn/**/CodeAnalysisTest/*
+src/roslyn/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/Resources/WindowsProxy.winmd # https://github.com/dotnet/roslyn/issues/66718
 
 src/runtime/src/libraries/System.Diagnostics.EventLog/src/Messages/EventLogMessages.res # Icon
+src/runtime/src/libraries/System.Speech/src/*.upsmap # https://github.com/dotnet/runtime/issues/81692
+src/runtime/src/libraries/System.Text.Encoding.CodePages/src/Data/codepages.nlp # https://github.com/dotnet/runtime/issues/81693
 src/runtime/src/mono/wasm/testassets/*
+src/runtime/src/mono/wasm/runtime/do-jit-call.wasm # https://github.com/dotnet/runtime/issues/81691
 src/runtime/src/native/external/brotli/common/dictionary.bin.br
 
 src/sdk/src/Assets/TestProjects/*


### PR DESCRIPTION
This will clear the scan so that we can see if something new pops-up. Most of the flagged binaries will not be need to be addressed but we track all of them already.

https://github.com/dotnet/arcade/issues/12372
