### PR TITLE
Add System.Common.Drawing prebuilt

### DIFF
--- a/src/SourceBuild/content/eng/Versions.props
+++ b/src/SourceBuild/content/eng/Versions.props
@@ -19,7 +19,7 @@
       prep.sh and pipeline scripts, outside of MSBuild.
     -->
     <PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Artifacts.0.1.0-8.0.100-5.centos.8-x64.tar.gz</PrivateSourceBuiltArtifactsUrl>
-    <PrivateSourceBuiltPrebuiltsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Prebuilts.0.1.0-8.0.100-12.centos.8-x64.tar.gz</PrivateSourceBuiltPrebuiltsUrl>
+    <PrivateSourceBuiltPrebuiltsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Prebuilts.0.1.0-8.0.100-13.centos.8-x64.tar.gz</PrivateSourceBuiltPrebuiltsUrl>
     <PrivateSourceBuiltSdkUrl_CentOS8Stream>https://dotnetcli.azureedge.net/source-built-artifacts/sdks/dotnet-sdk-8.0.100-preview.1.23115.1-centos.8-x64.tar.gz</PrivateSourceBuiltSdkUrl_CentOS8Stream>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Added `System.Drawing.Common.8.0.0-alpha.1.23076.9.nupkg` to the source-build prebuilt tarball.  This is needed by the bootstrap leg because of the following:

1. Stage 1 using Preview 2 PSB
  - Runtime removed System.Drawing.Common (https://github.com/dotnet/runtime/pull/83356)
    - System.Windows.Extensions still references SDC - because runtime is not using the per-repo pvp, it is forced to use the version from previous source-built artifacts 
2. Stage 2 (bootstrap)
  - Arcade build references System.Windows.Extensions from previous source-built artifacts which per Stage 1 comment above, requires System.Drawing.Common which in this context is the n-2 version.


