### PR TITLE
updating  snapcraft.yaml for .NET

### DIFF
--- a/src/snaps/dotnet-sdk-6.0/snap/snapcraft.yaml
+++ b/src/snaps/dotnet-sdk-6.0/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: dotnet-sdk
-version: 6.0.100-preview.2.21155.3
+version: 6.0.408
 summary: Cross-Platform .NET Core SDK
 description: |
   .NET Core SDK. https://dot.net/core.
@@ -16,21 +16,26 @@ base: core18
 parts:
   dotnet-sdk:
       plugin: dump
-      source: https://download.visualstudio.microsoft.com/download/pr/25c7e38e-0a6a-4d66-ac4e-b550a44b8a98/49128be84b903799259e7bebe8e9d969/dotnet-sdk-6.0.100-preview.2.21155.3-linux-x64.tar.gz
-      source-checksum: sha512/90d9b6070f7732dcf75f5a09a4f10f9b23c835a3bb144e0c3f1fa451cadd3d49c9781973b180f70a4d2798358a7c00f3c0b9b3bf35326fe4c94e470e84ac8c35
+      source: https://download.visualstudio.microsoft.com/download/pr/dd7d2255-c9c1-4c6f-b8ad-6e853d6bb574/c8e1b5f47bf17b317a84487491915178/dotnet-sdk-6.0.408-linux-x64.tar.gz
+      source-checksum: sha512/d5eed37ce6c07546aa217d6e786f3b67be2b6d97c23d5888d9ee5d5398e8a9bfc06202b14e3529245f7ec78f4036778caf69bdbe099de805fe1f566277e8440e
       stage-packages:
-        - libicu60
-        - libssl1.0.0
-        - libcurl3
-        - libgssapi-krb5-2
-        - libstdc++6
-        - zlib1g
-        - libgcc1
-        - libtinfo5
-        - liblttng-ust0
-        - liburcu6
+      - libicu60
+      - libc6
+      - libgcc1
+      - libstdc++6
+      - libssl1.0.0
+      - libcurl3
+      - libgssapi-krb5-2
+      - zlib1g
+      - lldb
+      - libunwind8
+      - libtinfo5
+      - liblttng-ust0
+      - liburcu6
 
   runtime-wrapper:
       plugin: dump
       source: .
+
+
 

--- a/src/snaps/dotnet-sdk-7.0/snap/snapcraft.yaml
+++ b/src/snaps/dotnet-sdk-7.0/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: dotnet-sdk
-version: 7.0.100-preview.1.22110.4
+version: 7.0.203
 summary: Cross-Platform .NET Core SDK
 description: |
   .NET Core SDK. https://dot.net/core.
@@ -16,8 +16,8 @@ base: core18
 parts:
   dotnet-sdk:
       plugin: dump
-      source: https://download.visualstudio.microsoft.com/download/pr/1af9d3c3-a20e-400c-abe5-3d80dec7b63b/803f8dc5cf21fb28245aba71a7fdbc05/dotnet-sdk-7.0.100-preview.1.22110.4-linux-x64.tar.gz
-      source-checksum: sha512/54488a911172f059e3823d6bf52e1fa87305eb09e84d97f81a40e0815fc8a73a480b149023283f557a672ef0341f022b8ca16ebec92264ee16a56fac8f35e2e2
+      source: https://download.visualstudio.microsoft.com/download/pr/ebfd0bf8-79bd-480a-9e81-0b217463738d/9adc6bf0614ce02670101e278a2d8555/dotnet-sdk-7.0.203-linux-x64.tar.gz
+      source-checksum: sha512/ed1ae7cd88591ec52e1515c4a25d9a832eca29e8a0889549fea35a320e6e356e3806a17289f71fc0b04c36b006ae74446c53771d976c170fcbe5977ac7db1cb6
       stage-packages:
       - libicu60
       - libc6
@@ -36,3 +36,6 @@ parts:
   runtime-wrapper:
       plugin: dump
       source: .
+
+
+

--- a/src/snaps/dotnet-sdk-8.0/snap/snapcraft.yaml
+++ b/src/snaps/dotnet-sdk-8.0/snap/snapcraft.yaml
@@ -1,0 +1,41 @@
+name: dotnet-sdk
+version: 8.0.100-preview.3.23178.7
+summary: Cross-Platform .NET Core SDK
+description: |
+  .NET Core SDK. https://dot.net/core.
+
+grade: stable
+confinement: classic
+
+apps:
+  dotnet:
+    command: dotnet
+
+base: core18
+
+parts:
+  dotnet-sdk:
+      plugin: dump
+      source: https://download.visualstudio.microsoft.com/download/pr/103d5e2c-d5c4-4101-bb6e-b82bc73a7d93/284a5cdccbc995f39806a3ba2dc17b93/dotnet-sdk-8.0.100-preview.3.23178.7-linux-x64.tar.gz
+      source-checksum: sha512/3b5d72979831256b9340a01db23d3b2dca801672546eeed04385949ed5f4363d3c731f31477ec82c7200ce88502dc45e03986c8acc8f2fc611b0343af5f1c488
+      stage-packages:
+      - libicu60
+      - libc6
+      - libgcc1
+      - libstdc++6
+      - libssl1.0.0
+      - libcurl3
+      - libgssapi-krb5-2
+      - zlib1g
+      - lldb
+      - libunwind8
+      - libtinfo5
+      - liblttng-ust0
+      - liburcu6
+
+  runtime-wrapper:
+      plugin: dump
+      source: .
+
+
+


### PR DESCRIPTION
Adding snapcraft.yaml files for .NET 8.0 and updating them for .NET 6.0 and .NET 7.0