### PR TITLE
Update source-build dotnet project to reflect real build order

### DIFF
--- a/src/SourceBuild/content/repo-projects/dotnet.proj
+++ b/src/SourceBuild/content/repo-projects/dotnet.proj
@@ -34,7 +34,6 @@
     <RepositoryReference Include="deployment-tools" />
     <!-- TODO: Reenable once format targets net8.0 (https://github.com/dotnet/format/issues/1802) -->
     <!-- <RepositoryReference Include="format" /> -->
-    <RepositoryReference Include="format" />
     <RepositoryReference Include="nuget-client" />
     <RepositoryReference Include="templating" />
     <RepositoryReference Include="test-templates" />

--- a/src/SourceBuild/content/repo-projects/dotnet.proj
+++ b/src/SourceBuild/content/repo-projects/dotnet.proj
@@ -23,10 +23,10 @@
     <RepositoryReference Include="razor" />
     <RepositoryReference Include="xliff-tasks" />
     <RepositoryReference Include="cecil" />
+    <RepositoryReference Include="symreader" />
+    <RepositoryReference Include="source-build-externals" />
     <RepositoryReference Include="runtime" />
     <RepositoryReference Include="roslyn" />
-    <RepositoryReference Include="source-build-externals" />
-    <RepositoryReference Include="symreader" />
     <RepositoryReference Include="xdt" />
     <RepositoryReference Include="msbuild" />
     <RepositoryReference Include="roslyn-analyzers" />
@@ -34,12 +34,13 @@
     <RepositoryReference Include="deployment-tools" />
     <!-- TODO: Reenable once format targets net8.0 (https://github.com/dotnet/format/issues/1802) -->
     <!-- <RepositoryReference Include="format" /> -->
-    <RepositoryReference Include="templating" />
+    <RepositoryReference Include="format" />
     <RepositoryReference Include="nuget-client" />
+    <RepositoryReference Include="templating" />
     <RepositoryReference Include="test-templates" />
     <RepositoryReference Include="fsharp" />
-    <RepositoryReference Include="sdk" />
     <RepositoryReference Include="vstest" />
+    <RepositoryReference Include="sdk" />
     <RepositoryReference Include="installer" />
 
     <!-- Package source-build artifacts -->


### PR DESCRIPTION
Update source-build project order in dotnet.proj to reflect the real build order.  This is not required but it is frequently referenced by source-build developers to get an idea of the order the projects are built in.
