### PR TITLE
Revert "Update SB version info for 8.0 Preview 2 release (#15851)"

### DIFF
--- a/src/SourceBuild/content/eng/Versions.props
+++ b/src/SourceBuild/content/eng/Versions.props
@@ -18,8 +18,8 @@
       These URLs can't be composed from their base URL and version as we read them from the
       prep.sh and pipeline scripts, outside of MSBuild.
     -->
-    <PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Artifacts.8.0.100-preview.2.centos.8-x64.tar.gz</PrivateSourceBuiltArtifactsUrl>
+    <PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Artifacts.0.1.0-8.0.100-5.centos.8-x64.tar.gz</PrivateSourceBuiltArtifactsUrl>
     <PrivateSourceBuiltPrebuiltsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Prebuilts.0.1.0-8.0.100-11.centos.8-x64.tar.gz</PrivateSourceBuiltPrebuiltsUrl>
-    <PrivateSourceBuiltSdkUrl_CentOS8Stream>https://dotnetcli.azureedge.net/source-built-artifacts/sdks/dotnet-sdk-8.0.100-preview.2.23158.1-centos.8-x64.tar.gz</PrivateSourceBuiltSdkUrl_CentOS8Stream>
+    <PrivateSourceBuiltSdkUrl_CentOS8Stream>https://dotnetcli.azureedge.net/source-built-artifacts/sdks/dotnet-sdk-8.0.100-preview.1.23115.1-centos.8-x64.tar.gz</PrivateSourceBuiltSdkUrl_CentOS8Stream>
   </PropertyGroup>
 </Project>

--- a/src/SourceBuild/content/global.json
+++ b/src/SourceBuild/content/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "8.0.100-preview.2.23157.25"
+    "dotnet": "8.0.100-alpha.1.23080.2"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.1",


### PR DESCRIPTION
Reverting this change for now because it seems like it's blocking CI with the following error:

```
    EXEC : error : Failed to load assembly 'System.CommandLine' [/vmr/src/runtime/artifacts/source-build/self/src/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj]
      Internal.TypeSystem.TypeSystemException+FileNotFoundException: Failed to load assembly 'System.CommandLine'
         at Internal.TypeSystem.ThrowHelper.ThrowFileNotFoundException(ExceptionStringID, String) in /_/src/coreclr/tools/Common/TypeSystem/Common/ThrowHelper.cs:line 35
         at Internal.TypeSystem.ResolutionFailure.Throw() in /_/src/coreclr/tools/Common/TypeSystem/Common/ResolutionFailure.cs:line 105
         at Internal.TypeSystem.Ecma.EcmaModule.GetObject(EntityHandle, NotFoundBehavior ) in /_/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaModule.cs:line 412
         at Internal.TypeSystem.Ecma.EcmaModule.GetType(EntityHandle) in /_/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaModule.cs:line 359
         at Internal.TypeSystem.Ecma.EcmaType.InitializeBaseType() in /_/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaType.cs:line 163
         at Internal.TypeSystem.Ecma.EcmaType.ComputeTypeFlags(TypeFlags) in /_/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaType.cs:line 199
         at Internal.TypeSystem.TypeDesc.InitializeTypeFlags(TypeFlags) in /_/src/coreclr/tools/Common/TypeSystem/Common/TypeDesc.cs:line 135
         at Internal.TypeSystem.Ecma.EcmaType.ComputeTypeFlags(TypeFlags) in /_/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaType.cs:line 247
         at Internal.TypeSystem.TypeDesc.InitializeTypeFlags(TypeFlags) in /_/src/coreclr/tools/Common/TypeSystem/Common/TypeDesc.cs:line 135
         at Internal.TypeSystem.MetadataFieldLayoutAlgorithm.ComputeInstanceLayout(DefType, InstanceLayoutKind) in /_/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs:line 41
         at Internal.TypeSystem.DefType.ComputeInstanceLayout(InstanceLayoutKind) in /_/src/coreclr/tools/Common/TypeSystem/Common/DefType.FieldLayout.cs:line 436
         at ILCompiler.CompilerTypeSystemContext.EnsureLoadableTypeUncached(TypeDesc) in /_/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.Validation.cs:line 137
         at Internal.TypeSystem.LockFreeReaderHashtable`2.CreateValueAndEnsureValueIsInTable(TKey) in /_/src/coreclr/tools/Common/TypeSystem/Common/Utilities/LockFreeReaderHashtable.cs:line 562
         at ILCompiler.DependencyAnalysis.EETypeNode..ctor(NodeFactory, TypeDesc) in /_/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs:line 85
         at ILCompiler.DependencyAnalysis.NodeFactory.CreateConstructedTypeNode(TypeDesc) in /_/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs:line 542
         at Internal.TypeSystem.LockFreeReaderHashtable`2.CreateValueAndEnsureValueIsInTable(TKey) in /_/src/coreclr/tools/Common/TypeSystem/Common/Utilities/LockFreeReaderHashtable.cs:line 562
         at ILCompiler.DependencyAnalysis.NodeFactory.ConstructedTypeSymbol(TypeDesc) in /_/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs:line 614
         at ILCompiler.DependencyAnalysis.ReflectionInvokeMapNode.AddDependenciesDueToReflectability(DependencyList&, NodeFactory, MethodDesc) in /_/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectionInvokeMapNode.cs:line 54
         at ILCompiler.MetadataManager.GetDependenciesDueToReflectability(DependencyList&, NodeFactory, MethodDesc) in /_/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs:line 399
         at ILCompiler.DependencyAnalysis.ReflectedMethodNode.GetStaticDependencies(NodeFactory) in /_/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectedMethodNode.cs:line 39
         at ILCompiler.DependencyAnalysisFramework.DependencyAnalyzer`2.GetStaticDependenciesImpl(DependencyNodeCore`1) in /_/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/DependencyAnalyzer.cs:line 182
         at ILCompiler.DependencyAnalysisFramework.DependencyAnalyzer`2.GetStaticDependencies(DependencyNodeCore`1) in /_/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/DependencyAnalyzer.cs:line 222
         at ILCompiler.DependencyAnalysisFramework.DependencyAnalyzer`2.ProcessMarkStack() in /_/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/DependencyAnalyzer.cs:line 257
         at ILCompiler.DependencyAnalysisFramework.DependencyAnalyzer`2.ComputeMarkedNodes() in /_/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/DependencyAnalyzer.cs:line 308
         at ILCompiler.ILScanner.ILCompiler.IILScanner.Scan() in /_/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILScanner.cs:line 140
         at ILCompiler.Program.<Run>g__RunScanner|3_0(<>c__DisplayClass3_0&) in /_/src/coreclr/tools/aot/ILCompiler/Program.cs:line 438
         at ILCompiler.Program.Run() in /_/src/coreclr/tools/aot/ILCompiler/Program.cs:line 418
         at ILCompiler.ILCompilerRootCommand.<>c__DisplayClass203_0.<.ctor>b__0(InvocationContext) in /_/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs:line 272
```

This is strange though because this same error was encountered in the build for that PR: https://github.com/dotnet/installer/pull/15851#issuecomment-1473947967. But it went away after merging the changes from https://github.com/dotnet/installer/pull/15823.