### PR TITLE
Add `blazor-web.js` to allowed binaries

### DIFF
--- a/src/VirtualMonoRepo/allowed-binaries.txt
+++ b/src/VirtualMonoRepo/allowed-binaries.txt
@@ -30,6 +30,7 @@ src/aspnetcore/src/*.ttf
 src/aspnetcore/src/*.woff
 src/aspnetcore/src/*.woff2
 src/aspnetcore/src/Components/Web.JS/dist/Release/blazor.server.js # JavaScript file with a null byte
+src/aspnetcore/src/Components/Web.JS/dist/Release/blazor.web.js # JavaScript file with a null byte
 src/aspnetcore/src/Components/Web.JS/dist/Release/blazor.webview.js # JavaScript file with a null byte
 src/aspnetcore/src/ProjectTemplates/Web.ProjectTemplates/**/app.db
 src/aspnetcore/src/submodules/spa-templates/**/app.db

--- a/src/VirtualMonoRepo/allowed-binaries.txt
+++ b/src/VirtualMonoRepo/allowed-binaries.txt
@@ -29,9 +29,7 @@ src/aspnetcore/src/*.otf
 src/aspnetcore/src/*.ttf
 src/aspnetcore/src/*.woff
 src/aspnetcore/src/*.woff2
-src/aspnetcore/src/Components/Web.JS/dist/Release/blazor.server.js # JavaScript file with a null byte
-src/aspnetcore/src/Components/Web.JS/dist/Release/blazor.web.js # JavaScript file with a null byte
-src/aspnetcore/src/Components/Web.JS/dist/Release/blazor.webview.js # JavaScript file with a null byte
+src/aspnetcore/src/Components/Web.JS/dist/Release/blazor.*.js # JavaScript files with a null bytes
 src/aspnetcore/src/ProjectTemplates/Web.ProjectTemplates/**/app.db
 src/aspnetcore/src/submodules/spa-templates/**/app.db
 


### PR DESCRIPTION
There was a new one that appeared last week: https://dev.azure.com/dnceng/internal/_build/results?buildId=2154598&view=logs&j=fa5c2909-0e29-5671-d5eb-16d6c40e0c4a&t=2a0bd486-3f67-5c59-da0c-b84d88848a4b&l=14

`src/aspnetcore/src/Components/Web.JS/dist/Release/blazor.web.js`