### PR TITLE
Update version of SB prebuilts tarball

### DIFF
--- a/src/SourceBuild/content/eng/Versions.props
+++ b/src/SourceBuild/content/eng/Versions.props
@@ -19,7 +19,7 @@
       prep.sh and pipeline scripts, outside of MSBuild.
     -->
     <PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Artifacts.8.0.100-preview.3.23178.7.centos.8-x64.tar.gz</PrivateSourceBuiltArtifactsUrl>
-    <PrivateSourceBuiltPrebuiltsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Prebuilts.0.1.0-8.0.100-22.centos.8-x64.tar.gz</PrivateSourceBuiltPrebuiltsUrl>
+    <PrivateSourceBuiltPrebuiltsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Prebuilts.0.1.0-8.0.100-23.centos.8-x64.tar.gz</PrivateSourceBuiltPrebuiltsUrl>
     <PrivateSourceBuiltSdkUrl_CentOS8Stream>https://dotnetcli.azureedge.net/source-built-artifacts/sdks/dotnet-sdk-8.0.100-preview.3.23210.1-centos.8-x64.tar.gz</PrivateSourceBuiltSdkUrl_CentOS8Stream>
   </PropertyGroup>
 </Project>

--- a/src/SourceBuild/content/eng/Versions.props
+++ b/src/SourceBuild/content/eng/Versions.props
@@ -19,7 +19,7 @@
       prep.sh and pipeline scripts, outside of MSBuild.
     -->
     <PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Artifacts.8.0.100-preview.3.23178.7.centos.8-x64.tar.gz</PrivateSourceBuiltArtifactsUrl>
-    <PrivateSourceBuiltPrebuiltsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Prebuilts.0.1.0-8.0.100-20.centos.8-x64.tar.gz</PrivateSourceBuiltPrebuiltsUrl>
+    <PrivateSourceBuiltPrebuiltsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Prebuilts.0.1.0-8.0.100-22.centos.8-x64.tar.gz</PrivateSourceBuiltPrebuiltsUrl>
     <PrivateSourceBuiltSdkUrl_CentOS8Stream>https://dotnetcli.azureedge.net/source-built-artifacts/sdks/dotnet-sdk-8.0.100-preview.3.23210.1-centos.8-x64.tar.gz</PrivateSourceBuiltSdkUrl_CentOS8Stream>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Removes the following packages:

* Microsoft.AspnetCore.App.Ref.5.0.0
* Microsoft.Net.ILLink.Tasks.7.0.100-1.23062.2
* Microsoft.NETCore.App.Host.linux-arm64.5.0.17
* Microsoft.NETCore.App.Host.linux-x64.5.0.17
* Microsoft.NETFramework.ReferenceAssemblies.1.0.3
* Microsoft.NETFramework.ReferenceAssemblies.net472.1.0.2
* Microsoft.NETFramework.ReferenceAssemblies.net472.1.0.3

Related to https://github.com/dotnet/source-build/issues/3349

Adds the following packages:

* For prebuilts [introduced by vstest](https://github.com/microsoft/vstest/issues/4403):
  * Microsoft.CodeCoverage.IO.17.7.1-beta.23213.1
  * Microsoft.Internal.TestPlatform.Remote.17.5.33617.425
  * System.Private.Uri.4.3.2

* For prebuilts [introduced by sdk](https://github.com/dotnet/sdk/pull/31863):
  * Microsoft.Build.Tasks.Git.8.0.0-beta.23210.3
  * Microsoft.SourceLink.Bitbucket.Git.8.0.0-beta.23210.3
  * Microsoft.SourceLink.Common.8.0.0-beta.23210.3