### PR TITLE
Clean n-1 SBRP packages after building SBRP

### DIFF
--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -332,6 +332,12 @@
     <!-- Copy lists of NonShipping packages to prebuilt-report dir -->
     <Copy SourceFiles="@(NonShippingPackageLists)" DestinationFolder="$(PackageReportDir)packagelists/" />
 
+    <!-- Building SBRP: At this point the References directory contains the previously-source-built SBRPs,
+         clear it before moving the current SBRPs.  This ensures n-1 SBRPs aren't required to build the product repos. -->
+    <RemoveDir
+      Condition="'$(_NupkgDestinationPath)' == '$(ReferencePackagesDir)'"
+      Directories="$(ReferencePackagesDir)" />
+
     <Move
       Condition="'@(SourceBuiltNupkgFiles)' != ''"
       SourceFiles="@(SourceBuiltNupkgFiles)"


### PR DESCRIPTION
The `<vmr>/prereqs/packages/reference` directory is where repo builds pick up all SBRP packages from.  This directory gets initialized with all previous source-built SBRPs as part of initializing the build environment at https://github.com/dotnet/installer/blob/main/src/SourceBuild/content/eng/tools/init-build.proj#L59.  After SBRP is built, the new SBRPs are moved into this directory at https://github.com/dotnet/installer/blob/main/src/SourceBuild/content/repo-projects/Directory.Build.targets#L316.  The issue is n-1 SBRPs are not cleaned up first.  This means any n-1 SBRPs that are no longer built are still available for repos to reference.  This makes it difficult to test removing SBRPs because it requires a stage 2 build to fully validate.

These changes cleanup the n-1 SBRPs before coping in the freshly built SBRPs.
