### PR TITLE
Prevent prebuilt tarball reuse in SB bootstrap leg

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -130,6 +130,10 @@ jobs:
       patterns: '*.tar.gz'
       displayName: Download Previous Build
 
+    # Exclude the prebuilts tarball from the copy. We don't want to reuse it.
+    - script: rm -f $(Pipeline.Workspace)/${{ parameters.reuseBuildArtifactsFrom }}_${{ parameters.architecture }}_Artifacts/*.Prebuilts.*.tar.gz
+      displayName: Remove Prebuilts Tarball
+
     - task: CopyFiles@2
       displayName: Copy Previous Build
       inputs:

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -127,12 +127,10 @@ jobs:
   - ${{ if ne(parameters.reuseBuildArtifactsFrom, '') }}:
     - download: current
       artifact: ${{ parameters.reuseBuildArtifactsFrom }}_${{ parameters.architecture }}_Artifacts
-      patterns: '*.tar.gz'
+      patterns: |
+        **/Private.SourceBuilt.Artifacts.*.tar.gz
+        **/dotnet-sdk-*.tar.gz
       displayName: Download Previous Build
-
-    # Exclude the prebuilts tarball from the copy. We don't want to reuse it.
-    - script: rm -f $(Pipeline.Workspace)/${{ parameters.reuseBuildArtifactsFrom }}_${{ parameters.architecture }}_Artifacts/*.Prebuilts.*.tar.gz
-      displayName: Remove Prebuilts Tarball
 
     - task: CopyFiles@2
       displayName: Copy Previous Build


### PR DESCRIPTION
The changes in #15954 exposed an issue in the pipeline that causes the prebuilts output by the Fedora bootstrapping stage 1 build to be reused by the stage 2 build. Instead, it should be using the prebuilt tarball as defined in Version.props.

This is caused by all of the tarballs produced by the stage 1 build to be copied to the artifacts location. This now automatically gets picked up as a result of the changes from #15954 instead of downloading the prebuilt tarball.

This is fixed by explicitly excluding the prebuilt tarball from the copying of the previous build's artifacts.