### PR TITLE
Support sync of a single repository into the VMR

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "microsoft.dotnet.darc": {
-      "version": "1.1.0-beta.23107.1",
+      "version": "1.1.0-beta.23116.2",
       "commands": [
         "darc"
       ]

--- a/.devcontainer/vmr-source-build/README.md
+++ b/.devcontainer/vmr-source-build/README.md
@@ -14,6 +14,8 @@ This Codespace can help you debug the source build of .NET. In case you have run
 the VMR which is what the VMR leg in the installer PR build doing. This build takes about 45
 minutes and, after completion, produces an archived .NET SDK in `/workspaces/artifacts/x64/Release`.
 
+## Build the SDK
+
 To build the VMR, run following:
 ```bash
 cd /workspaces/dotnet
@@ -22,6 +24,33 @@ unset RepositoryName
 ```
 
 > Please note that, at this time, the build modifies some of the checked-in sources so it might
-be preferential to rebuild the Codespace between attempts.
+be preferential to rebuild the Codespace between attempts (or reset the working tree changes).
 
 For more details, see the instructions at https://github.com/dotnet/dotnet.
+
+## Synchronize your changes in locally
+
+When debugging the build, you have two options how to test your changes in this environment.
+
+### Making changes to the VMR directly
+
+You can make the changes directly to the local checkout of the VMR at `/workspaces/dotnet`. You
+can then try to build the VMR and see if the change works for you.
+
+### Pull changes into the local VMR
+
+You can also make a fix in the individual source repository (e.g. `dotnet/runtime`) and push the
+fix into a branch (can be in your fork too). Once you have the commit pushed, you can pull this
+version of the repository into the VMR locally.
+
+Let's consider you pushed a commit with SHA `abcdef` into your fork at `github.com/billg/runtime`.
+You can now bring this version of runtime into the local VMR in this Codespace by running:
+
+```bash
+cd /workspaces/installer
+./eng/vmr-sync.sh             \
+  --repository runtime:abcdef \
+  --vmr /workspaces/dotnet    \
+  --tmp /workspaces/tmp       \
+  --remote remote:https://github.com/billg/runtime
+```

--- a/.devcontainer/vmr-source-build/README.md
+++ b/.devcontainer/vmr-source-build/README.md
@@ -52,5 +52,5 @@ cd /workspaces/installer
   --repository runtime:abcdef \
   --vmr /workspaces/dotnet    \
   --tmp /workspaces/tmp       \
-  --remote remote:https://github.com/billg/runtime
+  --remote runtime:https://github.com/billg/runtime
 ```

--- a/.devcontainer/vmr-source-build/README.md
+++ b/.devcontainer/vmr-source-build/README.md
@@ -54,3 +54,8 @@ cd /workspaces/installer
   --tmp /workspaces/tmp       \
   --remote runtime:https://github.com/billg/runtime
 ```
+
+You can now proceed building the VMR in the Codespace using instructions above. You can repeat
+this process and sync a new commit from your fork. Only note that, at this time, Source-Build
+modifies some of the checked-in sources so you'll need to revert the working tree changes
+between attempts.

--- a/.devcontainer/vmr-source-build/README.md
+++ b/.devcontainer/vmr-source-build/README.md
@@ -49,9 +49,9 @@ You can now bring this version of runtime into the local VMR in this Codespace b
 ```bash
 cd /workspaces/installer
 ./eng/vmr-sync.sh             \
-  --repository runtime:abcdef \
   --vmr /workspaces/dotnet    \
   --tmp /workspaces/tmp       \
+  --repository runtime:abcdef \
   --remote runtime:https://github.com/yourfork/runtime
 ```
 

--- a/.devcontainer/vmr-source-build/README.md
+++ b/.devcontainer/vmr-source-build/README.md
@@ -43,7 +43,7 @@ You can also make a fix in the individual source repository (e.g. `dotnet/runtim
 fix into a branch (can be in your fork too). Once you have the commit pushed, you can pull this
 version of the repository into the VMR locally.
 
-Let's consider you pushed a commit with SHA `abcdef` into your fork at `github.com/billg/runtime`.
+Let's consider you pushed a commit with SHA `abcdef` into your fork at `github.com/yourfork/runtime`.
 You can now bring this version of runtime into the local VMR in this Codespace by running:
 
 ```bash
@@ -52,7 +52,7 @@ cd /workspaces/installer
   --repository runtime:abcdef \
   --vmr /workspaces/dotnet    \
   --tmp /workspaces/tmp       \
-  --remote runtime:https://github.com/billg/runtime
+  --remote runtime:https://github.com/yourfork/runtime
 ```
 
 You can now proceed building the VMR in the Codespace using instructions above. You can repeat

--- a/.devcontainer/vmr-source-build/init.sh
+++ b/.devcontainer/vmr-source-build/init.sh
@@ -21,9 +21,11 @@ vmr_branch=$(git log --pretty=format:'%D' HEAD^ | grep 'origin/' | head -n1 | se
 
 pushd "$installer_dir"
   "./eng/vmr-sync.sh"      \
+    --repository "installer:$(git -C "$installer_dir" rev-parse HEAD)" \
     --vmr "$vmr_dir"       \
     --tmp "$tmp_dir"       \
     --branch "$vmr_branch" \
+    --recursive            \
     --debug
 popd
 

--- a/.devcontainer/vmr-source-build/init.sh
+++ b/.devcontainer/vmr-source-build/init.sh
@@ -25,11 +25,9 @@ vmr_branch=$(git -C "$installer_dir" log --pretty=format:'%D' HEAD^ \
 
 pushd "$installer_dir"
   "./eng/vmr-sync.sh"      \
-    --repository "installer:$(git -C "$installer_dir" rev-parse HEAD)" \
     --vmr "$vmr_dir"       \
     --tmp "$tmp_dir"       \
     --branch "$vmr_branch" \
-    --recursive            \
     --debug
 popd
 

--- a/.devcontainer/vmr-source-build/init.sh
+++ b/.devcontainer/vmr-source-build/init.sh
@@ -17,7 +17,11 @@ git -C "$installer_dir" fetch --all --unshallow
 
 # We will try to figure out, which branch is the current (PR) branch based off of
 # We need this to figure out, which VMR branch to use
-vmr_branch=$(git log --pretty=format:'%D' HEAD^ | grep 'origin/' | head -n1 | sed 's@origin/@@' | sed 's@,.*@@')
+vmr_branch=$(git -C "$installer_dir" log --pretty=format:'%D' HEAD^ \
+  | grep 'origin/' \
+  | head -n1 \
+  | sed 's@origin/@@' \
+  | sed 's@,.*@@')
 
 pushd "$installer_dir"
   "./eng/vmr-sync.sh"      \

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -208,13 +208,13 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>c453dfef2f41533de5cb03b2115aab9d0dfc74c6</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Darc" Version="1.1.0-beta.23107.1">
+    <Dependency Name="Microsoft.DotNet.Darc" Version="1.1.0-beta.23116.2">
       <Uri>https://github.com/dotnet/arcade-services</Uri>
-      <Sha>c6f3ec3b751020f757695bcd351b1cbb179e21bd</Sha>
+      <Sha>babaa0d787b3921bae3e97d053f6b73c74e750b0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.DarcLib" Version="1.1.0-beta.23107.1">
+    <Dependency Name="Microsoft.DotNet.DarcLib" Version="1.1.0-beta.23116.2">
       <Uri>https://github.com/dotnet/arcade-services</Uri>
-      <Sha>c6f3ec3b751020f757695bcd351b1cbb179e21bd</Sha>
+      <Sha>babaa0d787b3921bae3e97d053f6b73c74e750b0</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging.Console" Version="8.0.0-alpha.1.22557.12">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,7 +30,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/arcade-services -->
-    <MicrosoftDotNetDarcLibVersion>1.1.0-beta.23107.1</MicrosoftDotNetDarcLibVersion>
+    <MicrosoftDotNetDarcLibVersion>1.1.0-beta.23116.2</MicrosoftDotNetDarcLibVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/winforms -->

--- a/eng/pipelines/templates/steps/vmr-pull-updates.yml
+++ b/eng/pipelines/templates/steps/vmr-pull-updates.yml
@@ -33,7 +33,7 @@ steps:
     --vmr ${{ parameters.vmrPath }}
     --tmp $(Agent.TempDirectory)
     --branch ${{ parameters.vmrBranch }}
-    --repository "${{ parameters.targetRef }}:$(git rev-parse HEAD)"
+    --repository "installer:${{ parameters.targetRef }}"
     --recursive
     --readme-template $(Agent.BuildDirectory)/installer/src/VirtualMonoRepo/README.template.md
     --tpn-template $(Agent.BuildDirectory)/installer/src/VirtualMonoRepo/THIRD-PARTY-NOTICES.template.txt

--- a/eng/pipelines/templates/steps/vmr-pull-updates.yml
+++ b/eng/pipelines/templates/steps/vmr-pull-updates.yml
@@ -33,7 +33,8 @@ steps:
     --vmr ${{ parameters.vmrPath }}
     --tmp $(Agent.TempDirectory)
     --branch ${{ parameters.vmrBranch }}
-    --target-ref ${{ parameters.targetRef }}
+    --repository "${{ parameters.targetRef }}:$(git rev-parse HEAD)"
+    --recursive
     --readme-template $(Agent.BuildDirectory)/installer/src/VirtualMonoRepo/README.template.md
     --tpn-template $(Agent.BuildDirectory)/installer/src/VirtualMonoRepo/THIRD-PARTY-NOTICES.template.txt
     --debug

--- a/eng/vmr-sync.sh
+++ b/eng/vmr-sync.sh
@@ -207,12 +207,12 @@ highlight "Starting the synchronization to '$repository'.."
 set +e
 
 if [[ "$recursive" == "true" ]]; then
-  additional_mappings+=("--recursive")
+  additional_remotes+=("--recursive")
 fi
 
 # Synchronize the VMR
 
-if "$dotnet" darc vmr update --vmr "$vmr_dir" --tmp "$tmp_dir" --$verbosity --readme-template "$readme_template" --tpn-template "$tpn_template" "${additional_mappings[@]}" "$repository"; then
+if "$dotnet" darc vmr update --vmr "$vmr_dir" --tmp "$tmp_dir" --$verbosity --readme-template "$readme_template" --tpn-template "$tpn_template" "${additional_remotes[@]}" "$repository"; then
   highlight "Synchronization succeeded"
 else
   fail "Synchronization of dotnet/dotnet to '$repository' failed!"

--- a/eng/vmr-sync.sh
+++ b/eng/vmr-sync.sh
@@ -80,7 +80,7 @@ vmr_branch='main'
 repository=''
 recursive=false
 verbosity=verbose
-additional_remotes=("--additional-remotes" "installer:$installer_dir")
+additional_remotes="installer:$installer_dir"
 readme_template="$installer_dir/src/VirtualMonoRepo/README.template.md"
 tpn_template="$installer_dir/src/VirtualMonoRepo/THIRD-PARTY-NOTICES.template.txt"
 
@@ -107,7 +107,7 @@ while [[ $# -gt 0 ]]; do
       recursive=true
       ;;
     --remote)
-      additional_remotes+=("--additional-remotes" "$2")
+      additional_remotes="$additional_remotes,$2"
       shift
       ;;
     --readme-template)
@@ -206,13 +206,24 @@ dotnet="$scriptroot/../.dotnet/dotnet"
 highlight "Starting the synchronization to '$repository'.."
 set +e
 
+recursive_arg=''
 if [[ "$recursive" == "true" ]]; then
-  additional_remotes+=("--recursive")
+  recursive_arg="--recursive"
 fi
 
 # Synchronize the VMR
 
-if "$dotnet" darc vmr update --vmr "$vmr_dir" --tmp "$tmp_dir" --$verbosity --readme-template "$readme_template" --tpn-template "$tpn_template" "${additional_remotes[@]}" "$repository"; then
+"$dotnet" darc vmr update                    \
+  --vmr "$vmr_dir"                           \
+  --tmp "$tmp_dir"                           \
+  --$verbosity                               \
+  $recursive_arg                             \
+  --readme-template "$readme_template"       \
+  --tpn-template "$tpn_template"             \
+  --additional-remotes "$additional_remotes" \
+  "$repository"
+
+if [[ $? == 0 ]]; then
   highlight "Synchronization succeeded"
 else
   fail "Synchronization of dotnet/dotnet to '$repository' failed!"

--- a/eng/vmr-sync.sh
+++ b/eng/vmr-sync.sh
@@ -81,6 +81,8 @@ repository=''
 recursive=false
 verbosity=verbose
 additional_remotes=("--additional-remotes" "installer:$installer_dir")
+readme_template="$installer_dir/src/VirtualMonoRepo/README.template.md"
+tpn_template="$installer_dir/src/VirtualMonoRepo/THIRD-PARTY-NOTICES.template.txt"
 
 while [[ $# -gt 0 ]]; do
   opt="$(echo "$1" | tr "[:upper:]" "[:lower:]")"
@@ -162,14 +164,6 @@ fi
 
 # Sanitize the input
 
-if [[ -z "$readme_template" ]]; then
-  readme_template="$installer_dir/src/VirtualMonoRepo/README.template.md"
-fi
-
-if [[ -z "$tpn_template" ]]; then
-  tpn_template="$installer_dir/src/VirtualMonoRepo/THIRD-PARTY-NOTICES.template.txt"
-fi
-
 if [[ -z "$vmr_dir" ]]; then
   vmr_dir="$tmp_dir/dotnet"
 fi
@@ -218,7 +212,7 @@ fi
 
 # Synchronize the VMR
 
-if "$dotnet" darc vmr update --vmr "$vmr_dir" --tmp "$tmp_dir" --$verbosity --readme-template "$readme_template" --tpn-template "$tpn_template" "${additional_mappings[@]}"; then
+if "$dotnet" darc vmr update --vmr "$vmr_dir" --tmp "$tmp_dir" --$verbosity --readme-template "$readme_template" --tpn-template "$tpn_template" "${additional_mappings[@]}" "$repository"; then
   highlight "Synchronization succeeded"
 else
   fail "Synchronization of dotnet/dotnet to '$repository' failed!"

--- a/eng/vmr-sync.sh
+++ b/eng/vmr-sync.sh
@@ -43,6 +43,7 @@
 ###   --recursive
 ###       Optional. Recursively synchronize all the source build dependencies (declared in Version.Details.xml)
 ###       This is used when performing the full synchronization during installer's CI and the final VMR sync.
+###       Defaults to false unless no repository is supplied in which case a recursive sync of installer is performed.
 ###   --readme-template
 ###       Optional. Template for VMRs README.md used for regenerating the file to list the newest versions of
 ###       components.


### PR DESCRIPTION
Adds a useful scenario of pulling in a given commit of a given individual repository when in the Codespace

https://github.com/dotnet/arcade/issues/12101