### PR TITLE
Shutdown the build server before each build.

### DIFF
--- a/src/SourceBuild/tarball/content/repos/Directory.Build.targets
+++ b/src/SourceBuild/tarball/content/repos/Directory.Build.targets
@@ -376,7 +376,9 @@
           DependsOnTargets="BuildRepoReferences"
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(RepoCompletedSemaphorePath)Build.complete">
+
     <Exec Command="$(DotnetToolCommand) build-server shutdown" />
+
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Building $(ProjectBuildReason)" />
     <Message Importance="High" Text="Running command:" />
     <Message Importance="High" Text="  $(BuildCommand) $(RepoApiArgs)" Condition="'$(BuildCommand)' != ''" />

--- a/src/SourceBuild/tarball/content/repos/Directory.Build.targets
+++ b/src/SourceBuild/tarball/content/repos/Directory.Build.targets
@@ -376,6 +376,7 @@
           DependsOnTargets="BuildRepoReferences"
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(RepoCompletedSemaphorePath)Build.complete">
+    <Exec Command="$(DotnetToolCommand) build-server shutdown" />
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Building $(ProjectBuildReason)" />
     <Message Importance="High" Text="Running command:" />
     <Message Importance="High" Text="  $(BuildCommand) $(RepoApiArgs)" Condition="'$(BuildCommand)' != ''" />


### PR DESCRIPTION
This patch is from https://github.com/dotnet/source-build/issues/3159#issuecomment-1343339188, where an issue was reported that Alpine ppc64le builds were taking much longer than expected.  This issue was also seen on other platforms.  Killing the build server between repos has a small effect on platforms not experiencing this issues (just a process shutdown and startup) so this seems like the most straightforward change to make.

Fixes https://github.com/dotnet/source-build/issues/3159.