### PR TITLE
Fix vstest analyzer errors

### DIFF
--- a/src/SourceBuild/content/repo-projects/vstest.proj
+++ b/src/SourceBuild/content/repo-projects/vstest.proj
@@ -7,6 +7,10 @@
     <BuildCommand>$(ProjectDirectory)\eng\common\build$(ShellExtension) $(BuildCommandArgs)</BuildCommand>
 
     <DeterministicBuildOptOut>true</DeterministicBuildOptOut>
+
+    <!-- IDE0059 - Unnecessary assignment of a value: https://github.com/microsoft/vstest/issues/4424 -->
+    <!-- SYSLIB0051 - Type or member is obsolete: https://github.com/microsoft/vstest/pull/4425 -->
+    <RepoNoWarns>IDE0059;SYSLIB0051</RepoNoWarns>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Ignores the following analyzer errors when attempting to run a bootstrap stage 2 build:

```
/repos/dotnet/src/vstest/artifacts/source-build/self/src/src/Microsoft.TestPlatform.AdapterUtilities/ManagedNameUtilities/InvalidManagedNameException.cs(14,93): error SYSLIB0051: 'Exception.Exception(SerializationInfo, StreamingContext)' is obsolete: 'This API supports obsolete formatter-based serialization. It should not be called or extended by application code.' (https://aka.ms/dotnet-warnings/SYSLIB0051) [/repos/dotnet/src/vstest/artifacts/source-build/self/src/src/Microsoft.TestPlatform.AdapterUtilities/Microsoft.TestPlatform.AdapterUtilities.csproj::TargetFramework=net8.0]
```

```
/repos/dotnet/src/vstest/artifacts/source-build/self/src/src/Microsoft.TestPlatform.Utilities/XmlUtilities.cs(96,65): error IDE0059: Unnecessary assignment of a value to 'childNodeNavigator' (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0059) [/repos/dotnet/src/vstest/artifacts/source-build/self/src/src/Microsoft.TestPlatform.Utilities/Microsoft.TestPlatform.Utilities.csproj::TargetFramework=net8.0]
```

Related: https://github.com/microsoft/vstest/issues/4424, https://github.com/microsoft/vstest/pull/4425