### PR TITLE
Update source-build checked-in prebuilts

### DIFF
--- a/src/SourceBuild/content/eng/Versions.props
+++ b/src/SourceBuild/content/eng/Versions.props
@@ -19,7 +19,7 @@
       prep.sh and pipeline scripts, outside of MSBuild.
     -->
     <PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Artifacts.8.0.100-preview.3.23178.1.centos.8-x64.tar.gz</PrivateSourceBuiltArtifactsUrl>
-    <PrivateSourceBuiltPrebuiltsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Prebuilts.0.1.0-8.0.100-17.centos.8-x64.tar.gz</PrivateSourceBuiltPrebuiltsUrl>
+    <PrivateSourceBuiltPrebuiltsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Prebuilts.0.1.0-8.0.100-18.centos.8-x64.tar.gz</PrivateSourceBuiltPrebuiltsUrl>
     <PrivateSourceBuiltSdkUrl_CentOS8Stream>https://dotnetcli.azureedge.net/source-built-artifacts/sdks/dotnet-sdk-8.0.100-preview.3.23178.1-centos.8-x64.tar.gz</PrivateSourceBuiltSdkUrl_CentOS8Stream>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Added the following prebuilts:

1. Microsoft.NETFramework.ReferenceAssemblies.net472.1.0.2.nupkg - necessary until https://github.com/dotnet/installer/pull/16005 is merged which brings in the arcade based vstest with TFM filtering enabled.

Removed the following prebuilts:

1. dotnet/prereqs/packages/prebuilt/FSharp.Compiler.Service.43.7.300-preview.23123.3.nupkg
2. dotnet/prereqs/packages/prebuilt/FSharp.Core.7.0.300-beta.23123.3.nupkg
3. dotnet/prereqs/packages/prebuilt/FSharp.Core.7.0.300.nupkg
4. dotnet/prereqs/packages/prebuilt/Humanizer.Core.2.2.0.nupkg
5. dotnet/prereqs/packages/prebuilt/microsoft.aspnetcore.app.ref.6.0.13.nupkg
6. dotnet/prereqs/packages/prebuilt/microsoft.build.16.10.0.nupkg
7. dotnet/prereqs/packages/prebuilt/microsoft.build.16.11.0.nupkg
8. dotnet/prereqs/packages/prebuilt/microsoft.build.framework.16.10.0.nupkg
9. dotnet/prereqs/packages/prebuilt/microsoft.build.framework.16.11.0.nupkg
10. dotnet/prereqs/packages/prebuilt/microsoft.build.tasks.core.16.10.0.nupkg
11. dotnet/prereqs/packages/prebuilt/microsoft.build.tasks.core.16.11.0.nupkg
12. dotnet/prereqs/packages/prebuilt/microsoft.build.utilities.core.16.10.0.nupkg
13. dotnet/prereqs/packages/prebuilt/microsoft.build.utilities.core.16.11.0.nupkg
14. dotnet/prereqs/packages/prebuilt/microsoft.net.stringtools.1.0.0.nupkg
15. dotnet/prereqs/packages/prebuilt/microsoft.netcore.app.ref.6.0.13.nupkg
16. dotnet/prereqs/packages/prebuilt/microsoft.netframework.referenceassemblies.net20.1.0.3.nupkg
17. dotnet/prereqs/packages/prebuilt/microsoft.netframework.referenceassemblies.net45.1.0.3.nupkg
18. dotnet/prereqs/packages/prebuilt/microsoft.netframework.referenceassemblies.net48.1.0.3.nupkg
19. dotnet/prereqs/packages/prebuilt/microsoft.netframework.referenceassemblies.net452.1.0.3.nupkg
20. dotnet/prereqs/packages/prebuilt/microsoft.netframework.referenceassemblies.net462.1.0.3.nupkg
21. dotnet/prereqs/packages/prebuilt/microsoft.visualstudio.setup.configuration.interop.1.16.30.nupkg
22. dotnet/prereqs/packages/prebuilt/microsoft.win32.systemevents.7.0.0.nupkg
23. dotnet/prereqs/packages/prebuilt/microsoft.windowsdesktop.app.ref.7.0.2.nupkg
24. dotnet/prereqs/packages/prebuilt/system.configuration.configurationmanager.4.7.0.nupkg
25. dotnet/prereqs/packages/prebuilt/system.drawing.common.7.0.0.nupkg
26. dotnet/prereqs/packages/prebuilt/system.security.cryptography.protecteddata.4.7.0.nupkg
27. dotnet/prereqs/packages/prebuilt/system.security.cryptography.xml.4.7.0.nupkg
28. dotnet/prereqs/packages/prebuilt/System.Threading.Tasks.4.3.0.nupkg
