### PR TITLE
Enable trimming for the installer repo

### DIFF
--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -116,6 +116,10 @@
     <EnvironmentVariables Include="CheckEolTargetFramework=false" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TrimTargetFrameworks)' == 'true'">
+    <EnvironmentVariables Include="DotNetTargetFrameworkFilter=netcoreapp3.1%3bnet6.0%3bnet7.0%3bnet8.0" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(EnableExtraDebugging)' == 'true'">
     <!-- If MSBuild exits early, make sure debug output like 'MSBuild_*.failure.txt' ends up in a place we can see it. -->
     <EnvironmentVariables Include="MSBUILDDEBUGPATH=$(MSBuildDebugPathTargetDir)" />

--- a/src/SourceBuild/content/repo-projects/installer.proj
+++ b/src/SourceBuild/content/repo-projects/installer.proj
@@ -16,6 +16,8 @@
     <_platformIndex>$(NETCoreSdkPortableRuntimeIdentifier.LastIndexOf('-'))</_platformIndex>
     <PortableOS>$(NETCoreSdkPortableRuntimeIdentifier.Substring(0, $(_platformIndex)))</PortableOS>
 
+    <TrimTargetFrameworks>true</TrimTargetFrameworks>
+
     <RuntimeArg>--runtime-id $(OverrideTargetRid)</RuntimeArg>
 
     <BuildCommandArgs>$(StandardSourceBuildArgs)</BuildCommandArgs>


### PR DESCRIPTION
This enables trimming for the installer repo. I don't believe this makes any actual build differences in this repo given the limited number of projects and existing conditionalization.

I am going to be enabling this in the arcade inner build infra, but I want to unblock the work to work through more trimming issues in the meantime.