### PR TITLE
Update SB prebuilts tarball

### DIFF
--- a/src/SourceBuild/content/eng/Versions.props
+++ b/src/SourceBuild/content/eng/Versions.props
@@ -19,7 +19,7 @@
       prep.sh and pipeline scripts, outside of MSBuild.
     -->
     <PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Artifacts.8.0.100-preview.3.23178.7.centos.8-x64.tar.gz</PrivateSourceBuiltArtifactsUrl>
-    <PrivateSourceBuiltPrebuiltsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Prebuilts.0.1.0-8.0.100-19.centos.8-x64.tar.gz</PrivateSourceBuiltPrebuiltsUrl>
+    <PrivateSourceBuiltPrebuiltsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Prebuilts.0.1.0-8.0.100-20.centos.8-x64.tar.gz</PrivateSourceBuiltPrebuiltsUrl>
     <PrivateSourceBuiltSdkUrl_CentOS8Stream>https://dotnetcli.azureedge.net/source-built-artifacts/sdks/dotnet-sdk-8.0.100-preview.3.23210.1-centos.8-x64.tar.gz</PrivateSourceBuiltSdkUrl_CentOS8Stream>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This updates the link to the prebuilts tarball which includes the following additional 7.0.5 packages:

* Microsoft.AspNetCore.App.Ref.7.0.5
* Microsoft.NETCore.App.Host.centos.8-x64.7.0.5
* Microsoft.NETCore.App.Host.fedora.36-x64.7.0.5
* Microsoft.NETCore.App.Host.linux-arm64.7.0.5
* Microsoft.NETCore.App.Host.linux-x64.7.0.5
* Microsoft.NETCore.App.Ref.7.0.5

This resolves a build error, due to missing packages, in the bootstrapping stage 2 build for razor which depends on 7.0.5.