### PR TITLE
Update source-build prebuilts

### DIFF
--- a/src/SourceBuild/content/eng/Versions.props
+++ b/src/SourceBuild/content/eng/Versions.props
@@ -19,7 +19,7 @@
       prep.sh and pipeline scripts, outside of MSBuild.
     -->
     <PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Artifacts.8.0.100-preview.3.23178.7.centos.8-x64.tar.gz</PrivateSourceBuiltArtifactsUrl>
-    <PrivateSourceBuiltPrebuiltsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Prebuilts.0.1.0-8.0.100-18.centos.8-x64.tar.gz</PrivateSourceBuiltPrebuiltsUrl>
+    <PrivateSourceBuiltPrebuiltsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Prebuilts.0.1.0-8.0.100-19.centos.8-x64.tar.gz</PrivateSourceBuiltPrebuiltsUrl>
     <PrivateSourceBuiltSdkUrl_CentOS8Stream>https://dotnetcli.azureedge.net/source-built-artifacts/sdks/dotnet-sdk-8.0.100-preview.3.23210.1-centos.8-x64.tar.gz</PrivateSourceBuiltSdkUrl_CentOS8Stream>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Removing the following checked in prebuilts as a result of https://github.com/dotnet/installer/pull/16041.  This drops the tarball size from 263 MB to 123MB

microsoft.aspnetcore.app.runtime.osx-x64.7.0.2.nupkg
microsoft.aspnetcore.app.runtime.win-x64.7.0.2.nupkg
microsoft.aspnetcore.app.runtime.win-x86.7.0.2.nupkg
microsoft.netcore.app.host.osx-x64.7.0.2.nupkg
microsoft.netcore.app.host.win-x64.7.0.2.nupkg
microsoft.netcore.app.host.win-x86.7.0.2.nupkg
microsoft.netcore.app.runtime.osx-x64.7.0.2.nupkg
microsoft.netcore.app.runtime.win-x64.7.0.2.nupkg
microsoft.netcore.app.runtime.win-x86.7.0.2.nupkg