### PR TITLE
Exclude SignTool test binaries from the VMR

### DIFF
--- a/src/VirtualMonoRepo/allowed-binaries.txt
+++ b/src/VirtualMonoRepo/allowed-binaries.txt
@@ -20,8 +20,6 @@
 **/TestCert*.pfx
 **/tests/*
 
-src/arcade/src/Microsoft.DotNet.SignTool.Tests/*
-
 src/aspnetcore/**/samples/*
 src/aspnetcore/**/TestCertificates/*
 src/aspnetcore/src/*.eot

--- a/src/VirtualMonoRepo/source-mappings.json
+++ b/src/VirtualMonoRepo/source-mappings.json
@@ -52,7 +52,12 @@
     "mappings": [
         {
             "name": "arcade",
-            "defaultRemote": "https://github.com/dotnet/arcade"
+            "defaultRemote": "https://github.com/dotnet/arcade",
+            "exclude": [
+                "src/Microsoft.DotNet.SignTool.Tests/*.mpack",
+                "src/Microsoft.DotNet.SignTool.Tests/*.msi",
+                "src/Microsoft.DotNet.SignTool.Tests/*.vsix"
+            ]
         },
         {
             "name": "aspnetcore",


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/13191

The files will be removed here - https://github.com/dotnet/dotnet/pull/27