### PR TITLE
Fix Download MSFT sdk Tarball pattern

### DIFF
--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-build-tarball.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-build-tarball.yml
@@ -85,7 +85,7 @@ jobs:
   - ${{ if ne(parameters.excludeSdkContentTests, 'true') }}:
     - download: ${{ parameters.installerBuildResourceId }}
       artifact: BlobArtifacts
-      patterns: '**/dotnet-sdk-!(*-*)-linux-${{ parameters.architecture }}.tar.gz'
+      patterns: '**/dotnet-sdk-+([0-9]).+([0-9]).+([0-9])?(-@(preview|rc|rtm)*)-linux-${{ parameters.architecture }}.tar.gz'
       displayName: Download MSFT sdk Tarball
 
   - ${{ if eq(parameters.usePreviousArtifacts, 'true') }}:


### PR DESCRIPTION
Ports the changes from https://github.com/dotnet/installer/pull/14567 to the 6.0.1xx branch.

This is necessary because the tarball build for the 6.0.1xx branch has started to fail because it's not downloading the Microsoft SDK tarball. It's not finding a match based on the globbing pattern. When comparing against a previously working build, I see the [`Download build artifacts` task](https://docs.microsoft.com/azure/devops/pipelines/tasks/utility/download-build-artifacts) has changed from version 0.217.1 to 1.220.0 so that could be the reason. There's been no change to the actual tarball filename, other than incrementing the version number. But anyways, using the updated globbing pattern causes it to work correctly.