### PR TITLE
Update MAUI baseline manifests

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -223,13 +223,13 @@
   </PropertyGroup>
   <!-- Workload manifest package versions -->
   <PropertyGroup>
-    <MauiFeatureBand>8.0.100-preview.1</MauiFeatureBand>
-    <MauiWorkloadManifestVersion>8.0.0-preview.1.7626</MauiWorkloadManifestVersion>
-    <XamarinAndroidWorkloadManifestVersion>34.0.0-preview.1.148</XamarinAndroidWorkloadManifestVersion>
-    <XamarinIOSWorkloadManifestVersion>16.2.227-net8-p1</XamarinIOSWorkloadManifestVersion>
-    <XamarinMacCatalystWorkloadManifestVersion>16.2.227-net8-p1</XamarinMacCatalystWorkloadManifestVersion>
-    <XamarinMacOSWorkloadManifestVersion>13.1.227-net8-p1</XamarinMacOSWorkloadManifestVersion>
-    <XamarinTvOSWorkloadManifestVersion>16.1.1015-net8-p1</XamarinTvOSWorkloadManifestVersion>
+    <MauiFeatureBand>8.0.100-preview.2</MauiFeatureBand>
+    <MauiWorkloadManifestVersion>8.0.0-preview.2.7871</MauiWorkloadManifestVersion>
+    <XamarinAndroidWorkloadManifestVersion>34.0.0-preview.2.187</XamarinAndroidWorkloadManifestVersion>
+    <XamarinIOSWorkloadManifestVersion>16.2.374-net8-p2</XamarinIOSWorkloadManifestVersion>
+    <XamarinMacCatalystWorkloadManifestVersion>16.2.374-net8-p2</XamarinMacCatalystWorkloadManifestVersion>
+    <XamarinMacOSWorkloadManifestVersion>13.1.374-net8-p2</XamarinMacOSWorkloadManifestVersion>
+    <XamarinTvOSWorkloadManifestVersion>16.1.1162-net8-p2</XamarinTvOSWorkloadManifestVersion>
     <!-- Workloads from dotnet/emsdk -->
     <MicrosoftNETWorkloadEmscriptenCurrentManifest80100TransportPackageVersion>8.0.0-preview.3.23167.1</MicrosoftNETWorkloadEmscriptenCurrentManifest80100TransportPackageVersion>
     <EmscriptenWorkloadManifestVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest80100TransportPackageVersion)</EmscriptenWorkloadManifestVersion>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/sdk/issues/31260

A problem can occur if you:

* Install .NET 8 Preview 3

* `dotnet workload install maui`, some packs fail to install:

```
Workload installation failed: microsoft.ios.sdk::16.2.37 is not found in NuGet feeds
Workload installation failed: microsoft.android.sdk.windows::33.0.46 is not found in NuGet feeds
```

The current baseline manifests point to nightly builds right now, and so this fails unless you add the `dotnet8` feed:

    --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json

I think going forward, a reasonable solution will be:

* We always put public builds in the baseline manifests.

* MAUI baseline manifests lag behind one release.

This might change as we get to RCs or closer to GA.

Note that this will not solve: https://github.com/dotnet/installer/issues/15804

As the baseline manifests will always lag behind 1 release.