### PR TITLE
Remove usages of CentOS 7 based docker images

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -94,8 +94,8 @@ stages:
     - template: eng/build.yml
       parameters:
         agentOs: Linux
-        jobName: Build_CentOS_7_Debug_x64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7'
+        jobName: Build_CentOS_8_Stream_Debug_x64
+        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8'
         buildConfiguration: Debug
         buildArchitecture: x64
         linuxPortable: false

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -249,7 +249,7 @@ stages:
       parameters:
         agentOs: Linux
         jobName: Build_Linux_Portable_Rpm_Release_x64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-rpmpkg'
+        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm'
         buildConfiguration: Release
         buildArchitecture: x64
         # Do not publish zips and tarballs. The linux-x64 binaries are
@@ -261,7 +261,7 @@ stages:
       parameters:
         agentOs: Linux
         jobName: Build_Linux_Portable_Rpm_Release_Arm64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-rpmpkg'
+        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm'
         buildConfiguration: Release
         buildArchitecture: arm64
         runtimeIdentifier: 'linux-arm64'


### PR DESCRIPTION
Remove usage of CentOS 7 to enable us to consume the updated runtime bits that no longer support it.

Blocked on https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/846.

Needs https://github.com/dotnet/runtime/pull/84805