### PR TITLE
Fix tarball extraction when using wildcards (#15695)

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SourceBuiltArtifactsTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SourceBuiltArtifactsTests.cs
@@ -63,6 +63,6 @@ public class SourceBuiltArtifactsTests : SmokeTests
 
     private void ExtractFileFromTarball(string tarballPath, string filePath, string outputDir)
     {
-        ExecuteHelper.ExecuteProcessValidateExitCode("tar", $"xzf {tarballPath} -C {outputDir} {filePath}", OutputHelper);
+        ExecuteHelper.ExecuteProcessValidateExitCode("tar", $"--wildcards -xzf {tarballPath} -C {outputDir} {filePath}", OutputHelper);
     }
 }


### PR DESCRIPTION
(cherry picked from commit 9bd65f4d782334006f22bfaafd1b42a03ece4875)