### PR TITLE
Add cecil project to dotnet source-build project

### DIFF
--- a/src/SourceBuild/content/repo-projects/dotnet.proj
+++ b/src/SourceBuild/content/repo-projects/dotnet.proj
@@ -22,6 +22,7 @@
     <RepositoryReference Include="emsdk" />
     <RepositoryReference Include="razor" />
     <RepositoryReference Include="xliff-tasks" />
+    <RepositoryReference Include="cecil" />
     <RepositoryReference Include="runtime" />
     <RepositoryReference Include="roslyn" />
     <RepositoryReference Include="source-build-externals" />


### PR DESCRIPTION
This project is included in source-build because the runtime project has a [dependency](https://github.com/dotnet/installer/blob/main/src/SourceBuild/content/repo-projects/runtime.proj#L52) on it yet it was not included in the dotnet.proj.  It is a best practice to include all projects in the dotnet.proj mainly to make it easy to see which projects are included in source-build.
