### PR TITLE
Second attempt at reducing source-build tarball CI frequency

### DIFF
--- a/eng/source-build-tarball-build-official.yml
+++ b/eng/source-build-tarball-build-official.yml
@@ -7,8 +7,10 @@ resources:
     trigger:
       branches:
         include:
-        - release/*.1xx
-        - internal/release/*.1xx
+        - release/6.0.1xx
+        - internal/release/6.0.1xx
+        - release/7.0.1xx
+        - internal/release/7.0.1xx
       stages:
       - build
 


### PR DESCRIPTION
This is a second attempt at https://github.com/dotnet/installer/pull/16338.  The previous attempt failed to trigger CI.  My guess is the wildcard placement was not supported.  I have been unable to find documentation for the wildcard syntax that is supported (https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/resources-pipelines-pipeline-trigger?view=azure-pipelines).
