### PR TITLE
[release/8.0.1xx-preview2] Update dependencies from dotnet/source-build-reference-packages 

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -220,9 +220,9 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>af841c8b33cecc92d74222298f1e45bf7bf3d90a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.23123.2">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.23127.1">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>71ff04ed77c685b62f0b377ccdd4c17b8b6c15e6</Sha>
+      <Sha>9958e1ddf95c820caf386c5524c32b63bb1749be</Sha>
       <SourceBuildTarball RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceLink.GitHub" Version="1.2.0-beta-23121-02" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">


### PR DESCRIPTION
Cherry pick of https://github.com/dotnet/installer/pull/15647 to release/8.0.1xx-preview2.

This is needed to address prebuilts.
