### PR TITLE
Fix IDE analyzer errors for aspnetcore

### DIFF
--- a/src/SourceBuild/content/repo-projects/aspnetcore.proj
+++ b/src/SourceBuild/content/repo-projects/aspnetcore.proj
@@ -26,7 +26,9 @@
 
     <!-- CA1512 - Use 'ArgumentOutOfRangeException.ThrowIfEqual'
                   Requires https://github.com/dotnet/aspnetcore/issues/47673 -->
-    <RepoNoWarns>CA1512</RepoNoWarns>
+    <!-- IDE0005 - Using directive is unnecessary -->
+    <!-- IDE0059 - Unnecessary assignment of a value -->
+    <RepoNoWarns>CA1512;IDE0005;IDE0059</RepoNoWarns>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SourceBuild/content/repo-projects/aspnetcore.proj
+++ b/src/SourceBuild/content/repo-projects/aspnetcore.proj
@@ -26,8 +26,8 @@
 
     <!-- CA1512 - Use 'ArgumentOutOfRangeException.ThrowIfEqual'
                   Requires https://github.com/dotnet/aspnetcore/issues/47673 -->
-    <!-- IDE0005 - Using directive is unnecessary -->
-    <!-- IDE0059 - Unnecessary assignment of a value -->
+    <!-- IDE0005 - Using directive is unnecessary: https://github.com/dotnet/aspnetcore/issues/47932 -->
+    <!-- IDE0059 - Unnecessary assignment of a value: https://github.com/dotnet/aspnetcore/pull/47931 -->
     <RepoNoWarns>CA1512;IDE0005;IDE0059</RepoNoWarns>
   </PropertyGroup>
 


### PR DESCRIPTION
Ignores two IDE analyzer errors that showed up in the stage 2 bootstrap build:

```
CSC : error EnableGenerateDocumentationFile: Set MSBuild property 'GenerateDocumentationFile' to 'true' in project file to enable IDE0005 (Remove unnecessary usings/imports) on build (https://github.com/dotnet/roslyn/issues/41640) [/vmr/src/aspnetcore/artifacts/source-build/self/src/src/Components/Analyzers/src/Microsoft.AspNetCore.Components.Analyzers.csproj]
```

```
/repos/dotnet/src/aspnetcore/artifacts/source-build/self/src/src/Tools/dotnet-user-jwts/src/Commands/ListCommand.cs(55,45): error IDE0059: Unnecessary assignment of a value to 'jwts' (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0059) [/repos/dotnet/src/aspnetcore/artifacts/source-build/self/src/src/Tools/dotnet-user-jwts/src/dotnet-user-jwts.csproj]
```

Related to https://github.com/dotnet/aspnetcore/issues/47932, https://github.com/dotnet/aspnetcore/pull/47931