### PR TITLE
Fix BlazorWasm projects

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/WebScenarioTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/WebScenarioTests.cs
@@ -34,8 +34,7 @@ public class WebScenarioTests : SmokeTests
         }
 
         yield return new(nameof(WebScenarioTests), DotNetLanguage.CSharp, DotNetTemplate.Razor,         DotNetActions.Build | DotNetActions.Run | DotNetActions.Publish);
-        // TODO: Investigate and re-enable
-        //yield return new(nameof(WebScenarioTests), DotNetLanguage.CSharp, DotNetTemplate.BlazorWasm,    DotNetActions.Build | DotNetActions.Run | DotNetActions.Publish);
+        yield return new(nameof(WebScenarioTests), DotNetLanguage.CSharp, DotNetTemplate.BlazorWasm,    DotNetActions.Build | DotNetActions.Run | DotNetActions.Publish);
         yield return new(nameof(WebScenarioTests), DotNetLanguage.CSharp, DotNetTemplate.BlazorServer,  DotNetActions.Build | DotNetActions.Run | DotNetActions.Publish);
         yield return new(nameof(WebScenarioTests), DotNetLanguage.CSharp, DotNetTemplate.Worker);
         yield return new(nameof(WebScenarioTests), DotNetLanguage.CSharp, DotNetTemplate.Angular);

--- a/src/SourceBuild/patches/razor/0001-Fix-Microsoft.Extensions.ObjectPool-package-version.patch
+++ b/src/SourceBuild/patches/razor/0001-Fix-Microsoft.Extensions.ObjectPool-package-version.patch
@@ -1,0 +1,63 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nikola Milosavljevic <nikolam@microsoft.com>
+Date: Fri, 28 Apr 2023 07:06:18 +0000
+Subject: [PATCH] Fix Microsoft.Extensions.ObjectPool package version
+
+---
+ eng/Versions.props                                              | 2 ++
+ src/Compiler/Directory.Packages.props                           | 2 +-
+ ...osoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.csproj | 2 +-
+ .../Microsoft.AspNetCore.Razor.Utilities.Shared.csproj          | 2 +-
+ 4 files changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/eng/Versions.props b/eng/Versions.props
+index 559125601..6c101b515 100644
+--- a/eng/Versions.props
++++ b/eng/Versions.props
+@@ -94,6 +94,8 @@
+     <MicrosoftVisualStudioShellPackagesVersion>17.5.0-preview-2-33117-317</MicrosoftVisualStudioShellPackagesVersion>
+     <MicrosoftVisualStudioPackagesVersion>17.5.274-preview</MicrosoftVisualStudioPackagesVersion>
+     <VisualStudioLanguageServerProtocolVersion>17.6.4-preview</VisualStudioLanguageServerProtocolVersion>
++    <!-- dotnet/aspnetcore packages -->
++    <MicrosoftExtensionsObjectPoolPackageVersion>6.0.0</MicrosoftExtensionsObjectPoolPackageVersion>
+     <!-- dotnet/runtime packages -->
+     <MicrosoftExtensionsPackageVersion>6.0.0</MicrosoftExtensionsPackageVersion>
+     <SystemCollectionsImmutablePackageVersion>6.0.0</SystemCollectionsImmutablePackageVersion>
+diff --git a/src/Compiler/Directory.Packages.props b/src/Compiler/Directory.Packages.props
+index 118ed5d41..245b9bd4f 100644
+--- a/src/Compiler/Directory.Packages.props
++++ b/src/Compiler/Directory.Packages.props
+@@ -30,6 +30,6 @@
+     <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="$(Tooling_MicrosoftCodeAnalysisBannedApiAnalyzersPackageVersion)" />
+     <PackageVersion Include="Roslyn.Diagnostics.Analyzers" Version="$(Tooling_RoslynDiagnosticsAnalyzersPackageVersion)" />
+     <PackageVersion Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutablePackageVersion)" />
+-    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="$(MicrosoftExtensionsPackageVersion)" />
++    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="$(MicrosoftExtensionsObjectPoolPackageVersion)" />
+   </ItemGroup>
+ </Project>
+diff --git a/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.csproj b/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.csproj
+index 7a90709c3..278d12786 100644
+--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.csproj
++++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.csproj
+@@ -11,7 +11,7 @@
+   <ItemGroup>
+     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpPackageVersion)" />
+     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(MicrosoftCodeAnalysisWorkspacesCommonPackageVersion)" />
+-    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="$(MicrosoftExtensionsPackageVersion)" />
++    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="$(MicrosoftExtensionsObjectPoolPackageVersion)" />
+   </ItemGroup>
+ 
+   <ItemGroup>
+diff --git a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.csproj b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.csproj
+index 7b7fbdd73..e591d60de 100644
+--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.csproj
++++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.csproj
+@@ -11,7 +11,7 @@
+   </PropertyGroup>
+ 
+   <ItemGroup>
+-    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="$(MicrosoftExtensionsPackageVersion)" />
++    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="$(MicrosoftExtensionsObjectPoolPackageVersion)" />
+     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutablePackageVersion)" />
+   </ItemGroup>
+ 


### PR DESCRIPTION
Backport of https://github.com/dotnet/installer/pull/16252

Fixes: https://github.com/dotnet/source-build/issues/3410

Razor source-generator was including SBRP package for `Microsoft.Extensions.ObjectPool` which resulted in `Microsoft.Extensions.ObjectPool.dll` being a reference assembly. This was introduced with the following `razor` change: https://github.com/dotnet/razor/pull/8542

Package version property was incorrect - source-build could not override with live version of `Microsoft.Extensions.ObjectPool` package.

This PR does not address other instances of similarly named packages using `MicrosoftExtensionsPackageVersion` property. There are no other reference assemblies in final, source-build produced, SDK.

Also, re-enabling BlazorWasm test.