### PR TITLE
Add runtime source-build patch to fix stage2 build

### DIFF
--- a/src/SourceBuild/patches/runtime/0003-Directory.Build.props-don-t-overwrite-PackageOS-from.patch
+++ b/src/SourceBuild/patches/runtime/0003-Directory.Build.props-don-t-overwrite-PackageOS-from.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tom Deseyn <tom.deseyn@gmail.com>
+Date: Tue, 25 Apr 2023 21:33:21 +0200
+Subject: [PATCH] Directory.Build.props: don't overwrite PackageOS from
+ source-build.
+
+Backport: https://github.com/dotnet/runtime/pull/85350
+---
+ Directory.Build.props | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Directory.Build.props b/Directory.Build.props
+index e238fe3f9bc..ad38d4cae3a 100644
+--- a/Directory.Build.props
++++ b/Directory.Build.props
+@@ -207,7 +207,7 @@
+ 
+     <!-- source-build sets PackageOS to build with non-portable rid packages that were source-built previously. -->
+     <PackageRID Condition="'$(PackageOS)' != ''">$(PackageOS)-$(TargetArchitecture)</PackageRID>
+-    <PackageRID>$(_packageOS)-$(TargetArchitecture)</PackageRID>
++    <PackageRID Condition="'$(PackageRID)' == ''">$(_packageOS)-$(TargetArchitecture)</PackageRID>
+   </PropertyGroup>
+ 
+   <!-- ToolsRID is used for packages needed on the build host. -->


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/3420
