### PR TITLE
Update SB prebuilt tarball version

### DIFF
--- a/src/SourceBuild/content/eng/Versions.props
+++ b/src/SourceBuild/content/eng/Versions.props
@@ -19,7 +19,7 @@
       prep.sh and pipeline scripts, outside of MSBuild.
     -->
     <PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Artifacts.8.0.100-preview.2.centos.8-x64.tar.gz</PrivateSourceBuiltArtifactsUrl>
-    <PrivateSourceBuiltPrebuiltsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Prebuilts.0.1.0-8.0.100-11.centos.8-x64.tar.gz</PrivateSourceBuiltPrebuiltsUrl>
+    <PrivateSourceBuiltPrebuiltsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Prebuilts.0.1.0-8.0.100-12.centos.8-x64.tar.gz</PrivateSourceBuiltPrebuiltsUrl>
     <PrivateSourceBuiltSdkUrl_CentOS8Stream>https://dotnetcli.azureedge.net/source-built-artifacts/sdks/dotnet-sdk-8.0.100-preview.2.23158.1-centos.8-x64.tar.gz</PrivateSourceBuiltSdkUrl_CentOS8Stream>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Update the SB prebuilt tarball version which includes the addition of `Microsoft.NetCore.App.Host.linux-arm64.7.0.2`.

Fixes https://github.com/dotnet/source-build/issues/3239
