### PR TITLE
[release/6.0.1xx] SDK diff exclusions - backport

### DIFF
--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SdkContentTests.cs
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SdkContentTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Enumeration;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Xunit.Abstractions;
@@ -27,16 +28,15 @@ public class SdkContentTests : SmokeTests
     {
         const string msftFileListingFileName = "msftSdkFiles.txt";
         const string sbFileListingFileName = "sbSdkFiles.txt";
-        WriteTarballFileList(Config.MsftSdkTarballPath, msftFileListingFileName, isPortable: true);
-        WriteTarballFileList(Config.SdkTarballPath, sbFileListingFileName, isPortable: false);
+        WriteTarballFileList(Config.MsftSdkTarballPath, msftFileListingFileName, isPortable: true, "msft");
+        WriteTarballFileList(Config.SdkTarballPath, sbFileListingFileName, isPortable: false, "sb");
 
         string diff = BaselineHelper.DiffFiles(msftFileListingFileName, sbFileListingFileName, OutputHelper);
-        diff = BaselineHelper.RemoveVersions(diff);
         diff = RemoveDiffMarkers(diff);
         BaselineHelper.CompareContents("MsftToSbSdk.diff", diff, OutputHelper, Config.WarnOnSdkContentDiffs);
     }
 
-    private void WriteTarballFileList(string? tarballPath, string outputFileName, bool isPortable)
+    private void WriteTarballFileList(string? tarballPath, string outputFileName, bool isPortable, string sdkType)
     {
         if (!File.Exists(tarballPath))
         {
@@ -45,10 +45,33 @@ public class SdkContentTests : SmokeTests
 
         string fileListing = ExecuteHelper.ExecuteProcessValidateExitCode("tar", $"tf {tarballPath}", OutputHelper);
         fileListing = BaselineHelper.RemoveRids(fileListing, isPortable);
+        fileListing = BaselineHelper.RemoveVersions(fileListing);
         IEnumerable<string> files = fileListing.Split(Environment.NewLine).OrderBy(path => path);
+        files = RemoveExclusions(
+                    files,
+                    GetExclusionFilters(
+                        Path.Combine(BaselineHelper.GetAssetsDirectory(), "SdkDiffExclusions.txt"),
+                        sdkType));
 
         File.WriteAllLines(outputFileName, files);
     }
+
+        private static IEnumerable<string> RemoveExclusions(IEnumerable<string> files, IEnumerable<string> exclusions) =>
+            files.Where(item => !exclusions.Any(p => FileSystemName.MatchesSimpleExpression(p, item)));
+
+        private static IEnumerable<string> GetExclusionFilters(string exclusionsFilePath, string sdkType)
+        {
+            int prefixSkip = sdkType.Length + 1;
+            return File.ReadAllLines(exclusionsFilePath)
+                .Where(line => line.StartsWith(sdkType + ",")) // process only specific sdk exclusions
+                .Select(line =>
+                {
+                    // Ignore comments
+                    var index = line.IndexOf('#');
+                    return index >= 0 ? line[prefixSkip..index].TrimEnd() : line[prefixSkip..];
+                })
+                .ToList();
+        }
 
     private static string RemoveDiffMarkers(string source)
     {

--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkDiffExclusions.txt
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkDiffExclusions.txt
@@ -1,0 +1,33 @@
+# This list is processed using FileSystemName.MatchesSimpleExpression
+#
+# Format
+# {msft|sb},<path> [# comment]
+# msft = Microsoft built SDK
+# sb   = source-built SDK
+#
+# Examples
+# 'folder/*' matches 'folder/' and 'folder/abc'
+# 'folder/?*' matches 'folder/abc' but not 'folder/'
+#
+# We do not want to filter-out folder entries, therefore, we should use: '?*' and not just '*'
+
+msft,./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/?*   # Intentional - source-build includes SDK Publishing package that target latest .NET TFM
+msft,./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/?*   # Intentional - explicitly excluded from source-build
+
+# vstest localization is disabled in Linux builds - https://github.com/microsoft/vstest/issues/4305
+msft,./sdk/x.y.z/*?/Microsoft.CodeCoverage.IO.resources.dll
+msft,./sdk/x.y.z/*?/Microsoft.TestPlatform.*?.resources.dll
+msft,./sdk/x.y.z/*?/Microsoft.VisualStudio.TestPlatform.*?.resources.dll
+msft,./sdk/x.y.z/*?/Test.Utility.resources.dll
+msft,./sdk/x.y.z/*?/vstest.console.resources.dll
+msft,./sdk/x.y.z/Extensions/*?/Microsoft.TestPlatform.*?.resources.dll
+msft,./sdk/x.y.z/Extensions/*?/Microsoft.VisualStudio.TestPlatform.*?.resources.dll
+msft,./sdk/x.y.z/TestHost/*?/*?.resources.dll
+
+# nuget localization is not available for Linux builds - https://github.com/NuGet/Home/issues/12440
+msft,./sdk/x.y.z/*?/NuGet.*?.resources.dll
+msft,./sdk/x.y.z/*?/Microsoft.Build.NuGetSdkResolver.resources.dll
+
+# ILMerge is not supported in Linux builds - excluding the whole NuGet.Build.Tasks.Pack directory, to avoid a noisy diff
+msft,./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/*?
+sb,./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/*?

--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdk.diff
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdk.diff
@@ -45,122 +45,21 @@ index ------------
  ./packs/Microsoft.NETCore.App.Ref/x.y.z/
  ./packs/Microsoft.NETCore.App.Ref/x.y.z/analyzers/
 @@ ------------ @@
- ./sdk/x.y.z/AppHostTemplate/apphost
- ./sdk/x.y.z/cs/
- ./sdk/x.y.z/cs/dotnet.resources.dll
--./sdk/x.y.z/cs/Microsoft.Build.NuGetSdkResolver.resources.dll
- ./sdk/x.y.z/cs/Microsoft.Build.resources.dll
- ./sdk/x.y.z/cs/Microsoft.Build.Tasks.Core.resources.dll
- ./sdk/x.y.z/cs/Microsoft.Build.Utilities.Core.resources.dll
-@@ ------------ @@
  ./sdk/x.y.z/cs/Microsoft.TemplateEngine.Edge.resources.dll
  ./sdk/x.y.z/cs/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
  ./sdk/x.y.z/cs/Microsoft.TemplateSearch.Common.resources.dll
--./sdk/x.y.z/cs/Microsoft.TestPlatform.Build.resources.dll
--./sdk/x.y.z/cs/Microsoft.TestPlatform.CommunicationUtilities.resources.dll
--./sdk/x.y.z/cs/Microsoft.TestPlatform.CoreUtilities.resources.dll
--./sdk/x.y.z/cs/Microsoft.TestPlatform.CrossPlatEngine.resources.dll
--./sdk/x.y.z/cs/Microsoft.TestPlatform.Utilities.resources.dll
--./sdk/x.y.z/cs/Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll
 -./sdk/x.y.z/cs/Microsoft.VisualStudio.Coverage.IO.resources.dll
--./sdk/x.y.z/cs/Microsoft.VisualStudio.TestPlatform.Client.resources.dll
--./sdk/x.y.z/cs/Microsoft.VisualStudio.TestPlatform.Common.resources.dll
--./sdk/x.y.z/cs/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll
  ./sdk/x.y.z/cs/MSBuild.resources.dll
--./sdk/x.y.z/cs/NuGet.Build.Tasks.Console.resources.dll
--./sdk/x.y.z/cs/NuGet.Build.Tasks.resources.dll
--./sdk/x.y.z/cs/NuGet.CommandLine.XPlat.resources.dll
--./sdk/x.y.z/cs/NuGet.Commands.resources.dll
--./sdk/x.y.z/cs/NuGet.Common.resources.dll
--./sdk/x.y.z/cs/NuGet.Configuration.resources.dll
--./sdk/x.y.z/cs/NuGet.Credentials.resources.dll
--./sdk/x.y.z/cs/NuGet.DependencyResolver.Core.resources.dll
--./sdk/x.y.z/cs/NuGet.Frameworks.resources.dll
--./sdk/x.y.z/cs/NuGet.LibraryModel.resources.dll
--./sdk/x.y.z/cs/NuGet.Localization.resources.dll
--./sdk/x.y.z/cs/NuGet.PackageManagement.resources.dll
--./sdk/x.y.z/cs/NuGet.Packaging.Core.resources.dll
--./sdk/x.y.z/cs/NuGet.Packaging.resources.dll
--./sdk/x.y.z/cs/NuGet.ProjectModel.resources.dll
--./sdk/x.y.z/cs/NuGet.Protocol.resources.dll
--./sdk/x.y.z/cs/NuGet.Resolver.resources.dll
--./sdk/x.y.z/cs/NuGet.Versioning.resources.dll
--./sdk/x.y.z/cs/NuGet.VisualStudio.Contracts.resources.dll
  ./sdk/x.y.z/cs/System.CommandLine.resources.dll
--./sdk/x.y.z/cs/vstest.console.resources.dll
  ./sdk/x.y.z/Current/
- ./sdk/x.y.z/Current/Microsoft.Common.CrossTargeting.targets/
- ./sdk/x.y.z/Current/Microsoft.Common.CrossTargeting.targets/ImportAfter/
-@@ ------------ @@
- ./sdk/x.y.z/datacollector.runtimeconfig.json
- ./sdk/x.y.z/de/
- ./sdk/x.y.z/de/dotnet.resources.dll
--./sdk/x.y.z/de/Microsoft.Build.NuGetSdkResolver.resources.dll
- ./sdk/x.y.z/de/Microsoft.Build.resources.dll
- ./sdk/x.y.z/de/Microsoft.Build.Tasks.Core.resources.dll
- ./sdk/x.y.z/de/Microsoft.Build.Utilities.Core.resources.dll
 @@ ------------ @@
  ./sdk/x.y.z/de/Microsoft.TemplateEngine.Edge.resources.dll
  ./sdk/x.y.z/de/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
  ./sdk/x.y.z/de/Microsoft.TemplateSearch.Common.resources.dll
--./sdk/x.y.z/de/Microsoft.TestPlatform.Build.resources.dll
--./sdk/x.y.z/de/Microsoft.TestPlatform.CommunicationUtilities.resources.dll
--./sdk/x.y.z/de/Microsoft.TestPlatform.CoreUtilities.resources.dll
--./sdk/x.y.z/de/Microsoft.TestPlatform.CrossPlatEngine.resources.dll
--./sdk/x.y.z/de/Microsoft.TestPlatform.Utilities.resources.dll
--./sdk/x.y.z/de/Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll
 -./sdk/x.y.z/de/Microsoft.VisualStudio.Coverage.IO.resources.dll
--./sdk/x.y.z/de/Microsoft.VisualStudio.TestPlatform.Client.resources.dll
--./sdk/x.y.z/de/Microsoft.VisualStudio.TestPlatform.Common.resources.dll
--./sdk/x.y.z/de/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll
  ./sdk/x.y.z/de/MSBuild.resources.dll
--./sdk/x.y.z/de/NuGet.Build.Tasks.Console.resources.dll
--./sdk/x.y.z/de/NuGet.Build.Tasks.resources.dll
--./sdk/x.y.z/de/NuGet.CommandLine.XPlat.resources.dll
--./sdk/x.y.z/de/NuGet.Commands.resources.dll
--./sdk/x.y.z/de/NuGet.Common.resources.dll
--./sdk/x.y.z/de/NuGet.Configuration.resources.dll
--./sdk/x.y.z/de/NuGet.Credentials.resources.dll
--./sdk/x.y.z/de/NuGet.DependencyResolver.Core.resources.dll
--./sdk/x.y.z/de/NuGet.Frameworks.resources.dll
--./sdk/x.y.z/de/NuGet.LibraryModel.resources.dll
--./sdk/x.y.z/de/NuGet.Localization.resources.dll
--./sdk/x.y.z/de/NuGet.PackageManagement.resources.dll
--./sdk/x.y.z/de/NuGet.Packaging.Core.resources.dll
--./sdk/x.y.z/de/NuGet.Packaging.resources.dll
--./sdk/x.y.z/de/NuGet.ProjectModel.resources.dll
--./sdk/x.y.z/de/NuGet.Protocol.resources.dll
--./sdk/x.y.z/de/NuGet.Resolver.resources.dll
--./sdk/x.y.z/de/NuGet.Versioning.resources.dll
--./sdk/x.y.z/de/NuGet.VisualStudio.Contracts.resources.dll
  ./sdk/x.y.z/de/System.CommandLine.resources.dll
--./sdk/x.y.z/de/vstest.console.resources.dll
  ./sdk/x.y.z/dotnet-watch.deps.json
- ./sdk/x.y.z/dotnet-watch.runtimeconfig.json
- ./sdk/x.y.z/dotnet.deps.json
-@@ ------------ @@
- ./sdk/x.y.z/dotnet.runtimeconfig.json
- ./sdk/x.y.z/DotnetTools/
- ./sdk/x.y.z/DotnetTools/dotnet-dev-certs/
--./sdk/x.y.z/DotnetTools/dotnet-dev-certs/x.y.z/
--./sdk/x.y.z/DotnetTools/dotnet-dev-certs/x.y.z/tools/
--./sdk/x.y.z/DotnetTools/dotnet-dev-certs/x.y.z/tools/netx.y/
--./sdk/x.y.z/DotnetTools/dotnet-dev-certs/x.y.z/tools/netx.y/any/
--./sdk/x.y.z/DotnetTools/dotnet-dev-certs/x.y.z/tools/netx.y/any/dotnet-dev-certs.deps.json
--./sdk/x.y.z/DotnetTools/dotnet-dev-certs/x.y.z/tools/netx.y/any/dotnet-dev-certs.dll
--./sdk/x.y.z/DotnetTools/dotnet-dev-certs/x.y.z/tools/netx.y/any/dotnet-dev-certs.runtimeconfig.json
--./sdk/x.y.z/DotnetTools/dotnet-dev-certs/x.y.z/tools/netx.y/any/DotnetToolSettings.xml
-+./sdk/x.y.z/DotnetTools/dotnet-dev-certs/x.y.z/
-+./sdk/x.y.z/DotnetTools/dotnet-dev-certs/x.y.z/tools/
-+./sdk/x.y.z/DotnetTools/dotnet-dev-certs/x.y.z/tools/netx.y/
-+./sdk/x.y.z/DotnetTools/dotnet-dev-certs/x.y.z/tools/netx.y/any/
-+./sdk/x.y.z/DotnetTools/dotnet-dev-certs/x.y.z/tools/netx.y/any/dotnet-dev-certs.deps.json
-+./sdk/x.y.z/DotnetTools/dotnet-dev-certs/x.y.z/tools/netx.y/any/dotnet-dev-certs.dll
-+./sdk/x.y.z/DotnetTools/dotnet-dev-certs/x.y.z/tools/netx.y/any/dotnet-dev-certs.runtimeconfig.json
-+./sdk/x.y.z/DotnetTools/dotnet-dev-certs/x.y.z/tools/netx.y/any/DotnetToolSettings.xml
- ./sdk/x.y.z/DotnetTools/dotnet-format/
- ./sdk/x.y.z/DotnetTools/dotnet-format/cs/
- ./sdk/x.y.z/DotnetTools/dotnet-format/cs/dotnet-format.resources.dll
 @@ ------------ @@
  ./sdk/x.y.z/DotnetTools/dotnet-format/ru/Microsoft.CodeAnalysis.Workspaces.MSBuild.resources.dll
  ./sdk/x.y.z/DotnetTools/dotnet-format/ru/Microsoft.CodeAnalysis.Workspaces.resources.dll
@@ -193,49 +92,9 @@ index ------------
  ./sdk/x.y.z/DotnetTools/dotnet-format/tr/dotnet-format.resources.dll
  ./sdk/x.y.z/DotnetTools/dotnet-format/tr/Microsoft.CodeAnalysis.CSharp.Features.resources.dll
 @@ ------------ @@
- ./sdk/x.y.z/DotnetTools/dotnet-format/zh-Hant/Microsoft.CodeAnalysis.Workspaces.resources.dll
- ./sdk/x.y.z/DotnetTools/dotnet-format/zh-Hant/System.CommandLine.resources.dll
- ./sdk/x.y.z/DotnetTools/dotnet-user-secrets/
--./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/
--./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/
--./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/
--./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/
--./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/assets/
--./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/assets/SecretManager.targets
--./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/dotnet-user-secrets.deps.json
--./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/dotnet-user-secrets.dll
--./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/dotnet-user-secrets.runtimeconfig.json
--./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/DotnetToolSettings.xml
--./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/Microsoft.Extensions.Configuration.Abstractions.dll
--./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/Microsoft.Extensions.Configuration.dll
--./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/Microsoft.Extensions.Configuration.FileExtensions.dll
--./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/Microsoft.Extensions.Configuration.Json.dll
--./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/Microsoft.Extensions.Configuration.UserSecrets.dll
--./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/Microsoft.Extensions.FileProviders.Abstractions.dll
--./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/Microsoft.Extensions.FileProviders.Physical.dll
--./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/Microsoft.Extensions.FileSystemGlobbing.dll
--./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/Microsoft.Extensions.Primitives.dll
--./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/Newtonsoft.Json.dll
-+./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/
-+./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/
-+./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/
-+./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/
-+./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/assets/
-+./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/assets/SecretManager.targets
-+./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/dotnet-user-secrets.deps.json
-+./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/dotnet-user-secrets.dll
-+./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/dotnet-user-secrets.runtimeconfig.json
-+./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/DotnetToolSettings.xml
-+./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/Microsoft.Extensions.Configuration.Abstractions.dll
-+./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/Microsoft.Extensions.Configuration.dll
-+./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/Microsoft.Extensions.Configuration.FileExtensions.dll
-+./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/Microsoft.Extensions.Configuration.Json.dll
-+./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/Microsoft.Extensions.Configuration.UserSecrets.dll
-+./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/Microsoft.Extensions.FileProviders.Abstractions.dll
-+./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/Microsoft.Extensions.FileProviders.Physical.dll
-+./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/Microsoft.Extensions.FileSystemGlobbing.dll
-+./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/Microsoft.Extensions.Primitives.dll
-+./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/Newtonsoft.Json.dll
+ ./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/Microsoft.Extensions.FileSystemGlobbing.dll
+ ./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/Microsoft.Extensions.Primitives.dll
+ ./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/Newtonsoft.Json.dll
 +./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/runtimes/
 +./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/runtimes/browser/
 +./sdk/x.y.z/DotnetTools/dotnet-user-secrets/x.y.z/tools/netx.y/any/runtimes/browser/lib/
@@ -277,92 +136,20 @@ index ------------
  ./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/tr/dotnet-watch.resources.dll
  ./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/tr/Microsoft.CodeAnalysis.CSharp.Features.resources.dll
 @@ ------------ @@
- ./sdk/x.y.z/DotNetWatch.targets
- ./sdk/x.y.z/es/
- ./sdk/x.y.z/es/dotnet.resources.dll
--./sdk/x.y.z/es/Microsoft.Build.NuGetSdkResolver.resources.dll
- ./sdk/x.y.z/es/Microsoft.Build.resources.dll
- ./sdk/x.y.z/es/Microsoft.Build.Tasks.Core.resources.dll
- ./sdk/x.y.z/es/Microsoft.Build.Utilities.Core.resources.dll
-@@ ------------ @@
  ./sdk/x.y.z/es/Microsoft.TemplateEngine.Edge.resources.dll
  ./sdk/x.y.z/es/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
  ./sdk/x.y.z/es/Microsoft.TemplateSearch.Common.resources.dll
--./sdk/x.y.z/es/Microsoft.TestPlatform.Build.resources.dll
--./sdk/x.y.z/es/Microsoft.TestPlatform.CommunicationUtilities.resources.dll
--./sdk/x.y.z/es/Microsoft.TestPlatform.CoreUtilities.resources.dll
--./sdk/x.y.z/es/Microsoft.TestPlatform.CrossPlatEngine.resources.dll
--./sdk/x.y.z/es/Microsoft.TestPlatform.Utilities.resources.dll
--./sdk/x.y.z/es/Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll
 -./sdk/x.y.z/es/Microsoft.VisualStudio.Coverage.IO.resources.dll
--./sdk/x.y.z/es/Microsoft.VisualStudio.TestPlatform.Client.resources.dll
--./sdk/x.y.z/es/Microsoft.VisualStudio.TestPlatform.Common.resources.dll
--./sdk/x.y.z/es/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll
  ./sdk/x.y.z/es/MSBuild.resources.dll
--./sdk/x.y.z/es/NuGet.Build.Tasks.Console.resources.dll
--./sdk/x.y.z/es/NuGet.Build.Tasks.resources.dll
--./sdk/x.y.z/es/NuGet.CommandLine.XPlat.resources.dll
--./sdk/x.y.z/es/NuGet.Commands.resources.dll
--./sdk/x.y.z/es/NuGet.Common.resources.dll
--./sdk/x.y.z/es/NuGet.Configuration.resources.dll
--./sdk/x.y.z/es/NuGet.Credentials.resources.dll
--./sdk/x.y.z/es/NuGet.DependencyResolver.Core.resources.dll
--./sdk/x.y.z/es/NuGet.Frameworks.resources.dll
--./sdk/x.y.z/es/NuGet.LibraryModel.resources.dll
--./sdk/x.y.z/es/NuGet.Localization.resources.dll
--./sdk/x.y.z/es/NuGet.PackageManagement.resources.dll
--./sdk/x.y.z/es/NuGet.Packaging.Core.resources.dll
--./sdk/x.y.z/es/NuGet.Packaging.resources.dll
--./sdk/x.y.z/es/NuGet.ProjectModel.resources.dll
--./sdk/x.y.z/es/NuGet.Protocol.resources.dll
--./sdk/x.y.z/es/NuGet.Resolver.resources.dll
--./sdk/x.y.z/es/NuGet.Versioning.resources.dll
--./sdk/x.y.z/es/NuGet.VisualStudio.Contracts.resources.dll
  ./sdk/x.y.z/es/System.CommandLine.resources.dll
--./sdk/x.y.z/es/vstest.console.resources.dll
  ./sdk/x.y.z/Extensions/
 -./sdk/x.y.z/Extensions/cs/
--./sdk/x.y.z/Extensions/cs/Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll
--./sdk/x.y.z/Extensions/cs/Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll
--./sdk/x.y.z/Extensions/cs/Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll
--./sdk/x.y.z/Extensions/cs/Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll
--./sdk/x.y.z/Extensions/cs/Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll
 -./sdk/x.y.z/Extensions/de/
--./sdk/x.y.z/Extensions/de/Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll
--./sdk/x.y.z/Extensions/de/Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll
--./sdk/x.y.z/Extensions/de/Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll
--./sdk/x.y.z/Extensions/de/Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll
--./sdk/x.y.z/Extensions/de/Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll
 -./sdk/x.y.z/Extensions/es/
--./sdk/x.y.z/Extensions/es/Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll
--./sdk/x.y.z/Extensions/es/Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll
--./sdk/x.y.z/Extensions/es/Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll
--./sdk/x.y.z/Extensions/es/Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll
--./sdk/x.y.z/Extensions/es/Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll
 -./sdk/x.y.z/Extensions/fr/
--./sdk/x.y.z/Extensions/fr/Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll
--./sdk/x.y.z/Extensions/fr/Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll
--./sdk/x.y.z/Extensions/fr/Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll
--./sdk/x.y.z/Extensions/fr/Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll
--./sdk/x.y.z/Extensions/fr/Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll
 -./sdk/x.y.z/Extensions/it/
--./sdk/x.y.z/Extensions/it/Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll
--./sdk/x.y.z/Extensions/it/Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll
--./sdk/x.y.z/Extensions/it/Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll
--./sdk/x.y.z/Extensions/it/Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll
--./sdk/x.y.z/Extensions/it/Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll
 -./sdk/x.y.z/Extensions/ja/
--./sdk/x.y.z/Extensions/ja/Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll
--./sdk/x.y.z/Extensions/ja/Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll
--./sdk/x.y.z/Extensions/ja/Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll
--./sdk/x.y.z/Extensions/ja/Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll
--./sdk/x.y.z/Extensions/ja/Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll
 -./sdk/x.y.z/Extensions/ko/
--./sdk/x.y.z/Extensions/ko/Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll
--./sdk/x.y.z/Extensions/ko/Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll
--./sdk/x.y.z/Extensions/ko/Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll
--./sdk/x.y.z/Extensions/ko/Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll
--./sdk/x.y.z/Extensions/ko/Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll
 -./sdk/x.y.z/Extensions/Microsoft.Diagnostics.NETCore.Client.dll
  ./sdk/x.y.z/Extensions/Microsoft.TestPlatform.Extensions.BlameDataCollector.dll
  ./sdk/x.y.z/Extensions/Microsoft.TestPlatform.Extensions.EventLogCollector.dll
@@ -370,86 +157,22 @@ index ------------
  ./sdk/x.y.z/Extensions/Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.dll
  ./sdk/x.y.z/Extensions/Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.dll
 -./sdk/x.y.z/Extensions/pl/
--./sdk/x.y.z/Extensions/pl/Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll
--./sdk/x.y.z/Extensions/pl/Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll
--./sdk/x.y.z/Extensions/pl/Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll
--./sdk/x.y.z/Extensions/pl/Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll
--./sdk/x.y.z/Extensions/pl/Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll
 -./sdk/x.y.z/Extensions/pt-BR/
--./sdk/x.y.z/Extensions/pt-BR/Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll
--./sdk/x.y.z/Extensions/pt-BR/Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll
--./sdk/x.y.z/Extensions/pt-BR/Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll
--./sdk/x.y.z/Extensions/pt-BR/Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll
--./sdk/x.y.z/Extensions/pt-BR/Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll
 -./sdk/x.y.z/Extensions/ru/
--./sdk/x.y.z/Extensions/ru/Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll
--./sdk/x.y.z/Extensions/ru/Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll
--./sdk/x.y.z/Extensions/ru/Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll
--./sdk/x.y.z/Extensions/ru/Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll
--./sdk/x.y.z/Extensions/ru/Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll
 -./sdk/x.y.z/Extensions/tr/
--./sdk/x.y.z/Extensions/tr/Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll
--./sdk/x.y.z/Extensions/tr/Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll
--./sdk/x.y.z/Extensions/tr/Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll
--./sdk/x.y.z/Extensions/tr/Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll
--./sdk/x.y.z/Extensions/tr/Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll
 -./sdk/x.y.z/Extensions/zh-Hans/
--./sdk/x.y.z/Extensions/zh-Hans/Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll
--./sdk/x.y.z/Extensions/zh-Hans/Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll
--./sdk/x.y.z/Extensions/zh-Hans/Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll
--./sdk/x.y.z/Extensions/zh-Hans/Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll
--./sdk/x.y.z/Extensions/zh-Hans/Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll
 -./sdk/x.y.z/Extensions/zh-Hant/
--./sdk/x.y.z/Extensions/zh-Hant/Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll
--./sdk/x.y.z/Extensions/zh-Hant/Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll
--./sdk/x.y.z/Extensions/zh-Hant/Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll
--./sdk/x.y.z/Extensions/zh-Hant/Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll
--./sdk/x.y.z/Extensions/zh-Hant/Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll
  ./sdk/x.y.z/fr/
  ./sdk/x.y.z/fr/dotnet.resources.dll
--./sdk/x.y.z/fr/Microsoft.Build.NuGetSdkResolver.resources.dll
  ./sdk/x.y.z/fr/Microsoft.Build.resources.dll
- ./sdk/x.y.z/fr/Microsoft.Build.Tasks.Core.resources.dll
- ./sdk/x.y.z/fr/Microsoft.Build.Utilities.Core.resources.dll
 @@ ------------ @@
  ./sdk/x.y.z/fr/Microsoft.TemplateEngine.Edge.resources.dll
  ./sdk/x.y.z/fr/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
  ./sdk/x.y.z/fr/Microsoft.TemplateSearch.Common.resources.dll
--./sdk/x.y.z/fr/Microsoft.TestPlatform.Build.resources.dll
--./sdk/x.y.z/fr/Microsoft.TestPlatform.CommunicationUtilities.resources.dll
--./sdk/x.y.z/fr/Microsoft.TestPlatform.CoreUtilities.resources.dll
--./sdk/x.y.z/fr/Microsoft.TestPlatform.CrossPlatEngine.resources.dll
--./sdk/x.y.z/fr/Microsoft.TestPlatform.Utilities.resources.dll
--./sdk/x.y.z/fr/Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll
 -./sdk/x.y.z/fr/Microsoft.VisualStudio.Coverage.IO.resources.dll
--./sdk/x.y.z/fr/Microsoft.VisualStudio.TestPlatform.Client.resources.dll
--./sdk/x.y.z/fr/Microsoft.VisualStudio.TestPlatform.Common.resources.dll
--./sdk/x.y.z/fr/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll
  ./sdk/x.y.z/fr/MSBuild.resources.dll
--./sdk/x.y.z/fr/NuGet.Build.Tasks.Console.resources.dll
--./sdk/x.y.z/fr/NuGet.Build.Tasks.resources.dll
--./sdk/x.y.z/fr/NuGet.CommandLine.XPlat.resources.dll
--./sdk/x.y.z/fr/NuGet.Commands.resources.dll
--./sdk/x.y.z/fr/NuGet.Common.resources.dll
--./sdk/x.y.z/fr/NuGet.Configuration.resources.dll
--./sdk/x.y.z/fr/NuGet.Credentials.resources.dll
--./sdk/x.y.z/fr/NuGet.DependencyResolver.Core.resources.dll
--./sdk/x.y.z/fr/NuGet.Frameworks.resources.dll
--./sdk/x.y.z/fr/NuGet.LibraryModel.resources.dll
--./sdk/x.y.z/fr/NuGet.Localization.resources.dll
--./sdk/x.y.z/fr/NuGet.PackageManagement.resources.dll
--./sdk/x.y.z/fr/NuGet.Packaging.Core.resources.dll
--./sdk/x.y.z/fr/NuGet.Packaging.resources.dll
--./sdk/x.y.z/fr/NuGet.ProjectModel.resources.dll
--./sdk/x.y.z/fr/NuGet.Protocol.resources.dll
--./sdk/x.y.z/fr/NuGet.Resolver.resources.dll
--./sdk/x.y.z/fr/NuGet.Versioning.resources.dll
--./sdk/x.y.z/fr/NuGet.VisualStudio.Contracts.resources.dll
  ./sdk/x.y.z/fr/System.CommandLine.resources.dll
--./sdk/x.y.z/fr/vstest.console.resources.dll
  ./sdk/x.y.z/FSharp/
- ./sdk/x.y.z/FSharp/cs/
- ./sdk/x.y.z/FSharp/cs/FSharp.Build.resources.dll
 @@ ------------ @@
  ./sdk/x.y.z/FSharp/Microsoft.FSharp.Targets
  ./sdk/x.y.z/FSharp/Microsoft.NET.StringTools.dll
@@ -489,136 +212,29 @@ index ------------
  ./sdk/x.y.z/FSharp/tr/FSharp.Build.resources.dll
  ./sdk/x.y.z/FSharp/tr/FSharp.Compiler.Interactive.Settings.resources.dll
 @@ ------------ @@
- ./sdk/x.y.z/IncludedWorkloadManifests.txt
- ./sdk/x.y.z/it/
- ./sdk/x.y.z/it/dotnet.resources.dll
--./sdk/x.y.z/it/Microsoft.Build.NuGetSdkResolver.resources.dll
- ./sdk/x.y.z/it/Microsoft.Build.resources.dll
- ./sdk/x.y.z/it/Microsoft.Build.Tasks.Core.resources.dll
- ./sdk/x.y.z/it/Microsoft.Build.Utilities.Core.resources.dll
-@@ ------------ @@
  ./sdk/x.y.z/it/Microsoft.TemplateEngine.Edge.resources.dll
  ./sdk/x.y.z/it/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
  ./sdk/x.y.z/it/Microsoft.TemplateSearch.Common.resources.dll
--./sdk/x.y.z/it/Microsoft.TestPlatform.Build.resources.dll
--./sdk/x.y.z/it/Microsoft.TestPlatform.CommunicationUtilities.resources.dll
--./sdk/x.y.z/it/Microsoft.TestPlatform.CoreUtilities.resources.dll
--./sdk/x.y.z/it/Microsoft.TestPlatform.CrossPlatEngine.resources.dll
--./sdk/x.y.z/it/Microsoft.TestPlatform.Utilities.resources.dll
--./sdk/x.y.z/it/Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll
 -./sdk/x.y.z/it/Microsoft.VisualStudio.Coverage.IO.resources.dll
--./sdk/x.y.z/it/Microsoft.VisualStudio.TestPlatform.Client.resources.dll
--./sdk/x.y.z/it/Microsoft.VisualStudio.TestPlatform.Common.resources.dll
--./sdk/x.y.z/it/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll
  ./sdk/x.y.z/it/MSBuild.resources.dll
--./sdk/x.y.z/it/NuGet.Build.Tasks.Console.resources.dll
--./sdk/x.y.z/it/NuGet.Build.Tasks.resources.dll
--./sdk/x.y.z/it/NuGet.CommandLine.XPlat.resources.dll
--./sdk/x.y.z/it/NuGet.Commands.resources.dll
--./sdk/x.y.z/it/NuGet.Common.resources.dll
--./sdk/x.y.z/it/NuGet.Configuration.resources.dll
--./sdk/x.y.z/it/NuGet.Credentials.resources.dll
--./sdk/x.y.z/it/NuGet.DependencyResolver.Core.resources.dll
--./sdk/x.y.z/it/NuGet.Frameworks.resources.dll
--./sdk/x.y.z/it/NuGet.LibraryModel.resources.dll
--./sdk/x.y.z/it/NuGet.Localization.resources.dll
--./sdk/x.y.z/it/NuGet.PackageManagement.resources.dll
--./sdk/x.y.z/it/NuGet.Packaging.Core.resources.dll
--./sdk/x.y.z/it/NuGet.Packaging.resources.dll
--./sdk/x.y.z/it/NuGet.ProjectModel.resources.dll
--./sdk/x.y.z/it/NuGet.Protocol.resources.dll
--./sdk/x.y.z/it/NuGet.Resolver.resources.dll
--./sdk/x.y.z/it/NuGet.Versioning.resources.dll
--./sdk/x.y.z/it/NuGet.VisualStudio.Contracts.resources.dll
  ./sdk/x.y.z/it/System.CommandLine.resources.dll
--./sdk/x.y.z/it/vstest.console.resources.dll
  ./sdk/x.y.z/ja/
- ./sdk/x.y.z/ja/dotnet.resources.dll
--./sdk/x.y.z/ja/Microsoft.Build.NuGetSdkResolver.resources.dll
- ./sdk/x.y.z/ja/Microsoft.Build.resources.dll
- ./sdk/x.y.z/ja/Microsoft.Build.Tasks.Core.resources.dll
- ./sdk/x.y.z/ja/Microsoft.Build.Utilities.Core.resources.dll
 @@ ------------ @@
  ./sdk/x.y.z/ja/Microsoft.TemplateEngine.Edge.resources.dll
  ./sdk/x.y.z/ja/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
  ./sdk/x.y.z/ja/Microsoft.TemplateSearch.Common.resources.dll
--./sdk/x.y.z/ja/Microsoft.TestPlatform.Build.resources.dll
--./sdk/x.y.z/ja/Microsoft.TestPlatform.CommunicationUtilities.resources.dll
--./sdk/x.y.z/ja/Microsoft.TestPlatform.CoreUtilities.resources.dll
--./sdk/x.y.z/ja/Microsoft.TestPlatform.CrossPlatEngine.resources.dll
--./sdk/x.y.z/ja/Microsoft.TestPlatform.Utilities.resources.dll
--./sdk/x.y.z/ja/Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll
 -./sdk/x.y.z/ja/Microsoft.VisualStudio.Coverage.IO.resources.dll
--./sdk/x.y.z/ja/Microsoft.VisualStudio.TestPlatform.Client.resources.dll
--./sdk/x.y.z/ja/Microsoft.VisualStudio.TestPlatform.Common.resources.dll
--./sdk/x.y.z/ja/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll
  ./sdk/x.y.z/ja/MSBuild.resources.dll
--./sdk/x.y.z/ja/NuGet.Build.Tasks.Console.resources.dll
--./sdk/x.y.z/ja/NuGet.Build.Tasks.resources.dll
--./sdk/x.y.z/ja/NuGet.CommandLine.XPlat.resources.dll
--./sdk/x.y.z/ja/NuGet.Commands.resources.dll
--./sdk/x.y.z/ja/NuGet.Common.resources.dll
--./sdk/x.y.z/ja/NuGet.Configuration.resources.dll
--./sdk/x.y.z/ja/NuGet.Credentials.resources.dll
--./sdk/x.y.z/ja/NuGet.DependencyResolver.Core.resources.dll
--./sdk/x.y.z/ja/NuGet.Frameworks.resources.dll
--./sdk/x.y.z/ja/NuGet.LibraryModel.resources.dll
--./sdk/x.y.z/ja/NuGet.Localization.resources.dll
--./sdk/x.y.z/ja/NuGet.PackageManagement.resources.dll
--./sdk/x.y.z/ja/NuGet.Packaging.Core.resources.dll
--./sdk/x.y.z/ja/NuGet.Packaging.resources.dll
--./sdk/x.y.z/ja/NuGet.ProjectModel.resources.dll
--./sdk/x.y.z/ja/NuGet.Protocol.resources.dll
--./sdk/x.y.z/ja/NuGet.Resolver.resources.dll
--./sdk/x.y.z/ja/NuGet.Versioning.resources.dll
--./sdk/x.y.z/ja/NuGet.VisualStudio.Contracts.resources.dll
  ./sdk/x.y.z/ja/System.CommandLine.resources.dll
--./sdk/x.y.z/ja/vstest.console.resources.dll
  ./sdk/x.y.z/ko/
- ./sdk/x.y.z/ko/dotnet.resources.dll
--./sdk/x.y.z/ko/Microsoft.Build.NuGetSdkResolver.resources.dll
- ./sdk/x.y.z/ko/Microsoft.Build.resources.dll
- ./sdk/x.y.z/ko/Microsoft.Build.Tasks.Core.resources.dll
- ./sdk/x.y.z/ko/Microsoft.Build.Utilities.Core.resources.dll
 @@ ------------ @@
  ./sdk/x.y.z/ko/Microsoft.TemplateEngine.Edge.resources.dll
  ./sdk/x.y.z/ko/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
  ./sdk/x.y.z/ko/Microsoft.TemplateSearch.Common.resources.dll
--./sdk/x.y.z/ko/Microsoft.TestPlatform.Build.resources.dll
--./sdk/x.y.z/ko/Microsoft.TestPlatform.CommunicationUtilities.resources.dll
--./sdk/x.y.z/ko/Microsoft.TestPlatform.CoreUtilities.resources.dll
--./sdk/x.y.z/ko/Microsoft.TestPlatform.CrossPlatEngine.resources.dll
--./sdk/x.y.z/ko/Microsoft.TestPlatform.Utilities.resources.dll
--./sdk/x.y.z/ko/Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll
 -./sdk/x.y.z/ko/Microsoft.VisualStudio.Coverage.IO.resources.dll
--./sdk/x.y.z/ko/Microsoft.VisualStudio.TestPlatform.Client.resources.dll
--./sdk/x.y.z/ko/Microsoft.VisualStudio.TestPlatform.Common.resources.dll
--./sdk/x.y.z/ko/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll
  ./sdk/x.y.z/ko/MSBuild.resources.dll
--./sdk/x.y.z/ko/NuGet.Build.Tasks.Console.resources.dll
--./sdk/x.y.z/ko/NuGet.Build.Tasks.resources.dll
--./sdk/x.y.z/ko/NuGet.CommandLine.XPlat.resources.dll
--./sdk/x.y.z/ko/NuGet.Commands.resources.dll
--./sdk/x.y.z/ko/NuGet.Common.resources.dll
--./sdk/x.y.z/ko/NuGet.Configuration.resources.dll
--./sdk/x.y.z/ko/NuGet.Credentials.resources.dll
--./sdk/x.y.z/ko/NuGet.DependencyResolver.Core.resources.dll
--./sdk/x.y.z/ko/NuGet.Frameworks.resources.dll
--./sdk/x.y.z/ko/NuGet.LibraryModel.resources.dll
--./sdk/x.y.z/ko/NuGet.Localization.resources.dll
--./sdk/x.y.z/ko/NuGet.PackageManagement.resources.dll
--./sdk/x.y.z/ko/NuGet.Packaging.Core.resources.dll
--./sdk/x.y.z/ko/NuGet.Packaging.resources.dll
--./sdk/x.y.z/ko/NuGet.ProjectModel.resources.dll
--./sdk/x.y.z/ko/NuGet.Protocol.resources.dll
--./sdk/x.y.z/ko/NuGet.Resolver.resources.dll
--./sdk/x.y.z/ko/NuGet.Versioning.resources.dll
--./sdk/x.y.z/ko/NuGet.VisualStudio.Contracts.resources.dll
  ./sdk/x.y.z/ko/System.CommandLine.resources.dll
--./sdk/x.y.z/ko/vstest.console.resources.dll
  ./sdk/x.y.z/Microsoft.ApplicationInsights.dll
- ./sdk/x.y.z/Microsoft.AspNetCore.DeveloperCertificates.XPlat.dll
- ./sdk/x.y.z/Microsoft.Build.dll
 @@ ------------ @@
  ./sdk/x.y.z/Microsoft.DotNet.NativeWrapper.dll
  ./sdk/x.y.z/Microsoft.DotNet.SdkResolver.dll
@@ -654,91 +270,20 @@ index ------------
  ./sdk/x.y.z/Microsoft/Microsoft.NET.Build.Extensions/
  ./sdk/x.y.z/Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.ConflictResolution.targets
 @@ ------------ @@
- ./sdk/x.y.z/package.deps.json
- ./sdk/x.y.z/pl/
- ./sdk/x.y.z/pl/dotnet.resources.dll
--./sdk/x.y.z/pl/Microsoft.Build.NuGetSdkResolver.resources.dll
- ./sdk/x.y.z/pl/Microsoft.Build.resources.dll
- ./sdk/x.y.z/pl/Microsoft.Build.Tasks.Core.resources.dll
- ./sdk/x.y.z/pl/Microsoft.Build.Utilities.Core.resources.dll
-@@ ------------ @@
  ./sdk/x.y.z/pl/Microsoft.TemplateEngine.Edge.resources.dll
  ./sdk/x.y.z/pl/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
  ./sdk/x.y.z/pl/Microsoft.TemplateSearch.Common.resources.dll
--./sdk/x.y.z/pl/Microsoft.TestPlatform.Build.resources.dll
--./sdk/x.y.z/pl/Microsoft.TestPlatform.CommunicationUtilities.resources.dll
--./sdk/x.y.z/pl/Microsoft.TestPlatform.CoreUtilities.resources.dll
--./sdk/x.y.z/pl/Microsoft.TestPlatform.CrossPlatEngine.resources.dll
--./sdk/x.y.z/pl/Microsoft.TestPlatform.Utilities.resources.dll
--./sdk/x.y.z/pl/Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll
 -./sdk/x.y.z/pl/Microsoft.VisualStudio.Coverage.IO.resources.dll
--./sdk/x.y.z/pl/Microsoft.VisualStudio.TestPlatform.Client.resources.dll
--./sdk/x.y.z/pl/Microsoft.VisualStudio.TestPlatform.Common.resources.dll
--./sdk/x.y.z/pl/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll
  ./sdk/x.y.z/pl/MSBuild.resources.dll
--./sdk/x.y.z/pl/NuGet.Build.Tasks.Console.resources.dll
--./sdk/x.y.z/pl/NuGet.Build.Tasks.resources.dll
--./sdk/x.y.z/pl/NuGet.CommandLine.XPlat.resources.dll
--./sdk/x.y.z/pl/NuGet.Commands.resources.dll
--./sdk/x.y.z/pl/NuGet.Common.resources.dll
--./sdk/x.y.z/pl/NuGet.Configuration.resources.dll
--./sdk/x.y.z/pl/NuGet.Credentials.resources.dll
--./sdk/x.y.z/pl/NuGet.DependencyResolver.Core.resources.dll
--./sdk/x.y.z/pl/NuGet.Frameworks.resources.dll
--./sdk/x.y.z/pl/NuGet.LibraryModel.resources.dll
--./sdk/x.y.z/pl/NuGet.Localization.resources.dll
--./sdk/x.y.z/pl/NuGet.PackageManagement.resources.dll
--./sdk/x.y.z/pl/NuGet.Packaging.Core.resources.dll
--./sdk/x.y.z/pl/NuGet.Packaging.resources.dll
--./sdk/x.y.z/pl/NuGet.ProjectModel.resources.dll
--./sdk/x.y.z/pl/NuGet.Protocol.resources.dll
--./sdk/x.y.z/pl/NuGet.Resolver.resources.dll
--./sdk/x.y.z/pl/NuGet.Versioning.resources.dll
--./sdk/x.y.z/pl/NuGet.VisualStudio.Contracts.resources.dll
  ./sdk/x.y.z/pl/System.CommandLine.resources.dll
--./sdk/x.y.z/pl/vstest.console.resources.dll
  ./sdk/x.y.z/pt-BR/
- ./sdk/x.y.z/pt-BR/dotnet.resources.dll
--./sdk/x.y.z/pt-BR/Microsoft.Build.NuGetSdkResolver.resources.dll
- ./sdk/x.y.z/pt-BR/Microsoft.Build.resources.dll
- ./sdk/x.y.z/pt-BR/Microsoft.Build.Tasks.Core.resources.dll
- ./sdk/x.y.z/pt-BR/Microsoft.Build.Utilities.Core.resources.dll
 @@ ------------ @@
  ./sdk/x.y.z/pt-BR/Microsoft.TemplateEngine.Edge.resources.dll
  ./sdk/x.y.z/pt-BR/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
  ./sdk/x.y.z/pt-BR/Microsoft.TemplateSearch.Common.resources.dll
--./sdk/x.y.z/pt-BR/Microsoft.TestPlatform.Build.resources.dll
--./sdk/x.y.z/pt-BR/Microsoft.TestPlatform.CommunicationUtilities.resources.dll
--./sdk/x.y.z/pt-BR/Microsoft.TestPlatform.CoreUtilities.resources.dll
--./sdk/x.y.z/pt-BR/Microsoft.TestPlatform.CrossPlatEngine.resources.dll
--./sdk/x.y.z/pt-BR/Microsoft.TestPlatform.Utilities.resources.dll
--./sdk/x.y.z/pt-BR/Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll
 -./sdk/x.y.z/pt-BR/Microsoft.VisualStudio.Coverage.IO.resources.dll
--./sdk/x.y.z/pt-BR/Microsoft.VisualStudio.TestPlatform.Client.resources.dll
--./sdk/x.y.z/pt-BR/Microsoft.VisualStudio.TestPlatform.Common.resources.dll
--./sdk/x.y.z/pt-BR/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll
  ./sdk/x.y.z/pt-BR/MSBuild.resources.dll
--./sdk/x.y.z/pt-BR/NuGet.Build.Tasks.Console.resources.dll
--./sdk/x.y.z/pt-BR/NuGet.Build.Tasks.resources.dll
--./sdk/x.y.z/pt-BR/NuGet.CommandLine.XPlat.resources.dll
--./sdk/x.y.z/pt-BR/NuGet.Commands.resources.dll
--./sdk/x.y.z/pt-BR/NuGet.Common.resources.dll
--./sdk/x.y.z/pt-BR/NuGet.Configuration.resources.dll
--./sdk/x.y.z/pt-BR/NuGet.Credentials.resources.dll
--./sdk/x.y.z/pt-BR/NuGet.DependencyResolver.Core.resources.dll
--./sdk/x.y.z/pt-BR/NuGet.Frameworks.resources.dll
--./sdk/x.y.z/pt-BR/NuGet.LibraryModel.resources.dll
--./sdk/x.y.z/pt-BR/NuGet.Localization.resources.dll
--./sdk/x.y.z/pt-BR/NuGet.PackageManagement.resources.dll
--./sdk/x.y.z/pt-BR/NuGet.Packaging.Core.resources.dll
--./sdk/x.y.z/pt-BR/NuGet.Packaging.resources.dll
--./sdk/x.y.z/pt-BR/NuGet.ProjectModel.resources.dll
--./sdk/x.y.z/pt-BR/NuGet.Protocol.resources.dll
--./sdk/x.y.z/pt-BR/NuGet.Resolver.resources.dll
--./sdk/x.y.z/pt-BR/NuGet.Versioning.resources.dll
--./sdk/x.y.z/pt-BR/NuGet.VisualStudio.Contracts.resources.dll
  ./sdk/x.y.z/pt-BR/System.CommandLine.resources.dll
--./sdk/x.y.z/pt-BR/vstest.console.resources.dll
  ./sdk/x.y.z/ref/
 +./sdk/x.y.z/ref/Microsoft.TestPlatform.PlatformAbstractions.dll
 +./sdk/x.y.z/ref/Microsoft.VisualStudio.TestPlatform.ObjectModel.dll
@@ -762,52 +307,13 @@ index ------------
  ./sdk/x.y.z/Roslyn/bincore/tr/Microsoft.CodeAnalysis.CSharp.resources.dll
  ./sdk/x.y.z/Roslyn/bincore/tr/Microsoft.CodeAnalysis.resources.dll
 @@ ------------ @@
- ./sdk/x.y.z/Roslyn/zh-Hant/Microsoft.Build.Tasks.CodeAnalysis.resources.dll
- ./sdk/x.y.z/ru/
- ./sdk/x.y.z/ru/dotnet.resources.dll
--./sdk/x.y.z/ru/Microsoft.Build.NuGetSdkResolver.resources.dll
- ./sdk/x.y.z/ru/Microsoft.Build.resources.dll
- ./sdk/x.y.z/ru/Microsoft.Build.Tasks.Core.resources.dll
- ./sdk/x.y.z/ru/Microsoft.Build.Utilities.Core.resources.dll
-@@ ------------ @@
  ./sdk/x.y.z/ru/Microsoft.TemplateEngine.Edge.resources.dll
  ./sdk/x.y.z/ru/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
  ./sdk/x.y.z/ru/Microsoft.TemplateSearch.Common.resources.dll
--./sdk/x.y.z/ru/Microsoft.TestPlatform.Build.resources.dll
--./sdk/x.y.z/ru/Microsoft.TestPlatform.CommunicationUtilities.resources.dll
--./sdk/x.y.z/ru/Microsoft.TestPlatform.CoreUtilities.resources.dll
--./sdk/x.y.z/ru/Microsoft.TestPlatform.CrossPlatEngine.resources.dll
--./sdk/x.y.z/ru/Microsoft.TestPlatform.Utilities.resources.dll
--./sdk/x.y.z/ru/Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll
 -./sdk/x.y.z/ru/Microsoft.VisualStudio.Coverage.IO.resources.dll
--./sdk/x.y.z/ru/Microsoft.VisualStudio.TestPlatform.Client.resources.dll
--./sdk/x.y.z/ru/Microsoft.VisualStudio.TestPlatform.Common.resources.dll
--./sdk/x.y.z/ru/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll
  ./sdk/x.y.z/ru/MSBuild.resources.dll
--./sdk/x.y.z/ru/NuGet.Build.Tasks.Console.resources.dll
--./sdk/x.y.z/ru/NuGet.Build.Tasks.resources.dll
--./sdk/x.y.z/ru/NuGet.CommandLine.XPlat.resources.dll
--./sdk/x.y.z/ru/NuGet.Commands.resources.dll
--./sdk/x.y.z/ru/NuGet.Common.resources.dll
--./sdk/x.y.z/ru/NuGet.Configuration.resources.dll
--./sdk/x.y.z/ru/NuGet.Credentials.resources.dll
--./sdk/x.y.z/ru/NuGet.DependencyResolver.Core.resources.dll
--./sdk/x.y.z/ru/NuGet.Frameworks.resources.dll
--./sdk/x.y.z/ru/NuGet.LibraryModel.resources.dll
--./sdk/x.y.z/ru/NuGet.Localization.resources.dll
--./sdk/x.y.z/ru/NuGet.PackageManagement.resources.dll
--./sdk/x.y.z/ru/NuGet.Packaging.Core.resources.dll
--./sdk/x.y.z/ru/NuGet.Packaging.resources.dll
--./sdk/x.y.z/ru/NuGet.ProjectModel.resources.dll
--./sdk/x.y.z/ru/NuGet.Protocol.resources.dll
--./sdk/x.y.z/ru/NuGet.Resolver.resources.dll
--./sdk/x.y.z/ru/NuGet.Versioning.resources.dll
--./sdk/x.y.z/ru/NuGet.VisualStudio.Contracts.resources.dll
  ./sdk/x.y.z/ru/System.CommandLine.resources.dll
--./sdk/x.y.z/ru/vstest.console.resources.dll
  ./sdk/x.y.z/RuntimeIdentifierGraph.json
- ./sdk/x.y.z/runtimes/
- ./sdk/x.y.z/runtimes/any/
 @@ ------------ @@
  ./sdk/x.y.z/runtimes/any/native/NuGet.props
  ./sdk/x.y.z/runtimes/any/native/NuGet.RestoreEx.targets
@@ -822,11 +328,6 @@ index ------------
 +./sdk/x.y.z/runtimes/browser/lib/netx.y/System.Text.Encodings.Web.dll
  ./sdk/x.y.z/runtimes/win/
  ./sdk/x.y.z/runtimes/win/lib/
- ./sdk/x.y.z/runtimes/win/lib/netx.y/
- ./sdk/x.y.z/runtimes/win/lib/netx.y/System.Diagnostics.EventLog.dll
- ./sdk/x.y.z/runtimes/win/lib/netx.y/System.Diagnostics.EventLog.Messages.dll
-+./sdk/x.y.z/runtimes/win/lib/netx.y/System.Security.Cryptography.ProtectedData.dll
- ./sdk/x.y.z/runtimes/win/lib/netx.y/System.ServiceProcess.ServiceController.dll
 -./sdk/x.y.z/runtimes/win/lib/netcoreapp3.0/
 -./sdk/x.y.z/runtimes/win/lib/netcoreapp3.0/Microsoft.Win32.SystemEvents.dll
 -./sdk/x.y.z/runtimes/win/lib/netcoreapp3.0/System.Drawing.Common.dll
@@ -834,6 +335,11 @@ index ------------
 -./sdk/x.y.z/runtimes/win/lib/netcoreapp3.0/System.Windows.Extensions.dll
 -./sdk/x.y.z/runtimes/win/lib/netstandard2.0/
 -./sdk/x.y.z/runtimes/win/lib/netstandard2.0/System.Security.Cryptography.ProtectedData.dll
+ ./sdk/x.y.z/runtimes/win/lib/netx.y/
+ ./sdk/x.y.z/runtimes/win/lib/netx.y/System.Diagnostics.EventLog.dll
+ ./sdk/x.y.z/runtimes/win/lib/netx.y/System.Diagnostics.EventLog.Messages.dll
++./sdk/x.y.z/runtimes/win/lib/netx.y/System.Security.Cryptography.ProtectedData.dll
+ ./sdk/x.y.z/runtimes/win/lib/netx.y/System.ServiceProcess.ServiceController.dll
 +./sdk/x.y.z/runtimes/win/lib/netx.y/System.Text.Encoding.CodePages.dll
  ./sdk/x.y.z/SDKPrecomputedAssemblyReferences.cache
  ./sdk/x.y.z/SdkResolvers/
@@ -851,48 +357,6 @@ index ------------
  ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/targets/TransformTargets/Transforms/EnvironmentWithLocation.transform
  ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/
 -./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/cs/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/cs/Microsoft.NET.Sdk.Publish.Tasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/de/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/de/Microsoft.NET.Sdk.Publish.Tasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/es/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/es/Microsoft.NET.Sdk.Publish.Tasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/fr/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/fr/Microsoft.NET.Sdk.Publish.Tasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/it/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/it/Microsoft.NET.Sdk.Publish.Tasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/ja/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/ja/Microsoft.NET.Sdk.Publish.Tasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/ko/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/ko/Microsoft.NET.Sdk.Publish.Tasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/Microsoft.Bcl.AsyncInterfaces.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/Microsoft.NET.Sdk.Publish.Tasks.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/Microsoft.NET.Sdk.Publish.Tasks.dll.config
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/Microsoft.Web.Delegation.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/Microsoft.Web.Deployment.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/Microsoft.Web.Deployment.Tracing.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/Microsoft.Web.XmlTransform.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/pl/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/pl/Microsoft.NET.Sdk.Publish.Tasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/pt-BR/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/pt-BR/Microsoft.NET.Sdk.Publish.Tasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/ru/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/ru/Microsoft.NET.Sdk.Publish.Tasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/System.Buffers.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/System.Memory.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/System.Numerics.Vectors.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/System.Runtime.CompilerServices.Unsafe.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/System.Security.Cryptography.ProtectedData.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/System.Text.Encodings.Web.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/System.Text.Json.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/System.Threading.Tasks.Extensions.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/System.ValueTuple.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/tr/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/tr/Microsoft.NET.Sdk.Publish.Tasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/zh-Hans/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/zh-Hans/Microsoft.NET.Sdk.Publish.Tasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/zh-Hant/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/zh-Hant/Microsoft.NET.Sdk.Publish.Tasks.resources.dll
  ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/netx.y/
  ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/netx.y/cs/
  ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/netx.y/cs/Microsoft.NET.Sdk.Publish.Tasks.resources.dll
@@ -931,86 +395,6 @@ index ------------
  ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Web/tools/netx.y/ref/
  ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Web/tools/netx.y/ref/Microsoft.NET.Sdk.Web.Tasks.dll
 -./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/Icon.png
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/LICENSE.TXT
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/Sdk/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/Sdk/Sdk.props
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/Sdk/Sdk.targets
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/targets/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.WindowsForms.props
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.WindowsForms.targets
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.WPF.props
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.WinFX.targets
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/targets/System.Windows.Forms.Analyzers.props
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/THIRD-PARTY-NOTICES.TXT
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/cs/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/cs/PresentationBuildTasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/de/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/de/PresentationBuildTasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/es/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/es/PresentationBuildTasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/fr/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/fr/PresentationBuildTasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/it/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/it/PresentationBuildTasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/ja/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/ja/PresentationBuildTasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/ko/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/ko/PresentationBuildTasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/pl/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/pl/PresentationBuildTasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/PresentationBuildTasks.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/pt-BR/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/pt-BR/PresentationBuildTasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/ru/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/ru/PresentationBuildTasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/System.Collections.Immutable.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/System.Memory.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/System.Numerics.Vectors.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/System.Reflection.Metadata.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/System.Reflection.MetadataLoadContext.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/System.Runtime.CompilerServices.Unsafe.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/tr/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/tr/PresentationBuildTasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/zh-Hans/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/zh-Hans/PresentationBuildTasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/zh-Hant/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/zh-Hant/PresentationBuildTasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/netx.y/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/netx.y/cs/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/netx.y/cs/PresentationBuildTasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/netx.y/de/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/netx.y/de/PresentationBuildTasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/netx.y/es/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/netx.y/es/PresentationBuildTasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/netx.y/fr/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/netx.y/fr/PresentationBuildTasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/netx.y/it/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/netx.y/it/PresentationBuildTasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/netx.y/ja/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/netx.y/ja/PresentationBuildTasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/netx.y/ko/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/netx.y/ko/PresentationBuildTasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/netx.y/pl/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/netx.y/pl/PresentationBuildTasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/netx.y/PresentationBuildTasks.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/netx.y/pt-BR/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/netx.y/pt-BR/PresentationBuildTasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/netx.y/ru/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/netx.y/ru/PresentationBuildTasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/netx.y/System.Reflection.MetadataLoadContext.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/netx.y/tr/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/netx.y/tr/PresentationBuildTasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/netx.y/zh-Hans/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/netx.y/zh-Hans/PresentationBuildTasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/netx.y/zh-Hant/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/netx.y/zh-Hant/PresentationBuildTasks.resources.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/useSharedDesignerContext.txt
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/version.txt
  ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Worker/
  ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Worker/Sdk/
  ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Worker/Sdk/Sdk.props
@@ -1023,99 +407,7 @@ index ------------
  ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk/tools/net472/System.Runtime.CompilerServices.Unsafe.dll
  ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk/tools/net472/System.Text.Encodings.Web.dll
 @@ ------------ @@
- ./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/buildCrossTargeting/
- ./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/buildCrossTargeting/NuGet.Build.Tasks.Pack.targets
- ./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/cs/
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/cs/NuGet.Build.Tasks.Pack.resources.dll
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/de/
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/de/NuGet.Build.Tasks.Pack.resources.dll
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/es/
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/es/NuGet.Build.Tasks.Pack.resources.dll
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/fr/
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/fr/NuGet.Build.Tasks.Pack.resources.dll
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/it/
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/it/NuGet.Build.Tasks.Pack.resources.dll
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/ja/
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/ja/NuGet.Build.Tasks.Pack.resources.dll
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/ko/
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/ko/NuGet.Build.Tasks.Pack.resources.dll
- ./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/NuGet.Build.Tasks.Pack.dll
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/pl/
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/pl/NuGet.Build.Tasks.Pack.resources.dll
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/pt-BR/
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/pt-BR/NuGet.Build.Tasks.Pack.resources.dll
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/ru/
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/ru/NuGet.Build.Tasks.Pack.resources.dll
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/tr/
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/tr/NuGet.Build.Tasks.Pack.resources.dll
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/zh-Hans/
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/zh-Hans/NuGet.Build.Tasks.Pack.resources.dll
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/zh-Hant/
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/zh-Hant/NuGet.Build.Tasks.Pack.resources.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/NuGet.Commands.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/NuGet.Common.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/NuGet.Configuration.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/NuGet.Credentials.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/NuGet.DependencyResolver.Core.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/NuGet.Frameworks.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/NuGet.LibraryModel.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/NuGet.Packaging.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/NuGet.ProjectModel.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/NuGet.Protocol.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/NuGet.Versioning.dll
- ./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/cs/
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/cs/NuGet.Build.Tasks.Pack.resources.dll
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/de/
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/de/NuGet.Build.Tasks.Pack.resources.dll
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/es/
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/es/NuGet.Build.Tasks.Pack.resources.dll
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/fr/
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/fr/NuGet.Build.Tasks.Pack.resources.dll
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/it/
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/it/NuGet.Build.Tasks.Pack.resources.dll
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/ja/
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/ja/NuGet.Build.Tasks.Pack.resources.dll
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/ko/
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/ko/NuGet.Build.Tasks.Pack.resources.dll
- ./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/NuGet.Build.Tasks.Pack.dll
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/pl/
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/pl/NuGet.Build.Tasks.Pack.resources.dll
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/pt-BR/
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/pt-BR/NuGet.Build.Tasks.Pack.resources.dll
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/ru/
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/ru/NuGet.Build.Tasks.Pack.resources.dll
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/tr/
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/tr/NuGet.Build.Tasks.Pack.resources.dll
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/zh-Hans/
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/zh-Hans/NuGet.Build.Tasks.Pack.resources.dll
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/zh-Hant/
--./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/zh-Hant/NuGet.Build.Tasks.Pack.resources.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/NuGet.Commands.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/NuGet.Common.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/NuGet.Configuration.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/NuGet.Credentials.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/NuGet.DependencyResolver.Core.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/NuGet.Frameworks.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/NuGet.LibraryModel.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/NuGet.Packaging.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/NuGet.ProjectModel.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/NuGet.Protocol.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/Desktop/NuGet.Versioning.dll
- ./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/icon.png
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/NuGet.Commands.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/NuGet.Common.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/NuGet.Configuration.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/NuGet.Credentials.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/NuGet.DependencyResolver.Core.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/NuGet.Frameworks.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/NuGet.LibraryModel.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/NuGet.Packaging.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/NuGet.ProjectModel.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/NuGet.Protocol.dll
-+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/NuGet.Versioning.dll
+ ./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/
  ./sdk/x.y.z/System.CodeDom.dll
  ./sdk/x.y.z/System.CommandLine.dll
 -./sdk/x.y.z/System.Configuration.ConfigurationManager.dll
@@ -1144,56 +436,14 @@ index ------------
 +./sdk/x.y.z/testhost.x86.runtimeconfig.json
  ./sdk/x.y.z/TestHost/
 -./sdk/x.y.z/TestHost/cs/
--./sdk/x.y.z/TestHost/cs/Microsoft.TestPlatform.CommunicationUtilities.resources.dll
--./sdk/x.y.z/TestHost/cs/Microsoft.TestPlatform.CoreUtilities.resources.dll
--./sdk/x.y.z/TestHost/cs/Microsoft.TestPlatform.CrossPlatEngine.resources.dll
--./sdk/x.y.z/TestHost/cs/Microsoft.TestPlatform.Utilities.resources.dll
--./sdk/x.y.z/TestHost/cs/Microsoft.VisualStudio.TestPlatform.Common.resources.dll
--./sdk/x.y.z/TestHost/cs/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll
 -./sdk/x.y.z/TestHost/datacollector.exe
 -./sdk/x.y.z/TestHost/datacollector.exe.config
 -./sdk/x.y.z/TestHost/de/
--./sdk/x.y.z/TestHost/de/Microsoft.TestPlatform.CommunicationUtilities.resources.dll
--./sdk/x.y.z/TestHost/de/Microsoft.TestPlatform.CoreUtilities.resources.dll
--./sdk/x.y.z/TestHost/de/Microsoft.TestPlatform.CrossPlatEngine.resources.dll
--./sdk/x.y.z/TestHost/de/Microsoft.TestPlatform.Utilities.resources.dll
--./sdk/x.y.z/TestHost/de/Microsoft.VisualStudio.TestPlatform.Common.resources.dll
--./sdk/x.y.z/TestHost/de/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll
 -./sdk/x.y.z/TestHost/es/
--./sdk/x.y.z/TestHost/es/Microsoft.TestPlatform.CommunicationUtilities.resources.dll
--./sdk/x.y.z/TestHost/es/Microsoft.TestPlatform.CoreUtilities.resources.dll
--./sdk/x.y.z/TestHost/es/Microsoft.TestPlatform.CrossPlatEngine.resources.dll
--./sdk/x.y.z/TestHost/es/Microsoft.TestPlatform.Utilities.resources.dll
--./sdk/x.y.z/TestHost/es/Microsoft.VisualStudio.TestPlatform.Common.resources.dll
--./sdk/x.y.z/TestHost/es/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll
 -./sdk/x.y.z/TestHost/fr/
--./sdk/x.y.z/TestHost/fr/Microsoft.TestPlatform.CommunicationUtilities.resources.dll
--./sdk/x.y.z/TestHost/fr/Microsoft.TestPlatform.CoreUtilities.resources.dll
--./sdk/x.y.z/TestHost/fr/Microsoft.TestPlatform.CrossPlatEngine.resources.dll
--./sdk/x.y.z/TestHost/fr/Microsoft.TestPlatform.Utilities.resources.dll
--./sdk/x.y.z/TestHost/fr/Microsoft.VisualStudio.TestPlatform.Common.resources.dll
--./sdk/x.y.z/TestHost/fr/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll
 -./sdk/x.y.z/TestHost/it/
--./sdk/x.y.z/TestHost/it/Microsoft.TestPlatform.CommunicationUtilities.resources.dll
--./sdk/x.y.z/TestHost/it/Microsoft.TestPlatform.CoreUtilities.resources.dll
--./sdk/x.y.z/TestHost/it/Microsoft.TestPlatform.CrossPlatEngine.resources.dll
--./sdk/x.y.z/TestHost/it/Microsoft.TestPlatform.Utilities.resources.dll
--./sdk/x.y.z/TestHost/it/Microsoft.VisualStudio.TestPlatform.Common.resources.dll
--./sdk/x.y.z/TestHost/it/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll
 -./sdk/x.y.z/TestHost/ja/
--./sdk/x.y.z/TestHost/ja/Microsoft.TestPlatform.CommunicationUtilities.resources.dll
--./sdk/x.y.z/TestHost/ja/Microsoft.TestPlatform.CoreUtilities.resources.dll
--./sdk/x.y.z/TestHost/ja/Microsoft.TestPlatform.CrossPlatEngine.resources.dll
--./sdk/x.y.z/TestHost/ja/Microsoft.TestPlatform.Utilities.resources.dll
--./sdk/x.y.z/TestHost/ja/Microsoft.VisualStudio.TestPlatform.Common.resources.dll
--./sdk/x.y.z/TestHost/ja/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll
 -./sdk/x.y.z/TestHost/ko/
--./sdk/x.y.z/TestHost/ko/Microsoft.TestPlatform.CommunicationUtilities.resources.dll
--./sdk/x.y.z/TestHost/ko/Microsoft.TestPlatform.CoreUtilities.resources.dll
--./sdk/x.y.z/TestHost/ko/Microsoft.TestPlatform.CrossPlatEngine.resources.dll
--./sdk/x.y.z/TestHost/ko/Microsoft.TestPlatform.Utilities.resources.dll
--./sdk/x.y.z/TestHost/ko/Microsoft.VisualStudio.TestPlatform.Common.resources.dll
--./sdk/x.y.z/TestHost/ko/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll
  ./sdk/x.y.z/TestHost/Microsoft.TestPlatform.CommunicationUtilities.dll
  ./sdk/x.y.z/TestHost/Microsoft.TestPlatform.CoreUtilities.dll
  ./sdk/x.y.z/TestHost/Microsoft.TestPlatform.CrossPlatEngine.dll
@@ -1205,26 +455,8 @@ index ------------
  ./sdk/x.y.z/TestHost/Newtonsoft.Json.dll
  ./sdk/x.y.z/TestHost/NuGet.Frameworks.dll
 -./sdk/x.y.z/TestHost/pl/
--./sdk/x.y.z/TestHost/pl/Microsoft.TestPlatform.CommunicationUtilities.resources.dll
--./sdk/x.y.z/TestHost/pl/Microsoft.TestPlatform.CoreUtilities.resources.dll
--./sdk/x.y.z/TestHost/pl/Microsoft.TestPlatform.CrossPlatEngine.resources.dll
--./sdk/x.y.z/TestHost/pl/Microsoft.TestPlatform.Utilities.resources.dll
--./sdk/x.y.z/TestHost/pl/Microsoft.VisualStudio.TestPlatform.Common.resources.dll
--./sdk/x.y.z/TestHost/pl/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll
 -./sdk/x.y.z/TestHost/pt-BR/
--./sdk/x.y.z/TestHost/pt-BR/Microsoft.TestPlatform.CommunicationUtilities.resources.dll
--./sdk/x.y.z/TestHost/pt-BR/Microsoft.TestPlatform.CoreUtilities.resources.dll
--./sdk/x.y.z/TestHost/pt-BR/Microsoft.TestPlatform.CrossPlatEngine.resources.dll
--./sdk/x.y.z/TestHost/pt-BR/Microsoft.TestPlatform.Utilities.resources.dll
--./sdk/x.y.z/TestHost/pt-BR/Microsoft.VisualStudio.TestPlatform.Common.resources.dll
--./sdk/x.y.z/TestHost/pt-BR/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll
 -./sdk/x.y.z/TestHost/ru/
--./sdk/x.y.z/TestHost/ru/Microsoft.TestPlatform.CommunicationUtilities.resources.dll
--./sdk/x.y.z/TestHost/ru/Microsoft.TestPlatform.CoreUtilities.resources.dll
--./sdk/x.y.z/TestHost/ru/Microsoft.TestPlatform.CrossPlatEngine.resources.dll
--./sdk/x.y.z/TestHost/ru/Microsoft.TestPlatform.Utilities.resources.dll
--./sdk/x.y.z/TestHost/ru/Microsoft.VisualStudio.TestPlatform.Common.resources.dll
--./sdk/x.y.z/TestHost/ru/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll
 -./sdk/x.y.z/TestHost/System.Collections.Immutable.dll
 -./sdk/x.y.z/TestHost/System.Reflection.Metadata.dll
 -./sdk/x.y.z/TestHost/testhost.exe
@@ -1264,12 +496,6 @@ index ------------
 -./sdk/x.y.z/TestHost/testhost.x86.exe
 -./sdk/x.y.z/TestHost/testhost.x86.exe.config
 -./sdk/x.y.z/TestHost/tr/
--./sdk/x.y.z/TestHost/tr/Microsoft.TestPlatform.CommunicationUtilities.resources.dll
--./sdk/x.y.z/TestHost/tr/Microsoft.TestPlatform.CoreUtilities.resources.dll
--./sdk/x.y.z/TestHost/tr/Microsoft.TestPlatform.CrossPlatEngine.resources.dll
--./sdk/x.y.z/TestHost/tr/Microsoft.TestPlatform.Utilities.resources.dll
--./sdk/x.y.z/TestHost/tr/Microsoft.VisualStudio.TestPlatform.Common.resources.dll
--./sdk/x.y.z/TestHost/tr/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll
 -./sdk/x.y.z/TestHost/x64/
 -./sdk/x.y.z/TestHost/x64/msdia140.dll
 -./sdk/x.y.z/TestHost/x64/msdia140.dll.manifest
@@ -1277,19 +503,7 @@ index ------------
 -./sdk/x.y.z/TestHost/x86/msdia140.dll
 -./sdk/x.y.z/TestHost/x86/msdia140.dll.manifest
 -./sdk/x.y.z/TestHost/zh-Hans/
--./sdk/x.y.z/TestHost/zh-Hans/Microsoft.TestPlatform.CommunicationUtilities.resources.dll
--./sdk/x.y.z/TestHost/zh-Hans/Microsoft.TestPlatform.CoreUtilities.resources.dll
--./sdk/x.y.z/TestHost/zh-Hans/Microsoft.TestPlatform.CrossPlatEngine.resources.dll
--./sdk/x.y.z/TestHost/zh-Hans/Microsoft.TestPlatform.Utilities.resources.dll
--./sdk/x.y.z/TestHost/zh-Hans/Microsoft.VisualStudio.TestPlatform.Common.resources.dll
--./sdk/x.y.z/TestHost/zh-Hans/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll
 -./sdk/x.y.z/TestHost/zh-Hant/
--./sdk/x.y.z/TestHost/zh-Hant/Microsoft.TestPlatform.CommunicationUtilities.resources.dll
--./sdk/x.y.z/TestHost/zh-Hant/Microsoft.TestPlatform.CoreUtilities.resources.dll
--./sdk/x.y.z/TestHost/zh-Hant/Microsoft.TestPlatform.CrossPlatEngine.resources.dll
--./sdk/x.y.z/TestHost/zh-Hant/Microsoft.TestPlatform.Utilities.resources.dll
--./sdk/x.y.z/TestHost/zh-Hant/Microsoft.VisualStudio.TestPlatform.Common.resources.dll
--./sdk/x.y.z/TestHost/zh-Hant/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll
 +./sdk/x.y.z/TestHost/ref/
 +./sdk/x.y.z/TestHost/ref/testhost.dll
 +./sdk/x.y.z/TestHost/ref/testhost.x86.dll
@@ -1304,135 +518,31 @@ index ------------
 +./sdk/x.y.z/TestHost/testhost.x86.runtimeconfig.json
  ./sdk/x.y.z/tr/
  ./sdk/x.y.z/tr/dotnet.resources.dll
--./sdk/x.y.z/tr/Microsoft.Build.NuGetSdkResolver.resources.dll
  ./sdk/x.y.z/tr/Microsoft.Build.resources.dll
- ./sdk/x.y.z/tr/Microsoft.Build.Tasks.Core.resources.dll
- ./sdk/x.y.z/tr/Microsoft.Build.Utilities.Core.resources.dll
 @@ ------------ @@
  ./sdk/x.y.z/tr/Microsoft.TemplateEngine.Edge.resources.dll
  ./sdk/x.y.z/tr/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
  ./sdk/x.y.z/tr/Microsoft.TemplateSearch.Common.resources.dll
--./sdk/x.y.z/tr/Microsoft.TestPlatform.Build.resources.dll
--./sdk/x.y.z/tr/Microsoft.TestPlatform.CommunicationUtilities.resources.dll
--./sdk/x.y.z/tr/Microsoft.TestPlatform.CoreUtilities.resources.dll
--./sdk/x.y.z/tr/Microsoft.TestPlatform.CrossPlatEngine.resources.dll
--./sdk/x.y.z/tr/Microsoft.TestPlatform.Utilities.resources.dll
--./sdk/x.y.z/tr/Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll
 -./sdk/x.y.z/tr/Microsoft.VisualStudio.Coverage.IO.resources.dll
--./sdk/x.y.z/tr/Microsoft.VisualStudio.TestPlatform.Client.resources.dll
--./sdk/x.y.z/tr/Microsoft.VisualStudio.TestPlatform.Common.resources.dll
--./sdk/x.y.z/tr/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll
  ./sdk/x.y.z/tr/MSBuild.resources.dll
--./sdk/x.y.z/tr/NuGet.Build.Tasks.Console.resources.dll
--./sdk/x.y.z/tr/NuGet.Build.Tasks.resources.dll
--./sdk/x.y.z/tr/NuGet.CommandLine.XPlat.resources.dll
--./sdk/x.y.z/tr/NuGet.Commands.resources.dll
--./sdk/x.y.z/tr/NuGet.Common.resources.dll
--./sdk/x.y.z/tr/NuGet.Configuration.resources.dll
--./sdk/x.y.z/tr/NuGet.Credentials.resources.dll
--./sdk/x.y.z/tr/NuGet.DependencyResolver.Core.resources.dll
--./sdk/x.y.z/tr/NuGet.Frameworks.resources.dll
--./sdk/x.y.z/tr/NuGet.LibraryModel.resources.dll
--./sdk/x.y.z/tr/NuGet.Localization.resources.dll
--./sdk/x.y.z/tr/NuGet.PackageManagement.resources.dll
--./sdk/x.y.z/tr/NuGet.Packaging.Core.resources.dll
--./sdk/x.y.z/tr/NuGet.Packaging.resources.dll
--./sdk/x.y.z/tr/NuGet.ProjectModel.resources.dll
--./sdk/x.y.z/tr/NuGet.Protocol.resources.dll
--./sdk/x.y.z/tr/NuGet.Resolver.resources.dll
--./sdk/x.y.z/tr/NuGet.Versioning.resources.dll
--./sdk/x.y.z/tr/NuGet.VisualStudio.Contracts.resources.dll
  ./sdk/x.y.z/tr/System.CommandLine.resources.dll
--./sdk/x.y.z/tr/vstest.console.resources.dll
 +./sdk/x.y.z/vstest.console
  ./sdk/x.y.z/vstest.console.deps.json
  ./sdk/x.y.z/vstest.console.dll
  ./sdk/x.y.z/vstest.console.dll.config
- ./sdk/x.y.z/vstest.console.runtimeconfig.json
- ./sdk/x.y.z/zh-Hans/
- ./sdk/x.y.z/zh-Hans/dotnet.resources.dll
--./sdk/x.y.z/zh-Hans/Microsoft.Build.NuGetSdkResolver.resources.dll
- ./sdk/x.y.z/zh-Hans/Microsoft.Build.resources.dll
- ./sdk/x.y.z/zh-Hans/Microsoft.Build.Tasks.Core.resources.dll
- ./sdk/x.y.z/zh-Hans/Microsoft.Build.Utilities.Core.resources.dll
 @@ ------------ @@
  ./sdk/x.y.z/zh-Hans/Microsoft.TemplateEngine.Edge.resources.dll
  ./sdk/x.y.z/zh-Hans/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
  ./sdk/x.y.z/zh-Hans/Microsoft.TemplateSearch.Common.resources.dll
--./sdk/x.y.z/zh-Hans/Microsoft.TestPlatform.Build.resources.dll
--./sdk/x.y.z/zh-Hans/Microsoft.TestPlatform.CommunicationUtilities.resources.dll
--./sdk/x.y.z/zh-Hans/Microsoft.TestPlatform.CoreUtilities.resources.dll
--./sdk/x.y.z/zh-Hans/Microsoft.TestPlatform.CrossPlatEngine.resources.dll
--./sdk/x.y.z/zh-Hans/Microsoft.TestPlatform.Utilities.resources.dll
--./sdk/x.y.z/zh-Hans/Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll
 -./sdk/x.y.z/zh-Hans/Microsoft.VisualStudio.Coverage.IO.resources.dll
--./sdk/x.y.z/zh-Hans/Microsoft.VisualStudio.TestPlatform.Client.resources.dll
--./sdk/x.y.z/zh-Hans/Microsoft.VisualStudio.TestPlatform.Common.resources.dll
--./sdk/x.y.z/zh-Hans/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll
  ./sdk/x.y.z/zh-Hans/MSBuild.resources.dll
--./sdk/x.y.z/zh-Hans/NuGet.Build.Tasks.Console.resources.dll
--./sdk/x.y.z/zh-Hans/NuGet.Build.Tasks.resources.dll
--./sdk/x.y.z/zh-Hans/NuGet.CommandLine.XPlat.resources.dll
--./sdk/x.y.z/zh-Hans/NuGet.Commands.resources.dll
--./sdk/x.y.z/zh-Hans/NuGet.Common.resources.dll
--./sdk/x.y.z/zh-Hans/NuGet.Configuration.resources.dll
--./sdk/x.y.z/zh-Hans/NuGet.Credentials.resources.dll
--./sdk/x.y.z/zh-Hans/NuGet.DependencyResolver.Core.resources.dll
--./sdk/x.y.z/zh-Hans/NuGet.Frameworks.resources.dll
--./sdk/x.y.z/zh-Hans/NuGet.LibraryModel.resources.dll
--./sdk/x.y.z/zh-Hans/NuGet.Localization.resources.dll
--./sdk/x.y.z/zh-Hans/NuGet.PackageManagement.resources.dll
--./sdk/x.y.z/zh-Hans/NuGet.Packaging.Core.resources.dll
--./sdk/x.y.z/zh-Hans/NuGet.Packaging.resources.dll
--./sdk/x.y.z/zh-Hans/NuGet.ProjectModel.resources.dll
--./sdk/x.y.z/zh-Hans/NuGet.Protocol.resources.dll
--./sdk/x.y.z/zh-Hans/NuGet.Resolver.resources.dll
--./sdk/x.y.z/zh-Hans/NuGet.Versioning.resources.dll
--./sdk/x.y.z/zh-Hans/NuGet.VisualStudio.Contracts.resources.dll
  ./sdk/x.y.z/zh-Hans/System.CommandLine.resources.dll
--./sdk/x.y.z/zh-Hans/vstest.console.resources.dll
  ./sdk/x.y.z/zh-Hant/
- ./sdk/x.y.z/zh-Hant/dotnet.resources.dll
--./sdk/x.y.z/zh-Hant/Microsoft.Build.NuGetSdkResolver.resources.dll
- ./sdk/x.y.z/zh-Hant/Microsoft.Build.resources.dll
- ./sdk/x.y.z/zh-Hant/Microsoft.Build.Tasks.Core.resources.dll
- ./sdk/x.y.z/zh-Hant/Microsoft.Build.Utilities.Core.resources.dll
 @@ ------------ @@
  ./sdk/x.y.z/zh-Hant/Microsoft.TemplateEngine.Edge.resources.dll
  ./sdk/x.y.z/zh-Hant/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
  ./sdk/x.y.z/zh-Hant/Microsoft.TemplateSearch.Common.resources.dll
--./sdk/x.y.z/zh-Hant/Microsoft.TestPlatform.Build.resources.dll
--./sdk/x.y.z/zh-Hant/Microsoft.TestPlatform.CommunicationUtilities.resources.dll
--./sdk/x.y.z/zh-Hant/Microsoft.TestPlatform.CoreUtilities.resources.dll
--./sdk/x.y.z/zh-Hant/Microsoft.TestPlatform.CrossPlatEngine.resources.dll
--./sdk/x.y.z/zh-Hant/Microsoft.TestPlatform.Utilities.resources.dll
--./sdk/x.y.z/zh-Hant/Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll
 -./sdk/x.y.z/zh-Hant/Microsoft.VisualStudio.Coverage.IO.resources.dll
--./sdk/x.y.z/zh-Hant/Microsoft.VisualStudio.TestPlatform.Client.resources.dll
--./sdk/x.y.z/zh-Hant/Microsoft.VisualStudio.TestPlatform.Common.resources.dll
--./sdk/x.y.z/zh-Hant/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll
  ./sdk/x.y.z/zh-Hant/MSBuild.resources.dll
--./sdk/x.y.z/zh-Hant/NuGet.Build.Tasks.Console.resources.dll
--./sdk/x.y.z/zh-Hant/NuGet.Build.Tasks.resources.dll
--./sdk/x.y.z/zh-Hant/NuGet.CommandLine.XPlat.resources.dll
--./sdk/x.y.z/zh-Hant/NuGet.Commands.resources.dll
--./sdk/x.y.z/zh-Hant/NuGet.Common.resources.dll
--./sdk/x.y.z/zh-Hant/NuGet.Configuration.resources.dll
--./sdk/x.y.z/zh-Hant/NuGet.Credentials.resources.dll
--./sdk/x.y.z/zh-Hant/NuGet.DependencyResolver.Core.resources.dll
--./sdk/x.y.z/zh-Hant/NuGet.Frameworks.resources.dll
--./sdk/x.y.z/zh-Hant/NuGet.LibraryModel.resources.dll
--./sdk/x.y.z/zh-Hant/NuGet.Localization.resources.dll
--./sdk/x.y.z/zh-Hant/NuGet.PackageManagement.resources.dll
--./sdk/x.y.z/zh-Hant/NuGet.Packaging.Core.resources.dll
--./sdk/x.y.z/zh-Hant/NuGet.Packaging.resources.dll
--./sdk/x.y.z/zh-Hant/NuGet.ProjectModel.resources.dll
--./sdk/x.y.z/zh-Hant/NuGet.Protocol.resources.dll
--./sdk/x.y.z/zh-Hant/NuGet.Resolver.resources.dll
--./sdk/x.y.z/zh-Hant/NuGet.Versioning.resources.dll
--./sdk/x.y.z/zh-Hant/NuGet.VisualStudio.Contracts.resources.dll
  ./sdk/x.y.z/zh-Hant/System.CommandLine.resources.dll
--./sdk/x.y.z/zh-Hant/vstest.console.resources.dll
  ./shared/
- ./shared/Microsoft.AspNetCore.App/
-@@ ------------ @@


### PR DESCRIPTION
Backport of https://github.com/dotnet/installer/pull/15650

Fixes https://github.com/dotnet/source-build/issues/3266

Infrastructure change.

- Adds support for exclusions in SDK diffing tests.
- Fixes the issue with version abstraction by moving it to WriteTarballFileList, so exclusions are even possible - this makes the diffing infra the same as in 7.0 and 8.0
- Updates the exclusion list, compared to 8.0 and 7.0 versions, to account for differences in 6.0 codebase - TestHost is the only test-host directory, which also has some resources in LOC sub-directories