### PR TITLE
Fix tarball extraction when using wildcards

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SourceBuiltArtifactsTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SourceBuiltArtifactsTests.cs
@@ -63,6 +63,6 @@ public class SourceBuiltArtifactsTests : SmokeTests
 
     private void ExtractFileFromTarball(string tarballPath, string filePath, string outputDir)
     {
-        ExecuteHelper.ExecuteProcessValidateExitCode("tar", $"xzf {tarballPath} -C {outputDir} {filePath}", OutputHelper);
+        ExecuteHelper.ExecuteProcessValidateExitCode("tar", $"--wildcards -xzf {tarballPath} -C {outputDir} {filePath}", OutputHelper);
     }
 }


### PR DESCRIPTION
The VerifyVersionFile test in source-build is failing in the Ubuntu leg with the following failure:

```
System.InvalidOperationException : Failed to execute tar xzf /vmr/artifacts/x64/Release/dotnet-sdk-8.0.100-preview.3.23152.1-ubuntu.20.04-x64.tar.gz -C /vmr/test/Microsoft.DotNet.SourceBuild.SmokeTests/bin/Release/net8.0/sourcebuilt-artifacts ./sdk/*/.version
Exit code: 2

tar: Pattern matching characters used in file names
tar: Use --wildcards to enable pattern matching, or --no-wildcards to suppress this warning
tar: ./sdk/*/.version: Not found in archive
tar: Exiting with failure status due to previous errors
```

It seems the version of `tar` in Ubuntu has different behavior compared to the other distros where this was working. Because the file path being targeted to extract has a wildcard in it, `tar` requires that the `--wildcards` option be explicitly set. Otherwise, it defaults to not treating it as a wildcard, which then leads to the failure to find a file path of `./sdk/*/.version`.

I've fixed this by explicitly setting the `--wildcards` option. The use of this option is compatible with the other distros as well.

Fixes https://github.com/dotnet/source-build/issues/3294