### PR TITLE
Update MsftToSbSdk.diff

### DIFF
--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdk.diff
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdk.diff
@@ -26,7 +26,6 @@ index ------------
  ./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.IO.Pipelines.dll
  ./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.IO.Pipelines.xml
 +./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Runtime.CompilerServices.Unsafe.dll
-+./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Runtime.CompilerServices.Unsafe.xml
 +./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Security.AccessControl.dll
 +./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Security.AccessControl.xml
  ./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Security.Cryptography.Xml.dll
@@ -564,17 +563,3 @@ index ------------
  ./sdk/x.y.z/zh-Hant/MSBuild.resources.dll
  ./sdk/x.y.z/zh-Hant/System.CommandLine.resources.dll
  ./shared/
-@@ ------------ @@
- ./templates/
- ./templates/x.y.z/
- ./templates/x.y.z/microsoft.dotnet.common.itemtemplates.x.y.z.nupkg
--./templates/x.y.z/microsoft.dotnet.common.projecttemplates.x.y.z.0.116.nupkg
-+./templates/x.y.z/microsoft.dotnet.common.projecttemplates.x.y.z.0.115.nupkg
- ./templates/x.y.z/microsoft.dotnet.test.projecttemplates.x.y.z.0.2-betax.y.z.nupkg
--./templates/x.y.z/microsoft.dotnet.web.itemtemplates.x.y.z.0.16.nupkg
--./templates/x.y.z/microsoft.dotnet.web.projecttemplates.x.y.z.0.16.nupkg
--./templates/x.y.z/microsoft.dotnet.web.spa.projecttemplates.x.y.z.0.16.nupkg
-+./templates/x.y.z/microsoft.dotnet.web.itemtemplates.x.y.z.0.15.nupkg
-+./templates/x.y.z/microsoft.dotnet.web.projecttemplates.x.y.z.0.15.nupkg
-+./templates/x.y.z/microsoft.dotnet.web.spa.projecttemplates.x.y.z.0.15.nupkg
- ./ThirdPartyNotices.txt


### PR DESCRIPTION
There continues to be SDK diffs in the release/6.0.1xx branch even after the changes in https://github.com/dotnet/installer/pull/16087. When I made the changes for that PR, it required a local build which I may have not done correctly. But now, because of the changes in https://github.com/dotnet/installer/pull/16088, I can grab the actual diff output produced by the build. So that's what I've used to update the content here.