### PR TITLE
Add version property for Roslyn

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -86,6 +86,10 @@
     <MicrosoftDotnetTemplateLocatorPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetTemplateLocatorPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
+    <!-- Dependencies from https://github.com/dotnet/roslyn -->
+    <MicrosoftNetCompilersToolsetPackageVersion>4.6.0-2.23164.1</MicrosoftNetCompilersToolsetPackageVersion>
+  </PropertyGroup>
+  <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/corefx -->
     <MicrosoftNETCorePlatformsPackageVersion>8.0.0-preview.3.23166.1</MicrosoftNETCorePlatformsPackageVersion>
   </PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -87,7 +87,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/roslyn -->
-    <MicrosoftNetCompilersToolsetPackageVersion>4.6.0-2.23164.1</MicrosoftNetCompilersToolsetPackageVersion>
+    <MicrosoftNetCompilersToolsetPackageVersion>4.6.0-2.23166.9</MicrosoftNetCompilersToolsetPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/corefx -->


### PR DESCRIPTION
This hopefully will enable https://github.com/dotnet/installer/pull/15216 to use MicrosoftNetCompilersToolsetPackageVersion and have it automatically update using DARC.