### PR TITLE
Keep deployment-tools package versions in sync

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -122,6 +122,10 @@
     <!-- Dependencies from https://github.com/NuGet/NuGet.Client -->
     <NuGetVersioningPackageVersion>5.8.0</NuGetVersioningPackageVersion>
   </PropertyGroup>
+  <!-- Dependencies from https://github.com/dotnet/deployment-tools -->
+  <PropertyGroup>
+    <MicrosoftDeploymentDotNetReleasesVersion>1.0.0-preview.6.23206.1</MicrosoftDeploymentDotNetReleasesVersion>
+  </PropertyGroup>
   <PropertyGroup>
     <!-- Automated versions for asp.net templates -->
     <!-- Grab just the patch version from MicrosoftNETSdkPackageVersion (7.0.103-servicing becomes 03) -->
@@ -249,13 +253,6 @@
   <PropertyGroup>
     <!-- pinned dependency. This package is not being produced outside of the 2.0 branch of corefx and should not change. -->
     <CLI_NETStandardLibraryNETFrameworkVersion>2.0.1-servicing-26011-01</CLI_NETStandardLibraryNETFrameworkVersion>
-  </PropertyGroup>
-  <PropertyGroup>
-    <!--
-      pinned dependency. This package is not being produced outside of the 2.0 branch of corefx and should not change.
-      If changed, the Microsoft.Deployment.DotNet.Releases dependency in Version.Details.xml must be updated to be kept in sync.
-    -->
-    <DotNetDeploymentReleasesPackageVersion>1.0.0-preview5.1.22263.1</DotNetDeploymentReleasesPackageVersion>
   </PropertyGroup>
   <Import Project="$(RepositoryEngineeringDir)ManualVersions.props" />
 </Project>

--- a/src/VSTemplateLocator/VSTemplateLocator.csproj
+++ b/src/VSTemplateLocator/VSTemplateLocator.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="runtime.win-x86.Microsoft.NETCore.DotNetHostResolver" Version="$(MicrosoftNETCoreDotNetHostResolverPackageVersion)" ExcludeAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="runtime.win-x64.Microsoft.NETCore.DotNetHostResolver" Version="$(MicrosoftNETCoreDotNetHostResolverPackageVersion)" ExcludeAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="runtime.win-arm64.Microsoft.NETCore.DotNetHostResolver" Version="$(MicrosoftNETCoreDotNetHostResolverPackageVersion)" ExcludeAssets="all" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.Deployment.DotNet.Releases" Version="$(DotNetDeploymentReleasesPackageVersion)" ExcludeAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Deployment.DotNet.Releases" Version="$(MicrosoftDeploymentDotNetReleasesVersion)" ExcludeAssets="all" GeneratePathProperty="true" />
   </ItemGroup>
 
   <Target

--- a/src/redist/targets/GenerateMSBuildExtensions.targets
+++ b/src/redist/targets/GenerateMSBuildExtensions.targets
@@ -9,13 +9,13 @@
       <NETStandardLibraryNETFrameworkNuPkgPath>$(NuGetPackageRoot)$(NETStandardLibraryNETFrameworkPackageName.ToLower())/$(CLI_NETStandardLibraryNETFrameworkVersion.ToLower())</NETStandardLibraryNETFrameworkNuPkgPath>
 
       <DotNetDeploymentReleasesPackageName>Microsoft.Deployment.DotNet.Releases</DotNetDeploymentReleasesPackageName>
-      <DotNetDeploymentReleasesPkgPath>$(NuGetPackageRoot)$(DotNetDeploymentReleasesPackageName.ToLower())/$(DotNetDeploymentReleasesPackageVersion.ToLower())</DotNetDeploymentReleasesPkgPath>
+      <DotNetDeploymentReleasesPkgPath>$(NuGetPackageRoot)$(DotNetDeploymentReleasesPackageName.ToLower())/$(MicrosoftDeploymentDotNetReleasesVersion.ToLower())</DotNetDeploymentReleasesPkgPath>
   </PropertyGroup>
 
   <ItemGroup>
     <ExtensionPackageToRestore Include="$(MSBuildExtensionsPackageName)" Version="$(MicrosoftNETBuildExtensionsPackageVersion)"/>
     <ExtensionPackageToRestore Include="$(NETStandardLibraryNETFrameworkPackageName)" Version="$(CLI_NETStandardLibraryNETFrameworkVersion)"/>
-    <ExtensionPackageToRestore Include="$(DotNetDeploymentReleasesPackageName)" Version="$(DotNetDeploymentReleasesPackageVersion)"/>
+    <ExtensionPackageToRestore Include="$(DotNetDeploymentReleasesPackageName)" Version="$(MicrosoftDeploymentDotNetReleasesVersion)"/>
   </ItemGroup>
 
   <!-- Restore msbuild extensions via PackageReference -->


### PR DESCRIPTION
When running the Source-build bootstrapping stage 2 build, it gets the following error when building the installer repo:

```
/repos/dotnet/src/installer/artifacts/source-build/self/src/src/redist/redist.csproj
error NU1102: Unable to find package Microsoft.Deployment.DotNet.Releases with version (>= 1.0.0-preview5.1.22263.1) [/repos/dotnet/src/installer/artifacts/source-build/self/src/Microsoft.DotNet.Cli.sln]
- Found 1 version(s) in source-built [ Nearest version: 1.0.0-preview.6.23206.1 ] [/repos/dotnet/src/installer/artifacts/source-build/self/src/Microsoft.DotNet.Cli.sln]
- Found 1 version(s) in previously-source-built [ Nearest version: 1.0.0-preview.6.23206.1 ] [/repos/dotnet/src/installer/artifacts/source-build/self/src/Microsoft.DotNet.Cli.sln]
- Found 0 version(s) in prebuilt [/repos/dotnet/src/installer/artifacts/source-build/self/src/Microsoft.DotNet.Cli.sln]
- Found 0 version(s) in reference-packages [/repos/dotnet/src/installer/artifacts/source-build/self/src/Microsoft.DotNet.Cli.sln]
```

This is because the versions for the Microsoft.Deployment.DotNet.Releases package are out of sync between the Versions.Details.xml and Versions.props file. The Versions.props file is stale because its property name doesn't following the required naming convention to be updated automatically by darc. I've updated the name and version to hopefully keep things in sync.