### PR TITLE
Include the swr file in the nuget package

### DIFF
--- a/src/core-sdk-tasks/GenerateMSBuildExtensionsSWR.cs
+++ b/src/core-sdk-tasks/GenerateMSBuildExtensionsSWR.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Cli.Build
         {
             string sourceFolder = Path.Combine(MSBuildExtensionsLayoutDirectory, relativeSourcePath);
             var files = Directory.GetFiles(sourceFolder)
-                            .Where(f => !Path.GetExtension(f).Equals(".pdb", StringComparison.OrdinalIgnoreCase))
+                            .Where(f => !Path.GetExtension(f).Equals(".pdb", StringComparison.OrdinalIgnoreCase) || !Path.GetExtension(f).Equals(".swr", StringComparison.OrdinalIgnoreCase))
                             .ToList();
             if (files.Any(f => !Path.GetFileName(f).Equals("_._")))
             {

--- a/src/redist/targets/GenerateMSIs.targets
+++ b/src/redist/targets/GenerateMSIs.targets
@@ -484,15 +484,18 @@
                     $(GenerateNupkgPowershellScript)"
           Outputs="$(SdkMSBuildExtensionsNupkgFile);$(SdkMSBuildExtensionsSwrFile)">
 
+    <GenerateMSBuildExtensionsSWR MSBuildExtensionsLayoutDirectory="$(MSBuildExtensionsLayoutDirectory)"
+                                  OutputFile="$(SdkMSBuildExtensionsSwrFile)"/>
+
+    <!-- Include the swr file in the nuget package for VS authoring -->
+    <Copy SourceFiles="$(SdkMSBuildExtensionsSwrFile)" DestinationFolder="$(MSBuildExtensionsLayoutDirectory)" />
+
     <Exec Command="powershell -NoProfile -NoLogo $(GenerateNupkgPowershellScript) ^
                       '$(ArtifactsDir)' ^
                       '$(MSBuildExtensionsLayoutDirectory.TrimEnd('\'))' ^
                       '$(FullNugetVersion)' ^
                       '$(SdkMSBuildExtensionsNuspecFile)' ^
                       '$(SdkMSBuildExtensionsNupkgFile)'" />
-      
-      <GenerateMSBuildExtensionsSWR MSBuildExtensionsLayoutDirectory="$(MSBuildExtensionsLayoutDirectory)"
-                                    OutputFile="$(SdkMSBuildExtensionsSwrFile)"/>
 
   </Target>
 


### PR DESCRIPTION
Once this goes in and is in main, I can switch VS to pick up the swr file from the nuget unzip location. Once that is done in main, I can disable the swr file copy in the insertion pipeline.