### PR TITLE
SDK build under source-build should use MicrosoftNetCompilersToolsetVersion property

### DIFF
--- a/src/SourceBuild/patches/sdk/0002-Use-MicrosoftNetCompilersToolsetVersion-instead-of-M.patch
+++ b/src/SourceBuild/patches/sdk/0002-Use-MicrosoftNetCompilersToolsetVersion-instead-of-M.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nikola Milosavljevic <nikolam@microsoft.com>
+Date: Mon, 17 Apr 2023 20:19:53 +0000
+Subject: [PATCH] Use MicrosoftNetCompilersToolsetVersion instead of
+ MicrosoftNetCompilersToolsetPackageVersion
+
+Temporary fix for https://github.com/dotnet/source-build/issues/3392
+---
+ src/Layout/redist/redist.csproj                  | 4 ++--
+ src/Layout/redist/targets/GenerateLayout.targets | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/Layout/redist/redist.csproj b/src/Layout/redist/redist.csproj
+index ada9291ad2..032389051f 100644
+--- a/src/Layout/redist/redist.csproj
++++ b/src/Layout/redist/redist.csproj
+@@ -33,8 +33,8 @@
+     <PackageReference Condition=" '$(DotNetBuildFromSource)' != 'true' " Include="NuGet.Localization" Version="$(NuGetLocalizationPackageVersion)" />
+     <PackageReference Include="NuGet.ProjectModel" Version="$(NuGetProjectModelPackageVersion)" />
+     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="$(MicrosoftCodeAnalysisNetAnalyzersVersion)" ExcludeAssets="All" GeneratePathProperty="true"/>
+-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="$(MicrosoftNetCompilersToolsetPackageVersion)" ExcludeAssets="All" GeneratePathProperty="true"/>
+-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle" Version="$(MicrosoftNetCompilersToolsetPackageVersion)" ExcludeAssets="All" GeneratePathProperty="true"/>
++    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="$(MicrosoftNetCompilersToolsetVersion)" ExcludeAssets="All" GeneratePathProperty="true"/>
++    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle" Version="$(MicrosoftNetCompilersToolsetVersion)" ExcludeAssets="All" GeneratePathProperty="true"/>
+     <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="$(MicrosoftNETILLinkTasksPackageVersion)" ExcludeAssets="All" GeneratePathProperty="true" />
+     <PackageReference Include="Microsoft.FSharp.Compiler" Version="$(MicrosoftFSharpCompilerPackageVersion)" ExcludeAssets="All" GeneratePathProperty="true" />
+     <PackageReference Include="Microsoft.NET.Sdk.Razor.SourceGenerators.Transport" Version="$(MicrosoftNETSdkRazorSourceGeneratorsTransportPackageVersion)" GeneratePathProperty="true" />
+diff --git a/src/Layout/redist/targets/GenerateLayout.targets b/src/Layout/redist/targets/GenerateLayout.targets
+index 3d3d3a47d3..03e06be78d 100644
+--- a/src/Layout/redist/targets/GenerateLayout.targets
++++ b/src/Layout/redist/targets/GenerateLayout.targets
+@@ -27,7 +27,7 @@
+       <RoslynDirectory>$(OutputPath)/Roslyn</RoslynDirectory>
+     </PropertyGroup>
+     <ItemGroup>
+-      <RoslynBits Include="$(NuGetPackageRoot)/microsoft.net.compilers.toolset/$(MicrosoftNetCompilersToolsetPackageVersion)/tasks/net6.0/**/*" />
++      <RoslynBits Include="$(NuGetPackageRoot)/microsoft.net.compilers.toolset/$(MicrosoftNetCompilersToolsetVersion)/tasks/net6.0/**/*" />
+     </ItemGroup>
+     <Error Condition="'@(RoslynBits)' == ''" Text="Something moved around in Roslyn package, adjust code here accordingly. TFM change?" />
+     <Copy SourceFiles="@(RoslynBits)" DestinationFiles="@(RoslynBits->'$(RoslynDirectory)/%(RecursiveDir)%(Filename)%(Extension)')" />


### PR DESCRIPTION
This is a temporary solution for https://github.com/dotnet/source-build/issues/3392.

SDK build under source-build should use `MicrosoftNetCompilersToolsetVersion` property instead of `MicrosoftNetCompilersToolsetPackageVersion`.

## Issue description
Source-build, that uses Preview 3 toolset SDK, cannot override `MicrosoftNetCompilersToolsetPackageVersion` property. This was caused by Preview 3 toolset SDK setting this property in `Microsoft.NETCoreSdk.BundledVersions.props` file due to https://github.com/dotnet/installer/commit/3ca0db8956623a55772c644e0a0628c8bcfc4a5b. That issue was later fixed with https://github.com/dotnet/installer/commit/38be1b1ed87352079d0422fdf5c3d3a19286471c, in Preview 4.

A solution for this issue is to use `MicrosoftNetCompilersToolsetVersion` property in the following places:
https://github.com/dotnet/sdk/blob/f23aa760569111e3d80ec0501bb14f076548025b/src/Layout/redist/targets/GenerateLayout.targets#L30
https://github.com/dotnet/sdk/blob/f23aa760569111e3d80ec0501bb14f076548025b/src/Layout/redist/redist.csproj#L36
https://github.com/dotnet/sdk/blob/f23aa760569111e3d80ec0501bb14f076548025b/src/Layout/redist/redist.csproj#L37

Temporary solution is being implemented as a patch for `sdk` repo - https://github.com/dotnet/installer/blob/main/src/SourceBuild/patches/sdk/0002-Use-MicrosoftNetCompilersToolsetVersion-instead-of-M.patch

After Preview 4 ships, toolset SDK will be updated to a build that contains the fix, and this temporary solution can be reverted.