### PR TITLE
Allow disabling full signing in source-build

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -47,12 +47,6 @@ parameters:
 - name: buildFromArchive
   type: boolean
 
-# Some distros like CentOS Stream 9 use OpenSSL 3.0 which disables SHA1 signing.
-# This option overrides that default configuration and enables it. See https://github.com/dotnet/installer/pull/15289
-- name: overrideDistroDisablingSha1
-  type: boolean
-  default: false
-
 # Use the previous version's SDK to build the current one
 - name: withPreviousSDK
   type: boolean
@@ -196,11 +190,6 @@ jobs:
         customBuildArgs='--online'
       else
         customRunArgs="$customRunArgs --network none"
-      fi
-
-      # See https://github.com/dotnet/source-build/issues/3202
-      if [[ '${{ parameters.overrideDistroDisablingSha1 }}' == 'True' ]]; then
-        customRunArgs="$customRunArgs -e OPENSSL_ENABLE_SHA1_SIGNATURES=1"
       fi
 
       if [[ '${{ parameters.enablePoison }}' == 'True' ]]; then

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -78,7 +78,6 @@ stages:
       buildFromArchive: false            # 🚫
       enablePoison: false                # 🚫
       excludeOmniSharpTests: true        # ✅
-      overrideDistroDisablingSha1: false # 🚫
       runOnline: true                    # ✅
       withPreviousSDK: false             # 🚫
 
@@ -96,7 +95,6 @@ stages:
         buildFromArchive: false            # 🚫
         enablePoison: false                # 🚫
         excludeOmniSharpTests: true        # ✅
-        overrideDistroDisablingSha1: false # 🚫
         runOnline: true                    # ✅
         withPreviousSDK: true              # ✅
 
@@ -113,7 +111,6 @@ stages:
         buildFromArchive: true             # ✅
         enablePoison: false                # 🚫
         excludeOmniSharpTests: true        # ✅
-        overrideDistroDisablingSha1: false # 🚫
         runOnline: false                   # 🚫
         withPreviousSDK: false             # 🚫
 
@@ -130,7 +127,6 @@ stages:
         buildFromArchive: true            # ✅
         enablePoison: false               # 🚫
         excludeOmniSharpTests: false      # 🚫
-        overrideDistroDisablingSha1: true # ✅
         runOnline: false                  # 🚫
         withPreviousSDK: false            # 🚫
 
@@ -147,7 +143,6 @@ stages:
         buildFromArchive: true             # ✅
         enablePoison: true                 # ✅
         excludeOmniSharpTests: false       # 🚫
-        overrideDistroDisablingSha1: false # 🚫
         runOnline: false                   # 🚫
         withPreviousSDK: false             # 🚫
 
@@ -164,7 +159,6 @@ stages:
         buildFromArchive: false            # 🚫
         enablePoison: false                # 🚫
         excludeOmniSharpTests: false       # 🚫
-        overrideDistroDisablingSha1: false # 🚫
         runOnline: false                   # 🚫
         withPreviousSDK: false             # 🚫
 
@@ -179,7 +173,6 @@ stages:
         buildFromArchive: false            # 🚫
         enablePoison: false                # 🚫
         excludeOmniSharpTests: false       # 🚫
-        overrideDistroDisablingSha1: false # 🚫
         runOnline: false                   # 🚫
         withPreviousSDK: false             # 🚫
 
@@ -196,7 +189,6 @@ stages:
         buildFromArchive: false            # 🚫
         enablePoison: false                # 🚫
         excludeOmniSharpTests: false       # 🚫
-        overrideDistroDisablingSha1: false # 🚫
         runOnline: false                   # 🚫
         withPreviousSDK: false             # 🚫
         reuseBuildArtifactsFrom: Fedora36_Offline_MsftSdk

--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -35,6 +35,7 @@
     <GlobalJsonFile Condition="'$(GlobalJsonFile)' == '' and Exists('$(ProjectDirectory)global.json')">$(ProjectDirectory)global.json</GlobalJsonFile>
     <NuGetConfigFile Condition="'$(NuGetConfigFile)' == '' and Exists('$(ProjectDirectory)NuGet.config')">$(ProjectDirectory)NuGet.config</NuGetConfigFile>
     <NuGetConfigFile Condition="'$(NuGetConfigFile)' == '' and Exists('$(ProjectDirectory)NuGet.Config')">$(ProjectDirectory)NuGet.Config</NuGetConfigFile>
+    <FullAssemblySigningSupported Condition="'$(FullAssemblySigningSupported)' == ''">false</FullAssemblySigningSupported>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
@@ -114,6 +115,8 @@
 
     <!-- https://github.com/dotnet/source-build/issues/3081 -->
     <EnvironmentVariables Include="CheckEolTargetFramework=false" />
+
+    <EnvironmentVariables Include="FullAssemblySigningSupported=$(FullAssemblySigningSupported)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(EnableExtraDebugging)' == 'true'">


### PR DESCRIPTION
Full Signing requires RSA+SHA1 which is disabled in some environments (eg, RHEL 9, CentOS Stream 9). Expose a top-level flag to allow that to be disabled easily by users.

The actual implementation of that flag is not here; it's in arcade (see https://github.com/dotnet/arcade/pull/12749). Some repos have some nice-to-have fixes (eg, https://github.com/dotnet/source-build-reference-packages/pull/566), but it's mostly optional. The bootstrap arcade SDK being used to build this needs needs to contain the changes for us to be able to build SBRP and then arcade and then all the other repos that will use arcade.

For more context around RSA+SHA1 and the alternative (using public signing), see:

- https://github.com/dotnet/runtime/issues/65874
- https://github.com/dotnet/source-build/issues/3202
- https://github.com/dotnet/arcade/issues/12515
