### PR TITLE
Update installer table to point to preview 2 instead of 1 as branches have snapped.

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,20 +162,20 @@ Do not directly edit the table below. Use https://github.com/dotnet/installer/tr
 ### Table
 *Note* the 7.0.100 build will be finished internally. Below is the last public version available from that branch but is not fully updated with the final runtime.
 
-| Platform | main<br>(8.0.x&nbsp;Runtime) | 8.0.1xx-preview1<br>(8.0-preview1&nbsp;Runtime) | Release/7.0.3xx<br>(7.0.x&nbsp;Runtime) |
+| Platform | main<br>(8.0.x&nbsp;Runtime) | 8.0.1xx-preview2<br>(8.0-preview2&nbsp;Runtime) | Release/7.0.3xx<br>(7.0.x&nbsp;Runtime) |
 | :--------- | :----------: | :----------: | :----------: |
-| **Windows x64** | [![][win-x64-badge-main]][win-x64-version-main]<br>[Installer][win-x64-installer-main] - [Checksum][win-x64-installer-checksum-main]<br>[zip][win-x64-zip-main] - [Checksum][win-x64-zip-checksum-main] | [![][win-x64-badge-8.0.1XX-preview1]][win-x64-version-8.0.1XX-preview1]<br>[Installer][win-x64-installer-8.0.1XX-preview1] - [Checksum][win-x64-installer-checksum-8.0.1XX-preview1]<br>[zip][win-x64-zip-8.0.1XX-preview1] - [Checksum][win-x64-zip-checksum-8.0.1XX-preview1] | [![][win-x64-badge-7.0.3XX]][win-x64-version-7.0.3XX]<br>[Installer][win-x64-installer-7.0.3XX] - [Checksum][win-x64-installer-checksum-7.0.3XX]<br>[zip][win-x64-zip-7.0.3XX] - [Checksum][win-x64-zip-checksum-7.0.3XX] |
-| **Windows x86** | [![][win-x86-badge-main]][win-x86-version-main]<br>[Installer][win-x86-installer-main] - [Checksum][win-x86-installer-checksum-main]<br>[zip][win-x86-zip-main] - [Checksum][win-x86-zip-checksum-main] | [![][win-x86-badge-8.0.1XX-preview1]][win-x86-version-8.0.1XX-preview1]<br>[Installer][win-x86-installer-8.0.1XX-preview1] - [Checksum][win-x86-installer-checksum-8.0.1XX-preview1]<br>[zip][win-x86-zip-8.0.1XX-preview1] - [Checksum][win-x86-zip-checksum-8.0.1XX-preview1] | [![][win-x86-badge-7.0.3XX]][win-x86-version-7.0.3XX]<br>[Installer][win-x86-installer-7.0.3XX] - [Checksum][win-x86-installer-checksum-7.0.3XX]<br>[zip][win-x86-zip-7.0.3XX] - [Checksum][win-x86-zip-checksum-7.0.3XX] |
+| **Windows x64** | [![][win-x64-badge-main]][win-x64-version-main]<br>[Installer][win-x64-installer-main] - [Checksum][win-x64-installer-checksum-main]<br>[zip][win-x64-zip-main] - [Checksum][win-x64-zip-checksum-main] | [![][win-x64-badge-8.0.1XX-preview2]][win-x64-version-8.0.1XX-preview2]<br>[Installer][win-x64-installer-8.0.1XX-preview2] - [Checksum][win-x64-installer-checksum-8.0.1XX-preview2]<br>[zip][win-x64-zip-8.0.1XX-preview2] - [Checksum][win-x64-zip-checksum-8.0.1XX-preview2] | [![][win-x64-badge-7.0.3XX]][win-x64-version-7.0.3XX]<br>[Installer][win-x64-installer-7.0.3XX] - [Checksum][win-x64-installer-checksum-7.0.3XX]<br>[zip][win-x64-zip-7.0.3XX] - [Checksum][win-x64-zip-checksum-7.0.3XX] |
+| **Windows x86** | [![][win-x86-badge-main]][win-x86-version-main]<br>[Installer][win-x86-installer-main] - [Checksum][win-x86-installer-checksum-main]<br>[zip][win-x86-zip-main] - [Checksum][win-x86-zip-checksum-main] | [![][win-x86-badge-8.0.1XX-preview2]][win-x86-version-8.0.1XX-preview2]<br>[Installer][win-x86-installer-8.0.1XX-preview2] - [Checksum][win-x86-installer-checksum-8.0.1XX-preview2]<br>[zip][win-x86-zip-8.0.1XX-preview2] - [Checksum][win-x86-zip-checksum-8.0.1XX-preview2] | [![][win-x86-badge-7.0.3XX]][win-x86-version-7.0.3XX]<br>[Installer][win-x86-installer-7.0.3XX] - [Checksum][win-x86-installer-checksum-7.0.3XX]<br>[zip][win-x86-zip-7.0.3XX] - [Checksum][win-x86-zip-checksum-7.0.3XX] |
 | **Windows arm** | **N/A** | **N/A** | **N/A** |
-| **Windows arm64** | [![][win-arm64-badge-main]][win-arm64-version-main]<br>[Installer][win-arm64-installer-main] - [Checksum][win-arm64-installer-checksum-main]<br>[zip][win-arm64-zip-main] | [![][win-arm64-badge-8.0.1XX-preview1]][win-arm64-version-8.0.1XX-preview1]<br>[Installer][win-arm64-installer-8.0.1XX-preview1] - [Checksum][win-arm64-installer-checksum-8.0.1XX-preview1]<br>[zip][win-arm64-zip-8.0.1XX-preview1] | [![][win-arm64-badge-7.0.3XX]][win-arm64-version-7.0.3XX]<br>[Installer][win-arm64-installer-7.0.3XX] - [Checksum][win-arm64-installer-checksum-7.0.3XX]<br>[zip][win-arm64-zip-7.0.3XX] |
-| **macOS x64** | [![][osx-x64-badge-main]][osx-x64-version-main]<br>[Installer][osx-x64-installer-main] - [Checksum][osx-x64-installer-checksum-main]<br>[tar.gz][osx-x64-targz-main] - [Checksum][osx-x64-targz-checksum-main] | [![][osx-x64-badge-8.0.1XX-preview1]][osx-x64-version-8.0.1XX-preview1]<br>[Installer][osx-x64-installer-8.0.1XX-preview1] - [Checksum][osx-x64-installer-checksum-8.0.1XX-preview1]<br>[tar.gz][osx-x64-targz-8.0.1XX-preview1] - [Checksum][osx-x64-targz-checksum-8.0.1XX-preview1] | [![][osx-x64-badge-7.0.3XX]][osx-x64-version-7.0.3XX]<br>[Installer][osx-x64-installer-7.0.3XX] - [Checksum][osx-x64-installer-checksum-7.0.3XX]<br>[tar.gz][osx-x64-targz-7.0.3XX] - [Checksum][osx-x64-targz-checksum-7.0.3XX] |
-| **macOS arm64** | [![][osx-arm64-badge-main]][osx-arm64-version-main]<br>[Installer][osx-arm64-installer-main] - [Checksum][osx-arm64-installer-checksum-main]<br>[tar.gz][osx-arm64-targz-main] - [Checksum][osx-arm64-targz-checksum-main] | [![][osx-arm64-badge-8.0.1XX-preview1]][osx-arm64-version-8.0.1XX-preview1]<br>[Installer][osx-arm64-installer-8.0.1XX-preview1] - [Checksum][osx-arm64-installer-checksum-8.0.1XX-preview1]<br>[tar.gz][osx-arm64-targz-8.0.1XX-preview1] - [Checksum][osx-arm64-targz-checksum-8.0.1XX-preview1] | [![][osx-arm64-badge-7.0.3XX]][osx-arm64-version-7.0.3XX]<br>[Installer][osx-arm64-installer-7.0.3XX] - [Checksum][osx-arm64-installer-checksum-7.0.3XX]<br>[tar.gz][osx-arm64-targz-7.0.3XX] - [Checksum][osx-arm64-targz-checksum-7.0.3XX] |
-| **Linux x64** | [![][linux-badge-main]][linux-version-main]<br>[DEB Installer][linux-DEB-installer-main] - [Checksum][linux-DEB-installer-checksum-main]<br>[RPM Installer][linux-RPM-installer-main] - [Checksum][linux-RPM-installer-checksum-main]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-main] - [Checksum][linux-targz-checksum-main] | [![][linux-badge-8.0.1XX-preview1]][linux-version-8.0.1XX-preview1]<br>[DEB Installer][linux-DEB-installer-8.0.1XX-preview1] - [Checksum][linux-DEB-installer-checksum-8.0.1XX-preview1]<br>[RPM Installer][linux-RPM-installer-8.0.1XX-preview1] - [Checksum][linux-RPM-installer-checksum-8.0.1XX-preview1]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-8.0.1XX-preview1] - [Checksum][linux-targz-checksum-8.0.1XX-preview1] | [![][linux-badge-7.0.3XX]][linux-version-7.0.3XX]<br>[DEB Installer][linux-DEB-installer-7.0.3XX] - [Checksum][linux-DEB-installer-checksum-7.0.3XX]<br>[RPM Installer][linux-RPM-installer-7.0.3XX] - [Checksum][linux-RPM-installer-checksum-7.0.3XX]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-7.0.3XX] - [Checksum][linux-targz-checksum-7.0.3XX] |
-| **Linux arm** | [![][linux-arm-badge-main]][linux-arm-version-main]<br>[tar.gz][linux-arm-targz-main] - [Checksum][linux-arm-targz-checksum-main] | [![][linux-arm-badge-8.0.1XX-preview1]][linux-arm-version-8.0.1XX-preview1]<br>[tar.gz][linux-arm-targz-8.0.1XX-preview1] - [Checksum][linux-arm-targz-checksum-8.0.1XX-preview1] | [![][linux-arm-badge-7.0.3XX]][linux-arm-version-7.0.3XX]<br>[tar.gz][linux-arm-targz-7.0.3XX] - [Checksum][linux-arm-targz-checksum-7.0.3XX] |
-| **Linux arm64** | [![][linux-arm64-badge-main]][linux-arm64-version-main]<br>[tar.gz][linux-arm64-targz-main] - [Checksum][linux-arm64-targz-checksum-main] | [![][linux-arm64-badge-8.0.1XX-preview1]][linux-arm64-version-8.0.1XX-preview1]<br>[tar.gz][linux-arm64-targz-8.0.1XX-preview1] - [Checksum][linux-arm64-targz-checksum-8.0.1XX-preview1] | [![][linux-arm64-badge-7.0.3XX]][linux-arm64-version-7.0.3XX]<br>[tar.gz][linux-arm64-targz-7.0.3XX] - [Checksum][linux-arm64-targz-checksum-7.0.3XX] |
-| **Linux-musl-x64** | [![][linux-musl-x64-badge-main]][linux-musl-x64-version-main]<br>[tar.gz][linux-musl-x64-targz-main] - [Checksum][linux-musl-x64-targz-checksum-main] | [![][linux-musl-x64-badge-8.0.1XX-preview1]][linux-musl-x64-version-8.0.1XX-preview1]<br>[tar.gz][linux-musl-x64-targz-8.0.1XX-preview1] - [Checksum][linux-musl-x64-targz-checksum-8.0.1XX-preview1] | [![][linux-musl-x64-badge-7.0.3XX]][linux-musl-x64-version-7.0.3XX]<br>[tar.gz][linux-musl-x64-targz-7.0.3XX] - [Checksum][linux-musl-x64-targz-checksum-7.0.3XX] |
-| **Linux-musl-arm** | [![][linux-musl-arm-badge-main]][linux-musl-arm-version-main]<br>[tar.gz][linux-musl-arm-targz-main] - [Checksum][linux-musl-arm-targz-checksum-main] | [![][linux-musl-arm-badge-8.0.1XX-preview1]][linux-musl-arm-version-8.0.1XX-preview1]<br>[tar.gz][linux-musl-arm-targz-8.0.1XX-preview1] - [Checksum][linux-musl-arm-targz-checksum-8.0.1XX-preview1] | [![][linux-musl-arm-badge-7.0.3XX]][linux-musl-arm-version-7.0.3XX]<br>[tar.gz][linux-musl-arm-targz-7.0.3XX] - [Checksum][linux-musl-arm-targz-checksum-7.0.3XX] |
-| **Linux-musl-arm64** | [![][linux-musl-arm64-badge-main]][linux-musl-arm64-version-main]<br>[tar.gz][linux-musl-arm64-targz-main] - [Checksum][linux-musl-arm64-targz-checksum-main] | [![][linux-musl-arm64-badge-8.0.1XX-preview1]][linux-musl-arm64-version-8.0.1XX-preview1]<br>[tar.gz][linux-musl-arm64-targz-8.0.1XX-preview1] - [Checksum][linux-musl-arm64-targz-checksum-8.0.1XX-preview1] | [![][linux-musl-arm64-badge-7.0.3XX]][linux-musl-arm64-version-7.0.3XX]<br>[tar.gz][linux-musl-arm64-targz-7.0.3XX] - [Checksum][linux-musl-arm64-targz-checksum-7.0.3XX] |
+| **Windows arm64** | [![][win-arm64-badge-main]][win-arm64-version-main]<br>[Installer][win-arm64-installer-main] - [Checksum][win-arm64-installer-checksum-main]<br>[zip][win-arm64-zip-main] | [![][win-arm64-badge-8.0.1XX-preview2]][win-arm64-version-8.0.1XX-preview2]<br>[Installer][win-arm64-installer-8.0.1XX-preview2] - [Checksum][win-arm64-installer-checksum-8.0.1XX-preview2]<br>[zip][win-arm64-zip-8.0.1XX-preview2] | [![][win-arm64-badge-7.0.3XX]][win-arm64-version-7.0.3XX]<br>[Installer][win-arm64-installer-7.0.3XX] - [Checksum][win-arm64-installer-checksum-7.0.3XX]<br>[zip][win-arm64-zip-7.0.3XX] |
+| **macOS x64** | [![][osx-x64-badge-main]][osx-x64-version-main]<br>[Installer][osx-x64-installer-main] - [Checksum][osx-x64-installer-checksum-main]<br>[tar.gz][osx-x64-targz-main] - [Checksum][osx-x64-targz-checksum-main] | [![][osx-x64-badge-8.0.1XX-preview2]][osx-x64-version-8.0.1XX-preview2]<br>[Installer][osx-x64-installer-8.0.1XX-preview2] - [Checksum][osx-x64-installer-checksum-8.0.1XX-preview2]<br>[tar.gz][osx-x64-targz-8.0.1XX-preview2] - [Checksum][osx-x64-targz-checksum-8.0.1XX-preview2] | [![][osx-x64-badge-7.0.3XX]][osx-x64-version-7.0.3XX]<br>[Installer][osx-x64-installer-7.0.3XX] - [Checksum][osx-x64-installer-checksum-7.0.3XX]<br>[tar.gz][osx-x64-targz-7.0.3XX] - [Checksum][osx-x64-targz-checksum-7.0.3XX] |
+| **macOS arm64** | [![][osx-arm64-badge-main]][osx-arm64-version-main]<br>[Installer][osx-arm64-installer-main] - [Checksum][osx-arm64-installer-checksum-main]<br>[tar.gz][osx-arm64-targz-main] - [Checksum][osx-arm64-targz-checksum-main] | [![][osx-arm64-badge-8.0.1XX-preview2]][osx-arm64-version-8.0.1XX-preview2]<br>[Installer][osx-arm64-installer-8.0.1XX-preview2] - [Checksum][osx-arm64-installer-checksum-8.0.1XX-preview2]<br>[tar.gz][osx-arm64-targz-8.0.1XX-preview2] - [Checksum][osx-arm64-targz-checksum-8.0.1XX-preview2] | [![][osx-arm64-badge-7.0.3XX]][osx-arm64-version-7.0.3XX]<br>[Installer][osx-arm64-installer-7.0.3XX] - [Checksum][osx-arm64-installer-checksum-7.0.3XX]<br>[tar.gz][osx-arm64-targz-7.0.3XX] - [Checksum][osx-arm64-targz-checksum-7.0.3XX] |
+| **Linux x64** | [![][linux-badge-main]][linux-version-main]<br>[DEB Installer][linux-DEB-installer-main] - [Checksum][linux-DEB-installer-checksum-main]<br>[RPM Installer][linux-RPM-installer-main] - [Checksum][linux-RPM-installer-checksum-main]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-main] - [Checksum][linux-targz-checksum-main] | [![][linux-badge-8.0.1XX-preview2]][linux-version-8.0.1XX-preview2]<br>[DEB Installer][linux-DEB-installer-8.0.1XX-preview2] - [Checksum][linux-DEB-installer-checksum-8.0.1XX-preview2]<br>[RPM Installer][linux-RPM-installer-8.0.1XX-preview2] - [Checksum][linux-RPM-installer-checksum-8.0.1XX-preview2]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-8.0.1XX-preview2] - [Checksum][linux-targz-checksum-8.0.1XX-preview2] | [![][linux-badge-7.0.3XX]][linux-version-7.0.3XX]<br>[DEB Installer][linux-DEB-installer-7.0.3XX] - [Checksum][linux-DEB-installer-checksum-7.0.3XX]<br>[RPM Installer][linux-RPM-installer-7.0.3XX] - [Checksum][linux-RPM-installer-checksum-7.0.3XX]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-7.0.3XX] - [Checksum][linux-targz-checksum-7.0.3XX] |
+| **Linux arm** | [![][linux-arm-badge-main]][linux-arm-version-main]<br>[tar.gz][linux-arm-targz-main] - [Checksum][linux-arm-targz-checksum-main] | [![][linux-arm-badge-8.0.1XX-preview2]][linux-arm-version-8.0.1XX-preview2]<br>[tar.gz][linux-arm-targz-8.0.1XX-preview2] - [Checksum][linux-arm-targz-checksum-8.0.1XX-preview2] | [![][linux-arm-badge-7.0.3XX]][linux-arm-version-7.0.3XX]<br>[tar.gz][linux-arm-targz-7.0.3XX] - [Checksum][linux-arm-targz-checksum-7.0.3XX] |
+| **Linux arm64** | [![][linux-arm64-badge-main]][linux-arm64-version-main]<br>[tar.gz][linux-arm64-targz-main] - [Checksum][linux-arm64-targz-checksum-main] | [![][linux-arm64-badge-8.0.1XX-preview2]][linux-arm64-version-8.0.1XX-preview2]<br>[tar.gz][linux-arm64-targz-8.0.1XX-preview2] - [Checksum][linux-arm64-targz-checksum-8.0.1XX-preview2] | [![][linux-arm64-badge-7.0.3XX]][linux-arm64-version-7.0.3XX]<br>[tar.gz][linux-arm64-targz-7.0.3XX] - [Checksum][linux-arm64-targz-checksum-7.0.3XX] |
+| **Linux-musl-x64** | [![][linux-musl-x64-badge-main]][linux-musl-x64-version-main]<br>[tar.gz][linux-musl-x64-targz-main] - [Checksum][linux-musl-x64-targz-checksum-main] | [![][linux-musl-x64-badge-8.0.1XX-preview2]][linux-musl-x64-version-8.0.1XX-preview2]<br>[tar.gz][linux-musl-x64-targz-8.0.1XX-preview2] - [Checksum][linux-musl-x64-targz-checksum-8.0.1XX-preview2] | [![][linux-musl-x64-badge-7.0.3XX]][linux-musl-x64-version-7.0.3XX]<br>[tar.gz][linux-musl-x64-targz-7.0.3XX] - [Checksum][linux-musl-x64-targz-checksum-7.0.3XX] |
+| **Linux-musl-arm** | [![][linux-musl-arm-badge-main]][linux-musl-arm-version-main]<br>[tar.gz][linux-musl-arm-targz-main] - [Checksum][linux-musl-arm-targz-checksum-main] | [![][linux-musl-arm-badge-8.0.1XX-preview2]][linux-musl-arm-version-8.0.1XX-preview2]<br>[tar.gz][linux-musl-arm-targz-8.0.1XX-preview2] - [Checksum][linux-musl-arm-targz-checksum-8.0.1XX-preview2] | [![][linux-musl-arm-badge-7.0.3XX]][linux-musl-arm-version-7.0.3XX]<br>[tar.gz][linux-musl-arm-targz-7.0.3XX] - [Checksum][linux-musl-arm-targz-checksum-7.0.3XX] |
+| **Linux-musl-arm64** | [![][linux-musl-arm64-badge-main]][linux-musl-arm64-version-main]<br>[tar.gz][linux-musl-arm64-targz-main] - [Checksum][linux-musl-arm64-targz-checksum-main] | [![][linux-musl-arm64-badge-8.0.1XX-preview2]][linux-musl-arm64-version-8.0.1XX-preview2]<br>[tar.gz][linux-musl-arm64-targz-8.0.1XX-preview2] - [Checksum][linux-musl-arm64-targz-checksum-8.0.1XX-preview2] | [![][linux-musl-arm64-badge-7.0.3XX]][linux-musl-arm64-version-7.0.3XX]<br>[tar.gz][linux-musl-arm64-targz-7.0.3XX] - [Checksum][linux-musl-arm64-targz-checksum-7.0.3XX] |
 | **RHEL 6** | **N/A** | **N/A** | **N/A** |
 
 Reference notes:
@@ -192,12 +192,12 @@ Reference notes:
 [win-x64-zip-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-win-x64.zip
 [win-x64-zip-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-win-x64.zip.sha
 
-[win-x64-badge-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/win_x64_Release_version_badge.svg?no-cache
-[win-x64-version-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/productCommit-win-x64.txt
-[win-x64-installer-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-win-x64.exe
-[win-x64-installer-checksum-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-win-x64.exe.sha
-[win-x64-zip-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-win-x64.zip
-[win-x64-zip-checksum-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-win-x64.zip.sha
+[win-x64-badge-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/win_x64_Release_version_badge.svg?no-cache
+[win-x64-version-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/productCommit-win-x64.txt
+[win-x64-installer-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-win-x64.exe
+[win-x64-installer-checksum-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-win-x64.exe.sha
+[win-x64-zip-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-win-x64.zip
+[win-x64-zip-checksum-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-win-x64.zip.sha
 
 [win-x64-badge-7.0.3XX]: https://aka.ms/dotnet/7.0.3xx/daily/win_x64_Release_version_badge.svg?no-cache
 [win-x64-version-7.0.3XX]: https://aka.ms/dotnet/7.0.3xx/daily/productCommit-win-x64.txt
@@ -213,12 +213,12 @@ Reference notes:
 [win-x86-zip-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-win-x86.zip
 [win-x86-zip-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-win-x86.zip.sha
 
-[win-x86-badge-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/win_x86_Release_version_badge.svg?no-cache
-[win-x86-version-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/productCommit-win-x86.txt
-[win-x86-installer-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-win-x86.exe
-[win-x86-installer-checksum-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-win-x86.exe.sha
-[win-x86-zip-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-win-x86.zip
-[win-x86-zip-checksum-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-win-x86.zip.sha
+[win-x86-badge-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/win_x86_Release_version_badge.svg?no-cache
+[win-x86-version-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/productCommit-win-x86.txt
+[win-x86-installer-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-win-x86.exe
+[win-x86-installer-checksum-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-win-x86.exe.sha
+[win-x86-zip-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-win-x86.zip
+[win-x86-zip-checksum-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-win-x86.zip.sha
 
 [win-x86-badge-7.0.3XX]: https://aka.ms/dotnet/7.0.3xx/daily/win_x86_Release_version_badge.svg?no-cache
 [win-x86-version-7.0.3XX]: https://aka.ms/dotnet/7.0.3xx/daily/productCommit-win-x86.txt
@@ -234,12 +234,12 @@ Reference notes:
 [osx-x64-targz-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-osx-x64.tar.gz
 [osx-x64-targz-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-osx-x64.pkg.tar.gz.sha
 
-[osx-x64-badge-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/osx_x64_Release_version_badge.svg?no-cache
-[osx-x64-version-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/productCommit-osx-x64.txt
-[osx-x64-installer-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-osx-x64.pkg
-[osx-x64-installer-checksum-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-osx-x64.pkg.sha
-[osx-x64-targz-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-osx-x64.tar.gz
-[osx-x64-targz-checksum-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-osx-x64.pkg.tar.gz.sha
+[osx-x64-badge-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/osx_x64_Release_version_badge.svg?no-cache
+[osx-x64-version-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/productCommit-osx-x64.txt
+[osx-x64-installer-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-osx-x64.pkg
+[osx-x64-installer-checksum-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-osx-x64.pkg.sha
+[osx-x64-targz-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-osx-x64.tar.gz
+[osx-x64-targz-checksum-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-osx-x64.pkg.tar.gz.sha
 
 [osx-x64-badge-7.0.3XX]: https://aka.ms/dotnet/7.0.3xx/daily/osx_x64_Release_version_badge.svg?no-cache
 [osx-x64-version-7.0.3XX]: https://aka.ms/dotnet/7.0.3xx/daily/productCommit-osx-x64.txt
@@ -255,12 +255,12 @@ Reference notes:
 [osx-arm64-targz-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-osx-arm64.tar.gz
 [osx-arm64-targz-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-osx-arm64.pkg.tar.gz.sha
 
-[osx-arm64-badge-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/osx_arm64_Release_version_badge.svg?no-cache
-[osx-arm64-version-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/productCommit-osx-arm64.txt
-[osx-arm64-installer-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-osx-arm64.pkg
-[osx-arm64-installer-checksum-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-osx-arm64.pkg.sha
-[osx-arm64-targz-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-osx-arm64.tar.gz
-[osx-arm64-targz-checksum-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-osx-arm64.pkg.tar.gz.sha
+[osx-arm64-badge-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/osx_arm64_Release_version_badge.svg?no-cache
+[osx-arm64-version-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/productCommit-osx-arm64.txt
+[osx-arm64-installer-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-osx-arm64.pkg
+[osx-arm64-installer-checksum-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-osx-arm64.pkg.sha
+[osx-arm64-targz-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-osx-arm64.tar.gz
+[osx-arm64-targz-checksum-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-osx-arm64.pkg.tar.gz.sha
 
 [osx-arm64-badge-7.0.3XX]: https://aka.ms/dotnet/7.0.3xx/daily/osx_arm64_Release_version_badge.svg?no-cache
 [osx-arm64-version-7.0.3XX]: https://aka.ms/dotnet/7.0.3xx/daily/productCommit-osx-arm64.txt
@@ -278,14 +278,14 @@ Reference notes:
 [linux-targz-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-linux-x64.tar.gz
 [linux-targz-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-linux-x64.tar.gz.sha
 
-[linux-badge-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/linux_x64_Release_version_badge.svg?no-cache
-[linux-version-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/productCommit-linux-x64.txt
-[linux-DEB-installer-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-x64.deb
-[linux-DEB-installer-checksum-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-x64.deb.sha
-[linux-RPM-installer-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-x64.rpm
-[linux-RPM-installer-checksum-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-x64.rpm.sha
-[linux-targz-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-linux-x64.tar.gz
-[linux-targz-checksum-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-linux-x64.tar.gz.sha
+[linux-badge-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/linux_x64_Release_version_badge.svg?no-cache
+[linux-version-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/productCommit-linux-x64.txt
+[linux-DEB-installer-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-x64.deb
+[linux-DEB-installer-checksum-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-x64.deb.sha
+[linux-RPM-installer-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-x64.rpm
+[linux-RPM-installer-checksum-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-x64.rpm.sha
+[linux-targz-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-linux-x64.tar.gz
+[linux-targz-checksum-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-linux-x64.tar.gz.sha
 
 [linux-badge-7.0.3XX]: https://aka.ms/dotnet/7.0.3xx/daily/linux_x64_Release_version_badge.svg?no-cache
 [linux-version-7.0.3XX]: https://aka.ms/dotnet/7.0.3xx/daily/productCommit-linux-x64.txt
@@ -301,10 +301,10 @@ Reference notes:
 [linux-arm-targz-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-linux-arm.tar.gz
 [linux-arm-targz-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-linux-arm.tar.gz.sha
 
-[linux-arm-badge-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/linux_arm_Release_version_badge.svg?no-cache
-[linux-arm-version-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/productCommit-linux-arm.txt
-[linux-arm-targz-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-linux-arm.tar.gz
-[linux-arm-targz-checksum-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-linux-arm.tar.gz.sha
+[linux-arm-badge-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/linux_arm_Release_version_badge.svg?no-cache
+[linux-arm-version-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/productCommit-linux-arm.txt
+[linux-arm-targz-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-linux-arm.tar.gz
+[linux-arm-targz-checksum-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-linux-arm.tar.gz.sha
 
 [linux-arm-badge-7.0.3XX]: https://aka.ms/dotnet/7.0.3xx/daily/linux_arm_Release_version_badge.svg?no-cache
 [linux-arm-version-7.0.3XX]: https://aka.ms/dotnet/7.0.3xx/daily/productCommit-linux-arm.txt
@@ -316,10 +316,10 @@ Reference notes:
 [linux-arm64-targz-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-linux-arm64.tar.gz
 [linux-arm64-targz-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-linux-arm64.tar.gz.sha
 
-[linux-arm64-badge-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/linux_arm64_Release_version_badge.svg?no-cache
-[linux-arm64-version-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/productCommit-linux-arm64.txt
-[linux-arm64-targz-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-linux-arm64.tar.gz
-[linux-arm64-targz-checksum-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-linux-arm64.tar.gz.sha
+[linux-arm64-badge-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/linux_arm64_Release_version_badge.svg?no-cache
+[linux-arm64-version-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/productCommit-linux-arm64.txt
+[linux-arm64-targz-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-linux-arm64.tar.gz
+[linux-arm64-targz-checksum-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-linux-arm64.tar.gz.sha
 
 [linux-arm64-badge-7.0.3XX]: https://aka.ms/dotnet/7.0.3xx/daily/linux_arm64_Release_version_badge.svg?no-cache
 [linux-arm64-version-7.0.3XX]: https://aka.ms/dotnet/7.0.3xx/daily/productCommit-linux-arm64.txt
@@ -331,10 +331,10 @@ Reference notes:
 [rhel-6-targz-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-rhel.6-x64.tar.gz
 [rhel-6-targz-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-rhel.6-x64.tar.gz.sha
 
-[rhel-6-badge-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/rhel.6_x64_Release_version_badge.svg?no-cache
-[rhel-6-version-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/productCommit-rhel.6-x64.txt
-[rhel-6-targz-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-rhel.6-x64.tar.gz
-[rhel-6-targz-checksum-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-rhel.6-x64.tar.gz.sha
+[rhel-6-badge-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/rhel.6_x64_Release_version_badge.svg?no-cache
+[rhel-6-version-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/productCommit-rhel.6-x64.txt
+[rhel-6-targz-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-rhel.6-x64.tar.gz
+[rhel-6-targz-checksum-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-rhel.6-x64.tar.gz.sha
 
 [rhel-6-badge-7.0.3XX]: https://aka.ms/dotnet/7.0.3xx/daily/rhel.6_x64_Release_version_badge.svg?no-cache
 [rhel-6-version-7.0.3XX]: https://aka.ms/dotnet/7.0.3xx/daily/productCommit-rhel.6-x64.txt
@@ -346,10 +346,10 @@ Reference notes:
 [linux-musl-x64-targz-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-linux-musl-x64.tar.gz
 [linux-musl-x64-targz-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-linux-musl-x64.tar.gz.sha
 
-[linux-musl-x64-badge-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/linux_musl_x64_Release_version_badge.svg?no-cache
-[linux-musl-x64-version-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/productCommit-linux-musl-x64.txt
-[linux-musl-x64-targz-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-linux-musl-x64.tar.gz
-[linux-musl-x64-targz-checksum-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-linux-musl-x64.tar.gz.sha
+[linux-musl-x64-badge-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/linux_musl_x64_Release_version_badge.svg?no-cache
+[linux-musl-x64-version-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/productCommit-linux-musl-x64.txt
+[linux-musl-x64-targz-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-linux-musl-x64.tar.gz
+[linux-musl-x64-targz-checksum-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-linux-musl-x64.tar.gz.sha
 
 [linux-musl-x64-badge-7.0.3XX]: https://aka.ms/dotnet/7.0.3xx/daily/linux_musl_x64_Release_version_badge.svg?no-cache
 [linux-musl-x64-version-7.0.3XX]: https://aka.ms/dotnet/7.0.3xx/daily/productCommit-linux-musl-x64.txt
@@ -361,10 +361,10 @@ Reference notes:
 [linux-musl-arm-targz-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-linux-musl-arm.tar.gz
 [linux-musl-arm-targz-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-linux-musl-arm.tar.gz.sha
 
-[linux-musl-arm-badge-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/linux_musl_arm_Release_version_badge.svg?no-cache
-[linux-musl-arm-version-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/productCommit-linux-musl-arm.txt
-[linux-musl-arm-targz-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-linux-musl-arm.tar.gz
-[linux-musl-arm-targz-checksum-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-linux-musl-arm.tar.gz.sha
+[linux-musl-arm-badge-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/linux_musl_arm_Release_version_badge.svg?no-cache
+[linux-musl-arm-version-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/productCommit-linux-musl-arm.txt
+[linux-musl-arm-targz-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-linux-musl-arm.tar.gz
+[linux-musl-arm-targz-checksum-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-linux-musl-arm.tar.gz.sha
 
 [linux-musl-arm-badge-7.0.3XX]: https://aka.ms/dotnet/7.0.3xx/daily/linux_musl_arm_Release_version_badge.svg?no-cache
 [linux-musl-arm-version-7.0.3XX]: https://aka.ms/dotnet/7.0.3xx/daily/productCommit-linux-musl-arm.txt
@@ -376,10 +376,10 @@ Reference notes:
 [linux-musl-arm64-targz-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-linux-musl-arm64.tar.gz
 [linux-musl-arm64-targz-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-linux-musl-arm64.tar.gz.sha
 
-[linux-musl-arm64-badge-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/linux_musl_arm64_Release_version_badge.svg?no-cache
-[linux-musl-arm64-version-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/productCommit-linux-musl-arm64.txt
-[linux-musl-arm64-targz-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-linux-musl-arm64.tar.gz
-[linux-musl-arm64-targz-checksum-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-linux-musl-arm64.tar.gz.sha
+[linux-musl-arm64-badge-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/linux_musl_arm64_Release_version_badge.svg?no-cache
+[linux-musl-arm64-version-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/productCommit-linux-musl-arm64.txt
+[linux-musl-arm64-targz-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-linux-musl-arm64.tar.gz
+[linux-musl-arm64-targz-checksum-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-linux-musl-arm64.tar.gz.sha
 
 [linux-musl-arm64-badge-7.0.3XX]: https://aka.ms/dotnet/7.0.3xx/daily/linux_musl_arm64_Release_version_badge.svg?no-cache
 [linux-musl-arm64-version-7.0.3XX]: https://aka.ms/dotnet/7.0.3xx/daily/productCommit-linux-musl-arm64.txt
@@ -391,10 +391,10 @@ Reference notes:
 [win-arm-zip-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-win-arm.zip
 [win-arm-zip-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-win-arm.zip.sha
 
-[win-arm-badge-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/win_arm_Release_version_badge.svg?no-cache
-[win-arm-version-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/productCommit-win-arm.txt
-[win-arm-zip-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-win-arm.zip
-[win-arm-zip-checksum-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-win-arm.zip.sha
+[win-arm-badge-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/win_arm_Release_version_badge.svg?no-cache
+[win-arm-version-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/productCommit-win-arm.txt
+[win-arm-zip-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-win-arm.zip
+[win-arm-zip-checksum-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-win-arm.zip.sha
 
 [win-arm-badge-7.0.3XX]: https://aka.ms/dotnet/7.0.3xx/daily/win_arm_Release_version_badge.svg?no-cache
 [win-arm-version-7.0.3XX]: https://aka.ms/dotnet/7.0.3xx/daily/productCommit-win-arm.txt
@@ -408,12 +408,12 @@ Reference notes:
 [win-arm64-zip-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-win-arm64.zip
 [win-arm64-zip-checksum-main]: https://aka.ms/dotnet/8.0.1xx/daily/dotnet-sdk-win-arm64.zip.sha
 
-[win-arm64-badge-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/win_arm64_Release_version_badge.svg?no-cache
-[win-arm64-version-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/productCommit-win-arm64.txt
-[win-arm64-installer-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-win-arm64.exe
-[win-arm64-installer-checksum-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-win-arm64.exe.sha
-[win-arm64-zip-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-win-arm64.zip
-[win-arm64-zip-checksum-8.0.1XX-preview1]: https://aka.ms/dotnet/8.0.1xx-preview1/daily/dotnet-sdk-win-arm64.zip.sha
+[win-arm64-badge-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/win_arm64_Release_version_badge.svg?no-cache
+[win-arm64-version-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/productCommit-win-arm64.txt
+[win-arm64-installer-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-win-arm64.exe
+[win-arm64-installer-checksum-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-win-arm64.exe.sha
+[win-arm64-zip-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-win-arm64.zip
+[win-arm64-zip-checksum-8.0.1XX-preview2]: https://aka.ms/dotnet/8.0.1xx-preview2/daily/dotnet-sdk-win-arm64.zip.sha
 
 [win-arm64-badge-7.0.3XX]: https://aka.ms/dotnet/7.0.3xx/daily/win_arm64_Release_version_badge.svg?no-cache
 [win-arm64-version-7.0.3XX]: https://aka.ms/dotnet/7.0.3xx/daily/productCommit-win-arm64.txt


### PR DESCRIPTION
~~I'm not sure what needs to be done to create the preview 2 channels, those don't seem to be live yet. That's why this PR is marked as a draft. I assume after an official build this may occur.~~