### PR TITLE
Use full version for source-build artifacts

### DIFF
--- a/src/SourceBuild/content/Directory.Build.targets
+++ b/src/SourceBuild/content/Directory.Build.targets
@@ -10,6 +10,20 @@
     </ItemGroup>
   </Target>
 
+  <!-- Used by build.proj and repo-projects/package-source-build.proj -->
+  <Target Name="DetermineMicrosoftSourceBuildIntermediateInstallerVersion">
+    <!-- Manually load the installer version from the PVP.     -->
+    <XmlPeek XmlInputPath="$(IntermediatePath)PackageVersions.package-source-build.Current.props"
+             Query="msb:Project/msb:PropertyGroup/msb:MicrosoftSourceBuildIntermediateInstallerVersion/text()"
+             Namespaces="&lt;Namespace Prefix='msb' Uri='http://schemas.microsoft.com/developer/msbuild/2003'/&gt;">
+        <Output TaskParameter="Result" ItemName="MicrosoftSourceBuildIntermediateInstallerVersionItem" />
+    </XmlPeek>
+    <PropertyGroup>
+      <MicrosoftSourceBuildIntermediateInstallerVersion>@(MicrosoftSourceBuildIntermediateInstallerVersionItem)</MicrosoftSourceBuildIntermediateInstallerVersion>
+      <MicrosoftSourceBuildIntermediateInstallerVersion Condition="'$(MicrosoftSourceBuildIntermediateInstallerVersion)' == ''">$(installerOutputPackageVersion)</MicrosoftSourceBuildIntermediateInstallerVersion>
+    </PropertyGroup>
+  </Target>
+
   <Import Condition="'$(SkipArcadeSdkImport)' != 'true'" Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
 </Project>

--- a/src/SourceBuild/content/Directory.Build.targets
+++ b/src/SourceBuild/content/Directory.Build.targets
@@ -10,7 +10,6 @@
     </ItemGroup>
   </Target>
 
-  <!-- Used by build.proj and repo-projects/package-source-build.proj -->
   <Target Name="DetermineMicrosoftSourceBuildIntermediateInstallerVersion">
     <!-- Manually load the installer version from the PVP.     -->
     <XmlPeek XmlInputPath="$(IntermediatePath)PackageVersions.package-source-build.Current.props"

--- a/src/SourceBuild/content/build.proj
+++ b/src/SourceBuild/content/build.proj
@@ -115,7 +115,7 @@
           Condition="'$(SkipSmokeTestPrereqsTarballCreation)' != 'true'"
           DependsOnTargets="
             CheckIfCreateSmokeTestPrereqsExistToPack;
-            CreateCreateSmokeTestPrereqsTarballIfPrereqsExist"/>
+            CreateSmokeTestPrereqsTarballIfPrereqsExist"/>
 
   <Target Name="CheckIfCreateSmokeTestPrereqsExistToPack">
     <PropertyGroup>
@@ -130,10 +130,11 @@
     <Message Text="Found @(SmokeTestsPrereqs->Count()) prereqs in '$(SmokeTestsPackagesDir)'." Importance="High" />
   </Target>
 
-  <Target Name="CreateCreateSmokeTestPrereqsTarballIfPrereqsExist"
+  <Target Name="CreateSmokeTestPrereqsTarballIfPrereqsExist"
+          DependsOnTargets="DetermineMicrosoftSourceBuildIntermediateInstallerVersion"
           Condition="'@(SmokeTestsPrereqs->Count())' != '0'">
     <PropertyGroup>
-      <SmokeTestPrereqsTarballName>$(OutputPath)dotnet-smoke-test-prereqs.$(installerOutputPackageVersion).$(TargetRid).tar.gz</SmokeTestPrereqsTarballName>
+      <SmokeTestPrereqsTarballName>$(OutputPath)dotnet-smoke-test-prereqs.$(MicrosoftSourceBuildIntermediateInstallerVersion).$(TargetRid).tar.gz</SmokeTestPrereqsTarballName>
       <SmokeTestsPrereqPackagesDir>$(SmokeTestsArtifactsDir)prereq-packages/</SmokeTestsPrereqPackagesDir>
     </PropertyGroup>
 
@@ -187,9 +188,10 @@
   </Target>
 
   <Target Name="CreatePrebuiltsTarballIfPrebuiltsExist"
+          DependsOnTargets="DetermineMicrosoftSourceBuildIntermediateInstallerVersion"
           Condition="'@(PrebuiltFile->Count())' != '0'">
     <PropertyGroup>
-      <TarballFilePath>$(OutputPath)$(SourceBuiltPrebuiltsTarballName).$(installerOutputPackageVersion).$(TargetRid).tar.gz</TarballFilePath>
+      <TarballFilePath>$(OutputPath)$(SourceBuiltPrebuiltsTarballName).$(MicrosoftSourceBuildIntermediateInstallerVersion).$(TargetRid).tar.gz</TarballFilePath>
       <TarballWorkingDir>$(ResultingPrebuiltPackagesDir)</TarballWorkingDir>
     </PropertyGroup>
 

--- a/src/SourceBuild/content/repo-projects/package-source-build.proj
+++ b/src/SourceBuild/content/repo-projects/package-source-build.proj
@@ -13,7 +13,8 @@
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
-  <Target Name="RepoBuild">
+  <Target Name="RepoBuild"
+          DependsOnTargets="DetermineMicrosoftSourceBuildIntermediateInstallerVersion">
     <!-- Copy PVP to packages dir in order to package them together -->
     <Copy SourceFiles="$(IncludedPackageVersionPropsFile)" DestinationFiles="$(SourceBuiltPackagesPath)PackageVersions.props" />
 
@@ -46,21 +47,8 @@
       Directories="$(SourceBuildReferencePackagesDestination)extractArtifacts/" />
 
     <PropertyGroup>
-      <SourceBuiltTarballName>$(OutputPath)$(SourceBuiltArtifactsTarballName).$(installerOutputPackageVersion).$(TargetRid).tar.gz</SourceBuiltTarballName>
+      <SourceBuiltTarballName>$(OutputPath)$(SourceBuiltArtifactsTarballName).$(MicrosoftSourceBuildIntermediateInstallerVersion).$(TargetRid).tar.gz</SourceBuiltTarballName>
       <SourceBuiltVersionFileName>.version</SourceBuiltVersionFileName>
-    </PropertyGroup>
-
-    <!--
-      Manually load the installer version from the PVP. This is manually done instead of using an explicit
-      <Import> because the PVP does not exist at the time this project file is loaded.
-     -->
-    <XmlPeek XmlInputPath="$(CurrentSourceBuiltPackageVersionPropsPath)"
-             Query="msb:Project/msb:PropertyGroup/msb:MicrosoftSourceBuildIntermediateInstallerVersion/text()"
-             Namespaces="&lt;Namespace Prefix='msb' Uri='http://schemas.microsoft.com/developer/msbuild/2003'/&gt;">
-        <Output TaskParameter="Result" ItemName="MicrosoftSourceBuildIntermediateInstallerVersionItem" />
-    </XmlPeek>
-    <PropertyGroup>
-      <MicrosoftSourceBuildIntermediateInstallerVersion>@(MicrosoftSourceBuildIntermediateInstallerVersionItem)</MicrosoftSourceBuildIntermediateInstallerVersion>
     </PropertyGroup>
 
     <!-- Content of the .version file to include in the tarball -->


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/3268

All source-build artifacts are now correctly versioned, i.e.:

```
Private.SourceBuilt.Artifacts.8.0.100-preview.4.23217.1.fedora.36-x64.tar.gz
Private.SourceBuilt.Prebuilts.8.0.100-preview.4.23217.1.fedora.36-x64.tar.gz
dotnet-smoke-test-prereqs.8.0.100-preview.4.23217.1.fedora.36-x64.tar.gz
```
### Testing

Local VMR build and smoke-tests.
