### PR TITLE
Revert PVP flow for sourcelink

### DIFF
--- a/src/SourceBuild/content/repo-projects/sourcelink.proj
+++ b/src/SourceBuild/content/repo-projects/sourcelink.proj
@@ -8,8 +8,6 @@
 
     <!-- SourceLink builds before Arcade so it also needs the bootstrap Arcade version -->
     <UseBootstrapArcade>true</UseBootstrapArcade>
-
-    <PackageVersionPropsFlowType>DependenciesOnly</PackageVersionPropsFlowType>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This reverts the portion of commit ee2f220afa045cf23caa080dcf96cda6b556c8b4 from https://github.com/dotnet/installer/pull/15437 that enabled PVP flow for sourcelink. This is because it causes prebuilts to be introduced for the following assemblies: System.Text.Json and System.Reflection.Metadata.

Once https://github.com/dotnet/sourcelink/issues/964 is fixed, then this change can be added back, allowing PVP flow for sourcelink.