### PR TITLE
Disable source-build tarball official builds in unsupported branches

### DIFF
--- a/eng/source-build-tarball-build-official.yml
+++ b/eng/source-build-tarball-build-official.yml
@@ -11,10 +11,12 @@ resources:
         - release/*
         - internal/release/*
         exclude:
-        - release/6.0.3xx
-        - internal/release/6.0.3xx
-        - release/6.0.4xx
-        - internal/release/6.0.4xx
+        - release/7.0.2xx
+        - internal/release/7.0.2xx
+        - release/7.0.3xx
+        - internal/release/7.0.3xx
+        - release/7.0.4xx
+        - internal/release/7.0.4xx
       stages:
       - build
 


### PR DESCRIPTION
This is being done to avoid wasting build agent compute.
