### PR TITLE
PVP workaround for system.drawing.common removal

### DIFF
--- a/src/SourceBuild/content/eng/Versions.props
+++ b/src/SourceBuild/content/eng/Versions.props
@@ -19,7 +19,7 @@
       prep.sh and pipeline scripts, outside of MSBuild.
     -->
     <PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Artifacts.0.1.0-8.0.100-5.centos.8-x64.tar.gz</PrivateSourceBuiltArtifactsUrl>
-    <PrivateSourceBuiltPrebuiltsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Prebuilts.0.1.0-8.0.100-13.centos.8-x64.tar.gz</PrivateSourceBuiltPrebuiltsUrl>
+    <PrivateSourceBuiltPrebuiltsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Prebuilts.0.1.0-8.0.100-14.centos.8-x64.tar.gz</PrivateSourceBuiltPrebuiltsUrl>
     <PrivateSourceBuiltSdkUrl_CentOS8Stream>https://dotnetcli.azureedge.net/source-built-artifacts/sdks/dotnet-sdk-8.0.100-preview.1.23115.1-centos.8-x64.tar.gz</PrivateSourceBuiltSdkUrl_CentOS8Stream>
   </PropertyGroup>
 </Project>

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -167,7 +167,13 @@
     <ItemGroup>
       <_CurrentSourceBuiltPackages Include="$(SourceBuiltPackagesPath)*.nupkg"
                                    Exclude="$(SourceBuiltPackagesPath)*.symbols.nupkg" />
-      <_PreviouslyBuiltSourceBuiltPackages Include="$(PrebuiltSourceBuiltPackagesPath)*.nupkg" />
+
+      <!-- TODO: Remove Remove System.Drawing.Common exclusion once previous source-build artifacts have been updated to no longer include it.
+           System.Drawing.Common is excluded in response to https://github.com/dotnet/runtime/pull/83356 in order to avoid rebuilts and 
+           bootstrap issues as a result.  This wouldn't be an in the future once Runtime onboards to the per repo pvp feature
+           (https://github.com/dotnet/source-build/issues/3043). -->
+      <_PreviouslyBuiltSourceBuiltPackages Include="$(PrebuiltSourceBuiltPackagesPath)*.nupkg" 
+                                           Exclude="$(PrebuiltSourceBuiltPackagesPath)System.Drawing.Common*.nupkg" />
                                       
       <_CurrentAdditionalAssetDirs Include="$(SourceBuiltToolsetDir)" Condition="Exists('$(SourceBuiltToolsetDir)')" />
     </ItemGroup>


### PR DESCRIPTION
This PR contains the following changes:

1. Added a more robust workaround for System.Drawing.Common being removed from Runtime than what was added in https://github.com/dotnet/installer/pull/15868.  As I result of this, I removed the System.Drawing.Common prebuilt added in that PR.
2. Added the following prebuilts - Eventually these should be new SBRPs but it required the 7.0 targeting pack which we do not want to add yet until all repos have been upgraded to target net8.0.
  1. System.Drawing.Common,7.0.0
  2. Microsoft.Win32.SystemEvents,7.0.0

Once merged, I will log a follow-up issue to cleanup this workaround as part of the preview 3 public PR.
