### PR TITLE
Write and upload updated baselines for source-build content tests

### DIFF
--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-build-tarball.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-build-tarball.yml
@@ -182,6 +182,8 @@ jobs:
       find src/ -type f -name "*.binlog" -exec cp {} --parents -t ${targetFolder} \;
       find src/ -type f -name "*.log" -exec cp {} --parents -t ${targetFolder} \;
       find test/ -type f -name "*.binlog" -exec cp {} --parents -t ${targetFolder} \;
+      find test/ -type f -name "Updated*.diff" -exec cp {} --parents -t ${targetFolder} \;
+      find test/ -type f -name "Updated*.txt" -exec cp {} --parents -t ${targetFolder} \;
     displayName: Prepare BuildLogs staging directory
     continueOnError: true
     condition: succeededOrFailed()

--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/BaselineHelper.cs
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/BaselineHelper.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.SourceBuild.SmokeTests
 
         public static void CompareContents(string baselineFileName, string actualContents, ITestOutputHelper outputHelper, bool warnOnDiffs = false)
         {
-            string actualFilePath = Path.Combine(Environment.CurrentDirectory, $"{baselineFileName}");
+            string actualFilePath = Path.Combine(DotNetHelper.LogsDirectory, $"Updated{baselineFileName}");
             File.WriteAllText(actualFilePath, actualContents);
 
             CompareFiles(baselineFileName, actualFilePath, outputHelper, warnOnDiffs);


### PR DESCRIPTION
Backports the changes from #14092 to release/6.0.1xx

(cherry picked from commit f5683bb85df4b428cc187347e5510e5fff6c7c2f)
