### PR TITLE
Update the minimum VS version automatically

### DIFF
--- a/src/redist/targets/GenerateMSIs.targets
+++ b/src/redist/targets/GenerateMSIs.targets
@@ -309,6 +309,17 @@
                       Overwrite="true" />
   </Target>
 
+  <Target Name="GetMinimumVSVersion"
+          BeforeTargets="GenerateSdkBundle"
+          Condition=" '$(OS)' == 'Windows_NT' "
+          Outputs="$(MinimumVSVersion)">
+
+          <PropertyGroup>
+            <FileToRead Condition="$([System.Text.RegularExpressions.Regex]::Match(%(SDKInternalFiles.Identity),'.*minimumMSBuildVersion').Success) ">%(SDKInternalFiles.Identity)</FileToRead>
+            <MinimumVSVersion>$([System.IO.File]::ReadAllText($(FileToRead)).Trim())</MinimumVSVersion>
+          </PropertyGroup>
+  </Target>
+
   <Target Name="GenerateSdkBundle"
           DependsOnTargets="GenerateLayout;AcquireWix;MsiTargetsSetupInputOutputs;GenerateSdkMsi;GenerateTemplatesMsis;GenerateWorkloadManifestsWxs"
           Condition=" '$(OS)' == 'Windows_NT' "

--- a/src/redist/targets/GenerateMSIs.targets
+++ b/src/redist/targets/GenerateMSIs.targets
@@ -315,9 +315,12 @@
           Outputs="$(MinimumVSVersion)">
 
           <PropertyGroup>
-            <FileToRead Condition="$([System.Text.RegularExpressions.Regex]::Match(%(SDKInternalFiles.Identity),'.*minimumMSBuildVersion').Success) ">%(SDKInternalFiles.Identity)</FileToRead>
-            <MinimumVSVersion>$([System.IO.File]::ReadAllText($(FileToRead)).Trim())</MinimumVSVersion>
+            <MinimumMSBuildVersionFile Condition="$([System.Text.RegularExpressions.Regex]::Match(%(SDKInternalFiles.Identity),'.*minimumMSBuildVersion').Success) ">%(SDKInternalFiles.Identity)</MinimumMSBuildVersionFile>
           </PropertyGroup>
+
+          <ReadLinesFromFile File="$(MinimumMSBuildVersionFile)">
+            <Output TaskParameter="Lines" PropertyName="MinimumVSVersion"/>
+          </ReadLinesFromFile>
   </Target>
 
   <Target Name="GenerateSdkBundle"
@@ -365,6 +368,7 @@
                       -DotnetCLINugetVersion '$(Version)' ^
                       -VersionMajor '$(VersionMajor)' ^
                       -VersionMinor '$(VersionMinor)' ^
+                      -MinimumVSVersion '$(MinimumVSVersion)' ^
                       -WindowsDesktopVersion '$(MicrosoftWindowsDesktopAppRuntimePackageVersion)' ^
                       -UpgradeCode '$(CombinedFrameworkSDKHostInstallerUpgradeCode)' ^
                       -DependencyKeyName '$(SdkDependencyKeyName)' ^

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1028/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1028/bundle.wxl
@@ -76,7 +76,7 @@
   <String Id="InstallationNoteTitle">安裝附註</String>
   <String Id="InstallationNote">安裝程序期間將會執行命令，加快專案還原速度並啟用離線存取。最多需要一分鐘的時間完成。
   </String>
-  <String Id="VisualStudioWarning">若預計要搭配 Visual Studio 使用 .NET [VERSIONMAJOR].[VERSIONMINOR]，需要 Visual Studio 2022 17.4 或更新版本。&lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;深入了解&lt;/A&gt;.
+  <String Id="VisualStudioWarning">若預計要搭配 Visual Studio 使用 .NET [VERSIONMAJOR].[VERSIONMINOR]，需要 Visual Studio 2022 [MINIMUMVSVERSION] 或更新版本。&lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;深入了解&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">按一下 “安裝” 即表示您同意下列條款:</String>
   <String Id="InstallPathx64x86">x64 SDK 安裝的安裝路徑: "[DOTNETHOME_X64]" 不能與 x86 SDK 安裝的路徑相同: "[DOTNETHOME_X86]"</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1029/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1029/bundle.wxl
@@ -76,7 +76,7 @@ Prostředky
   <String Id="InstallationNoteTitle">Poznámka k instalaci</String>
   <String Id="InstallationNote">Během procesu instalace se spustí příkaz, který zlepší rychlost obnovení projektu a povolí offline přístup. Akce se dokončí přibližně za minutu.
   </String>
-  <String Id="VisualStudioWarning">Pokud plánujete používat .NET [VERSIONMAJOR].[VERSIONMINOR] s Visual Studio, vyžaduje se Visual Studio 2022 17.4 nebo novější. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Další informace&lt;/A&gt;.
+  <String Id="VisualStudioWarning">Pokud plánujete používat .NET [VERSIONMAJOR].[VERSIONMINOR] s Visual Studio, vyžaduje se Visual Studio 2022 [MINIMUMVSVERSION] nebo novější. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Další informace&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Kliknutím na Nainstalovat vyjadřujete souhlas s následujícími podmínkami:</String>
   <String Id="InstallPathx64x86">Instalační cesta pro instalace sady x64 SDK[ DOTNETHOME_X64] nemůže být stejná jako u instalací sady x86 SDK: [DOTNETHOME_X86].</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1031/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1031/bundle.wxl
@@ -76,7 +76,7 @@ Ressourcen
   <String Id="InstallationNoteTitle">Installationshinweis</String>
   <String Id="InstallationNote">Während des Installationsvorgangs wird ein Befehl ausgeführt, durch den die Geschwindigkeit der Projektwiederherstellung verbessert und der Offlinezugriff aktiviert wird. Der Vorgang dauert bis zu einer Minute.
   </String>
-  <String Id="VisualStudioWarning">Wenn Sie beabsichtigen, .NET [VERSIONMAJOR].[VERSIONMINOR] mit Visual Studio zu verwenden, ist Visual Studio 2022 17.4 oder höher erforderlich. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Weitere Informationen&lt;/A&gt;.
+  <String Id="VisualStudioWarning">Wenn Sie beabsichtigen, .NET [VERSIONMAJOR].[VERSIONMINOR] mit Visual Studio zu verwenden, ist Visual Studio 2022 [MINIMUMVSVERSION] oder höher erforderlich. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Weitere Informationen&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Durch Klicken auf „Installieren2 stimmen Sie den nachstehenden Bedingungen zu:</String>
   <String Id="InstallPathx64x86">Der Installationspfad „[DOTNETHOME_X64]“ für x64 SDK-Installationen kann nicht derselbe sein wie für x86 SDK-Installationen: „[DOTNETHOME_X86]“</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1033/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1033/bundle.wxl
@@ -76,7 +76,7 @@ Resources
   <String Id="InstallationNoteTitle">Installation note</String>
   <String Id="InstallationNote">A command will be run during the install process that will improve project restore speed and enable offline access. It will take up to a minute to complete.
   </String>
-  <String Id="VisualStudioWarning">If you plan to use .NET [VERSIONMAJOR].[VERSIONMINOR] with Visual Studio, Visual Studio 2022 17.4 or newer is required. &lt;A HREF=&quot;https://aka.ms/dotnet[VERSIONMAJOR]-release-notes&quot;&gt;Learn more&lt;/A&gt;.
+  <String Id="VisualStudioWarning">If you plan to use .NET [VERSIONMAJOR].[VERSIONMINOR] with Visual Studio, Visual Studio 2022 [MINIMUMVSVERSION] or newer is required. &lt;A HREF=&quot;https://aka.ms/dotnet[VERSIONMAJOR]-release-notes&quot;&gt;Learn more&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">By clicking Install, you agree to the following terms:</String>
   <String Id="InstallPathx64x86">The installation path for x64 SDK installations: &quot;[DOTNETHOME_X64]&quot; cannot be the same as for x86 SDK installations: &quot;[DOTNETHOME_X86]&quot;</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1036/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1036/bundle.wxl
@@ -76,7 +76,7 @@ Ressources
   <String Id="InstallationNoteTitle">Note d’installation</String>
   <String Id="InstallationNote">Une commande va être exécutée pendant le processus d'installation, ce qui va améliorer la vitesse de restauration du projet et permettre l'accès hors connexion. L'opération va prendre environ une minute.
   </String>
-  <String Id="VisualStudioWarning">Si vous envisagez d’utiliser .NET [VERSIONMAJOR].[VERSIONMINOR] avec Visual Studio, Visual Studio 2022 17.4 ou une version ultérieure est nécessaire. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;En savoir plus&lt;/A&gt;.
+  <String Id="VisualStudioWarning">Si vous envisagez d’utiliser .NET [VERSIONMAJOR].[VERSIONMINOR] avec Visual Studio, Visual Studio 2022 [MINIMUMVSVERSION] ou une version ultérieure est nécessaire. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;En savoir plus&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">En cliquant sur Installer, vous acceptez les conditions suivantes :</String>
   <String Id="InstallPathx64x86">Le chemin d’installation des installations du Kit de développement logiciel (SDK) x64 : « [DOTNETHOME_X64] » ne peut pas être identique à celui des installations du Kit de développement logiciel (SDK) x86 : « [DOTNETHOME_X86] »</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1040/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1040/bundle.wxl
@@ -76,7 +76,7 @@ Risorse
   <String Id="InstallationNoteTitle">Nota sull'installazione</String>
   <String Id="InstallationNote">Durante il processo di installazione verrà eseguito un comando che migliorerà la velocità di ripristino del progetto e abiliterà l'accesso offline. Il completamento del comando richiederà un minuto.
   </String>
-  <String Id="VisualStudioWarning">Se si prevede di usare .NET [VERSIONMAJOR]. [VERSIONMINOR] con Visual Studio, è necessario Visual Studio 2022 17.4 o versione successiva. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Altre informazioni&lt;/A&gt;. 
+  <String Id="VisualStudioWarning">Se si prevede di usare .NET [VERSIONMAJOR]. [VERSIONMINOR] con Visual Studio, è necessario Visual Studio 2022 [MINIMUMVSVERSION] o versione successiva. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Altre informazioni&lt;/A&gt;. 
 </String>
   <String Id="LicenseAssent">Facendo clic su Installa, si accettano le condizioni seguenti:</String>
   <String Id="InstallPathx64x86">Percorso di installazione per le installazioni x64 SDK: "[DOTNETHOME_X64]" non può essere uguale a quello delle installazioni di x86 SDK: "[DOTNETHOME_X86]"</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1041/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1041/bundle.wxl
@@ -76,7 +76,7 @@
   <String Id="InstallationNoteTitle">インストール メモ</String>
   <String Id="InstallationNote">コマンドはインストール処理中に実行されるので、プロジェクトの復元速度が向上し、オフラインでアクセスできます。完了するまでに最大 1 分かかります。
   </String>
-  <String Id="VisualStudioWarning">.NET [VERSIONMAJOR].[VERSIONMINOR] を Visual Studio で使用する場合は、Visual Studio 2022 17.4 以降が必要です。&lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;詳細情報&lt;/A&gt;.
+  <String Id="VisualStudioWarning">.NET [VERSIONMAJOR].[VERSIONMINOR] を Visual Studio で使用する場合は、Visual Studio 2022 [MINIMUMVSVERSION] 以降が必要です。&lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;詳細情報&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">インストール をクリックすると、次の条項に同意したものと見なされます:</String>
   <String Id="InstallPathx64x86">x64 SDK インストールのインストール パス: "[DOTNETHOME_X64]" を x86 SDK インストールの場合と同じにすることはできません: "[DOTNETHOME_X86]"</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1042/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1042/bundle.wxl
@@ -76,7 +76,7 @@
   <String Id="InstallationNoteTitle">설치 정보</String>
   <String Id="InstallationNote">프로젝트 복원 속도를 향상하고 오프라인 액세스를 사용할 수 있도록 하는 설치 프로세스 중 명령이 실행됩니다. 완료하는 데 최대 1분이 걸립니다.
   </String>
-  <String Id="VisualStudioWarning">Visual Studio에서 .NET [VERSIONMAJOR].[VERSIONMINOR]를 사용하려는 경우 Visual Studio 2022 17.4 이상이 필요합니다. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Learn more&lt;/A&gt;.
+  <String Id="VisualStudioWarning">Visual Studio에서 .NET [VERSIONMAJOR].[VERSIONMINOR]를 사용하려는 경우 Visual Studio 2022 [MINIMUMVSVERSION] 이상이 필요합니다. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Learn more&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">설치를 클릭하면 다음 사용 약관에 동의하는 것입니다.</String>
   <String Id="InstallPathx64x86">x64 SDK 설치의 설치 경로: " [DOTNETHOME_x64]" x86 SDK 설치의 경우와 같을 수 없습니다. " [DOTNETHOME_X86]"</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1045/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1045/bundle.wxl
@@ -76,7 +76,7 @@ Zasoby
   <String Id="InstallationNoteTitle">Uwaga dotycząca instalacji</String>
   <String Id="InstallationNote">W trakcie procesu instalacji zostanie uruchomione polecenie, które zwiększy szybkość przywracania projektu i umożliwi dostęp do trybu offline. Zajmie to maksymalnie minutę.
   </String>
-  <String Id="VisualStudioWarning">Jeśli planujesz używać platformy .NET [VERSIONMAJOR].[VERSIONMINOR] z programem Visual Studio, wymagany jest program Visual Studio 2022 17.4 lub nowszy. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Dowiedz się więcej&lt;/A&gt;.
+  <String Id="VisualStudioWarning">Jeśli planujesz używać platformy .NET [VERSIONMAJOR].[VERSIONMINOR] z programem Visual Studio, wymagany jest program Visual Studio 2022 [MINIMUMVSVERSION] lub nowszy. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Dowiedz się więcej&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Klikając pozycję Zainstaluj, wyrażasz zgodę na następujące warunki:</String>
   <String Id="InstallPathx64x86">Ścieżka instalacji w przypadku instalacji zestawu SDK x64: „[DOTNETHOME_X64]” nie może być taka sama jak w przypadku instalacji zestawu SDK x86: „[DOTNETHOME_X86]”</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1046/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1046/bundle.wxl
@@ -76,7 +76,7 @@ Recursos
   <String Id="InstallationNoteTitle">Nota de instalação</String>
   <String Id="InstallationNote">Um comando será executado durante o processo de instalação que melhorará a velocidade de restauração do projeto e habilitará o acesso offline. Isso levará até um minuto para ser concluído.
   </String>
-  <String Id="VisualStudioWarning">Se você planeja usar o .NET [VERSIONMAJOR].[VERSIONMINOR] com o Visual Studio, Visual Studio 2022 17.4 ou mais recente é necessário. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Saiba mais&lt;/A&gt;.
+  <String Id="VisualStudioWarning">Se você planeja usar o .NET [VERSIONMAJOR].[VERSIONMINOR] com o Visual Studio, Visual Studio 2022 [MINIMUMVSVERSION] ou mais recente é necessário. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Saiba mais&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Ao clicar em Instalar, você concorda com os termos a seguir:</String>
   <String Id="InstallPathx64x86">O caminho da instalação para instalações do SDK x64: "[DOTNETHOME_X64]" não pode ser o mesmo que para instalações do SDK x86: "[DOTNETHOME_X86]"</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1049/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1049/bundle.wxl
@@ -76,7 +76,7 @@
   <String Id="InstallationNoteTitle">Примечание по установке</String>
   <String Id="InstallationNote">В процессе установки будет выполнена команда, которая увеличит скорость восстановления проекта и обеспечит автономный доступ. Выполнение займет до минуты.
   </String>
-  <String Id="VisualStudioWarning">Если вы планируете использовать .NET [VERSIONMAJOR].[VERSIONMINOR] с Visual Studio, требуется Visual Studio 2022 версии 17.4 или более поздней. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Дополнительные сведения&lt;/A&gt;.
+  <String Id="VisualStudioWarning">Если вы планируете использовать .NET [VERSIONMAJOR].[VERSIONMINOR] с Visual Studio, требуется Visual Studio 2022 версии [MINIMUMVSVERSION] или более поздней. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Дополнительные сведения&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Нажимая кнопку "Установить", вы принимаете следующие условия.</String>
   <String Id="InstallPathx64x86">Совпадение пути установки недопустимо для установок пакетов SDK x64: "[DOTNETHOME_X64]" и SDK x86: "[DOTNETHOME_X86]".</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1055/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1055/bundle.wxl
@@ -76,7 +76,7 @@ Kaynaklar
   <String Id="InstallationNoteTitle">Yükleme notu</String>
   <String Id="InstallationNote">Yükleme işlemi sırasında, proje geri yükleme hızını artıran ve çevrimdışı erişimi etkinleştiren bir komut çalıştırılır. Tamamlanması bir dakikanızı alır.
   </String>
-  <String Id="VisualStudioWarning">Visual Studio ile .NET [VERSIONMAJOR].[VERSIONMINOR] kullanmayı planlıyorsanız Visual Studio 2022 17.4 veya üzeri bir sürüm gerekir. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Daha fazla bilgi edinin&lt;/A&gt;.
+  <String Id="VisualStudioWarning">Visual Studio ile .NET [VERSIONMAJOR].[VERSIONMINOR] kullanmayı planlıyorsanız Visual Studio 2022 [MINIMUMVSVERSION] veya üzeri bir sürüm gerekir. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Daha fazla bilgi edinin&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Yükle'ye tıklayarak aşağıdaki koşulları kabul etmiş olursunuz:</String>
   <String Id="InstallPathx64x86">x64 SDK yüklemelerinin yükleme yolu ("[DOTNETHOME_X64]"), x86 SDK yüklemelerinin yükleme yolu ("[DOTNETHOME_X86]") ile aynı olamaz</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/2052/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/2052/bundle.wxl
@@ -76,7 +76,7 @@
   <String Id="InstallationNoteTitle">安装说明</String>
   <String Id="InstallationNote">将在要提升项目还原速度并实现脱机访问的安装进程期间运行命令。此操作最多 1 分钟即可完成。
   </String>
-  <String Id="VisualStudioWarning">如果你计划使用 .NET [VERSIONMAJOR].[VERSIONMINOR] 与 Visual Studio、Visual Studio 2022 17.4 或更高版本是必需的。&lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;了解详细信息&lt;/A&gt;。
+  <String Id="VisualStudioWarning">如果你计划使用 .NET [VERSIONMAJOR].[VERSIONMINOR] 与 Visual Studio、Visual Studio 2022 [MINIMUMVSVERSION] 或更高版本是必需的。&lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;了解详细信息&lt;/A&gt;。
 </String>
   <String Id="LicenseAssent">单击“安装”即表示你同意以下条款:</String>
   <String Id="InstallPathx64x86">x64 SDK 安装的安装路径: "[DOTNETHOME_X64]" 不能与 x86 SDK 安装的路径相同: "[DOTNETHOME_X86]"</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/3082/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/3082/bundle.wxl
@@ -77,7 +77,7 @@ Recursos
   <String Id="InstallationNoteTitle">Nota de instalación</String>
   <String Id="InstallationNote">Se ejecutará un comando durante el proceso de instalación que mejorará la velocidad de restauración del proyecto y permitirá el acceso sin conexión. La operación tardará hasta un minuto en completarse.
   </String>
-  <String Id="VisualStudioWarning">Si tiene previsto utilizar .NET [VERSIONMAJOR].[VERSIONMINOR] con Visual Studio, necesitará Visual Studio 2022 17.4 o una versión más reciente. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Learn more&lt;/A&gt;.
+  <String Id="VisualStudioWarning">Si tiene previsto utilizar .NET [VERSIONMAJOR].[VERSIONMINOR] con Visual Studio, necesitará Visual Studio 2022 [MINIMUMVSVERSION] o una versión más reciente. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Learn more&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Al hacer clic en Instalar, acepta los siguientes términos:</String>
   <String Id="InstallPathx64x86">La ruta de instalación para las instalaciones del SDK x64: "[DOTNETHOME_X64]" no puede ser la misma que para las instalaciones del SDK x86: "[DOTNETHOME_X86]"</String>

--- a/src/redist/targets/packaging/windows/clisdk/bundle.wxs
+++ b/src/redist/targets/packaging/windows/clisdk/bundle.wxs
@@ -152,6 +152,7 @@
     <Variable Name="DOTNETHOMESIMILARITYCHECKOVERRIDE" Type="string" Value="" bal:Overridable="yes" />
     <Variable Name="VERSIONMAJOR" Type="string" Value="$(var.VersionMajor)" bal:Overridable="no" />
     <Variable Name="VERSIONMINOR" Type="string" Value="$(var.VersionMinor)" bal:Overridable="no" />
+    <Variable Name="MINIMUMVSVERSION" Type="string" Value="$(var.MinimumVSVersion)" bal:Overridable="no" />
       
     <Chain DisableSystemRestore="yes" ParallelCache="yes">
       

--- a/src/redist/targets/packaging/windows/clisdk/generatebundle.ps1
+++ b/src/redist/targets/packaging/windows/clisdk/generatebundle.ps1
@@ -24,6 +24,7 @@ param(
     [Parameter(Mandatory=$true)][string]$ProductMoniker,
     [Parameter(Mandatory=$true)][string]$DotnetMSIVersion,
     [Parameter(Mandatory=$true)][string]$SDKBundleVersion,
+    [Parameter(Mandatory=$true)][string]$MinimumVSVersion,
     [Parameter(Mandatory=$true)][string]$DotnetCLINugetVersion,
     [Parameter(Mandatory=$true)][string]$VersionMajor,
     [Parameter(Mandatory=$true)][string]$VersionMinor,
@@ -49,6 +50,7 @@ function RunCandleForBundle
         -dProductMoniker="$ProductMoniker" `
         -dBuildVersion="$DotnetMSIVersion" `
         -dSDKBundleVersion="$SDKBundleVersion" `
+        -dMinimumVSVersion="$MinimumVSVersion" `
         -dSDKProductBandVersion="$SDKProductBandVersion" `
         -dNugetVersion="$DotnetCLINugetVersion" `
         -dVersionMajor="$VersionMajor" `
@@ -72,7 +74,6 @@ function RunCandleForBundle
         -dTemplatesMsiSourcePath="$TemplatesMSIFile" `
         -dManifestsMsiSourcePath="$ManifestsMSIFile" `
         -dWinFormsAndWpfVersion="$WindowsDesktopVersion" `
-        -dMinimumVSVersion="$MinimumVSVersion" `
         -dAdditionalSharedFXMsiSourcePath="$AdditionalSharedFxMSIFile" `
         -dAdditionalHostFXRMsiSourcePath="$AdditionalHostFxrMSIFile" `
         -dAdditionalSharedHostMsiSourcePath="$AdditionalSharedHostMSIFile" `

--- a/src/redist/targets/packaging/windows/clisdk/generatebundle.ps1
+++ b/src/redist/targets/packaging/windows/clisdk/generatebundle.ps1
@@ -72,6 +72,7 @@ function RunCandleForBundle
         -dTemplatesMsiSourcePath="$TemplatesMSIFile" `
         -dManifestsMsiSourcePath="$ManifestsMSIFile" `
         -dWinFormsAndWpfVersion="$WindowsDesktopVersion" `
+        -dMinimumVSVersion="$MinimumVSVersion" `
         -dAdditionalSharedFXMsiSourcePath="$AdditionalSharedFxMSIFile" `
         -dAdditionalHostFXRMsiSourcePath="$AdditionalHostFxrMSIFile" `
         -dAdditionalSharedHostMsiSourcePath="$AdditionalSharedHostMSIFile" `


### PR DESCRIPTION
Grab it from the sdk file and push it to the SDK setup Ux

Changes from prior behavior:
1. It now shows an additional digit (eg. 17.4.0)
2. It can't be changed manually to be different than what the SDK is
3. The SDK can't be updated past the most recently released VS version (at least the PR failed)

@baronfel that last one is potentially problematic as people expect it to say 17.6 even though 17.6 hasn't released yet. I'll poke around the other PR to see if there are pre images we can use instead.
<img width="362" alt="image" src="https://user-images.githubusercontent.com/12663534/232158536-8c9be584-ff5c-4b2d-a4cf-a7214298d2ac.png">
