### PR TITLE
[release/8.0.1xx-preview4] Fix building RPMs

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -254,7 +254,7 @@ stages:
         buildArchitecture: x64
         # Do not publish zips and tarballs. The linux-x64 binaries are
         # already published by Build_LinuxPortable_Release_x64
-        additionalBuildParameters: '/p:PublishBinariesAndBadge=false'
+        additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:IsRPMBasedDistro=true'
         linuxPortable: true
         runTests: false
     - template: eng/build.yml
@@ -267,7 +267,7 @@ stages:
         runtimeIdentifier: 'linux-arm64'
         # Do not publish zips and tarballs. The linux-x64 binaries are
         # already published by Build_LinuxPortable_Release_x64
-        additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:CLIBUILD_SKIP_TESTS=true'
+        additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:CLIBUILD_SKIP_TESTS=true  /p:IsRPMBasedDistro=true'
         linuxPortable: true
         runTests: false
     - template: eng/build.yml

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -38,6 +38,7 @@
 
       <CoreSetupRid Condition="'$(CoreSetupRid)' == ''">$(HostRid)</CoreSetupRid>
       <CoreSetupRid Condition=" ('$(OSName)' == 'win' or '$(OSName)' == 'osx' or '$(OSName)' == 'freebsd') and '$(DotNetBuildFromSource)' != 'true' ">$(OSName)-$(Architecture)</CoreSetupRid>
+      <CoreSetupRid Condition="$(HostRid.StartsWith('mariner.2.0'))">$(HostRid.Replace('mariner.2.0', 'cm.2'))</CoreSetupRid>
 
       <!-- only the runtime OSX .pkgs have a `-internal` suffix -->
       <InstallerStartSuffix Condition="$([MSBuild]::IsOSPlatform('OSX'))">-internal</InstallerStartSuffix>

--- a/src/redist/targets/GenerateRPMs.targets
+++ b/src/redist/targets/GenerateRPMs.targets
@@ -330,18 +330,18 @@
           Outputs="$(RpmTestResultsXmlFile)" >
 
     <!-- Install Dependencies and SDK Packages -->
-    <Exec Command="rpm --import https://packages.microsoft.com/keys/microsoft.asc" />
-    <Exec Command="rpm -iv $(DownloadedRuntimeDepsInstallerFile)" />
-    <Exec Command="rpm -iv $(DownloadedNetCoreAppHostPackInstallerFile)" />
-    <Exec Command="rpm -iv $(DownloadedNetCoreAppTargetingPackInstallerFile)" />
-    <Exec Command="rpm -iv $(DownloadedNetStandardTargetingPackInstallerFile)" />
-    <Exec Command="rpm -iv $(DownloadedAspNetTargetingPackInstallerFile)" />
-    <Exec Command="rpm -iv $(DownloadedSharedHostInstallerFile)" />
-    <Exec Command="rpm -iv $(DownloadedHostFxrInstallerFile)" />
-    <Exec Command="rpm -iv $(DownloadedSharedFrameworkInstallerFile)" />
+    <Exec Command="sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc" />
+    <Exec Command="sudo rpm -iv $(DownloadedRuntimeDepsInstallerFile)" />
+    <Exec Command="sudo rpm -iv $(DownloadedNetCoreAppHostPackInstallerFile)" />
+    <Exec Command="sudo rpm -iv $(DownloadedNetCoreAppTargetingPackInstallerFile)" />
+    <Exec Command="sudo rpm -iv $(DownloadedNetStandardTargetingPackInstallerFile)" />
+    <Exec Command="sudo rpm -iv $(DownloadedAspNetTargetingPackInstallerFile)" />
+    <Exec Command="sudo rpm -iv $(DownloadedSharedHostInstallerFile)" />
+    <Exec Command="sudo rpm -iv $(DownloadedHostFxrInstallerFile)" />
+    <Exec Command="sudo rpm -iv $(DownloadedSharedFrameworkInstallerFile)" />
     <!-- Ignore dependencies, which may have an incoherent dependency on dotnet-runtime -->
-    <Exec Command="rpm -iv --nodeps $(DownloadedAspNetCoreSharedFxInstallerFile)" />
-    <Exec Command="rpm -iv $(SdkRPMInstallerFile)" />
+    <Exec Command="sudo rpm -iv --nodeps $(DownloadedAspNetCoreSharedFxInstallerFile)" />
+    <Exec Command="sudo rpm -iv $(SdkRPMInstallerFile)" />
 
     <!-- Run End-2-end Tests https://github.com/dotnet/core-sdk/issues/1174
     <DotNetRestore ProjectPath="$(EndToEndTestProject)"
@@ -351,15 +351,15 @@
                 ToolPath="$(RpmInstalledDirectory)" />-->
     
     <!-- Clean up Packages -->
-    <Exec Command="rpm -ev --nodeps $(SdkRpmPackageName)" />
-    <Exec Command="rpm -ev --nodeps $(AspNetCoreSharedFxRpmPackageName)" />
-    <Exec Command="rpm -ev --nodeps $(SharedFxRpmPackageName)" />
-    <Exec Command="rpm -ev --nodeps $(HostFxrRpmPackageName)" />
-    <Exec Command="rpm -ev --nodeps $(SharedHostRpmPackageName)" />
-    <Exec Command="rpm -ev --nodeps $(AspNetTargetingPackRpmPackageName)" />
-    <Exec Command="rpm -ev --nodeps $(NetStandardTargetingPackRpmPackageName)" />
-    <Exec Command="rpm -ev --nodeps $(NetCoreAppTargetingPackRpmPackageName)" />
-    <Exec Command="rpm -ev --nodeps $(NetCoreAppHostPackRpmPackageName)" />
-    <Exec Command="rpm -ev --nodeps $(RuntimeDepsPackageName)" />
+    <Exec Command="sudo rpm -ev --nodeps $(SdkRpmPackageName)" />
+    <Exec Command="sudo rpm -ev --nodeps $(AspNetCoreSharedFxRpmPackageName)" />
+    <Exec Command="sudo rpm -ev --nodeps $(SharedFxRpmPackageName)" />
+    <Exec Command="sudo rpm -ev --nodeps $(HostFxrRpmPackageName)" />
+    <Exec Command="sudo rpm -ev --nodeps $(SharedHostRpmPackageName)" />
+    <Exec Command="sudo rpm -ev --nodeps $(AspNetTargetingPackRpmPackageName)" />
+    <Exec Command="sudo rpm -ev --nodeps $(NetStandardTargetingPackRpmPackageName)" />
+    <Exec Command="sudo rpm -ev --nodeps $(NetCoreAppTargetingPackRpmPackageName)" />
+    <Exec Command="sudo rpm -ev --nodeps $(NetCoreAppHostPackRpmPackageName)" />
+    <Exec Command="sudo rpm -ev --nodeps $(RuntimeDepsPackageName)" />
   </Target>
 </Project>

--- a/src/redist/targets/GenerateRPMs.targets
+++ b/src/redist/targets/GenerateRPMs.targets
@@ -330,18 +330,18 @@
           Outputs="$(RpmTestResultsXmlFile)" >
 
     <!-- Install Dependencies and SDK Packages -->
-    <Exec Command="sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc" />
-    <Exec Command="sudo rpm -iv $(DownloadedRuntimeDepsInstallerFile)" />
-    <Exec Command="sudo rpm -iv $(DownloadedNetCoreAppHostPackInstallerFile)" />
-    <Exec Command="sudo rpm -iv $(DownloadedNetCoreAppTargetingPackInstallerFile)" />
-    <Exec Command="sudo rpm -iv $(DownloadedNetStandardTargetingPackInstallerFile)" />
-    <Exec Command="sudo rpm -iv $(DownloadedAspNetTargetingPackInstallerFile)" />
-    <Exec Command="sudo rpm -iv $(DownloadedSharedHostInstallerFile)" />
-    <Exec Command="sudo rpm -iv $(DownloadedHostFxrInstallerFile)" />
-    <Exec Command="sudo rpm -iv $(DownloadedSharedFrameworkInstallerFile)" />
+    <Exec Command="rpm --import https://packages.microsoft.com/keys/microsoft.asc" />
+    <Exec Command="rpm -iv $(DownloadedRuntimeDepsInstallerFile)" />
+    <Exec Command="rpm -iv $(DownloadedNetCoreAppHostPackInstallerFile)" />
+    <Exec Command="rpm -iv $(DownloadedNetCoreAppTargetingPackInstallerFile)" />
+    <Exec Command="rpm -iv $(DownloadedNetStandardTargetingPackInstallerFile)" />
+    <Exec Command="rpm -iv $(DownloadedAspNetTargetingPackInstallerFile)" />
+    <Exec Command="rpm -iv $(DownloadedSharedHostInstallerFile)" />
+    <Exec Command="rpm -iv $(DownloadedHostFxrInstallerFile)" />
+    <Exec Command="rpm -iv $(DownloadedSharedFrameworkInstallerFile)" />
     <!-- Ignore dependencies, which may have an incoherent dependency on dotnet-runtime -->
-    <Exec Command="sudo rpm -iv --nodeps $(DownloadedAspNetCoreSharedFxInstallerFile)" />
-    <Exec Command="sudo rpm -iv $(SdkRPMInstallerFile)" />
+    <Exec Command="rpm -iv --nodeps $(DownloadedAspNetCoreSharedFxInstallerFile)" />
+    <Exec Command="rpm -iv $(SdkRPMInstallerFile)" />
 
     <!-- Run End-2-end Tests https://github.com/dotnet/core-sdk/issues/1174
     <DotNetRestore ProjectPath="$(EndToEndTestProject)"
@@ -351,15 +351,15 @@
                 ToolPath="$(RpmInstalledDirectory)" />-->
     
     <!-- Clean up Packages -->
-    <Exec Command="sudo rpm -ev --nodeps $(SdkRpmPackageName)" />
-    <Exec Command="sudo rpm -ev --nodeps $(AspNetCoreSharedFxRpmPackageName)" />
-    <Exec Command="sudo rpm -ev --nodeps $(SharedFxRpmPackageName)" />
-    <Exec Command="sudo rpm -ev --nodeps $(HostFxrRpmPackageName)" />
-    <Exec Command="sudo rpm -ev --nodeps $(SharedHostRpmPackageName)" />
-    <Exec Command="sudo rpm -ev --nodeps $(AspNetTargetingPackRpmPackageName)" />
-    <Exec Command="sudo rpm -ev --nodeps $(NetStandardTargetingPackRpmPackageName)" />
-    <Exec Command="sudo rpm -ev --nodeps $(NetCoreAppTargetingPackRpmPackageName)" />
-    <Exec Command="sudo rpm -ev --nodeps $(NetCoreAppHostPackRpmPackageName)" />
-    <Exec Command="sudo rpm -ev --nodeps $(RuntimeDepsPackageName)" />
+    <Exec Command="rpm -ev --nodeps $(SdkRpmPackageName)" />
+    <Exec Command="rpm -ev --nodeps $(AspNetCoreSharedFxRpmPackageName)" />
+    <Exec Command="rpm -ev --nodeps $(SharedFxRpmPackageName)" />
+    <Exec Command="rpm -ev --nodeps $(HostFxrRpmPackageName)" />
+    <Exec Command="rpm -ev --nodeps $(SharedHostRpmPackageName)" />
+    <Exec Command="rpm -ev --nodeps $(AspNetTargetingPackRpmPackageName)" />
+    <Exec Command="rpm -ev --nodeps $(NetStandardTargetingPackRpmPackageName)" />
+    <Exec Command="rpm -ev --nodeps $(NetCoreAppTargetingPackRpmPackageName)" />
+    <Exec Command="rpm -ev --nodeps $(NetCoreAppHostPackRpmPackageName)" />
+    <Exec Command="rpm -ev --nodeps $(RuntimeDepsPackageName)" />
   </Target>
 </Project>


### PR DESCRIPTION
Fixes Issue https://github.com/dotnet/installer/issues/16228

main PR #16249

# Description

<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

Currently P4 isn't producing RPM installers. This PR re-enables building RPM installers by updating the RPM build steps to recognize CBL-Mariner as a platform to build RPM installers on.

# Customer Impact

<!-- What is the impact to customers of not taking this fix? -->
We won't produce installers for RPM-based Linux distros.

# Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->
Yes, all previous releases have shipped RPMs.

# Testing

<!-- What kind of testing has been done with the fix. -->
I've validated that this produces RPM installers like previous preview builds.

# Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
Minimal risk, as I've validated that we produce the correct installers.