### PR TITLE
Patch to fix command-line-api to work with latest SDK

### DIFF
--- a/src/SourceBuild/patches/command-line-api/0003-Explicitly-cast-default-for-Task.Delay-method.patch
+++ b/src/SourceBuild/patches/command-line-api/0003-Explicitly-cast-default-for-Task.Delay-method.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matt Thalman <mthalman@microsoft.com>
+Date: Mon, 17 Apr 2023 12:26:51 -0500
+Subject: [PATCH] Explicitly cast default for Task.Delay method
+
+Backport: Not needed since this code is removed in latest version of command-line-api
+---
+ src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+index 0fb30887..cd59971d 100644
+--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
++++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+@@ -107,7 +107,7 @@ namespace System.CommandLine
+                     if (timeout! > TimeSpan.Zero)
+                     {
+                         Task
+-                            .Delay(timeout.Value, default)
++                            .Delay(timeout.Value, (CancellationToken)default)
+                             .ContinueWith(t =>
+                             {
+                                 // Prevent our ProcessExit from intervene and block the exit


### PR DESCRIPTION
The stage 2 bootstrapping build of the VMR is failing with the following error:

```
##[error]/vmr/src/command-line-api/artifacts/source-build/self/src/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs(110,30): error CS0121: (NETCORE_ENGINEERING_TELEMETRY=Build) The call is ambiguous between the following methods or properties: 'Task.Delay(TimeSpan, CancellationToken)' and 'Task.Delay(TimeSpan, TimeProvider)'
```

This is caused by the current code of command-line-api in the VMR not being compatible with the newly added code changes in https://github.com/dotnet/runtime/pull/83604.

I've added a patch which fixes this by explicitly casting `default` to the desired parameter type. This does not need to be backported to command-line-api because this affected code no longer exists in the latest version of that repo.