### PR TITLE
Fix Ubuntu 20.04 artifact name in SDK diffing pipeline

### DIFF
--- a/eng/pipelines/source-build-sdk-diff-tests.yml
+++ b/eng/pipelines/source-build-sdk-diff-tests.yml
@@ -44,7 +44,7 @@ jobs:
 - template: templates/jobs/sdk-diff-tests.yml
   parameters:
     buildName: Ubuntu2004_Offline_MsftSdk
-    targetRid: ubuntu.2004-x64
+    targetRid: ubuntu.20.04-x64
     architecture: x64
     dotnetDotnetRunId: ${{ parameters.dotnetDotnetRunId }}
 

--- a/eng/pipelines/templates/jobs/sdk-diff-tests.yml
+++ b/eng/pipelines/templates/jobs/sdk-diff-tests.yml
@@ -85,14 +85,14 @@ jobs:
       msft_sdk_tarball_name=$(find "$(Pipeline.Workspace)/Artifacts" -name "dotnet-sdk-*-linux-${{ parameters.architecture }}.tar.gz" -exec basename {} \;)
 
       if [[ -z "$msft_sdk_tarball_name" ]]; then
-        echo "Microsoft SDK tarball does not exist in '$(Pipeline.Workspace)/Artifacts'. The associated build 'https://dev.azure.com/dnceng/internal/_build/results?buildId=$(InstallerBuildId)&view=results' might have failed."
+        echo "Microsoft SDK tarball does not exist in '$(Pipeline.Workspace)/Artifacts'. The associated build https://dev.azure.com/dnceng/internal/_build/results?buildId=$(InstallerBuildId) might have failed."
         exit 1
       fi
 
       sdk_tarball_name=$(find "$(Pipeline.Workspace)/Artifacts" -name "dotnet-sdk-*-${{ parameters.targetRid }}.tar.gz" -exec basename {} \;)
 
       if [[ -z "$sdk_tarball_name" ]]; then
-        echo "Source-build SDK tarball does not exist in '$(Pipeline.Workspace)/Artifacts'. The associated build 'https://dev.azure.com/dnceng/internal/_build/results?buildId=$(DotnetDotnetBuildId)&view=results' might have failed"
+        echo "Source-build SDK tarball does not exist in '$(Pipeline.Workspace)/Artifacts'. The associated build https://dev.azure.com/dnceng/internal/_build/results?buildId=$(DotnetDotnetBuildId) might have failed"
         exit 1
       fi
 


### PR DESCRIPTION
Fixes error from here: https://dev.azure.com/dnceng/internal/_build/results?buildId=2145511&view=logs&j=67ebba3a-b1f8-5aac-5101-90d16d101f72&t=39ac3b64-da7a-5fae-b528-0366912b1a30&l=13

Artifact name is `dotnet-sdk-8.0.100-preview.3.23177.1-ubuntu.20.04-x64.tar.gz`

Example fixed build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2145731&view=logs&j=67ebba3a-b1f8-5aac-5101-90d16d101f72&t=39ac3b64-da7a-5fae-b528-0366912b1a30