### PR TITLE
Enable source-build prebuilts detection

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,5 +1,29 @@
 <UsageData>
   <IgnorePatterns>
-    <UsagePattern IdentityGlob="*/*" />
+    <UsagePattern IdentityGlob="Microsoft.SourceBuild.Intermediate.*/*" />
+
+    <!--
+      Temporary exclusion for NuGet packages, since NuGet is not producing source-build intermediate package,
+      see: https://github.com/NuGet/Home/issues/11059
+
+      Once that's fixed, NuGet package version should be updated to newest, and intermediate product dependency
+      added to Version.Details.xml
+    -->
+    <UsagePattern IdentityGlob="NuGet.Common/*5.8.0*" />
+    <UsagePattern IdentityGlob="NuGet.Configuration/*5.8.0*" />
+    <UsagePattern IdentityGlob="NuGet.Frameworks/*5.8.0*" />
+    <UsagePattern IdentityGlob="NuGet.Packaging/*5.8.0*" />
+    <UsagePattern IdentityGlob="NuGet.Versioning/*5.8.0*" />
+
+    <!-- Referenced by NuGet.Packaging.5.8.0 - could be resolved when version of NuGet packages gets updated. -->
+    <UsagePattern IdentityGlob="System.Security.Cryptography.Cng/5.0.0-preview.3.20214.6" />
+    <UsagePattern IdentityGlob="System.Security.Cryptography.Pkcs/5.0.0-preview.3.20214.6" />
+
+    <!-- These are coming in via runtime but the source-build infra isn't able to automatically pick up the right intermediate. -->
+    <UsagePattern IdentityGlob="Microsoft.NET.Workload.Mono.ToolChain*/*8.0.*" />
+    <UsagePattern IdentityGlob="Microsoft.NETCore.App.Crossgen2.linux-x64/*8.0.*" />
+    <UsagePattern IdentityGlob="Microsoft.NETCore.App.Host.linux-x64/*8.0.*" />
+    <UsagePattern IdentityGlob="Microsoft.NETCore.App.Ref/*8.0.*" />
+    <UsagePattern IdentityGlob="Microsoft.NETCore.Platforms/*8.0.*" />
   </IgnorePatterns>
 </UsageData>

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -20,10 +20,6 @@
     <UsagePattern IdentityGlob="System.Security.Cryptography.Pkcs/5.0.0-preview.3.20214.6" />
 
     <!-- These are coming in via runtime but the source-build infra isn't able to automatically pick up the right intermediate. -->
-    <UsagePattern IdentityGlob="Microsoft.NET.Workload.Mono.ToolChain*/*8.0.*" />
     <UsagePattern IdentityGlob="Microsoft.NETCore.App.Crossgen2.linux-x64/*8.0.*" />
-    <UsagePattern IdentityGlob="Microsoft.NETCore.App.Host.linux-x64/*8.0.*" />
-    <UsagePattern IdentityGlob="Microsoft.NETCore.App.Ref/*8.0.*" />
-    <UsagePattern IdentityGlob="Microsoft.NETCore.Platforms/*8.0.*" />
   </IgnorePatterns>
 </UsageData>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -20,7 +20,7 @@
     <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.8.0" Version="8.0.0-preview.5.23252.13" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>bc9dad2351827fdbbde7b10ff97f253a065d49e5</Sha>
-      <SourceBuildTarball RepoName="runtime" ManagedOnly="true" />
+      <SourceBuild RepoName="runtime" ManagedOnly="false" />
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.0-preview.5.23252.13" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/installer/issues/16319

﻿### Summary of the changes

The goal is to enable per-repo source-build to detect prebuilt packages.

Currently, all prebuilts are excluded due to known issues called out in comments.