### PR TITLE
Required source-build changes for Preview 3

### DIFF
--- a/src/SourceBuild/patches/roslyn/0001-Only-pack-the-shipping-non-shipping-nupkgs-for-rosly.patch
+++ b/src/SourceBuild/patches/roslyn/0001-Only-pack-the-shipping-non-shipping-nupkgs-for-rosly.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nikola Milosavljevic <nikolam@microsoft.com>
+Date: Thu, 6 Apr 2023 19:53:04 +0000
+Subject: [PATCH] Only pack the shipping/non-shipping nupkgs for roslyn
+
+Avoid packing release, pre-release stable nupkgs, and symbol nupkg.
+
+Backport: https://github.com/dotnet/roslyn/pull/67679
+---
+ eng/SourceBuild.props | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/eng/SourceBuild.props b/eng/SourceBuild.props
+index d5d41e7167e..a8b55f352ad 100644
+--- a/eng/SourceBuild.props
++++ b/eng/SourceBuild.props
+@@ -4,8 +4,21 @@
+     <GitHubRepositoryName>roslyn</GitHubRepositoryName>
+     <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
+     <SourceBuildTrimNetFrameworkTargets>true</SourceBuildTrimNetFrameworkTargets>
++    <!-- Roslyn produces stable release branded and stable pre-release branded artifacts in addition to the normal non-stable artifacts.
++         Only the non-stable artifacts should flow downstream in source build -->
++    <EnableDefaultSourceBuildIntermediateItems>false</EnableDefaultSourceBuildIntermediateItems>
+   </PropertyGroup>
+ 
++  <Target Name="GetCustomIntermediateNupkgContents" BeforeTargets="GetCategorizedIntermediateNupkgContents">
++    <ItemGroup>
++      <IntermediateNupkgArtifactFile Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)Shipping\**\*.nupkg" />
++      <IntermediateNupkgArtifactFile Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)NonShipping\**\*.nupkg" />
++      <!-- Don't pack any symbol packages: not needed for downstream source-build CI.
++          Roslyn's symbol packages come in .Symbols.<version>.nupkg instead of the standard format. -->
++      <IntermediateNupkgArtifactFile Remove="$(CurrentRepoSourceBuildArtifactsPackagesDir)**\*.Symbols.*.nupkg" />
++    </ItemGroup>
++  </Target>
++
+   <!--
+     The build script passes in the full path of the sln to build.  This must be overridden in order to build
+     the cloned source in the inner build.

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -351,7 +351,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <NetCoreRoot Condition="'%24(NetCoreRoot)' == ''">%24([MSBuild]::NormalizePath('%24(MSBuildThisFileDirectory)..\..\'))</NetCoreRoot>
     <NetCoreTargetingPackRoot Condition="'%24(NetCoreTargetingPackRoot)' == ''">%24([MSBuild]::EnsureTrailingSlash('%24(NetCoreRoot)'))packs</NetCoreTargetingPackRoot>
 
-    <MicrosoftNetCompilersToolsetPackageVersion>$(MicrosoftNetCompilersToolsetPackageVersion)</MicrosoftNetCompilersToolsetPackageVersion>
+    <MicrosoftNetFrameworkCompilersToolsetPackageVersion>$(MicrosoftNetCompilersToolsetPackageVersion)</MicrosoftNetFrameworkCompilersToolsetPackageVersion>
     <NETCoreAppMaximumVersion>$(_NETCoreAppTargetFrameworkVersion)</NETCoreAppMaximumVersion>
     <BundledNETCoreAppTargetFrameworkVersion>$(_NETCoreAppTargetFrameworkVersion)</BundledNETCoreAppTargetFrameworkVersion>
     <BundledNETCoreAppPackageVersion>$(_NETCoreAppPackageVersion)</BundledNETCoreAppPackageVersion>


### PR DESCRIPTION
This PR brings the required changes for source-build in Preview 3. It enables building source-build with previously source-built SDK.

Cherry-picking following 2 commits:
- https://github.com/dotnet/installer/commit/38be1b1ed87352079d0422fdf5c3d3a19286471c
- https://github.com/dotnet/installer/commit/9cf1901b1563b062cefa99ecc796b9687d6c6b67