### PR TITLE
Change the name of the file and add tizen. 

### DIFF
--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -481,7 +481,7 @@
                       Overwrite="true" />
   </Target>
 
-  <Target Name="CopyIncludedWorkloadManifestFile" >
+  <Target Name="CopyKnownWorkloadManifestFile" >
 
     <ItemGroup>
       <WorkloadManifestFilesContent Include="$([MSBuild]::ValueOrDefault('%(BundledManifests.Identity)', '').ToLower())" />
@@ -489,7 +489,11 @@
 
     <Error Text="No workload manifest content found." Condition="'@(WorkloadManifestFilesContent->Count())' == '0'" />
 
-    <WriteLinesToFile File="$(SdkOutputDirectory)IncludedWorkloadManifests.txt"
+    <ItemGroup>
+      <WorkloadManifestFilesContent Include="samsung.net.sdk.tizen" />
+    </ItemGroup>
+
+    <WriteLinesToFile File="$(SdkOutputDirectory)KnownWorkloadManifests.txt"
                       Lines="@(WorkloadManifestFilesContent)"
                       Overwrite="true" />
   </Target>
@@ -565,7 +569,7 @@
                             LayoutBundledComponents;
                             GenerateFullNuGetVersion;
                             GenerateVersionFile;
-                            CopyIncludedWorkloadManifestFile;
+                            CopyKnownWorkloadManifestFile;
                             GenerateBundledVersions;
                             LayoutRuntimeGraph;
                             LayoutTemplates;


### PR DESCRIPTION
This will have to wait till the SDK PR is in most likely.

We consulted internally on this. Workloads does not officiallly support third party workloads. Tizen has gone through the official process to request a TFM and been approved by nuget. To reduce their impact to the upgrade experience, we have agreed that in this specific case, we will add tizen to the known list to look for through fallback logic because of the nuget approval.

https://github.com/NuGet/Home/issues/4175
https://github.com/dotnet/sdk/issues/30661