### PR TITLE
[7.0.1xx] Automate Asp.net template updates in dotnet/installer

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -114,7 +114,7 @@
     <!-- Grab just the patch version from MicrosoftNETSdkPackageVersion (7.0.103-servicing becomes 03) -->
     <MicrosoftNETSdkFeatureAndPatchVersion>$(MicrosoftNETSdkPackageVersion.Split('.')[2])</MicrosoftNETSdkFeatureAndPatchVersion>
     <MicrosoftNETSdkFeatureAndPatchVersion>$(MicrosoftNETSdkFeatureAndPatchVersion.Split('-')[0])</MicrosoftNETSdkFeatureAndPatchVersion>
-    <MicrosoftNETSdkPatchVersion>$(MicrosoftNETSdkPatchVersion.Substring(1))</MicrosoftNETSdkPatchVersion>
+    <MicrosoftNETSdkPatchVersion>$(MicrosoftNETSdkFeatureAndPatchVersion.Substring(1))</MicrosoftNETSdkPatchVersion>
     <!-- 
       Between branding and shipping, the templates should stay at last month's version.
       If the incoming SDK version is 2 versions behind us, we know we just branded but haven't done the internal -> public merge yet.

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -106,16 +106,16 @@
   <PropertyGroup>
     <!-- Automated versions for asp.net templates -->
     <!-- Grab just the patch version from MicrosoftNETSdkPackageVersion (7.0.103-servicing becomes 03) -->
-    <MicrosoftNETSdkPactchVersion>$(MicrosoftNETSdkPackageVersion.Split('.')[2])</MicrosoftNETSdkPactchVersion>
-    <MicrosoftNETSdkPactchVersion>$(MicrosoftNETSdkPactchVersion.Split('-')[0])</MicrosoftNETSdkPactchVersion>
-    <MicrosoftNETSdkPactchVersion>$(MicrosoftNETSdkPactchVersion.Substring(1))</MicrosoftNETSdkPactchVersion>
+    <MicrosoftNETSdkPatchVersion>$(MicrosoftNETSdkPackageVersion.Split('.')[2])</MicrosoftNETSdkPatchVersion>
+    <MicrosoftNETSdkPatchVersion>$(MicrosoftNETSdkPactchVersion.Split('-')[0])</MicrosoftNETSdkPatchVersion>
+    <MicrosoftNETSdkPatchVersion>$(MicrosoftNETSdkPactchVersion.Substring(1))</MicrosoftNETSdkPatchVersion>
     <!-- 
       Between branding and shipping, the templates should stay at last month's version.
       If the incoming SDK version is 2 versions behind us, we know we just branded but haven't done the internal -> public merge yet.
       Therefore we stay at last month's version.
     -->
     <AspNetCoreTemplateFeature60>$([MSBuild]::Add($(VersionFeature), 9))</AspNetCoreTemplateFeature60>
-    <AspNetCoreTemplateFeature60 Condition="$([MSBuild]::Subtract($(VersionFeature), $(MicrosoftNETSdkPactchVersion))) &lt; 2">$([MSBuild]::Add($(AspNetCoreTemplateFeature60), 1))</AspNetCoreTemplateFeature60>
+    <AspNetCoreTemplateFeature60 Condition="$([MSBuild]::Subtract($(VersionFeature), $(MicrosoftNETSdkPatchVersion))) &lt; 2">$([MSBuild]::Add($(AspNetCoreTemplateFeature60), 1))</AspNetCoreTemplateFeature60>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Cross-release dependency versions -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -116,6 +116,7 @@
     -->
     <AspNetCoreTemplateFeature60>$([MSBuild]::Add($(VersionFeature), 9))</AspNetCoreTemplateFeature60>
     <AspNetCoreTemplateFeature60 Condition="$([MSBuild]::Subtract($(VersionFeature), $(MicrosoftNETSdkPactchVersion))) &lt; 2">$([MSBuild]::Add($(AspNetCoreTemplateFeature60), 1))</AspNetCoreTemplateFeature60>
+  </PropertyGroup>
   <PropertyGroup>
     <!-- Cross-release dependency versions -->
     <MicrosoftDotNetCommonItemTemplates50PackageVersion>5.0.403</MicrosoftDotNetCommonItemTemplates50PackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -104,6 +104,19 @@
     <NuGetVersioningPackageVersion>5.8.0</NuGetVersioningPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
+    <!-- Automated versions for asp.net templates -->
+    <!-- Grab just the patch version from MicrosoftNETSdkPackageVersion (7.0.103-servicing becomes 03) -->
+    <MicrosoftNETSdkPactchVersion>$(MicrosoftNETSdkPackageVersion.Split('.')[2])</MicrosoftNETSdkPactchVersion>
+    <MicrosoftNETSdkPactchVersion>$(MicrosoftNETSdkPactchVersion.Split('-')[0])</MicrosoftNETSdkPactchVersion>
+    <MicrosoftNETSdkPactchVersion>$(MicrosoftNETSdkPactchVersion.Substring(1))</MicrosoftNETSdkPactchVersion>
+    <!-- 
+      Between branding and shipping, the templates should stay at last month's version.
+      If the incoming SDK version is 2 versions behind us, we know we just branded but haven't done the internal -> public merge yet.
+      Therefore we stay at last month's version.
+    -->
+    <AspNetCoreTemplateFeature60>$([MSBuild]::Add($(VersionFeature), 9))</AspNetCoreTemplateFeature60>
+    <AspNetCoreTemplateFeature60 Condition="$([MSBuild]::Subtract($(VersionFeature), $(MicrosoftNETSdkPactchVersion))) &lt; 2">$([MSBuild]::Add($(AspNetCoreTemplateFeature60), 1))</AspNetCoreTemplateFeature60>
+  <PropertyGroup>
     <!-- Cross-release dependency versions -->
     <MicrosoftDotNetCommonItemTemplates50PackageVersion>5.0.403</MicrosoftDotNetCommonItemTemplates50PackageVersion>
     <MicrosoftDotNetCommonItemTemplates60PackageVersion>6.0.302</MicrosoftDotNetCommonItemTemplates60PackageVersion>
@@ -135,7 +148,7 @@
     <NUnit3Templates60PackageVersion>$(NUnit3DotNetNewTemplatePackageVersion)</NUnit3Templates60PackageVersion>
     <MicrosoftDotNetCommonItemTemplates60PackageVersion>$(MicrosoftDotNetCommonItemTemplates60PackageVersion)</MicrosoftDotNetCommonItemTemplates60PackageVersion>
     <MicrosoftDotNetCommonProjectTemplates60PackageVersion>$(MicrosoftDotNetCommonItemTemplates60PackageVersion)</MicrosoftDotNetCommonProjectTemplates60PackageVersion>
-    <AspNetCorePackageVersionFor60Templates>6.0.14</AspNetCorePackageVersionFor60Templates>
+    <AspNetCorePackageVersionFor60Templates>6.0.$(AspNetCoreTemplateFeature60)</AspNetCorePackageVersionFor60Templates>
     <!-- 5.0 Template versions -->
     <MicrosoftDotnetWinFormsProjectTemplates50PackageVersion>$(MicrosoftWinFormsProjectTemplates50PackageVersion)</MicrosoftDotnetWinFormsProjectTemplates50PackageVersion>
     <MicrosoftDotNetWpfProjectTemplates50PackageVersion>$(MicrosoftWPFProjectTemplates50PackageVersion)</MicrosoftDotNetWpfProjectTemplates50PackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -19,6 +19,12 @@
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
   </PropertyGroup>
+  <PropertyGroup>
+    <VersionFeature21>30</VersionFeature21>
+    <VersionFeature31>32</VersionFeature31>
+    <VersionFeature50>17</VersionFeature50>
+    <VersionFeature60>$([MSBuild]::Add($(VersionFeature), 11))</VersionFeature60>
+  </PropertyGroup>
   <!-- Restore feeds -->
   <PropertyGroup Label="Restore feeds">
     <!-- In an orchestrated build, this may be overridden to other Azure feeds. -->
@@ -106,23 +112,25 @@
   <PropertyGroup>
     <!-- Automated versions for asp.net templates -->
     <!-- Grab just the patch version from MicrosoftNETSdkPackageVersion (7.0.103-servicing becomes 03) -->
-    <MicrosoftNETSdkPatchVersion>$(MicrosoftNETSdkPackageVersion.Split('.')[2])</MicrosoftNETSdkPatchVersion>
-    <MicrosoftNETSdkPatchVersion>$(MicrosoftNETSdkPatchVersion.Split('-')[0])</MicrosoftNETSdkPatchVersion>
+    <MicrosoftNETSdkFeatureAndPatchVersion>$(MicrosoftNETSdkPackageVersion.Split('.')[2])</MicrosoftNETSdkFeatureAndPatchVersion>
+    <MicrosoftNETSdkFeatureAndPatchVersion>$(MicrosoftNETSdkFeatureAndPatchVersion.Split('-')[0])</MicrosoftNETSdkFeatureAndPatchVersion>
     <MicrosoftNETSdkPatchVersion>$(MicrosoftNETSdkPatchVersion.Substring(1))</MicrosoftNETSdkPatchVersion>
     <!-- 
       Between branding and shipping, the templates should stay at last month's version.
       If the incoming SDK version is 2 versions behind us, we know we just branded but haven't done the internal -> public merge yet.
       Therefore we stay at last month's version.
+      We also need to special case the 1st patch release, because the incoming SDK version will never be 2 versions behind us in that case.
+      Instead the indicator is that the incoming SDK version is not RTM or greater yet.
     -->
-    <AspNetCoreTemplateFeature60>$([MSBuild]::Add($(VersionFeature), 9))</AspNetCoreTemplateFeature60>
-    <AspNetCoreTemplateFeature60 Condition="$([MSBuild]::Subtract($(VersionFeature), $(MicrosoftNETSdkPatchVersion))) &lt; 2">$([MSBuild]::Add($(AspNetCoreTemplateFeature60), 1))</AspNetCoreTemplateFeature60>
+    <SubtractOneFromTemplateVersions Condition="$([MSBuild]::Subtract($(VersionFeature), $(MicrosoftNETSdkPatchVersion))) >= 2">true</SubtractOneFromTemplateVersions>
+    <SubtractOneFromTemplateVersions Condition="$(VersionFeature) >= 1 AND ! $(MicrosoftNETSdkPackageVersion.Contains('rtm')) AND ! $(MicrosoftNETSdkPackageVersion.Contains('servicing'))">true</SubtractOneFromTemplateVersions>
+    <AspNetCoreTemplateFeature60>$([MSBuild]::Subtract($(VersionFeature60), 1))</AspNetCoreTemplateFeature60>
+    <AspNetCoreTemplateFeature60 Condition="'$(SubtractOneFromTemplateVersions)' == 'true'">$([MSBuild]::Subtract($(AspNetCoreTemplateFeature60), 1))</AspNetCoreTemplateFeature60>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Cross-release dependency versions -->
     <MicrosoftDotNetCommonItemTemplates50PackageVersion>5.0.403</MicrosoftDotNetCommonItemTemplates50PackageVersion>
     <MicrosoftDotNetCommonItemTemplates60PackageVersion>6.0.302</MicrosoftDotNetCommonItemTemplates60PackageVersion>
-    <MicrosoftAspNetCoreAppRuntime50PackageVersion>5.0.13</MicrosoftAspNetCoreAppRuntime50PackageVersion>
-    <MicrosoftAspNetCoreAppRuntime60PackageVersion>6.0.1</MicrosoftAspNetCoreAppRuntime60PackageVersion>
     <MicrosoftWinFormsProjectTemplates50PackageVersion>5.0.17-servicing.22215.4</MicrosoftWinFormsProjectTemplates50PackageVersion>
     <MicrosoftWPFProjectTemplates50PackageVersion>5.0.17-servicing.22218.2</MicrosoftWPFProjectTemplates50PackageVersion>
     <MicrosoftWinFormsProjectTemplates60PackageVersion>6.0.7-servicing.22322.3</MicrosoftWinFormsProjectTemplates60PackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -107,8 +107,8 @@
     <!-- Automated versions for asp.net templates -->
     <!-- Grab just the patch version from MicrosoftNETSdkPackageVersion (7.0.103-servicing becomes 03) -->
     <MicrosoftNETSdkPatchVersion>$(MicrosoftNETSdkPackageVersion.Split('.')[2])</MicrosoftNETSdkPatchVersion>
-    <MicrosoftNETSdkPatchVersion>$(MicrosoftNETSdkPactchVersion.Split('-')[0])</MicrosoftNETSdkPatchVersion>
-    <MicrosoftNETSdkPatchVersion>$(MicrosoftNETSdkPactchVersion.Substring(1))</MicrosoftNETSdkPatchVersion>
+    <MicrosoftNETSdkPatchVersion>$(MicrosoftNETSdkPatchVersion.Split('-')[0])</MicrosoftNETSdkPatchVersion>
+    <MicrosoftNETSdkPatchVersion>$(MicrosoftNETSdkPatchVersion.Substring(1))</MicrosoftNETSdkPatchVersion>
     <!-- 
       Between branding and shipping, the templates should stay at last month's version.
       If the incoming SDK version is 2 versions behind us, we know we just branded but haven't done the internal -> public merge yet.

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -59,13 +59,6 @@
 
   </Target>
 
-  <PropertyGroup>
-      <VersionFeature21>30</VersionFeature21>
-      <VersionFeature31>32</VersionFeature31>
-      <VersionFeature50>17</VersionFeature50>
-      <VersionFeature60>$([MSBuild]::Add($(VersionFeature), 11))</VersionFeature60>
-  </PropertyGroup>
-
   <Target Name="GenerateBundledVersionsProps" DependsOnTargets="SetupBundledComponents">
     <PropertyGroup>
       <BundledVersionsPropsFileName>Microsoft.NETCoreSdk.BundledVersions.props</BundledVersionsPropsFileName>


### PR DESCRIPTION
@marcpopMSFT @mmitche @dougbu what do you think? The idea is that after we bump branding but before we do the internal -> public merge, `MicrosoftNETSdkPackageVersion` will be 2 versions behind `VersionFeature`. We can use that as  a queue to know when we need to add N vs. when we need to add N+1 to `VersionFeature` to get `AspNetCoreTemplateFeature60`.

Part of https://github.com/dotnet/aspnetcore/issues/45576 - will port to other 7.0 branches when done