### PR TITLE
Add source-build batches to unblock bootstrap build

### DIFF
--- a/src/SourceBuild/patches/roslyn/0001-Patch-to-prevent-WPF-from-loading.patch
+++ b/src/SourceBuild/patches/roslyn/0001-Patch-to-prevent-WPF-from-loading.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michael Simons <msimons@microsoft.com>
+Date: Wed, 1 Mar 2023 00:59:46 +0000
+Subject: [PATCH] Patch to prevent WPF from loading
+
+Backport: https://github.com/dotnet/source-build/issues/3280
+---
+ src/Tools/IdeBenchmarks/IdeBenchmarks.csproj | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/Tools/IdeBenchmarks/IdeBenchmarks.csproj b/src/Tools/IdeBenchmarks/IdeBenchmarks.csproj
+index cf0e1886b83..2ee6d355401 100644
+--- a/src/Tools/IdeBenchmarks/IdeBenchmarks.csproj
++++ b/src/Tools/IdeBenchmarks/IdeBenchmarks.csproj
+@@ -7,7 +7,7 @@
+     <TargetFramework>net472</TargetFramework>
+     <IsShipping>false</IsShipping>
+     <NoWarn>$(NoWarn),CA2007</NoWarn>
+-    <UseWpf>true</UseWpf>
++    <UseWpf Condition="'$(DotNetBuildFromSource)' != 'true'">true</UseWpf>
+   </PropertyGroup>
+   <ItemGroup>
+     <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />

--- a/src/SourceBuild/patches/runtime/0001-Fix-for-item-based-msbuild-pattern.patch
+++ b/src/SourceBuild/patches/runtime/0001-Fix-for-item-based-msbuild-pattern.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michael Simons <msimons@microsoft.com>
+Date: Wed, 1 Mar 2023 00:08:32 +0000
+Subject: [PATCH] Fix for item-based msbuild pattern
+
+Backport: https://github.com/dotnet/runtime/issues/82795
+---
+ src/tasks/Crossgen2Tasks/Microsoft.NET.CrossGen.targets | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/src/tasks/Crossgen2Tasks/Microsoft.NET.CrossGen.targets b/src/tasks/Crossgen2Tasks/Microsoft.NET.CrossGen.targets
+index 251336540b5..72a3537a5ce 100644
+--- a/src/tasks/Crossgen2Tasks/Microsoft.NET.CrossGen.targets
++++ b/src/tasks/Crossgen2Tasks/Microsoft.NET.CrossGen.targets
+@@ -346,7 +346,13 @@ Copyright (c) .NET Foundation. All rights reserved.
+                             _CreateR2RImages;
+                             _CreateR2RSymbols">
+ 
+-    <AllowEmptyTelemetry EventName="ReadyToRun" EventData="PublishReadyToRunUseCrossgen2=$(PublishReadyToRunUseCrossgen2);Crossgen2PackVersion=%(ResolvedCrossgen2Pack.NuGetPackageVersion);CompileListCount=@(_ReadyToRunCompileList->Count());FailedCount=@(_ReadyToRunCompilationFailures->Count())" />
++    <ItemGroup>
++       <_R2RCrossgenTelemetry Include="PublishReadyToRunUseCrossgen2" Value="$(PublishReadyToRunUseCrossgen2)" />
++       <_R2RCrossgenTelemetry Include="Crossgen2PackVersion" Value="%(ResolvedCrossgen2Pack.NuGetPackageVersion)" />
++       <_R2RCrossgenTelemetry Include="CompileListCount" Value="@(_ReadyToRunCompileList->Count())" />
++       <_R2RCrossgenTelemetry Include="FailedCount" Value="@(_ReadyToRunCompilationFailures->Count())" />
++    </ItemGroup>
++    <AllowEmptyTelemetry EventName="ReadyToRun" EventData="@(_R2RCrossgenTelemetry)" />
+ 
+     <NETSdkError Condition="'@(_ReadyToRunCompilationFailures)' != ''" ResourceName="ReadyToRunCompilationFailed" />
+ 

--- a/src/SourceBuild/patches/sdk/0001-Update-BroswerRefresh-TFM.patch
+++ b/src/SourceBuild/patches/sdk/0001-Update-BroswerRefresh-TFM.patch
@@ -3,20 +3,20 @@ From: Michael Simons <msimons@microsoft.com>
 Date: Wed, 1 Mar 2023 01:12:26 +0000
 Subject: [PATCH] Update BroswerRefresh TFM
 
-Backport: https://github.com/dotnet/sdk/issues/30272
 ---
- .../Microsoft.AspNetCore.Watch.BrowserRefresh.csproj             | 1 +
- 1 file changed, 1 insertion(+)
+ .../Microsoft.AspNetCore.Watch.BrowserRefresh.csproj            | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/BuiltInTools/BrowserRefresh/Microsoft.AspNetCore.Watch.BrowserRefresh.csproj b/src/BuiltInTools/BrowserRefresh/Microsoft.AspNetCore.Watch.BrowserRefresh.csproj
-index fc35c0ec3d..63a380855a 100644
+index fc35c0ec3d..6e429eb963 100644
 --- a/src/BuiltInTools/BrowserRefresh/Microsoft.AspNetCore.Watch.BrowserRefresh.csproj
 +++ b/src/BuiltInTools/BrowserRefresh/Microsoft.AspNetCore.Watch.BrowserRefresh.csproj
-@@ -2,6 +2,7 @@
+@@ -1,7 +1,7 @@
+ ﻿<Project Sdk="Microsoft.NET.Sdk">
    <PropertyGroup>
      <!-- Intentionally pinned. This feature is supported in projects targeting 6.0 or newer.-->
-     <TargetFramework>net6.0</TargetFramework>
-+    <TargetFramework Condition="'$(DotNetBuildFromSource)' == 'true'">$(NetCurrent)</TargetFramework>
+-    <TargetFramework>net6.0</TargetFramework>
++    <TargetFramework>net8.0</TargetFramework>
      <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
  
      <IsPackable>false</IsPackable>

--- a/src/SourceBuild/patches/sdk/0001-Update-BroswerRefresh-TFM.patch
+++ b/src/SourceBuild/patches/sdk/0001-Update-BroswerRefresh-TFM.patch
@@ -16,7 +16,7 @@ index fc35c0ec3d..63a380855a 100644
    <PropertyGroup>
      <!-- Intentionally pinned. This feature is supported in projects targeting 6.0 or newer.-->
      <TargetFramework>net6.0</TargetFramework>
-+    <TargetFramework Condition="'$(DotNetBuildFromSource)' != 'true'">$(NetCurrent)</TargetFramework>
++    <TargetFramework Condition="'$(DotNetBuildFromSource)' == 'true'">$(NetCurrent)</TargetFramework>
      <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
  
      <IsPackable>false</IsPackable>

--- a/src/SourceBuild/patches/sdk/0001-Update-BroswerRefresh-TFM.patch
+++ b/src/SourceBuild/patches/sdk/0001-Update-BroswerRefresh-TFM.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michael Simons <msimons@microsoft.com>
+Date: Wed, 1 Mar 2023 01:12:26 +0000
+Subject: [PATCH] Update BroswerRefresh TFM
+
+Backport: https://github.com/dotnet/sdk/issues/30272
+---
+ .../Microsoft.AspNetCore.Watch.BrowserRefresh.csproj             | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/BuiltInTools/BrowserRefresh/Microsoft.AspNetCore.Watch.BrowserRefresh.csproj b/src/BuiltInTools/BrowserRefresh/Microsoft.AspNetCore.Watch.BrowserRefresh.csproj
+index fc35c0ec3d..63a380855a 100644
+--- a/src/BuiltInTools/BrowserRefresh/Microsoft.AspNetCore.Watch.BrowserRefresh.csproj
++++ b/src/BuiltInTools/BrowserRefresh/Microsoft.AspNetCore.Watch.BrowserRefresh.csproj
+@@ -2,6 +2,7 @@
+   <PropertyGroup>
+     <!-- Intentionally pinned. This feature is supported in projects targeting 6.0 or newer.-->
+     <TargetFramework>net6.0</TargetFramework>
++    <TargetFramework Condition="'$(DotNetBuildFromSource)' != 'true'">$(NetCurrent)</TargetFramework>
+     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
+ 
+     <IsPackable>false</IsPackable>


### PR DESCRIPTION
Adding patch to address https://github.com/dotnet/runtime/issues/82795 and unblock source-build.
