### PR TITLE
Update source-build-tarball-build-official CI triggers to run on 1xx branches

### DIFF
--- a/eng/source-build-tarball-build-official.yml
+++ b/eng/source-build-tarball-build-official.yml
@@ -7,14 +7,8 @@ resources:
     trigger:
       branches:
         include:
-        - main
-        - release/*
-        - internal/release/*
-        exclude:
-        - release/6.0.3xx
-        - internal/release/6.0.3xx
-        - release/6.0.4xx
-        - internal/release/6.0.4xx
+        - release/*.1xx
+        - internal/release/*.1xx
       stages:
       - build
 


### PR DESCRIPTION
This is being done to preserve build agent compute.  We should only be running source-build CI on the .1xx branches where source-build is supported.
