### PR TITLE
Disable VerifyVersionFile test

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SourceBuiltArtifactsTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SourceBuiltArtifactsTests.cs
@@ -13,7 +13,8 @@ public class SourceBuiltArtifactsTests : SmokeTests
 {
     public SourceBuiltArtifactsTests(ITestOutputHelper outputHelper) : base(outputHelper) { }
 
-    [Fact]
+    // Disabling due to https://github.com/dotnet/source-build/issues/3426
+    //[Fact]
     public void VerifyVersionFile()
     {
         string outputDir = Path.Combine(Directory.GetCurrentDirectory(), "sourcebuilt-artifacts");


### PR DESCRIPTION
Disabling the test due to https://github.com/dotnet/source-build/issues/3426

This test failure doesn't indicate any issue with the product. The `.version` file in question is just useful for diagnostic purposes from the outputted artifacts file.