### PR TITLE
Use artifacts and SDK from latest Preview 3 build

### DIFF
--- a/src/SourceBuild/content/eng/Versions.props
+++ b/src/SourceBuild/content/eng/Versions.props
@@ -18,8 +18,8 @@
       These URLs can't be composed from their base URL and version as we read them from the
       prep.sh and pipeline scripts, outside of MSBuild.
     -->
-    <PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Artifacts.8.0.100-preview.2.centos.8-x64.tar.gz</PrivateSourceBuiltArtifactsUrl>
+    <PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Artifacts.8.0.100-preview.3.23178.1.centos.8-x64.tar.gz</PrivateSourceBuiltArtifactsUrl>
     <PrivateSourceBuiltPrebuiltsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Prebuilts.0.1.0-8.0.100-17.centos.8-x64.tar.gz</PrivateSourceBuiltPrebuiltsUrl>
-    <PrivateSourceBuiltSdkUrl_CentOS8Stream>https://dotnetcli.azureedge.net/source-built-artifacts/sdks/dotnet-sdk-8.0.100-preview.2.23158.1-centos.8-x64.tar.gz</PrivateSourceBuiltSdkUrl_CentOS8Stream>
+    <PrivateSourceBuiltSdkUrl_CentOS8Stream>https://dotnetcli.azureedge.net/source-built-artifacts/sdks/dotnet-sdk-8.0.100-preview.3.23178.1-centos.8-x64.tar.gz</PrivateSourceBuiltSdkUrl_CentOS8Stream>
   </PropertyGroup>
 </Project>

--- a/src/SourceBuild/content/global.json
+++ b/src/SourceBuild/content/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "8.0.100-preview.3.23178.1"
+    "dotnet": "8.0.100-preview.2.23157.25"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.1",

--- a/src/SourceBuild/content/global.json
+++ b/src/SourceBuild/content/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "8.0.100-preview.2.23157.25"
+    "dotnet": "8.0.100-preview.3.23178.1"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.1",

--- a/src/SourceBuild/content/global.json
+++ b/src/SourceBuild/content/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "8.0.100-preview.2.23157.25"
+    "dotnet": "8.0.100-preview.3.23178.7"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.1",

--- a/src/SourceBuild/patches/roslyn/0001-Only-pack-the-shipping-non-shipping-nupkgs-for-rosly.patch
+++ b/src/SourceBuild/patches/roslyn/0001-Only-pack-the-shipping-non-shipping-nupkgs-for-rosly.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nikola Milosavljevic <nikolam@microsoft.com>
+Date: Thu, 6 Apr 2023 19:53:04 +0000
+Subject: [PATCH] Only pack the shipping/non-shipping nupkgs for roslyn
+
+Avoid packing release, pre-release stable nupkgs, and symbol nupkg.
+
+Backport: https://github.com/dotnet/roslyn/pull/67679
+---
+ eng/SourceBuild.props | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/eng/SourceBuild.props b/eng/SourceBuild.props
+index d5d41e7167e..a8b55f352ad 100644
+--- a/eng/SourceBuild.props
++++ b/eng/SourceBuild.props
+@@ -4,8 +4,21 @@
+     <GitHubRepositoryName>roslyn</GitHubRepositoryName>
+     <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
+     <SourceBuildTrimNetFrameworkTargets>true</SourceBuildTrimNetFrameworkTargets>
++    <!-- Roslyn produces stable release branded and stable pre-release branded artifacts in addition to the normal non-stable artifacts.
++         Only the non-stable artifacts should flow downstream in source build -->
++    <EnableDefaultSourceBuildIntermediateItems>false</EnableDefaultSourceBuildIntermediateItems>
+   </PropertyGroup>
+ 
++  <Target Name="GetCustomIntermediateNupkgContents" BeforeTargets="GetCategorizedIntermediateNupkgContents">
++    <ItemGroup>
++      <IntermediateNupkgArtifactFile Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)Shipping\**\*.nupkg" />
++      <IntermediateNupkgArtifactFile Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)NonShipping\**\*.nupkg" />
++      <!-- Don't pack any symbol packages: not needed for downstream source-build CI.
++          Roslyn's symbol packages come in .Symbols.<version>.nupkg instead of the standard format. -->
++      <IntermediateNupkgArtifactFile Remove="$(CurrentRepoSourceBuildArtifactsPackagesDir)**\*.Symbols.*.nupkg" />
++    </ItemGroup>
++  </Target>
++
+   <!--
+     The build script passes in the full path of the sln to build.  This must be overridden in order to build
+     the cloned source in the inner build.


### PR DESCRIPTION
We need to update artifacts and SDK to latest Preview 3 build, to pick up newer Arcade SDK package than the one available in `main`. Without this update we cannot enable TFM trimming in `arcade` repo.