### PR TITLE
Update SB version info for 8.0 Preview 2 release

### DIFF
--- a/src/SourceBuild/content/eng/Versions.props
+++ b/src/SourceBuild/content/eng/Versions.props
@@ -18,8 +18,8 @@
       These URLs can't be composed from their base URL and version as we read them from the
       prep.sh and pipeline scripts, outside of MSBuild.
     -->
-    <PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Artifacts.0.1.0-8.0.100-5.centos.8-x64.tar.gz</PrivateSourceBuiltArtifactsUrl>
+    <PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Artifacts.8.0.100-preview.2.centos.8-x64.tar.gz</PrivateSourceBuiltArtifactsUrl>
     <PrivateSourceBuiltPrebuiltsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Prebuilts.0.1.0-8.0.100-13.centos.8-x64.tar.gz</PrivateSourceBuiltPrebuiltsUrl>
-    <PrivateSourceBuiltSdkUrl_CentOS8Stream>https://dotnetcli.azureedge.net/source-built-artifacts/sdks/dotnet-sdk-8.0.100-preview.1.23115.1-centos.8-x64.tar.gz</PrivateSourceBuiltSdkUrl_CentOS8Stream>
+    <PrivateSourceBuiltSdkUrl_CentOS8Stream>https://dotnetcli.azureedge.net/source-built-artifacts/sdks/dotnet-sdk-8.0.100-preview.2.23158.1-centos.8-x64.tar.gz</PrivateSourceBuiltSdkUrl_CentOS8Stream>
   </PropertyGroup>
 </Project>

--- a/src/SourceBuild/content/global.json
+++ b/src/SourceBuild/content/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "8.0.100-alpha.1.23080.2"
+    "dotnet": "8.0.100-preview.2.23157.25"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.1",

--- a/src/SourceBuild/patches/runtime/0002-Revert-switch-to-self-hosted-NativeAOT-compiler.patch
+++ b/src/SourceBuild/patches/runtime/0002-Revert-switch-to-self-hosted-NativeAOT-compiler.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matt Thalman <mthalman@microsoft.com>
+Date: Mon, 20 Mar 2023 15:35:53 -0500
+Subject: [PATCH] Revert switch to self-hosted NativeAOT compiler
+
+Backport: https://github.com/dotnet/runtime/issues/83695
+---
+ src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj | 10 ++++------
+ 1 file changed, 4 insertions(+), 6 deletions(-)
+
+diff --git a/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj b/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
+index db48433db73..fb49fd1a3f2 100644
+--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
++++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
+@@ -10,12 +10,10 @@
+   <!-- BEGIN: Workaround for https://github.com/dotnet/runtime/issues/67742 -->
+   <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != 'true'">
+     <PublishDir>$(RuntimeBinDir)ilc-published/</PublishDir>
+-    <NativeAotSupported Condition="'$(TargetOS)' != 'windows' and '$(TargetOS)' != 'linux' and '$(TargetOS)' != 'osx'">false</NativeAotSupported>
+-    <NativeAotSupported Condition="'$(TargetArchitecture)' != 'x64'">false</NativeAotSupported>
+-    <PublishAot Condition="'$(NativeAotSupported)' == 'true'">true</PublishAot>
+-    <PublishReadyToRun Condition="'$(NativeAotSupported)' != 'true'">true</PublishReadyToRun>
+-    <PublishSingleFile Condition="'$(NativeAotSupported)' != 'true'">true</PublishSingleFile>
+-    <PublishTrimmed Condition="'$(NativeAotSupported)' != 'true'">true</PublishTrimmed>
++    <PublishTrimmed>true</PublishTrimmed>
++    <!-- Don't R2R on ARM64 machines because ARM64 crossgen2 that comes with .NET SDK <= 7.0 Preview 7 crashes.-->
++    <PublishReadyToRun Condition="'$(BuildArchitecture)' != 'arm64'">true</PublishReadyToRun>
++    <PublishSingleFile>true</PublishSingleFile>
+   </PropertyGroup>
+ 
+   <Target Name="PublishCompiler"

--- a/src/SourceBuild/patches/runtime/0002-Revert-switch-to-self-hosted-NativeAOT-compiler.patch
+++ b/src/SourceBuild/patches/runtime/0002-Revert-switch-to-self-hosted-NativeAOT-compiler.patch
@@ -5,27 +5,18 @@ Subject: [PATCH] Revert switch to self-hosted NativeAOT compiler
 
 Backport: https://github.com/dotnet/runtime/issues/83695
 ---
- src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj | 10 ++++------
- 1 file changed, 4 insertions(+), 6 deletions(-)
+ src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj | 1 +
+ 1 file changed, 1 insertion(+)
 
 diff --git a/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj b/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
-index db48433db73..fb49fd1a3f2 100644
+index db48433db73..982bbc78427 100644
 --- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
 +++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
-@@ -10,12 +10,10 @@
-   <!-- BEGIN: Workaround for https://github.com/dotnet/runtime/issues/67742 -->
-   <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != 'true'">
+@@ -12,6 +12,7 @@
      <PublishDir>$(RuntimeBinDir)ilc-published/</PublishDir>
--    <NativeAotSupported Condition="'$(TargetOS)' != 'windows' and '$(TargetOS)' != 'linux' and '$(TargetOS)' != 'osx'">false</NativeAotSupported>
--    <NativeAotSupported Condition="'$(TargetArchitecture)' != 'x64'">false</NativeAotSupported>
--    <PublishAot Condition="'$(NativeAotSupported)' == 'true'">true</PublishAot>
--    <PublishReadyToRun Condition="'$(NativeAotSupported)' != 'true'">true</PublishReadyToRun>
--    <PublishSingleFile Condition="'$(NativeAotSupported)' != 'true'">true</PublishSingleFile>
--    <PublishTrimmed Condition="'$(NativeAotSupported)' != 'true'">true</PublishTrimmed>
-+    <PublishTrimmed>true</PublishTrimmed>
-+    <!-- Don't R2R on ARM64 machines because ARM64 crossgen2 that comes with .NET SDK <= 7.0 Preview 7 crashes.-->
-+    <PublishReadyToRun Condition="'$(BuildArchitecture)' != 'arm64'">true</PublishReadyToRun>
-+    <PublishSingleFile>true</PublishSingleFile>
-   </PropertyGroup>
- 
-   <Target Name="PublishCompiler"
+     <NativeAotSupported Condition="'$(TargetOS)' != 'windows' and '$(TargetOS)' != 'linux' and '$(TargetOS)' != 'osx'">false</NativeAotSupported>
+     <NativeAotSupported Condition="'$(TargetArchitecture)' != 'x64'">false</NativeAotSupported>
++    <NativeAotSupported>false</NativeAotSupported>
+     <PublishAot Condition="'$(NativeAotSupported)' == 'true'">true</PublishAot>
+     <PublishReadyToRun Condition="'$(NativeAotSupported)' != 'true'">true</PublishReadyToRun>
+     <PublishSingleFile Condition="'$(NativeAotSupported)' != 'true'">true</PublishSingleFile>


### PR DESCRIPTION
This is another attempt at updating the SB version info to target 8.0 Preview 2 (see previous attempt at #15851). This fixes the issue identified in the previous attempt by applying a patch for ILCompiler (see https://github.com/dotnet/runtime/issues/83695).