### PR TITLE
Fix TFM path for Test CLI package

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/BasicScenarioTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/BasicScenarioTests.cs
@@ -31,10 +31,9 @@ public class BasicScenarioTests : SmokeTests
         {
             yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.Console,  DotNetActions.Build | DotNetActions.Run | DotNetActions.PublishComplex | DotNetActions.PublishR2R);
             yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.ClassLib, DotNetActions.Build | DotNetActions.Publish);
-            // TODO: Investigate and re-enable - dotnet test fails to find application
-            // yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.XUnit,    DotNetActions.Test);
-            // yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.NUnit,    DotNetActions.Test);
-            // yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.MSTest,   DotNetActions.Test);
+            yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.XUnit,    DotNetActions.Test);
+            yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.NUnit,    DotNetActions.Test);
+            yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.MSTest,   DotNetActions.Test);
         }
     }
 }

--- a/src/SourceBuild/patches/sdk/0003-Fix-TFM-path-for-Test-CLI-package.patch
+++ b/src/SourceBuild/patches/sdk/0003-Fix-TFM-path-for-Test-CLI-package.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nikola Milosavljevic <nikolam@microsoft.com>
+Date: Fri, 21 Apr 2023 15:32:28 +0000
+Subject: [PATCH] Fix TFM path for Test CLI package
+
+---
+ src/Layout/redist/targets/GenerateLayout.targets | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/Layout/redist/targets/GenerateLayout.targets b/src/Layout/redist/targets/GenerateLayout.targets
+index 1bc37d90eb..f83c0b39f1 100644
+--- a/src/Layout/redist/targets/GenerateLayout.targets
++++ b/src/Layout/redist/targets/GenerateLayout.targets
+@@ -195,7 +195,7 @@
+           BeforeTargets="Build">
+     <PropertyGroup>
+       <TestCliNuGetDirectoryTargetFramework Condition="'$(DotNetBuildFromSource)' != 'true'" >netcoreapp3.1</TestCliNuGetDirectoryTargetFramework>
+-      <TestCliNuGetDirectoryTargetFramework Condition="'$(DotNetBuildFromSource)' == 'true'" >net7.0</TestCliNuGetDirectoryTargetFramework>
++      <TestCliNuGetDirectoryTargetFramework Condition="'$(DotNetBuildFromSource)' == 'true'" >net8.0</TestCliNuGetDirectoryTargetFramework>
+       <TestCliNuGetDirectory>$(NuGetPackageRoot)/microsoft.testplatform.cli/$(MicrosoftTestPlatformCLIPackageVersion)/contentFiles/any/$(TestCliNuGetDirectoryTargetFramework)/</TestCliNuGetDirectory>
+     </PropertyGroup>
+     <ItemGroup>
+@@ -210,6 +210,7 @@
+       <TestCliBits Include="$(TestCliNuGetDirectory)**/*"
+                    Exclude="@(TestCliBitsToExclude)" />
+     </ItemGroup>
++    <Error Condition="'@(TestCliBits)' == ''" Text="Something moved around in Test CLI package, adjust code here accordingly. TFM change?" />
+     <Copy SourceFiles="@(TestCliBits)" DestinationFiles="@(TestCliBits->'$(OutputPath)/%(RecursiveDir)%(Filename)%(Extension)')" />
+   </Target>
+ 

--- a/src/SourceBuild/patches/sdk/0003-Fix-TFM-path-for-Test-CLI-package.patch
+++ b/src/SourceBuild/patches/sdk/0003-Fix-TFM-path-for-Test-CLI-package.patch
@@ -3,6 +3,7 @@ From: Nikola Milosavljevic <nikolam@microsoft.com>
 Date: Fri, 21 Apr 2023 15:32:28 +0000
 Subject: [PATCH] Fix TFM path for Test CLI package
 
+Backport: https://github.com/dotnet/source-build/issues/3406
 ---
  src/Layout/redist/targets/GenerateLayout.targets | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/3406

## Summary of changes

Microsoft.TestPlatform.CLI was recently updated to move from `net7.0` to `net8.0`. This change updates the path in SDK layout creation process, and adds a validation to ensure we catch future similar changes.