### PR TITLE
Update SB test baselines

### DIFF
--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MissingXmlDoc.txt
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MissingXmlDoc.txt
@@ -1,6 +1,7 @@
 Microsoft.AspNetCore.App.Ref/analyzers/dotnet/cs/Microsoft.AspNetCore.App.Analyzers.xml
 Microsoft.AspNetCore.App.Ref/analyzers/dotnet/cs/Microsoft.AspNetCore.App.CodeFixes.xml
 Microsoft.AspNetCore.App.Ref/analyzers/dotnet/roslyn4.0/cs/Microsoft.Extensions.Logging.Generators.xml
+Microsoft.AspNetCore.App.Ref/ref/netx.y/System.Runtime.CompilerServices.Unsafe.xml
 Microsoft.NETCore.App.Ref/analyzers/dotnet/cs/System.Text.Json.SourceGeneration.xml
 Microsoft.NETCore.App.Ref/ref/netx.y/Microsoft.VisualBasic.xml
 Microsoft.NETCore.App.Ref/ref/netx.y/mscorlib.xml

--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdk.diff
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdk.diff
@@ -14,7 +14,21 @@ index ------------
  ./packs/Microsoft.AspNetCore.App.Ref/
  ./packs/Microsoft.AspNetCore.App.Ref/x.y.z/
 @@ ------------ @@
+ ./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/Microsoft.JSInterop.xml
+ ./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/Microsoft.Net.Http.Headers.dll
+ ./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/Microsoft.Net.Http.Headers.xml
++./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Diagnostics.DiagnosticSource.dll
++./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Diagnostics.DiagnosticSource.xml
+ ./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Diagnostics.EventLog.dll
+ ./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Diagnostics.EventLog.xml
++./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Formats.Asn1.dll
++./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Formats.Asn1.xml
+ ./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.IO.Pipelines.dll
  ./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.IO.Pipelines.xml
++./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Runtime.CompilerServices.Unsafe.dll
++./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Runtime.CompilerServices.Unsafe.xml
++./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Security.AccessControl.dll
++./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Security.AccessControl.xml
  ./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Security.Cryptography.Xml.dll
  ./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Security.Cryptography.Xml.xml
 -./packs/Microsoft.NETCore.App.Host.portable-rid/
@@ -29,6 +43,10 @@ index ------------
 -./packs/Microsoft.NETCore.App.Host.portable-rid/x.y.z/runtimes/portable-rid/native/libnethost.so
 -./packs/Microsoft.NETCore.App.Host.portable-rid/x.y.z/runtimes/portable-rid/native/nethost.h
 -./packs/Microsoft.NETCore.App.Host.portable-rid/x.y.z/runtimes/portable-rid/native/singlefilehost
++./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Text.Encodings.Web.dll
++./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Text.Encodings.Web.xml
++./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Text.Json.dll
++./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Text.Json.xml
 +./packs/Microsoft.NETCore.App.Host.banana-rid/
 +./packs/Microsoft.NETCore.App.Host.banana-rid/x.y.z/
 +./packs/Microsoft.NETCore.App.Host.banana-rid/x.y.z/runtimes/
@@ -545,7 +563,18 @@ index ------------
 -./sdk/x.y.z/zh-Hant/Microsoft.VisualStudio.Coverage.IO.resources.dll
  ./sdk/x.y.z/zh-Hant/MSBuild.resources.dll
  ./sdk/x.y.z/zh-Hant/System.CommandLine.resources.dll
- ./sdk/x.y.z/zh-Hant/vstest.console.resources.dll
  ./shared/
- ./shared/Microsoft.AspNetCore.App/x.y.z/
-
+@@ ------------ @@
+ ./templates/
+ ./templates/x.y.z/
+ ./templates/x.y.z/microsoft.dotnet.common.itemtemplates.x.y.z.nupkg
+-./templates/x.y.z/microsoft.dotnet.common.projecttemplates.x.y.z.0.116.nupkg
++./templates/x.y.z/microsoft.dotnet.common.projecttemplates.x.y.z.0.115.nupkg
+ ./templates/x.y.z/microsoft.dotnet.test.projecttemplates.x.y.z.0.2-betax.y.z.nupkg
+-./templates/x.y.z/microsoft.dotnet.web.itemtemplates.x.y.z.0.16.nupkg
+-./templates/x.y.z/microsoft.dotnet.web.projecttemplates.x.y.z.0.16.nupkg
+-./templates/x.y.z/microsoft.dotnet.web.spa.projecttemplates.x.y.z.0.16.nupkg
++./templates/x.y.z/microsoft.dotnet.web.itemtemplates.x.y.z.0.15.nupkg
++./templates/x.y.z/microsoft.dotnet.web.projecttemplates.x.y.z.0.15.nupkg
++./templates/x.y.z/microsoft.dotnet.web.spa.projecttemplates.x.y.z.0.15.nupkg
+ ./ThirdPartyNotices.txt


### PR DESCRIPTION
Updating to reflect changes for the [6.0.116 release](https://github.com/dotnet/release/issues/503).