### PR TITLE
Add sourcelink patch to workaround MSBuild cache issue

### DIFF
--- a/src/SourceBuild/patches/sourcelink/0003-Workaround-for-msbuild-cache-issue.patch
+++ b/src/SourceBuild/patches/sourcelink/0003-Workaround-for-msbuild-cache-issue.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: tmat <tomas.matousek@microsoft.com>
+Date: Fri, 21 Apr 2023 09:02:35 -0700
+Subject: [PATCH] Workaround for msbuild cache issue
+
+Backport: https://github.com/dotnet/sourcelink/pull/1008
+---
+ src/Microsoft.Build.Tasks.Git/RepositoryTask.cs | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/src/Microsoft.Build.Tasks.Git/RepositoryTask.cs b/src/Microsoft.Build.Tasks.Git/RepositoryTask.cs
+index 9647abf..ef838b5 100644
+--- a/src/Microsoft.Build.Tasks.Git/RepositoryTask.cs
++++ b/src/Microsoft.Build.Tasks.Git/RepositoryTask.cs
+@@ -147,7 +147,15 @@ private string GetCacheKey(string repositoryId)
+ 
+         private bool TryGetCachedRepositoryInstance(string cacheKey, bool requireCached, [NotNullWhen(true)]out GitRepository? repository)
+         {
+-            var entry = (StrongBox<GitRepository?>)BuildEngine4.GetRegisteredTaskObject(cacheKey, RegisteredTaskObjectLifetime.Build);
++            StrongBox<GitRepository?>? entry;
++            try
++            {
++                entry = (StrongBox<GitRepository?>?)BuildEngine4.GetRegisteredTaskObject(cacheKey, RegisteredTaskObjectLifetime.Build);
++            }
++            catch (InvalidCastException) // workaround for https://github.com/dotnet/msbuild/issues/8478
++            {
++                entry = null;
++            }
+ 
+             if (entry != null)
+             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/3399
Backport: https://github.com/dotnet/sourcelink/pull/1008