### PR TITLE
Fix vstest analyzer errors (#16269)

### DIFF
--- a/src/SourceBuild/content/repo-projects/vstest.proj
+++ b/src/SourceBuild/content/repo-projects/vstest.proj
@@ -7,6 +7,10 @@
     <BuildCommand>$(ProjectDirectory)\eng\common\build$(ShellExtension) $(BuildCommandArgs)</BuildCommand>
 
     <DeterministicBuildOptOut>true</DeterministicBuildOptOut>
+
+    <!-- IDE0059 - Unnecessary assignment of a value: https://github.com/microsoft/vstest/issues/4424 -->
+    <!-- SYSLIB0051 - Type or member is obsolete: https://github.com/microsoft/vstest/pull/4425 -->
+    <RepoNoWarns>IDE0059;SYSLIB0051</RepoNoWarns>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Port of https://github.com/dotnet/installer/pull/16269 to the main branch

(cherry picked from commit 11a0906a633047ee23b05bd1ddacac2ec1283e9e)
