### PR TITLE
TFM trimming - emsdk - Move NoTargetFrameworkFiltering property to Directory.Build.props

### DIFF
--- a/src/SourceBuild/patches/emsdk/0001-Move-NoTargetFrameworkFiltering-property.patch
+++ b/src/SourceBuild/patches/emsdk/0001-Move-NoTargetFrameworkFiltering-property.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nikola Milosavljevic <nikolam@microsoft.com>
+Date: Mon, 24 Apr 2023 14:00:42 +0000
+Subject: [PATCH] Move NoTargetFrameworkFiltering property
+
+---
+ Directory.Build.props | 5 +++++
+ eng/SourceBuild.props | 1 -
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/Directory.Build.props b/Directory.Build.props
+index 69862d8..defa3f0 100644
+--- a/Directory.Build.props
++++ b/Directory.Build.props
+@@ -2,6 +2,11 @@
+ <Project>
+   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+ 
++  <PropertyGroup>
++    <!-- Emsdk doesn't support Arcade-driven target framework filtering. -->
++    <NoTargetFrameworkFiltering>true</NoTargetFrameworkFiltering>
++  </PropertyGroup>
++
+   <PropertyGroup Condition="'$(StabilizePackageVersion)' == 'true'">
+     <StableVersion>$(VersionPrefix)</StableVersion>
+   </PropertyGroup>
+diff --git a/eng/SourceBuild.props b/eng/SourceBuild.props
+index 63164b2..c4009f3 100644
+--- a/eng/SourceBuild.props
++++ b/eng/SourceBuild.props
+@@ -3,7 +3,6 @@
+   <PropertyGroup>
+     <GitHubRepositoryName>emsdk</GitHubRepositoryName>
+     <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
+-    <NoTargetFrameworkFiltering>true</NoTargetFrameworkFiltering>
+   </PropertyGroup>
+ 
+ </Project>

--- a/src/SourceBuild/patches/emsdk/0001-Move-NoTargetFrameworkFiltering-property.patch
+++ b/src/SourceBuild/patches/emsdk/0001-Move-NoTargetFrameworkFiltering-property.patch
@@ -3,6 +3,7 @@ From: Nikola Milosavljevic <nikolam@microsoft.com>
 Date: Mon, 24 Apr 2023 14:00:42 +0000
 Subject: [PATCH] Move NoTargetFrameworkFiltering property
 
+Backport: https://github.com/dotnet/source-build/issues/3417
 ---
  Directory.Build.props | 5 +++++
  eng/SourceBuild.props | 1 -


### PR DESCRIPTION
Patch for this issue: https://github.com/dotnet/source-build/issues/3417

`NoTargetFrameworkFiltering` property, in `emsdk` repo, should be moved from `eng/SourceBuild.props` to `Directory.Build.props`. Without this change, switching to opt-out TFM model (https://github.com/dotnet/source-build/issues/3362) would cause all `emsdk` projects to get excluded from the build.

This would match the implementation in the `runtime` repo (https://github.com/dotnet/runtime/blob/018a9bd43851c998f9239aedf2fcc09c5eff7488/Directory.Build.props#L304-L305).

This change is a prerequisite for https://github.com/dotnet/arcade/pull/13271
