### PR TITLE
Add cecil to SB repos

### DIFF
--- a/src/SourceBuild/content/repo-projects/cecil.proj
+++ b/src/SourceBuild/content/repo-projects/cecil.proj
@@ -3,8 +3,6 @@
 
   <PropertyGroup>
     <BuildCommand>$(StandardSourceBuildCommand) $(StandardSourceBuildArgs)</BuildCommand>
-    <GlobalJsonFile>$(ProjectDirectory)global.json</GlobalJsonFile>
-    <NuGetConfigFile>$(ProjectDirectory)NuGet.config</NuGetConfigFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SourceBuild/content/repo-projects/cecil.proj
+++ b/src/SourceBuild/content/repo-projects/cecil.proj
@@ -1,0 +1,15 @@
+<Project>
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
+  <PropertyGroup>
+    <BuildCommand>$(StandardSourceBuildCommand) $(StandardSourceBuildArgs)</BuildCommand>
+    <GlobalJsonFile>$(ProjectDirectory)global.json</GlobalJsonFile>
+    <NuGetConfigFile>$(ProjectDirectory)NuGet.config</NuGetConfigFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <RepositoryReference Include="arcade" />
+  </ItemGroup>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+</Project>

--- a/src/SourceBuild/content/repo-projects/runtime.proj
+++ b/src/SourceBuild/content/repo-projects/runtime.proj
@@ -49,6 +49,7 @@
   <!-- Repository References -->
   <ItemGroup>
       <RepositoryReference Include="arcade" />
+      <RepositoryReference Include="cecil" />
       <RepositoryReference Include="symreader" />
       <RepositoryReference Include="source-build-externals" />
   </ItemGroup>


### PR DESCRIPTION
I've confirmed this eliminates the cecil prebuilt.

Fixes dotnet/source-build#3232