### PR TITLE
Add lock comment to loc all of the .NET product strings

### DIFF
--- a/eng/loc/wxl_loc.lss
+++ b/eng/loc/wxl_loc.lss
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<LS_SETTINGS_FILE xmlns="">
+	<LS_SETTINGS_DESCRIPTION>
+		<![CDATA[]]>
+	</LS_SETTINGS_DESCRIPTION>
+	<optionSet id="LSOptions">
+		<optionSet id="Defaults" displayName="Option Defaults">
+			<optionSet id="Espresso" displayName="Espresso" />
+			<optionSet id="Parsers" displayName="Parsers" />
+		</optionSet>
+		<optionSet id="User" displayName="User Overrides">
+			<optionSet id="Espresso" displayName="Espresso" />
+			<optionSet id="Parsers" displayName="Parsers" />
+		</optionSet>
+		<optionSet id="Project" displayName="Project Overrides">
+			<optionSet id="Espresso" displayName="Espresso">
+				<optionSet id="TranslationPlatform" displayName="Translation Platform" helpText="Settings for the Translation Platform">
+					<optionSet id="Pseudo Translation Settings" displayName="Pseudo Translation Settings" helpText="Use these settings to control the pseudo localization process.">
+						<optionSet id="Delimiter and String Extension Settings" displayName="Delimiter and String Extension Settings" helpText="Use these settings to specify delimiters and extensions.">
+							<option id="\PseudoTranslation\Delimiters and Extensions\Extension String" displayName="String to add to extend pseudo localized strings" helpText="Enter the string to use to extend the pseudo localized strings.">
+								<string defaultValue=" !!!" currentValue=" 表昌良字" />
+							</option>
+						</optionSet>
+					</optionSet>
+				</optionSet>
+			</optionSet>
+			<optionSet id="Parsers" displayName="Parsers">
+				<optionSet id="Parser 210" displayName="POMXML Parser options" helpText="View file locXML.xml for details.">
+					<option id="IncTermNoResId" displayName="Include Terms that have no Resource Identifier" helpText="With this option turned off, only those terms with user defined resource id will be exposed.">
+						<boolean defaultValue="1" currentValue="0" />
+					</option>
+					<option id="settingFile" displayName="Loc Setting File" helpText="With this option, users specify their own loc setting file.">
+						<string defaultValue="locxml.xml" currentValue="locxml_wxl.xml" />
+					</option>
+					<option id="POMXMLUpdateLocCommentsOnly" displayName="Update Loc Instructions (_locComment) only" helpText="With this option turned ON and the Update Instructions option turned ON only Loc Instructions (_locComment) will be imported into the instruction field. If a localizable item does not have an explicit _locComment then the instruction field will be left blank.">
+						<boolean defaultValue="0" currentValue="1" />
+					</option>
+				</optionSet>
+		      </optionSet>
+		</optionSet>
+	</optionSet>
+</LS_SETTINGS_FILE>

--- a/src/redist/targets/packaging/osx/clisdk/resources/conclusion.html.lci
+++ b/src/redist/targets/packaging/osx/clisdk/resources/conclusion.html.lci
@@ -8,7 +8,7 @@
     <Item ItemId=";align" ItemType="0" PsrId="22" Leaf="false">
       <Disp Icon="Str" Disp="true" LocTbl="false" />
       <Item ItemId="0;0b232ca5c87c0123c6f54f37576b9bcf" ItemType="23;Attr:&lt;DIV&gt;:align" PsrId="22" InstFlg="true" Leaf="true">
-        <Str Cat="Property" UsrLk="true">
+        <Str Cat="Property">
           <Val><![CDATA[left]]></Val>
         </Str>
         <Disp Icon="Str" Order="2" />
@@ -17,7 +17,7 @@
         </Cmts>
       </Item>
       <Item ItemId="1;0b232ca5c87c0123c6f54f37576b9bcf" ItemType="23;Attr:&lt;DIV&gt;:align" PsrId="22" InstFlg="true" Leaf="true">
-        <Str Cat="Property" UsrLk="true">
+        <Str Cat="Property">
           <Val><![CDATA[left]]></Val>
         </Str>
         <Disp Icon="Str" Order="8" />
@@ -26,7 +26,7 @@
         </Cmts>
       </Item>
       <Item ItemId="2;0b232ca5c87c0123c6f54f37576b9bcf" ItemType="23;Attr:&lt;DIV&gt;:align" PsrId="22" InstFlg="true" Leaf="true">
-        <Str Cat="Property" UsrLk="true">
+        <Str Cat="Property">
           <Val><![CDATA[left]]></Val>
         </Str>
         <Disp Icon="Str" Order="12" />
@@ -38,7 +38,7 @@
     <Item ItemId=";charset" ItemType="0" PsrId="22" Leaf="false">
       <Disp Icon="Str" Disp="true" LocTbl="false" />
       <Item ItemId="0;bfca00b0e0c56e9d0dcf189318935756" ItemType="23;Attr:&lt;META&gt;:charset" PsrId="22" InstFlg="true" Leaf="true">
-        <Str Cat="Text" UsrLk="true">
+        <Str Cat="Text">
           <Val><![CDATA[utf-8]]></Val>
         </Str>
         <Disp Icon="Str" Order="1" />
@@ -53,7 +53,7 @@
     <Item ItemId=";font-family" ItemType="0" PsrId="22" Leaf="false">
       <Disp Icon="Str" Disp="true" LocTbl="false" />
       <Item ItemId="0;481e5bb208bdaa170e6b4abf59597f63" ItemType="26;Style:&lt;DIV&gt;:font-family" PsrId="22" InstFlg="true" Leaf="true">
-        <Str Cat="Font Name" UsrLk="true">
+        <Str Cat="Font Name">
           <Val><![CDATA[Helvetica]]></Val>
         </Str>
         <Disp Icon="Str" Order="3" />
@@ -62,7 +62,7 @@
         </Cmts>
       </Item>
       <Item ItemId="1;481e5bb208bdaa170e6b4abf59597f63" ItemType="26;Style:&lt;DIV&gt;:font-family" PsrId="22" InstFlg="true" Leaf="true">
-        <Str Cat="Font Name" UsrLk="true">
+        <Str Cat="Font Name">
           <Val><![CDATA[Helvetica]]></Val>
         </Str>
         <Disp Icon="Str" Order="9" />
@@ -71,10 +71,43 @@
         </Cmts>
       </Item>
       <Item ItemId="2;481e5bb208bdaa170e6b4abf59597f63" ItemType="26;Style:&lt;DIV&gt;:font-family" PsrId="22" InstFlg="true" Leaf="true">
-        <Str Cat="Font Name" UsrLk="true">
+        <Str Cat="Font Name">
           <Val><![CDATA[Helvetica]]></Val>
         </Str>
         <Disp Icon="Str" Order="13" />
+        <Cmts>
+          <Cmt Name="LcxAdmin"><![CDATA[{Locked}]]></Cmt>
+        </Cmts>
+      </Item>
+    </Item>
+  </Item>
+  <Item ItemId=";HTML Content" ItemType="0" PsrId="22" Leaf="false">
+    <Disp Icon="Expand" Expand="true" Disp="true" LocTbl="false" />
+    <Item ItemId=";Regular Content" ItemType="0" PsrId="22" Leaf="false">
+      <Disp Icon="Str" Disp="true" LocTbl="false" />
+      <Item ItemId="0;9201fda65e3d51fc5640e405f7725605" ItemType="18;HTML" PsrId="22" Leaf="true">
+        <Str Cat="HTML Text" UsrLk="true">
+          <Val><![CDATA[.NET Runtime {DOTNETRUNTIMEVERSION}]]></Val>
+        </Str>
+        <Disp Icon="Str" Order="6" />
+        <Cmts>
+          <Cmt Name="LcxAdmin"><![CDATA[{Locked}]]></Cmt>
+        </Cmts>
+      </Item>
+      <Item ItemId="0;be079210226377ae6ac1d38e25db11ae" ItemType="18;HTML" PsrId="22" Leaf="true">
+        <Str Cat="HTML Text" UsrLk="true">
+          <Val><![CDATA[ASP.NET Core Runtime {ASPNETCOREVERSION}]]></Val>
+        </Str>
+        <Disp Icon="Str" Order="7" />
+        <Cmts>
+          <Cmt Name="LcxAdmin"><![CDATA[{Locked}]]></Cmt>
+        </Cmts>
+      </Item>
+      <Item ItemId="0;e05366ff05654d87aee69e8ae4e65364" ItemType="18;HTML" PsrId="22" Leaf="true">
+        <Str Cat="HTML Text" UsrLk="true">
+          <Val><![CDATA[.NET SDK {DOTNETSDKVERSION}]]></Val>
+        </Str>
+        <Disp Icon="Str" Order="5" />
         <Cmts>
           <Cmt Name="LcxAdmin"><![CDATA[{Locked}]]></Cmt>
         </Cmts>

--- a/src/redist/targets/packaging/osx/clisdk/resources/welcome.html.lci
+++ b/src/redist/targets/packaging/osx/clisdk/resources/welcome.html.lci
@@ -8,7 +8,7 @@
     <Item ItemId=";align" ItemType="0" PsrId="22" Leaf="false">
       <Disp Icon="Str" Disp="true" LocTbl="false" />
       <Item ItemId="0;0b232ca5c87c0123c6f54f37576b9bcf" ItemType="23;Attr:&lt;DIV&gt;:align" PsrId="22" InstFlg="true" Leaf="true">
-        <Str Cat="Property" UsrLk="true">
+        <Str Cat="Property">
           <Val><![CDATA[left]]></Val>
         </Str>
         <Disp Icon="Str" Order="2" />
@@ -17,7 +17,7 @@
         </Cmts>
       </Item>
       <Item ItemId="1;0b232ca5c87c0123c6f54f37576b9bcf" ItemType="23;Attr:&lt;DIV&gt;:align" PsrId="22" InstFlg="true" Leaf="true">
-        <Str Cat="Property" UsrLk="true">
+        <Str Cat="Property">
           <Val><![CDATA[left]]></Val>
         </Str>
         <Disp Icon="Str" Order="6" />
@@ -26,7 +26,7 @@
         </Cmts>
       </Item>
       <Item ItemId="2;0b232ca5c87c0123c6f54f37576b9bcf" ItemType="23;Attr:&lt;DIV&gt;:align" PsrId="22" InstFlg="true" Leaf="true">
-        <Str Cat="Property" UsrLk="true">
+        <Str Cat="Property">
           <Val><![CDATA[left]]></Val>
         </Str>
         <Disp Icon="Str" Order="13" />
@@ -38,7 +38,7 @@
     <Item ItemId=";charset" ItemType="0" PsrId="22" Leaf="false">
       <Disp Icon="Str" Disp="true" LocTbl="false" />
       <Item ItemId="0;bfca00b0e0c56e9d0dcf189318935756" ItemType="23;Attr:&lt;META&gt;:charset" PsrId="22" InstFlg="true" Leaf="true">
-        <Str Cat="Text" UsrLk="true">
+        <Str Cat="Text">
           <Val><![CDATA[utf-8]]></Val>
         </Str>
         <Disp Icon="Str" Order="1" />
@@ -53,7 +53,7 @@
     <Item ItemId=";font-family" ItemType="0" PsrId="22" Leaf="false">
       <Disp Icon="Str" Disp="true" LocTbl="false" />
       <Item ItemId="0;481e5bb208bdaa170e6b4abf59597f63" ItemType="26;Style:&lt;DIV&gt;:font-family" PsrId="22" InstFlg="true" Leaf="true">
-        <Str Cat="Font Name" UsrLk="true">
+        <Str Cat="Font Name">
           <Val><![CDATA[Helvetica]]></Val>
         </Str>
         <Disp Icon="Str" Order="3" />
@@ -62,7 +62,7 @@
         </Cmts>
       </Item>
       <Item ItemId="1;481e5bb208bdaa170e6b4abf59597f63" ItemType="26;Style:&lt;DIV&gt;:font-family" PsrId="22" InstFlg="true" Leaf="true">
-        <Str Cat="Font Name" UsrLk="true">
+        <Str Cat="Font Name">
           <Val><![CDATA[Helvetica]]></Val>
         </Str>
         <Disp Icon="Str" Order="7" />
@@ -71,10 +71,25 @@
         </Cmts>
       </Item>
       <Item ItemId="2;481e5bb208bdaa170e6b4abf59597f63" ItemType="26;Style:&lt;DIV&gt;:font-family" PsrId="22" InstFlg="true" Leaf="true">
-        <Str Cat="Font Name" UsrLk="true">
+        <Str Cat="Font Name">
           <Val><![CDATA[Helvetica]]></Val>
         </Str>
         <Disp Icon="Str" Order="14" />
+        <Cmts>
+          <Cmt Name="LcxAdmin"><![CDATA[{Locked}]]></Cmt>
+        </Cmts>
+      </Item>
+    </Item>
+  </Item>
+  <Item ItemId=";HTML Content" ItemType="0" PsrId="22" Leaf="false">
+    <Disp Icon="Expand" Expand="true" Disp="true" LocTbl="false" />
+    <Item ItemId=";Regular Content" ItemType="0" PsrId="22" Leaf="false">
+      <Disp Icon="Str" Disp="true" LocTbl="false" />
+      <Item ItemId="0;3743368085be61f5b4814f3127fe51a7" ItemType="18;HTML" PsrId="22" Leaf="true">
+        <Str Cat="HTML Text" UsrLk="true">
+          <Val><![CDATA[.NET SDK]]></Val>
+        </Str>
+        <Disp Icon="Str" Order="4" />
         <Cmts>
           <Cmt Name="LcxAdmin"><![CDATA[{Locked}]]></Cmt>
         </Cmts>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1028/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1028/bundle.wxl
@@ -47,7 +47,7 @@
   <String Id="FilesInUseDontCloseRadioButton">不關閉應用程式，需要重新啟動(&amp;D)</String>
   <String Id="FilesInUseOkButton">確定(&amp;O)</String>
   <String Id="FilesInUseCancelButton">取消(&amp;C)</String>
-  <String  _locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" Id="FirstTimeWelcomeMessage">安裝成功。
+  <String  Id="FirstTimeWelcomeMessage"><!--_locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" -->安裝成功。
 
 已安裝下列產品:
     * .NET SDK [DOTNETSDKVERSION]
@@ -63,8 +63,8 @@
     * 如需 SDK 文件，請前往 https://aka.ms/dotnet-sdk-docs
     * 如需版本資訊，請前往 https://aka.ms/dotnet[VERSIONMAJOR]-release-notes
     * 如需教學課程，請前往 https://aka.ms/dotnet-tutorials</String>
-  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeHeaderMessage">.NET SDK</String>
-  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeDescription">
+  <String Id="WelcomeHeaderMessage"><!--_locComment="{Locked='.NET SDK'}"-->.NET SDK</String>
+  <String Id="WelcomeDescription"><!--_locComment="{Locked='.NET SDK'}"-->
     .NET SDK 可用於建置、執行及測試 .NET 應用程式。您可以選擇多種語言、編輯器以及開發人員工具，並可利用程式庫的大型生態系統，來建置 Web、行動裝置、桌面、遊戲及 IoT 的應用程式。希望您會喜歡!</String>
   <String Id="LearnMoreTitle">深入了解 .NET</String>
   <String Id="ResourcesHeader">資源</String>
@@ -76,7 +76,7 @@
   <String Id="InstallationNoteTitle">安裝附註</String>
   <String Id="InstallationNote">安裝程序期間將會執行命令，加快專案還原速度並啟用離線存取。最多需要一分鐘的時間完成。
   </String>
-  <String _locComment="{Locked='Visual Studio'}" Id="VisualStudioWarning">若預計要搭配 Visual Studio 使用 .NET [VERSIONMAJOR].[VERSIONMINOR]，需要 Visual Studio 2022 [MINIMUMVSVERSION] 或更新版本。&lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;深入了解&lt;/A&gt;.
+  <String  Id="VisualStudioWarning"><!--_locComment="{Locked='Visual Studio'}"-->若預計要搭配 Visual Studio 使用 .NET [VERSIONMAJOR].[VERSIONMINOR]，需要 Visual Studio 2022 [MINIMUMVSVERSION] 或更新版本。&lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;深入了解&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">按一下 “安裝” 即表示您同意下列條款:</String>
   <String Id="InstallPathx64x86">x64 SDK 安裝的安裝路徑: "[DOTNETHOME_X64]" 不能與 x86 SDK 安裝的路徑相同: "[DOTNETHOME_X86]"</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1028/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1028/bundle.wxl
@@ -47,7 +47,7 @@
   <String Id="FilesInUseDontCloseRadioButton">不關閉應用程式，需要重新啟動(&amp;D)</String>
   <String Id="FilesInUseOkButton">確定(&amp;O)</String>
   <String Id="FilesInUseCancelButton">取消(&amp;C)</String>
-  <String Id="FirstTimeWelcomeMessage">安裝成功。
+  <String  _locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" Id="FirstTimeWelcomeMessage">安裝成功。
 
 已安裝下列產品:
     * .NET SDK [DOTNETSDKVERSION]
@@ -63,8 +63,8 @@
     * 如需 SDK 文件，請前往 https://aka.ms/dotnet-sdk-docs
     * 如需版本資訊，請前往 https://aka.ms/dotnet[VERSIONMAJOR]-release-notes
     * 如需教學課程，請前往 https://aka.ms/dotnet-tutorials</String>
-  <String Id="WelcomeHeaderMessage">.NET SDK</String>
-  <String Id="WelcomeDescription">
+  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeHeaderMessage">.NET SDK</String>
+  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeDescription">
     .NET SDK 可用於建置、執行及測試 .NET 應用程式。您可以選擇多種語言、編輯器以及開發人員工具，並可利用程式庫的大型生態系統，來建置 Web、行動裝置、桌面、遊戲及 IoT 的應用程式。希望您會喜歡!</String>
   <String Id="LearnMoreTitle">深入了解 .NET</String>
   <String Id="ResourcesHeader">資源</String>
@@ -76,7 +76,7 @@
   <String Id="InstallationNoteTitle">安裝附註</String>
   <String Id="InstallationNote">安裝程序期間將會執行命令，加快專案還原速度並啟用離線存取。最多需要一分鐘的時間完成。
   </String>
-  <String Id="VisualStudioWarning">若預計要搭配 Visual Studio 使用 .NET [VERSIONMAJOR].[VERSIONMINOR]，需要 Visual Studio 2022 [MINIMUMVSVERSION] 或更新版本。&lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;深入了解&lt;/A&gt;.
+  <String _locComment="{Locked='Visual Studio'}" Id="VisualStudioWarning">若預計要搭配 Visual Studio 使用 .NET [VERSIONMAJOR].[VERSIONMINOR]，需要 Visual Studio 2022 [MINIMUMVSVERSION] 或更新版本。&lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;深入了解&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">按一下 “安裝” 即表示您同意下列條款:</String>
   <String Id="InstallPathx64x86">x64 SDK 安裝的安裝路徑: "[DOTNETHOME_X64]" 不能與 x86 SDK 安裝的路徑相同: "[DOTNETHOME_X86]"</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1029/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1029/bundle.wxl
@@ -47,7 +47,7 @@
   <String Id="FilesInUseDontCloseRadioButton">A&amp;plikace nezavírejte. Bude potřeba provést restart.</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Zrušit</String>
-  <String Id="FirstTimeWelcomeMessage">Instalace byla úspěšná. 
+  <String  _locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" Id="FirstTimeWelcomeMessage">Instalace byla úspěšná. 
 
 Byly nainstalovány následující produkty:
     • .NET SDK [DOTNETSDKVERSION]
@@ -63,8 +63,8 @@ Prostředky
     • Dokumentace SDK https://aka.ms/dotnet-sdk-docs
     • Poznámky k verzi https://aka.ms/dotnet[VERSIONMAJOR]-release-notes
     • Kurzy https://aka.ms/dotnet-tutorials</String>
-  <String Id="WelcomeHeaderMessage">Sada .NET SDK</String>
-  <String Id="WelcomeDescription">
+  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeHeaderMessage">Sada .NET SDK</String>
+  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeDescription">
     Sada .NET SDK slouží k sestavování, spouštění a testování aplikací .NET. Můžete si vybrat z několika jazyků, editorů a vývojářských nástrojů a využít rozsáhlého ekosystému knihoven k vytváření aplikací pro web, mobilní zařízení, stolní počítače, hry a IoT. Doufáme, že se vám bude líbit!</String>
   <String Id="LearnMoreTitle">Další informace o .NET</String>
   <String Id="ResourcesHeader">Prostředky</String>
@@ -76,7 +76,7 @@ Prostředky
   <String Id="InstallationNoteTitle">Poznámka k instalaci</String>
   <String Id="InstallationNote">Během procesu instalace se spustí příkaz, který zlepší rychlost obnovení projektu a povolí offline přístup. Akce se dokončí přibližně za minutu.
   </String>
-  <String Id="VisualStudioWarning">Pokud plánujete používat .NET [VERSIONMAJOR].[VERSIONMINOR] s Visual Studio, vyžaduje se Visual Studio 2022 [MINIMUMVSVERSION] nebo novější. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Další informace&lt;/A&gt;.
+  <String _locComment="{Locked='Visual Studio'}" Id="VisualStudioWarning">Pokud plánujete používat .NET [VERSIONMAJOR].[VERSIONMINOR] s Visual Studio, vyžaduje se Visual Studio 2022 [MINIMUMVSVERSION] nebo novější. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Další informace&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Kliknutím na Nainstalovat vyjadřujete souhlas s následujícími podmínkami:</String>
   <String Id="InstallPathx64x86">Instalační cesta pro instalace sady x64 SDK[ DOTNETHOME_X64] nemůže být stejná jako u instalací sady x86 SDK: [DOTNETHOME_X86].</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1029/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1029/bundle.wxl
@@ -47,7 +47,7 @@
   <String Id="FilesInUseDontCloseRadioButton">A&amp;plikace nezavírejte. Bude potřeba provést restart.</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Zrušit</String>
-  <String  _locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" Id="FirstTimeWelcomeMessage">Instalace byla úspěšná. 
+  <String  Id="FirstTimeWelcomeMessage"><!--_locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" -->Instalace byla úspěšná. 
 
 Byly nainstalovány následující produkty:
     • .NET SDK [DOTNETSDKVERSION]
@@ -63,8 +63,8 @@ Prostředky
     • Dokumentace SDK https://aka.ms/dotnet-sdk-docs
     • Poznámky k verzi https://aka.ms/dotnet[VERSIONMAJOR]-release-notes
     • Kurzy https://aka.ms/dotnet-tutorials</String>
-  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeHeaderMessage">Sada .NET SDK</String>
-  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeDescription">
+  <String Id="WelcomeHeaderMessage"><!--_locComment="{Locked='.NET SDK'}"-->Sada .NET SDK</String>
+  <String Id="WelcomeDescription"><!--_locComment="{Locked='.NET SDK'}"-->
     Sada .NET SDK slouží k sestavování, spouštění a testování aplikací .NET. Můžete si vybrat z několika jazyků, editorů a vývojářských nástrojů a využít rozsáhlého ekosystému knihoven k vytváření aplikací pro web, mobilní zařízení, stolní počítače, hry a IoT. Doufáme, že se vám bude líbit!</String>
   <String Id="LearnMoreTitle">Další informace o .NET</String>
   <String Id="ResourcesHeader">Prostředky</String>
@@ -76,7 +76,7 @@ Prostředky
   <String Id="InstallationNoteTitle">Poznámka k instalaci</String>
   <String Id="InstallationNote">Během procesu instalace se spustí příkaz, který zlepší rychlost obnovení projektu a povolí offline přístup. Akce se dokončí přibližně za minutu.
   </String>
-  <String _locComment="{Locked='Visual Studio'}" Id="VisualStudioWarning">Pokud plánujete používat .NET [VERSIONMAJOR].[VERSIONMINOR] s Visual Studio, vyžaduje se Visual Studio 2022 [MINIMUMVSVERSION] nebo novější. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Další informace&lt;/A&gt;.
+  <String  Id="VisualStudioWarning"><!--_locComment="{Locked='Visual Studio'}"-->Pokud plánujete používat .NET [VERSIONMAJOR].[VERSIONMINOR] s Visual Studio, vyžaduje se Visual Studio 2022 [MINIMUMVSVERSION] nebo novější. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Další informace&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Kliknutím na Nainstalovat vyjadřujete souhlas s následujícími podmínkami:</String>
   <String Id="InstallPathx64x86">Instalační cesta pro instalace sady x64 SDK[ DOTNETHOME_X64] nemůže být stejná jako u instalací sady x86 SDK: [DOTNETHOME_X86].</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1031/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1031/bundle.wxl
@@ -47,7 +47,7 @@
   <String Id="FilesInUseDontCloseRadioButton">&amp;Anwendungen nicht schließen. Ein Neustart ist erforderlich.</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Abbrechen</String>
-  <String Id="FirstTimeWelcomeMessage">Die Installation war erfolgreich.
+  <String  _locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" Id="FirstTimeWelcomeMessage">Die Installation war erfolgreich.
 
 Die folgenden Produkte wurden unter installiert:
     • .NET-SDK [DOTNETSDKVERSION]
@@ -63,8 +63,8 @@ Ressourcen
     • SDK-Dokumentation: https://aka.ms/dotnet-sdk-docs
     • Versionshinweise: https://aka.ms/dotnet[VERSIONMAJOR]-release-notes
     • Tutorials: https://aka.ms/dotnet-tutorials</String>
-  <String Id="WelcomeHeaderMessage">.NET-SDK</String>
-  <String Id="WelcomeDescription">
+  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeHeaderMessage">.NET-SDK</String>
+  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeDescription">
     Das .NET-SDK wird zum Erstellen, Ausführen und Testen von .NET-Anwendungen verwendet. Sie können aus mehreren Sprachen, Editoren und Entwicklertools auswählen und ein großes Ökosystem von Bibliotheken nutzen, um Apps für das Web, mobile Geräte, Desktops, Gaming und IoT zu entwickeln. Wir wünschen Ihnen viel Spaß damit!</String>
   <String Id="LearnMoreTitle">Weitere Informationen zu .NET</String>
   <String Id="ResourcesHeader">Ressourcen</String>
@@ -76,7 +76,7 @@ Ressourcen
   <String Id="InstallationNoteTitle">Installationshinweis</String>
   <String Id="InstallationNote">Während des Installationsvorgangs wird ein Befehl ausgeführt, durch den die Geschwindigkeit der Projektwiederherstellung verbessert und der Offlinezugriff aktiviert wird. Der Vorgang dauert bis zu einer Minute.
   </String>
-  <String Id="VisualStudioWarning">Wenn Sie beabsichtigen, .NET [VERSIONMAJOR].[VERSIONMINOR] mit Visual Studio zu verwenden, ist Visual Studio 2022 [MINIMUMVSVERSION] oder höher erforderlich. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Weitere Informationen&lt;/A&gt;.
+  <String _locComment="{Locked='Visual Studio'}" Id="VisualStudioWarning">Wenn Sie beabsichtigen, .NET [VERSIONMAJOR].[VERSIONMINOR] mit Visual Studio zu verwenden, ist Visual Studio 2022 [MINIMUMVSVERSION] oder höher erforderlich. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Weitere Informationen&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Durch Klicken auf „Installieren2 stimmen Sie den nachstehenden Bedingungen zu:</String>
   <String Id="InstallPathx64x86">Der Installationspfad „[DOTNETHOME_X64]“ für x64 SDK-Installationen kann nicht derselbe sein wie für x86 SDK-Installationen: „[DOTNETHOME_X86]“</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1031/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1031/bundle.wxl
@@ -47,7 +47,7 @@
   <String Id="FilesInUseDontCloseRadioButton">&amp;Anwendungen nicht schließen. Ein Neustart ist erforderlich.</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Abbrechen</String>
-  <String  _locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" Id="FirstTimeWelcomeMessage">Die Installation war erfolgreich.
+  <String  Id="FirstTimeWelcomeMessage"><!--_locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" -->Die Installation war erfolgreich.
 
 Die folgenden Produkte wurden unter installiert:
     • .NET-SDK [DOTNETSDKVERSION]
@@ -63,8 +63,8 @@ Ressourcen
     • SDK-Dokumentation: https://aka.ms/dotnet-sdk-docs
     • Versionshinweise: https://aka.ms/dotnet[VERSIONMAJOR]-release-notes
     • Tutorials: https://aka.ms/dotnet-tutorials</String>
-  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeHeaderMessage">.NET-SDK</String>
-  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeDescription">
+  <String Id="WelcomeHeaderMessage"><!--_locComment="{Locked='.NET SDK'}"-->.NET-SDK</String>
+  <String Id="WelcomeDescription"><!--_locComment="{Locked='.NET SDK'}"-->
     Das .NET-SDK wird zum Erstellen, Ausführen und Testen von .NET-Anwendungen verwendet. Sie können aus mehreren Sprachen, Editoren und Entwicklertools auswählen und ein großes Ökosystem von Bibliotheken nutzen, um Apps für das Web, mobile Geräte, Desktops, Gaming und IoT zu entwickeln. Wir wünschen Ihnen viel Spaß damit!</String>
   <String Id="LearnMoreTitle">Weitere Informationen zu .NET</String>
   <String Id="ResourcesHeader">Ressourcen</String>
@@ -76,7 +76,7 @@ Ressourcen
   <String Id="InstallationNoteTitle">Installationshinweis</String>
   <String Id="InstallationNote">Während des Installationsvorgangs wird ein Befehl ausgeführt, durch den die Geschwindigkeit der Projektwiederherstellung verbessert und der Offlinezugriff aktiviert wird. Der Vorgang dauert bis zu einer Minute.
   </String>
-  <String _locComment="{Locked='Visual Studio'}" Id="VisualStudioWarning">Wenn Sie beabsichtigen, .NET [VERSIONMAJOR].[VERSIONMINOR] mit Visual Studio zu verwenden, ist Visual Studio 2022 [MINIMUMVSVERSION] oder höher erforderlich. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Weitere Informationen&lt;/A&gt;.
+  <String  Id="VisualStudioWarning"><!--_locComment="{Locked='Visual Studio'}"-->Wenn Sie beabsichtigen, .NET [VERSIONMAJOR].[VERSIONMINOR] mit Visual Studio zu verwenden, ist Visual Studio 2022 [MINIMUMVSVERSION] oder höher erforderlich. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Weitere Informationen&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Durch Klicken auf „Installieren2 stimmen Sie den nachstehenden Bedingungen zu:</String>
   <String Id="InstallPathx64x86">Der Installationspfad „[DOTNETHOME_X64]“ für x64 SDK-Installationen kann nicht derselbe sein wie für x86 SDK-Installationen: „[DOTNETHOME_X86]“</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1033/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1033/bundle.wxl
@@ -47,7 +47,7 @@
   <String Id="FilesInUseDontCloseRadioButton">&amp;Do not close applications. A reboot will be required.</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
-  <String _locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" Id="FirstTimeWelcomeMessage">The installation was successful.
+  <String Id="FirstTimeWelcomeMessage"><!--_locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" -->The installation was successful.
 
 The following products were installed:
     • .NET SDK [DOTNETSDKVERSION]
@@ -63,8 +63,8 @@ Resources
     • SDK Documentation https://aka.ms/dotnet-sdk-docs
     • Release Notes https://aka.ms/dotnet[VERSIONMAJOR]-release-notes
     • Tutorials https://aka.ms/dotnet-tutorials</String>
-  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeHeaderMessage">.NET SDK</String>
-  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeDescription">
+  <String Id="WelcomeHeaderMessage"><!--_locComment="{Locked='.NET SDK'}"-->.NET SDK</String>
+  <String Id="WelcomeDescription"><!--_locComment="{Locked='.NET SDK'}"-->
     The .NET SDK is used to build, run, and test .NET applications. You can choose from multiple languages, editors, and developer tools, and take advantage of a large ecosystem of libraries to build apps for web, mobile, desktop, gaming, and IoT. We hope you enjoy it!</String>
   <String Id="LearnMoreTitle">Learn more about .NET</String>
   <String Id="ResourcesHeader">Resources</String>
@@ -76,7 +76,7 @@ Resources
   <String Id="InstallationNoteTitle">Installation note</String>
   <String Id="InstallationNote">A command will be run during the install process that will improve project restore speed and enable offline access. It will take up to a minute to complete.
   </String>
-  <String _locComment="{Locked='Visual Studio'}" Id="VisualStudioWarning">If you plan to use .NET [VERSIONMAJOR].[VERSIONMINOR] with Visual Studio, Visual Studio 2022 [MINIMUMVSVERSION] or newer is required. &lt;A HREF=&quot;https://aka.ms/dotnet[VERSIONMAJOR]-release-notes&quot;&gt;Learn more&lt;/A&gt;.
+  <String  Id="VisualStudioWarning"><!--_locComment="{Locked='Visual Studio'}"-->If you plan to use .NET [VERSIONMAJOR].[VERSIONMINOR] with Visual Studio, Visual Studio 2022 [MINIMUMVSVERSION] or newer is required. &lt;A HREF=&quot;https://aka.ms/dotnet[VERSIONMAJOR]-release-notes&quot;&gt;Learn more&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">By clicking Install, you agree to the following terms:</String>
   <String Id="InstallPathx64x86">The installation path for x64 SDK installations: &quot;[DOTNETHOME_X64]&quot; cannot be the same as for x86 SDK installations: &quot;[DOTNETHOME_X86]&quot;</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1033/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1033/bundle.wxl
@@ -47,7 +47,7 @@
   <String Id="FilesInUseDontCloseRadioButton">&amp;Do not close applications. A reboot will be required.</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
-  <String Id="FirstTimeWelcomeMessage">The installation was successful.
+  <String _locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" Id="FirstTimeWelcomeMessage">The installation was successful.
 
 The following products were installed:
     • .NET SDK [DOTNETSDKVERSION]
@@ -63,8 +63,8 @@ Resources
     • SDK Documentation https://aka.ms/dotnet-sdk-docs
     • Release Notes https://aka.ms/dotnet[VERSIONMAJOR]-release-notes
     • Tutorials https://aka.ms/dotnet-tutorials</String>
-  <String Id="WelcomeHeaderMessage">.NET SDK</String>
-  <String Id="WelcomeDescription">
+  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeHeaderMessage">.NET SDK</String>
+  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeDescription">
     The .NET SDK is used to build, run, and test .NET applications. You can choose from multiple languages, editors, and developer tools, and take advantage of a large ecosystem of libraries to build apps for web, mobile, desktop, gaming, and IoT. We hope you enjoy it!</String>
   <String Id="LearnMoreTitle">Learn more about .NET</String>
   <String Id="ResourcesHeader">Resources</String>
@@ -76,7 +76,7 @@ Resources
   <String Id="InstallationNoteTitle">Installation note</String>
   <String Id="InstallationNote">A command will be run during the install process that will improve project restore speed and enable offline access. It will take up to a minute to complete.
   </String>
-  <String Id="VisualStudioWarning">If you plan to use .NET [VERSIONMAJOR].[VERSIONMINOR] with Visual Studio, Visual Studio 2022 [MINIMUMVSVERSION] or newer is required. &lt;A HREF=&quot;https://aka.ms/dotnet[VERSIONMAJOR]-release-notes&quot;&gt;Learn more&lt;/A&gt;.
+  <String _locComment="{Locked='Visual Studio'}" Id="VisualStudioWarning">If you plan to use .NET [VERSIONMAJOR].[VERSIONMINOR] with Visual Studio, Visual Studio 2022 [MINIMUMVSVERSION] or newer is required. &lt;A HREF=&quot;https://aka.ms/dotnet[VERSIONMAJOR]-release-notes&quot;&gt;Learn more&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">By clicking Install, you agree to the following terms:</String>
   <String Id="InstallPathx64x86">The installation path for x64 SDK installations: &quot;[DOTNETHOME_X64]&quot; cannot be the same as for x86 SDK installations: &quot;[DOTNETHOME_X86]&quot;</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1036/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1036/bundle.wxl
@@ -47,7 +47,7 @@
   <String Id="FilesInUseDontCloseRadioButton">&amp;Ne pas fermer les applications. Un redémarrage sera nécessaire.</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Annuler</String>
-  <String  _locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" Id="FirstTimeWelcomeMessage">L’installation a réussi.
+  <String  Id="FirstTimeWelcomeMessage"><!--_locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" -->L’installation a réussi.
 
 Les éléments suivants ont été installés :
     • Kit SDK .NET [DOTNETSDKVERSION]
@@ -63,8 +63,8 @@ Ressources
     • Documentation de kit SDK sur https://aka.ms/dotnet-sdk-docs
     • Notes de publication sur https://aka.ms/dotnet[VERSIONMAJOR]-release-notes
     • Tutoriels sur https://aka.ms/dotnet-tutorials</String>
-  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeHeaderMessage">Kit de développement logiciel (SDK) .NET</String>
-  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeDescription">
+  <String Id="WelcomeHeaderMessage"><!--_locComment="{Locked='.NET SDK'}"-->Kit de développement logiciel (SDK) .NET</String>
+  <String Id="WelcomeDescription"><!--_locComment="{Locked='.NET SDK'}"-->
     Le Kit de développement logiciel (SDK) .NET permet de générer, d’exécuter et de tester des applications .NET. Vous pouvez choisir parmi plusieurs langages, éditeurs et outils de développement. De plus, vous pouvez bénéficier d’un vaste écosystème de bibliothèques afin de générer des applications pour le web, les appareils mobiles, les ordinateurs de bureau, les jeux et l’IoT. Nous espérons que vous l’apprécierez !</String>
   <String Id="LearnMoreTitle">En savoir plus sur .NET</String>
   <String Id="ResourcesHeader">Ressources</String>
@@ -76,7 +76,7 @@ Ressources
   <String Id="InstallationNoteTitle">Note d’installation</String>
   <String Id="InstallationNote">Une commande va être exécutée pendant le processus d'installation, ce qui va améliorer la vitesse de restauration du projet et permettre l'accès hors connexion. L'opération va prendre environ une minute.
   </String>
-  <String _locComment="{Locked='Visual Studio'}" Id="VisualStudioWarning">Si vous envisagez d’utiliser .NET [VERSIONMAJOR].[VERSIONMINOR] avec Visual Studio, Visual Studio 2022 [MINIMUMVSVERSION] ou une version ultérieure est nécessaire. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;En savoir plus&lt;/A&gt;.
+  <String  Id="VisualStudioWarning"><!--_locComment="{Locked='Visual Studio'}"-->Si vous envisagez d’utiliser .NET [VERSIONMAJOR].[VERSIONMINOR] avec Visual Studio, Visual Studio 2022 [MINIMUMVSVERSION] ou une version ultérieure est nécessaire. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;En savoir plus&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">En cliquant sur Installer, vous acceptez les conditions suivantes :</String>
   <String Id="InstallPathx64x86">Le chemin d’installation des installations du Kit de développement logiciel (SDK) x64 : « [DOTNETHOME_X64] » ne peut pas être identique à celui des installations du Kit de développement logiciel (SDK) x86 : « [DOTNETHOME_X86] »</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1036/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1036/bundle.wxl
@@ -47,7 +47,7 @@
   <String Id="FilesInUseDontCloseRadioButton">&amp;Ne pas fermer les applications. Un redémarrage sera nécessaire.</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Annuler</String>
-  <String Id="FirstTimeWelcomeMessage">L’installation a réussi.
+  <String  _locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" Id="FirstTimeWelcomeMessage">L’installation a réussi.
 
 Les éléments suivants ont été installés :
     • Kit SDK .NET [DOTNETSDKVERSION]
@@ -63,8 +63,8 @@ Ressources
     • Documentation de kit SDK sur https://aka.ms/dotnet-sdk-docs
     • Notes de publication sur https://aka.ms/dotnet[VERSIONMAJOR]-release-notes
     • Tutoriels sur https://aka.ms/dotnet-tutorials</String>
-  <String Id="WelcomeHeaderMessage">Kit de développement logiciel (SDK) .NET</String>
-  <String Id="WelcomeDescription">
+  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeHeaderMessage">Kit de développement logiciel (SDK) .NET</String>
+  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeDescription">
     Le Kit de développement logiciel (SDK) .NET permet de générer, d’exécuter et de tester des applications .NET. Vous pouvez choisir parmi plusieurs langages, éditeurs et outils de développement. De plus, vous pouvez bénéficier d’un vaste écosystème de bibliothèques afin de générer des applications pour le web, les appareils mobiles, les ordinateurs de bureau, les jeux et l’IoT. Nous espérons que vous l’apprécierez !</String>
   <String Id="LearnMoreTitle">En savoir plus sur .NET</String>
   <String Id="ResourcesHeader">Ressources</String>
@@ -76,7 +76,7 @@ Ressources
   <String Id="InstallationNoteTitle">Note d’installation</String>
   <String Id="InstallationNote">Une commande va être exécutée pendant le processus d'installation, ce qui va améliorer la vitesse de restauration du projet et permettre l'accès hors connexion. L'opération va prendre environ une minute.
   </String>
-  <String Id="VisualStudioWarning">Si vous envisagez d’utiliser .NET [VERSIONMAJOR].[VERSIONMINOR] avec Visual Studio, Visual Studio 2022 [MINIMUMVSVERSION] ou une version ultérieure est nécessaire. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;En savoir plus&lt;/A&gt;.
+  <String _locComment="{Locked='Visual Studio'}" Id="VisualStudioWarning">Si vous envisagez d’utiliser .NET [VERSIONMAJOR].[VERSIONMINOR] avec Visual Studio, Visual Studio 2022 [MINIMUMVSVERSION] ou une version ultérieure est nécessaire. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;En savoir plus&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">En cliquant sur Installer, vous acceptez les conditions suivantes :</String>
   <String Id="InstallPathx64x86">Le chemin d’installation des installations du Kit de développement logiciel (SDK) x64 : « [DOTNETHOME_X64] » ne peut pas être identique à celui des installations du Kit de développement logiciel (SDK) x86 : « [DOTNETHOME_X86] »</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1040/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1040/bundle.wxl
@@ -47,7 +47,7 @@
   <String Id="FilesInUseDontCloseRadioButton">&amp;Non chiudere le applicazioni; sarà necessario riavviare il sistema</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Annulla</String>
-  <String Id="FirstTimeWelcomeMessage">Installazione completata.
+  <String  _locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" Id="FirstTimeWelcomeMessage">Installazione completata.
 
 Sono stati installati i prodotti seguenti:
     • .NET SDK [DOTNETSDKVERSION]
@@ -63,8 +63,8 @@ Risorse
     • Documentazione SDK https://aka.ms/dotnet-sdk-docs
     • Note sulla versione https://aka.ms/dotnet[VERSIONMAJOR]-release-notes
     • Tutorial https://aka.ms/dotnet-tutorials</String>
-  <String Id="WelcomeHeaderMessage">.NET SDK</String>
-  <String Id="WelcomeDescription">
+  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeHeaderMessage">.NET SDK</String>
+  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeDescription">
     .NET SDK consente di creare, eseguire e testare applicazioni .NET. È possibile scegliere tra più linguaggi, editor e strumenti di sviluppo e sfruttare un vasto ecosistema di librerie per creare app per Web, dispositivi mobili, desktop, giochi e IoT.</String>
   <String Id="LearnMoreTitle">Altre informazioni su .NET</String>
   <String Id="ResourcesHeader">Risorse</String>
@@ -76,7 +76,7 @@ Risorse
   <String Id="InstallationNoteTitle">Nota sull'installazione</String>
   <String Id="InstallationNote">Durante il processo di installazione verrà eseguito un comando che migliorerà la velocità di ripristino del progetto e abiliterà l'accesso offline. Il completamento del comando richiederà un minuto.
   </String>
-  <String Id="VisualStudioWarning">Se si prevede di usare .NET [VERSIONMAJOR]. [VERSIONMINOR] con Visual Studio, è necessario Visual Studio 2022 [MINIMUMVSVERSION] o versione successiva. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Altre informazioni&lt;/A&gt;. 
+  <String _locComment="{Locked='Visual Studio'}" Id="VisualStudioWarning">Se si prevede di usare .NET [VERSIONMAJOR]. [VERSIONMINOR] con Visual Studio, è necessario Visual Studio 2022 [MINIMUMVSVERSION] o versione successiva. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Altre informazioni&lt;/A&gt;. 
 </String>
   <String Id="LicenseAssent">Facendo clic su Installa, si accettano le condizioni seguenti:</String>
   <String Id="InstallPathx64x86">Percorso di installazione per le installazioni x64 SDK: "[DOTNETHOME_X64]" non può essere uguale a quello delle installazioni di x86 SDK: "[DOTNETHOME_X86]"</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1040/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1040/bundle.wxl
@@ -47,7 +47,7 @@
   <String Id="FilesInUseDontCloseRadioButton">&amp;Non chiudere le applicazioni; sarà necessario riavviare il sistema</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Annulla</String>
-  <String  _locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" Id="FirstTimeWelcomeMessage">Installazione completata.
+  <String  Id="FirstTimeWelcomeMessage"><!--_locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" -->Installazione completata.
 
 Sono stati installati i prodotti seguenti:
     • .NET SDK [DOTNETSDKVERSION]
@@ -63,8 +63,8 @@ Risorse
     • Documentazione SDK https://aka.ms/dotnet-sdk-docs
     • Note sulla versione https://aka.ms/dotnet[VERSIONMAJOR]-release-notes
     • Tutorial https://aka.ms/dotnet-tutorials</String>
-  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeHeaderMessage">.NET SDK</String>
-  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeDescription">
+  <String Id="WelcomeHeaderMessage"><!--_locComment="{Locked='.NET SDK'}"-->.NET SDK</String>
+  <String Id="WelcomeDescription"><!--_locComment="{Locked='.NET SDK'}"-->
     .NET SDK consente di creare, eseguire e testare applicazioni .NET. È possibile scegliere tra più linguaggi, editor e strumenti di sviluppo e sfruttare un vasto ecosistema di librerie per creare app per Web, dispositivi mobili, desktop, giochi e IoT.</String>
   <String Id="LearnMoreTitle">Altre informazioni su .NET</String>
   <String Id="ResourcesHeader">Risorse</String>
@@ -76,7 +76,7 @@ Risorse
   <String Id="InstallationNoteTitle">Nota sull'installazione</String>
   <String Id="InstallationNote">Durante il processo di installazione verrà eseguito un comando che migliorerà la velocità di ripristino del progetto e abiliterà l'accesso offline. Il completamento del comando richiederà un minuto.
   </String>
-  <String _locComment="{Locked='Visual Studio'}" Id="VisualStudioWarning">Se si prevede di usare .NET [VERSIONMAJOR]. [VERSIONMINOR] con Visual Studio, è necessario Visual Studio 2022 [MINIMUMVSVERSION] o versione successiva. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Altre informazioni&lt;/A&gt;. 
+  <String  Id="VisualStudioWarning"><!--_locComment="{Locked='Visual Studio'}"-->Se si prevede di usare .NET [VERSIONMAJOR]. [VERSIONMINOR] con Visual Studio, è necessario Visual Studio 2022 [MINIMUMVSVERSION] o versione successiva. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Altre informazioni&lt;/A&gt;. 
 </String>
   <String Id="LicenseAssent">Facendo clic su Installa, si accettano le condizioni seguenti:</String>
   <String Id="InstallPathx64x86">Percorso di installazione per le installazioni x64 SDK: "[DOTNETHOME_X64]" non può essere uguale a quello delle installazioni di x86 SDK: "[DOTNETHOME_X86]"</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1041/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1041/bundle.wxl
@@ -47,7 +47,7 @@
   <String Id="FilesInUseDontCloseRadioButton">アプリケーションを終了させない (コンピューターの再起動が必要になります)(&amp;D)</String>
   <String Id="FilesInUseOkButton">OK(&amp;O)</String>
   <String Id="FilesInUseCancelButton">キャンセル(&amp;C)</String>
-  <String  _locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" Id="FirstTimeWelcomeMessage">インストールが成功しました。
+  <String  Id="FirstTimeWelcomeMessage"><!--_locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" -->インストールが成功しました。
 
 以下の製品がインストールされました
     • .NET SDK [DOTNETSDKVERSION]
@@ -63,8 +63,8 @@
     • SDK ドキュメント https://aka.ms/dotnet-sdk-docs
     • リリース ノート  https://aka.ms/dotnet[VERSIONMAJOR]-release-notes
     • チュートリアル https://aka.ms/dotnet-tutorials</String>
-  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeHeaderMessage">.NET SDK</String>
-  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeDescription">
+  <String Id="WelcomeHeaderMessage"><!--_locComment="{Locked='.NET SDK'}"-->.NET SDK</String>
+  <String Id="WelcomeDescription"><!--_locComment="{Locked='.NET SDK'}"-->
     .Net SDK は、.NET アプリケーションをビルド、実行、テストするために使用されます。複数の言語、エディター、開発者ツールから選択し、ライブラリの大規模なエコシステムを利用して、Web、モバイル、デスクトップ、ゲーム、IoT 用のアプリを作成できます。お楽しみいただければ幸いです。</String>
   <String Id="LearnMoreTitle">.Net の詳細情報</String>
   <String Id="ResourcesHeader">リソース</String>
@@ -76,7 +76,7 @@
   <String Id="InstallationNoteTitle">インストール メモ</String>
   <String Id="InstallationNote">コマンドはインストール処理中に実行されるので、プロジェクトの復元速度が向上し、オフラインでアクセスできます。完了するまでに最大 1 分かかります。
   </String>
-  <String _locComment="{Locked='Visual Studio'}" Id="VisualStudioWarning">.NET [VERSIONMAJOR].[VERSIONMINOR] を Visual Studio で使用する場合は、Visual Studio 2022 [MINIMUMVSVERSION] 以降が必要です。&lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;詳細情報&lt;/A&gt;.
+  <String  Id="VisualStudioWarning"><!--_locComment="{Locked='Visual Studio'}"-->.NET [VERSIONMAJOR].[VERSIONMINOR] を Visual Studio で使用する場合は、Visual Studio 2022 [MINIMUMVSVERSION] 以降が必要です。&lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;詳細情報&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">インストール をクリックすると、次の条項に同意したものと見なされます:</String>
   <String Id="InstallPathx64x86">x64 SDK インストールのインストール パス: "[DOTNETHOME_X64]" を x86 SDK インストールの場合と同じにすることはできません: "[DOTNETHOME_X86]"</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1041/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1041/bundle.wxl
@@ -47,7 +47,7 @@
   <String Id="FilesInUseDontCloseRadioButton">アプリケーションを終了させない (コンピューターの再起動が必要になります)(&amp;D)</String>
   <String Id="FilesInUseOkButton">OK(&amp;O)</String>
   <String Id="FilesInUseCancelButton">キャンセル(&amp;C)</String>
-  <String Id="FirstTimeWelcomeMessage">インストールが成功しました。
+  <String  _locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" Id="FirstTimeWelcomeMessage">インストールが成功しました。
 
 以下の製品がインストールされました
     • .NET SDK [DOTNETSDKVERSION]
@@ -63,8 +63,8 @@
     • SDK ドキュメント https://aka.ms/dotnet-sdk-docs
     • リリース ノート  https://aka.ms/dotnet[VERSIONMAJOR]-release-notes
     • チュートリアル https://aka.ms/dotnet-tutorials</String>
-  <String Id="WelcomeHeaderMessage">.NET SDK</String>
-  <String Id="WelcomeDescription">
+  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeHeaderMessage">.NET SDK</String>
+  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeDescription">
     .Net SDK は、.NET アプリケーションをビルド、実行、テストするために使用されます。複数の言語、エディター、開発者ツールから選択し、ライブラリの大規模なエコシステムを利用して、Web、モバイル、デスクトップ、ゲーム、IoT 用のアプリを作成できます。お楽しみいただければ幸いです。</String>
   <String Id="LearnMoreTitle">.Net の詳細情報</String>
   <String Id="ResourcesHeader">リソース</String>
@@ -76,7 +76,7 @@
   <String Id="InstallationNoteTitle">インストール メモ</String>
   <String Id="InstallationNote">コマンドはインストール処理中に実行されるので、プロジェクトの復元速度が向上し、オフラインでアクセスできます。完了するまでに最大 1 分かかります。
   </String>
-  <String Id="VisualStudioWarning">.NET [VERSIONMAJOR].[VERSIONMINOR] を Visual Studio で使用する場合は、Visual Studio 2022 [MINIMUMVSVERSION] 以降が必要です。&lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;詳細情報&lt;/A&gt;.
+  <String _locComment="{Locked='Visual Studio'}" Id="VisualStudioWarning">.NET [VERSIONMAJOR].[VERSIONMINOR] を Visual Studio で使用する場合は、Visual Studio 2022 [MINIMUMVSVERSION] 以降が必要です。&lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;詳細情報&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">インストール をクリックすると、次の条項に同意したものと見なされます:</String>
   <String Id="InstallPathx64x86">x64 SDK インストールのインストール パス: "[DOTNETHOME_X64]" を x86 SDK インストールの場合と同じにすることはできません: "[DOTNETHOME_X86]"</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1042/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1042/bundle.wxl
@@ -47,7 +47,7 @@
   <String Id="FilesInUseDontCloseRadioButton">응용 프로그램을 닫지 않습니다(&amp;D). 다시 부팅해야 합니다.</String>
   <String Id="FilesInUseOkButton">확인(&amp;O)</String>
   <String Id="FilesInUseCancelButton">취소(&amp;C)</String>
-  <String  _locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" Id="FirstTimeWelcomeMessage">설치가 완료되었습니다.
+  <String  Id="FirstTimeWelcomeMessage"><!--_locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" -->설치가 완료되었습니다.
 
 다음 제품이 설치되었습니다.
     • .NET SDK [DOTNETSDKVERSION]
@@ -63,8 +63,8 @@
     • SDK 설명서 https://aka.ms/dotnet-sdk-docs
     • 릴리스 정보 https://aka.ms/dotnet[VERSIONMAJOR]-release-notes
     • 자습서 https://aka.ms/dotnet-tutorials</String>
-  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeHeaderMessage">.NET SDK</String>
-  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeDescription">
+  <String Id="WelcomeHeaderMessage"><!--_locComment="{Locked='.NET SDK'}"-->.NET SDK</String>
+  <String Id="WelcomeDescription"><!--_locComment="{Locked='.NET SDK'}"-->
     .NET SDK는 .NET 애플리케이션을 빌드, 실행 및 테스트하는 데 사용됩니다. 여러 언어, 편집기 및 개발자 도구 중에서 선택하고 대규모 라이브러리 에코시스템을 활용하여 웹, 모바일, 데스크톱, 게임 및 IoT용 앱을 빌드할 수 있습니다. .NET SDK를 유용하게 사용하시길 바랍니다.</String>
   <String Id="LearnMoreTitle">.NET에 대한 자세한 정보</String>
   <String Id="ResourcesHeader">리소스</String>
@@ -76,7 +76,7 @@
   <String Id="InstallationNoteTitle">설치 정보</String>
   <String Id="InstallationNote">프로젝트 복원 속도를 향상하고 오프라인 액세스를 사용할 수 있도록 하는 설치 프로세스 중 명령이 실행됩니다. 완료하는 데 최대 1분이 걸립니다.
   </String>
-  <String _locComment="{Locked='Visual Studio'}" Id="VisualStudioWarning">Visual Studio에서 .NET [VERSIONMAJOR].[VERSIONMINOR]를 사용하려는 경우 Visual Studio 2022 [MINIMUMVSVERSION] 이상이 필요합니다. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Learn more&lt;/A&gt;.
+  <String  Id="VisualStudioWarning"><!--_locComment="{Locked='Visual Studio'}"-->Visual Studio에서 .NET [VERSIONMAJOR].[VERSIONMINOR]를 사용하려는 경우 Visual Studio 2022 [MINIMUMVSVERSION] 이상이 필요합니다. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Learn more&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">설치를 클릭하면 다음 사용 약관에 동의하는 것입니다.</String>
   <String Id="InstallPathx64x86">x64 SDK 설치의 설치 경로: " [DOTNETHOME_x64]" x86 SDK 설치의 경우와 같을 수 없습니다. " [DOTNETHOME_X86]"</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1042/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1042/bundle.wxl
@@ -47,7 +47,7 @@
   <String Id="FilesInUseDontCloseRadioButton">응용 프로그램을 닫지 않습니다(&amp;D). 다시 부팅해야 합니다.</String>
   <String Id="FilesInUseOkButton">확인(&amp;O)</String>
   <String Id="FilesInUseCancelButton">취소(&amp;C)</String>
-  <String Id="FirstTimeWelcomeMessage">설치가 완료되었습니다.
+  <String  _locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" Id="FirstTimeWelcomeMessage">설치가 완료되었습니다.
 
 다음 제품이 설치되었습니다.
     • .NET SDK [DOTNETSDKVERSION]
@@ -63,8 +63,8 @@
     • SDK 설명서 https://aka.ms/dotnet-sdk-docs
     • 릴리스 정보 https://aka.ms/dotnet[VERSIONMAJOR]-release-notes
     • 자습서 https://aka.ms/dotnet-tutorials</String>
-  <String Id="WelcomeHeaderMessage">.NET SDK</String>
-  <String Id="WelcomeDescription">
+  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeHeaderMessage">.NET SDK</String>
+  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeDescription">
     .NET SDK는 .NET 애플리케이션을 빌드, 실행 및 테스트하는 데 사용됩니다. 여러 언어, 편집기 및 개발자 도구 중에서 선택하고 대규모 라이브러리 에코시스템을 활용하여 웹, 모바일, 데스크톱, 게임 및 IoT용 앱을 빌드할 수 있습니다. .NET SDK를 유용하게 사용하시길 바랍니다.</String>
   <String Id="LearnMoreTitle">.NET에 대한 자세한 정보</String>
   <String Id="ResourcesHeader">리소스</String>
@@ -76,7 +76,7 @@
   <String Id="InstallationNoteTitle">설치 정보</String>
   <String Id="InstallationNote">프로젝트 복원 속도를 향상하고 오프라인 액세스를 사용할 수 있도록 하는 설치 프로세스 중 명령이 실행됩니다. 완료하는 데 최대 1분이 걸립니다.
   </String>
-  <String Id="VisualStudioWarning">Visual Studio에서 .NET [VERSIONMAJOR].[VERSIONMINOR]를 사용하려는 경우 Visual Studio 2022 [MINIMUMVSVERSION] 이상이 필요합니다. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Learn more&lt;/A&gt;.
+  <String _locComment="{Locked='Visual Studio'}" Id="VisualStudioWarning">Visual Studio에서 .NET [VERSIONMAJOR].[VERSIONMINOR]를 사용하려는 경우 Visual Studio 2022 [MINIMUMVSVERSION] 이상이 필요합니다. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Learn more&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">설치를 클릭하면 다음 사용 약관에 동의하는 것입니다.</String>
   <String Id="InstallPathx64x86">x64 SDK 설치의 설치 경로: " [DOTNETHOME_x64]" x86 SDK 설치의 경우와 같을 수 없습니다. " [DOTNETHOME_X86]"</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1045/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1045/bundle.wxl
@@ -47,7 +47,7 @@
   <String Id="FilesInUseDontCloseRadioButton">&amp;Nie zamykaj aplikacji. Będzie konieczne ponowne uruchomienie.</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Anuluj</String>
-  <String Id="FirstTimeWelcomeMessage">Instalacja zakończyła się pomyślnie.
+  <String  _locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" Id="FirstTimeWelcomeMessage">Instalacja zakończyła się pomyślnie.
 
 Następujące produkty zostały zainstalowane:
     • Zestaw SDK .NET [DOTNETSDKVERSION]
@@ -63,8 +63,8 @@ Zasoby
     • Dokumentacja dotycząca zestawu SDK https://aka.ms/dotnet-sdk-docs
     • Informacje o wersji https://aka.ms/dotnet[VERSIONMAJOR]-release-notes
     • Samouczki https://aka.ms/dotnet-tutorials</String>
-  <String Id="WelcomeHeaderMessage">.NET SDK</String>
-  <String Id="WelcomeDescription">
+  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeHeaderMessage">.NET SDK</String>
+  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeDescription">
     Zestaw SDK platformy .NET służy do tworzenia, uruchamiania i testowania aplikacji platformy .NET. Możesz wybierać spośród wielu języków, edytorów i narzędzi deweloperskich oraz korzystać z dużego ekosystemu bibliotek do tworzenia aplikacji internetowych, mobilnych, na komputer, gry i Internet rzeczy. Mamy nadzieję, że Ci się to spodoba!</String>
   <String Id="LearnMoreTitle">Dowiedz się więcej o platformie .NET</String>
   <String Id="ResourcesHeader">Zasoby</String>
@@ -76,7 +76,7 @@ Zasoby
   <String Id="InstallationNoteTitle">Uwaga dotycząca instalacji</String>
   <String Id="InstallationNote">W trakcie procesu instalacji zostanie uruchomione polecenie, które zwiększy szybkość przywracania projektu i umożliwi dostęp do trybu offline. Zajmie to maksymalnie minutę.
   </String>
-  <String Id="VisualStudioWarning">Jeśli planujesz używać platformy .NET [VERSIONMAJOR].[VERSIONMINOR] z programem Visual Studio, wymagany jest program Visual Studio 2022 [MINIMUMVSVERSION] lub nowszy. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Dowiedz się więcej&lt;/A&gt;.
+  <String _locComment="{Locked='Visual Studio'}" Id="VisualStudioWarning">Jeśli planujesz używać platformy .NET [VERSIONMAJOR].[VERSIONMINOR] z programem Visual Studio, wymagany jest program Visual Studio 2022 [MINIMUMVSVERSION] lub nowszy. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Dowiedz się więcej&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Klikając pozycję Zainstaluj, wyrażasz zgodę na następujące warunki:</String>
   <String Id="InstallPathx64x86">Ścieżka instalacji w przypadku instalacji zestawu SDK x64: „[DOTNETHOME_X64]” nie może być taka sama jak w przypadku instalacji zestawu SDK x86: „[DOTNETHOME_X86]”</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1045/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1045/bundle.wxl
@@ -47,7 +47,7 @@
   <String Id="FilesInUseDontCloseRadioButton">&amp;Nie zamykaj aplikacji. Będzie konieczne ponowne uruchomienie.</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Anuluj</String>
-  <String  _locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" Id="FirstTimeWelcomeMessage">Instalacja zakończyła się pomyślnie.
+  <String  Id="FirstTimeWelcomeMessage"><!--_locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" -->Instalacja zakończyła się pomyślnie.
 
 Następujące produkty zostały zainstalowane:
     • Zestaw SDK .NET [DOTNETSDKVERSION]
@@ -63,8 +63,8 @@ Zasoby
     • Dokumentacja dotycząca zestawu SDK https://aka.ms/dotnet-sdk-docs
     • Informacje o wersji https://aka.ms/dotnet[VERSIONMAJOR]-release-notes
     • Samouczki https://aka.ms/dotnet-tutorials</String>
-  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeHeaderMessage">.NET SDK</String>
-  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeDescription">
+  <String Id="WelcomeHeaderMessage"><!--_locComment="{Locked='.NET SDK'}"-->.NET SDK</String>
+  <String Id="WelcomeDescription"><!--_locComment="{Locked='.NET SDK'}"-->
     Zestaw SDK platformy .NET służy do tworzenia, uruchamiania i testowania aplikacji platformy .NET. Możesz wybierać spośród wielu języków, edytorów i narzędzi deweloperskich oraz korzystać z dużego ekosystemu bibliotek do tworzenia aplikacji internetowych, mobilnych, na komputer, gry i Internet rzeczy. Mamy nadzieję, że Ci się to spodoba!</String>
   <String Id="LearnMoreTitle">Dowiedz się więcej o platformie .NET</String>
   <String Id="ResourcesHeader">Zasoby</String>
@@ -76,7 +76,7 @@ Zasoby
   <String Id="InstallationNoteTitle">Uwaga dotycząca instalacji</String>
   <String Id="InstallationNote">W trakcie procesu instalacji zostanie uruchomione polecenie, które zwiększy szybkość przywracania projektu i umożliwi dostęp do trybu offline. Zajmie to maksymalnie minutę.
   </String>
-  <String _locComment="{Locked='Visual Studio'}" Id="VisualStudioWarning">Jeśli planujesz używać platformy .NET [VERSIONMAJOR].[VERSIONMINOR] z programem Visual Studio, wymagany jest program Visual Studio 2022 [MINIMUMVSVERSION] lub nowszy. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Dowiedz się więcej&lt;/A&gt;.
+  <String  Id="VisualStudioWarning"><!--_locComment="{Locked='Visual Studio'}"-->Jeśli planujesz używać platformy .NET [VERSIONMAJOR].[VERSIONMINOR] z programem Visual Studio, wymagany jest program Visual Studio 2022 [MINIMUMVSVERSION] lub nowszy. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Dowiedz się więcej&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Klikając pozycję Zainstaluj, wyrażasz zgodę na następujące warunki:</String>
   <String Id="InstallPathx64x86">Ścieżka instalacji w przypadku instalacji zestawu SDK x64: „[DOTNETHOME_X64]” nie może być taka sama jak w przypadku instalacji zestawu SDK x86: „[DOTNETHOME_X86]”</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1046/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1046/bundle.wxl
@@ -47,7 +47,7 @@
   <String Id="FilesInUseDontCloseRadioButton">&amp;Não feche os aplicativos. Uma reinicialização será necessária.</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancelar</String>
-  <String Id="FirstTimeWelcomeMessage">A instalação foi bem sucedida.
+  <String  _locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" Id="FirstTimeWelcomeMessage">A instalação foi bem sucedida.
 
 Os seguintes produtos foram instalados:
     • .NET SDK [DOTNETSDKVERSION]
@@ -63,8 +63,8 @@ Recursos
     • Documentação do SDK https://aka.ms/dotnet-sdk-docs
     • Notas de Versão https://aka.ms/dotnet[VERSIONMAJOR]-release-notes
     • Tutoriais https://aka.ms/dotnet-tutorials</String>
-  <String Id="WelcomeHeaderMessage">SDK do .NET</String>
-  <String Id="WelcomeDescription">
+  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeHeaderMessage">SDK do .NET</String>
+  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeDescription">
     O SDK do .NET é usado para criar, executar e testar aplicativos .NET. Você pode escolher entre vários idiomas, editores e ferramentas de desenvolvedor e aproveitar um grande ecossistema de bibliotecas para criar aplicativos para Web, dispositivos móveis, desktop, jogos e IoT. Esperamos que você goste!</String>
   <String Id="LearnMoreTitle">Saiba mais sobre o .NET</String>
   <String Id="ResourcesHeader">Recursos</String>
@@ -76,7 +76,7 @@ Recursos
   <String Id="InstallationNoteTitle">Nota de instalação</String>
   <String Id="InstallationNote">Um comando será executado durante o processo de instalação que melhorará a velocidade de restauração do projeto e habilitará o acesso offline. Isso levará até um minuto para ser concluído.
   </String>
-  <String Id="VisualStudioWarning">Se você planeja usar o .NET [VERSIONMAJOR].[VERSIONMINOR] com o Visual Studio, Visual Studio 2022 [MINIMUMVSVERSION] ou mais recente é necessário. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Saiba mais&lt;/A&gt;.
+  <String _locComment="{Locked='Visual Studio'}" Id="VisualStudioWarning">Se você planeja usar o .NET [VERSIONMAJOR].[VERSIONMINOR] com o Visual Studio, Visual Studio 2022 [MINIMUMVSVERSION] ou mais recente é necessário. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Saiba mais&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Ao clicar em Instalar, você concorda com os termos a seguir:</String>
   <String Id="InstallPathx64x86">O caminho da instalação para instalações do SDK x64: "[DOTNETHOME_X64]" não pode ser o mesmo que para instalações do SDK x86: "[DOTNETHOME_X86]"</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1046/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1046/bundle.wxl
@@ -47,7 +47,7 @@
   <String Id="FilesInUseDontCloseRadioButton">&amp;Não feche os aplicativos. Uma reinicialização será necessária.</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancelar</String>
-  <String  _locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" Id="FirstTimeWelcomeMessage">A instalação foi bem sucedida.
+  <String  Id="FirstTimeWelcomeMessage"><!--_locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" -->A instalação foi bem sucedida.
 
 Os seguintes produtos foram instalados:
     • .NET SDK [DOTNETSDKVERSION]
@@ -63,8 +63,8 @@ Recursos
     • Documentação do SDK https://aka.ms/dotnet-sdk-docs
     • Notas de Versão https://aka.ms/dotnet[VERSIONMAJOR]-release-notes
     • Tutoriais https://aka.ms/dotnet-tutorials</String>
-  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeHeaderMessage">SDK do .NET</String>
-  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeDescription">
+  <String Id="WelcomeHeaderMessage"><!--_locComment="{Locked='.NET SDK'}"-->SDK do .NET</String>
+  <String Id="WelcomeDescription"><!--_locComment="{Locked='.NET SDK'}"-->
     O SDK do .NET é usado para criar, executar e testar aplicativos .NET. Você pode escolher entre vários idiomas, editores e ferramentas de desenvolvedor e aproveitar um grande ecossistema de bibliotecas para criar aplicativos para Web, dispositivos móveis, desktop, jogos e IoT. Esperamos que você goste!</String>
   <String Id="LearnMoreTitle">Saiba mais sobre o .NET</String>
   <String Id="ResourcesHeader">Recursos</String>
@@ -76,7 +76,7 @@ Recursos
   <String Id="InstallationNoteTitle">Nota de instalação</String>
   <String Id="InstallationNote">Um comando será executado durante o processo de instalação que melhorará a velocidade de restauração do projeto e habilitará o acesso offline. Isso levará até um minuto para ser concluído.
   </String>
-  <String _locComment="{Locked='Visual Studio'}" Id="VisualStudioWarning">Se você planeja usar o .NET [VERSIONMAJOR].[VERSIONMINOR] com o Visual Studio, Visual Studio 2022 [MINIMUMVSVERSION] ou mais recente é necessário. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Saiba mais&lt;/A&gt;.
+  <String  Id="VisualStudioWarning"><!--_locComment="{Locked='Visual Studio'}"-->Se você planeja usar o .NET [VERSIONMAJOR].[VERSIONMINOR] com o Visual Studio, Visual Studio 2022 [MINIMUMVSVERSION] ou mais recente é necessário. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Saiba mais&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Ao clicar em Instalar, você concorda com os termos a seguir:</String>
   <String Id="InstallPathx64x86">O caminho da instalação para instalações do SDK x64: "[DOTNETHOME_X64]" não pode ser o mesmo que para instalações do SDK x86: "[DOTNETHOME_X86]"</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1049/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1049/bundle.wxl
@@ -47,7 +47,7 @@
   <String Id="FilesInUseDontCloseRadioButton">&amp;Не закрывайте приложения. Потребуется перезагрузка компьютера.</String>
   <String Id="FilesInUseOkButton">&amp;ОК</String>
   <String Id="FilesInUseCancelButton">&amp;Отменить</String>
-  <String Id="FirstTimeWelcomeMessage">Установка выполнена.
+  <String  _locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" Id="FirstTimeWelcomeMessage">Установка выполнена.
 
 Установлены следующие компоненты:
     • Пакет SDK для .NET [DOTNETSDKVERSION]
@@ -63,8 +63,8 @@
     • Документация по SDK: https://aka.ms/dotnet-sdk-docs
     • Заметки о выпуске: https://aka.ms/dotnet[VERSIONMAJOR]-release-notes
     • Учебники: https://aka.ms/dotnet-tutorials</String>
-  <String Id="WelcomeHeaderMessage">Пакет SDK для .NET</String>
-  <String Id="WelcomeDescription">
+  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeHeaderMessage">Пакет SDK для .NET</String>
+  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeDescription">
     Пакет SDK для .NET используется для сборки, запуска и тестирования приложений .NET. Вы можете выбрать один из нескольких языков, использовать различные редакторы и инструменты для разработчиков, а также воспользоваться преимуществами большой экосистемы библиотек для создания веб-приложений, мобильных и классических приложений, игр и приложений Интернета вещей. Надеемся, вам понравится!</String>
   <String Id="LearnMoreTitle">Дополнительные сведения о .NET</String>
   <String Id="ResourcesHeader">Ресурсы</String>
@@ -76,7 +76,7 @@
   <String Id="InstallationNoteTitle">Примечание по установке</String>
   <String Id="InstallationNote">В процессе установки будет выполнена команда, которая увеличит скорость восстановления проекта и обеспечит автономный доступ. Выполнение займет до минуты.
   </String>
-  <String Id="VisualStudioWarning">Если вы планируете использовать .NET [VERSIONMAJOR].[VERSIONMINOR] с Visual Studio, требуется Visual Studio 2022 версии [MINIMUMVSVERSION] или более поздней. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Дополнительные сведения&lt;/A&gt;.
+  <String _locComment="{Locked='Visual Studio'}" Id="VisualStudioWarning">Если вы планируете использовать .NET [VERSIONMAJOR].[VERSIONMINOR] с Visual Studio, требуется Visual Studio 2022 версии [MINIMUMVSVERSION] или более поздней. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Дополнительные сведения&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Нажимая кнопку "Установить", вы принимаете следующие условия.</String>
   <String Id="InstallPathx64x86">Совпадение пути установки недопустимо для установок пакетов SDK x64: "[DOTNETHOME_X64]" и SDK x86: "[DOTNETHOME_X86]".</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1049/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1049/bundle.wxl
@@ -47,7 +47,7 @@
   <String Id="FilesInUseDontCloseRadioButton">&amp;Не закрывайте приложения. Потребуется перезагрузка компьютера.</String>
   <String Id="FilesInUseOkButton">&amp;ОК</String>
   <String Id="FilesInUseCancelButton">&amp;Отменить</String>
-  <String  _locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" Id="FirstTimeWelcomeMessage">Установка выполнена.
+  <String  Id="FirstTimeWelcomeMessage"><!--_locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" -->Установка выполнена.
 
 Установлены следующие компоненты:
     • Пакет SDK для .NET [DOTNETSDKVERSION]
@@ -63,8 +63,8 @@
     • Документация по SDK: https://aka.ms/dotnet-sdk-docs
     • Заметки о выпуске: https://aka.ms/dotnet[VERSIONMAJOR]-release-notes
     • Учебники: https://aka.ms/dotnet-tutorials</String>
-  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeHeaderMessage">Пакет SDK для .NET</String>
-  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeDescription">
+  <String Id="WelcomeHeaderMessage"><!--_locComment="{Locked='.NET SDK'}"-->Пакет SDK для .NET</String>
+  <String Id="WelcomeDescription"><!--_locComment="{Locked='.NET SDK'}"-->
     Пакет SDK для .NET используется для сборки, запуска и тестирования приложений .NET. Вы можете выбрать один из нескольких языков, использовать различные редакторы и инструменты для разработчиков, а также воспользоваться преимуществами большой экосистемы библиотек для создания веб-приложений, мобильных и классических приложений, игр и приложений Интернета вещей. Надеемся, вам понравится!</String>
   <String Id="LearnMoreTitle">Дополнительные сведения о .NET</String>
   <String Id="ResourcesHeader">Ресурсы</String>
@@ -76,7 +76,7 @@
   <String Id="InstallationNoteTitle">Примечание по установке</String>
   <String Id="InstallationNote">В процессе установки будет выполнена команда, которая увеличит скорость восстановления проекта и обеспечит автономный доступ. Выполнение займет до минуты.
   </String>
-  <String _locComment="{Locked='Visual Studio'}" Id="VisualStudioWarning">Если вы планируете использовать .NET [VERSIONMAJOR].[VERSIONMINOR] с Visual Studio, требуется Visual Studio 2022 версии [MINIMUMVSVERSION] или более поздней. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Дополнительные сведения&lt;/A&gt;.
+  <String  Id="VisualStudioWarning"><!--_locComment="{Locked='Visual Studio'}"-->Если вы планируете использовать .NET [VERSIONMAJOR].[VERSIONMINOR] с Visual Studio, требуется Visual Studio 2022 версии [MINIMUMVSVERSION] или более поздней. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Дополнительные сведения&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Нажимая кнопку "Установить", вы принимаете следующие условия.</String>
   <String Id="InstallPathx64x86">Совпадение пути установки недопустимо для установок пакетов SDK x64: "[DOTNETHOME_X64]" и SDK x86: "[DOTNETHOME_X86]".</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1055/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1055/bundle.wxl
@@ -47,7 +47,7 @@
   <String Id="FilesInUseDontCloseRadioButton">&amp;Uygulamaları kapatmayın. Sistemi yeniden başlatmanız gerekir.</String>
   <String Id="FilesInUseOkButton">&amp;Tamam</String>
   <String Id="FilesInUseCancelButton">İ&amp;ptal</String>
-  <String  _locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" Id="FirstTimeWelcomeMessage">Yükleme başarılı oldu.
+  <String  Id="FirstTimeWelcomeMessage"><!--_locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" -->Yükleme başarılı oldu.
 
 Aşağıdakiler ürünler yüklendi:
     • .NET SDK [DOTNETSDKVERSION]
@@ -63,8 +63,8 @@ Kaynaklar
     • SDK Belgeleri https://aka.ms/dotnet-sdk-docs
     • Sürüm Notları https://aka.ms/dotnet[VERSIONMAJOR]-release-notes
     • Öğreticiler https://aka.ms/dotnet-tutorials</String>
-  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeHeaderMessage">.NET SDK</String>
-  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeDescription">
+  <String Id="WelcomeHeaderMessage"><!--_locComment="{Locked='.NET SDK'}"-->.NET SDK</String>
+  <String Id="WelcomeDescription"><!--_locComment="{Locked='.NET SDK'}"-->
     .NET SDK, .NET uygulamalarını derlemek, çalıştırmak ve test etmek için kullanılır. Birden çok dil, düzenleyici ve geliştirici aracı arasından seçim yapabilirsiniz ve web, mobil, masaüstü, oyun ve IoT uygulamaları oluşturmak için büyük bir kitaplık ekosisteminden yararlanabilirsiniz. Beğeneceğinizi umuyoruz!</String>
   <String Id="LearnMoreTitle">.NET hakkında daha fazla bilgi edinin</String>
   <String Id="ResourcesHeader">Kaynaklar</String>
@@ -76,7 +76,7 @@ Kaynaklar
   <String Id="InstallationNoteTitle">Yükleme notu</String>
   <String Id="InstallationNote">Yükleme işlemi sırasında, proje geri yükleme hızını artıran ve çevrimdışı erişimi etkinleştiren bir komut çalıştırılır. Tamamlanması bir dakikanızı alır.
   </String>
-  <String _locComment="{Locked='Visual Studio'}" Id="VisualStudioWarning">Visual Studio ile .NET [VERSIONMAJOR].[VERSIONMINOR] kullanmayı planlıyorsanız Visual Studio 2022 [MINIMUMVSVERSION] veya üzeri bir sürüm gerekir. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Daha fazla bilgi edinin&lt;/A&gt;.
+  <String  Id="VisualStudioWarning"><!--_locComment="{Locked='Visual Studio'}"-->Visual Studio ile .NET [VERSIONMAJOR].[VERSIONMINOR] kullanmayı planlıyorsanız Visual Studio 2022 [MINIMUMVSVERSION] veya üzeri bir sürüm gerekir. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Daha fazla bilgi edinin&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Yükle'ye tıklayarak aşağıdaki koşulları kabul etmiş olursunuz:</String>
   <String Id="InstallPathx64x86">x64 SDK yüklemelerinin yükleme yolu ("[DOTNETHOME_X64]"), x86 SDK yüklemelerinin yükleme yolu ("[DOTNETHOME_X86]") ile aynı olamaz</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/1055/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/1055/bundle.wxl
@@ -47,7 +47,7 @@
   <String Id="FilesInUseDontCloseRadioButton">&amp;Uygulamaları kapatmayın. Sistemi yeniden başlatmanız gerekir.</String>
   <String Id="FilesInUseOkButton">&amp;Tamam</String>
   <String Id="FilesInUseCancelButton">İ&amp;ptal</String>
-  <String Id="FirstTimeWelcomeMessage">Yükleme başarılı oldu.
+  <String  _locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" Id="FirstTimeWelcomeMessage">Yükleme başarılı oldu.
 
 Aşağıdakiler ürünler yüklendi:
     • .NET SDK [DOTNETSDKVERSION]
@@ -63,8 +63,8 @@ Kaynaklar
     • SDK Belgeleri https://aka.ms/dotnet-sdk-docs
     • Sürüm Notları https://aka.ms/dotnet[VERSIONMAJOR]-release-notes
     • Öğreticiler https://aka.ms/dotnet-tutorials</String>
-  <String Id="WelcomeHeaderMessage">.NET SDK</String>
-  <String Id="WelcomeDescription">
+  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeHeaderMessage">.NET SDK</String>
+  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeDescription">
     .NET SDK, .NET uygulamalarını derlemek, çalıştırmak ve test etmek için kullanılır. Birden çok dil, düzenleyici ve geliştirici aracı arasından seçim yapabilirsiniz ve web, mobil, masaüstü, oyun ve IoT uygulamaları oluşturmak için büyük bir kitaplık ekosisteminden yararlanabilirsiniz. Beğeneceğinizi umuyoruz!</String>
   <String Id="LearnMoreTitle">.NET hakkında daha fazla bilgi edinin</String>
   <String Id="ResourcesHeader">Kaynaklar</String>
@@ -76,7 +76,7 @@ Kaynaklar
   <String Id="InstallationNoteTitle">Yükleme notu</String>
   <String Id="InstallationNote">Yükleme işlemi sırasında, proje geri yükleme hızını artıran ve çevrimdışı erişimi etkinleştiren bir komut çalıştırılır. Tamamlanması bir dakikanızı alır.
   </String>
-  <String Id="VisualStudioWarning">Visual Studio ile .NET [VERSIONMAJOR].[VERSIONMINOR] kullanmayı planlıyorsanız Visual Studio 2022 [MINIMUMVSVERSION] veya üzeri bir sürüm gerekir. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Daha fazla bilgi edinin&lt;/A&gt;.
+  <String _locComment="{Locked='Visual Studio'}" Id="VisualStudioWarning">Visual Studio ile .NET [VERSIONMAJOR].[VERSIONMINOR] kullanmayı planlıyorsanız Visual Studio 2022 [MINIMUMVSVERSION] veya üzeri bir sürüm gerekir. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Daha fazla bilgi edinin&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Yükle'ye tıklayarak aşağıdaki koşulları kabul etmiş olursunuz:</String>
   <String Id="InstallPathx64x86">x64 SDK yüklemelerinin yükleme yolu ("[DOTNETHOME_X64]"), x86 SDK yüklemelerinin yükleme yolu ("[DOTNETHOME_X86]") ile aynı olamaz</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/2052/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/2052/bundle.wxl
@@ -47,7 +47,7 @@
   <String Id="FilesInUseDontCloseRadioButton">不关闭应用程序(&amp;D)。需要重启。</String>
   <String Id="FilesInUseOkButton">确定(&amp;O)</String>
   <String Id="FilesInUseCancelButton">取消(&amp;C)</String>
-  <String Id="FirstTimeWelcomeMessage">已成功安装。
+  <String  _locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" Id="FirstTimeWelcomeMessage">已成功安装。
 
 下列产品已安装: 
     • .NET SDK [DOTNETSDKVERSION]
@@ -63,8 +63,8 @@
     • SDK 文档: https://aka.ms/dotnet-sdk-docs
     • 发行说明: https://aka.ms/dotnet[VERSIONMAJOR]-release-notes
     • 教程: https://aka.ms/dotnet-tutorials</String>
-  <String Id="WelcomeHeaderMessage">.NET SDK</String>
-  <String Id="WelcomeDescription">
+  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeHeaderMessage">.NET SDK</String>
+  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeDescription">
     .NET SDK 用于生成、运行和测试 .NET 应用程序。有多种语言、编辑器和开发人员工具可供选择，你也可使用由库构成的大型生态系统来构建面向 Web、移动设备、桌面、游戏和 IoT 的应用。希望你喜欢它!</String>
   <String Id="LearnMoreTitle">了解有关 .NET 的详细信息</String>
   <String Id="ResourcesHeader">资源</String>
@@ -76,7 +76,7 @@
   <String Id="InstallationNoteTitle">安装说明</String>
   <String Id="InstallationNote">将在要提升项目还原速度并实现脱机访问的安装进程期间运行命令。此操作最多 1 分钟即可完成。
   </String>
-  <String Id="VisualStudioWarning">如果你计划使用 .NET [VERSIONMAJOR].[VERSIONMINOR] 与 Visual Studio、Visual Studio 2022 [MINIMUMVSVERSION] 或更高版本是必需的。&lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;了解详细信息&lt;/A&gt;。
+  <String _locComment="{Locked='Visual Studio'}" Id="VisualStudioWarning">如果你计划使用 .NET [VERSIONMAJOR].[VERSIONMINOR] 与 Visual Studio、Visual Studio 2022 [MINIMUMVSVERSION] 或更高版本是必需的。&lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;了解详细信息&lt;/A&gt;。
 </String>
   <String Id="LicenseAssent">单击“安装”即表示你同意以下条款:</String>
   <String Id="InstallPathx64x86">x64 SDK 安装的安装路径: "[DOTNETHOME_X64]" 不能与 x86 SDK 安装的路径相同: "[DOTNETHOME_X86]"</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/2052/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/2052/bundle.wxl
@@ -47,7 +47,7 @@
   <String Id="FilesInUseDontCloseRadioButton">不关闭应用程序(&amp;D)。需要重启。</String>
   <String Id="FilesInUseOkButton">确定(&amp;O)</String>
   <String Id="FilesInUseCancelButton">取消(&amp;C)</String>
-  <String  _locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" Id="FirstTimeWelcomeMessage">已成功安装。
+  <String  Id="FirstTimeWelcomeMessage"><!--_locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" -->已成功安装。
 
 下列产品已安装: 
     • .NET SDK [DOTNETSDKVERSION]
@@ -63,8 +63,8 @@
     • SDK 文档: https://aka.ms/dotnet-sdk-docs
     • 发行说明: https://aka.ms/dotnet[VERSIONMAJOR]-release-notes
     • 教程: https://aka.ms/dotnet-tutorials</String>
-  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeHeaderMessage">.NET SDK</String>
-  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeDescription">
+  <String Id="WelcomeHeaderMessage"><!--_locComment="{Locked='.NET SDK'}"-->.NET SDK</String>
+  <String Id="WelcomeDescription"><!--_locComment="{Locked='.NET SDK'}"-->
     .NET SDK 用于生成、运行和测试 .NET 应用程序。有多种语言、编辑器和开发人员工具可供选择，你也可使用由库构成的大型生态系统来构建面向 Web、移动设备、桌面、游戏和 IoT 的应用。希望你喜欢它!</String>
   <String Id="LearnMoreTitle">了解有关 .NET 的详细信息</String>
   <String Id="ResourcesHeader">资源</String>
@@ -76,7 +76,7 @@
   <String Id="InstallationNoteTitle">安装说明</String>
   <String Id="InstallationNote">将在要提升项目还原速度并实现脱机访问的安装进程期间运行命令。此操作最多 1 分钟即可完成。
   </String>
-  <String _locComment="{Locked='Visual Studio'}" Id="VisualStudioWarning">如果你计划使用 .NET [VERSIONMAJOR].[VERSIONMINOR] 与 Visual Studio、Visual Studio 2022 [MINIMUMVSVERSION] 或更高版本是必需的。&lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;了解详细信息&lt;/A&gt;。
+  <String  Id="VisualStudioWarning"><!--_locComment="{Locked='Visual Studio'}"-->如果你计划使用 .NET [VERSIONMAJOR].[VERSIONMINOR] 与 Visual Studio、Visual Studio 2022 [MINIMUMVSVERSION] 或更高版本是必需的。&lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;了解详细信息&lt;/A&gt;。
 </String>
   <String Id="LicenseAssent">单击“安装”即表示你同意以下条款:</String>
   <String Id="InstallPathx64x86">x64 SDK 安装的安装路径: "[DOTNETHOME_X64]" 不能与 x86 SDK 安装的路径相同: "[DOTNETHOME_X86]"</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/3082/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/3082/bundle.wxl
@@ -48,7 +48,7 @@
   <String Id="FilesInUseDontCloseRadioButton">&amp;No cerrar las aplicaciones. Será necesario un reinicio.</String>
   <String Id="FilesInUseOkButton">&amp;Aceptar</String>
   <String Id="FilesInUseCancelButton">&amp;Cancelar</String>
-  <String Id="FirstTimeWelcomeMessage">La instalación se ha realizado correctamente.
+  <String  _locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" Id="FirstTimeWelcomeMessage">La instalación se ha realizado correctamente.
 
 Se han instalado los siguientes productos:
     • .NET SDK [DOTNETSDKVERSION]
@@ -64,8 +64,8 @@ Recursos
     • Documentación del SDK https://aka.ms/dotnet-sdk-docs
     • Notas de la versión https://aka.ms/dotnet[VERSIONMAJOR]-release-notes
     • Tutoriales https://aka.ms/dotnet-tutorials</String>
-  <String Id="WelcomeHeaderMessage">SDK de .NET</String>
-  <String Id="WelcomeDescription">
+  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeHeaderMessage">SDK de .NET</String>
+  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeDescription">
     El SDK de .NET se utiliza para crear, ejecutar y probar aplicaciones .NET. Puede elegir entre varios lenguajes, editores y herramientas de desarrollo, y aprovechar un amplio ecosistema de bibliotecas para crear aplicaciones para web, móvil, escritorio, juegos e IoT. Esperamos que lo disfrutes.</String>
   <String Id="LearnMoreTitle">Más información sobre .NET</String>
   <String Id="ResourcesHeader">Recursos</String>
@@ -77,7 +77,7 @@ Recursos
   <String Id="InstallationNoteTitle">Nota de instalación</String>
   <String Id="InstallationNote">Se ejecutará un comando durante el proceso de instalación que mejorará la velocidad de restauración del proyecto y permitirá el acceso sin conexión. La operación tardará hasta un minuto en completarse.
   </String>
-  <String Id="VisualStudioWarning">Si tiene previsto utilizar .NET [VERSIONMAJOR].[VERSIONMINOR] con Visual Studio, necesitará Visual Studio 2022 [MINIMUMVSVERSION] o una versión más reciente. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Learn more&lt;/A&gt;.
+  <String _locComment="{Locked='Visual Studio'}" Id="VisualStudioWarning">Si tiene previsto utilizar .NET [VERSIONMAJOR].[VERSIONMINOR] con Visual Studio, necesitará Visual Studio 2022 [MINIMUMVSVERSION] o una versión más reciente. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Learn more&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Al hacer clic en Instalar, acepta los siguientes términos:</String>
   <String Id="InstallPathx64x86">La ruta de instalación para las instalaciones del SDK x64: "[DOTNETHOME_X64]" no puede ser la misma que para las instalaciones del SDK x86: "[DOTNETHOME_X86]"</String>

--- a/src/redist/targets/packaging/windows/clisdk/LCID/3082/bundle.wxl
+++ b/src/redist/targets/packaging/windows/clisdk/LCID/3082/bundle.wxl
@@ -48,7 +48,7 @@
   <String Id="FilesInUseDontCloseRadioButton">&amp;No cerrar las aplicaciones. Será necesario un reinicio.</String>
   <String Id="FilesInUseOkButton">&amp;Aceptar</String>
   <String Id="FilesInUseCancelButton">&amp;Cancelar</String>
-  <String  _locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" Id="FirstTimeWelcomeMessage">La instalación se ha realizado correctamente.
+  <String  Id="FirstTimeWelcomeMessage"><!--_locComment="{Locked='.NET SDK'}{Locked='.NET Runtime'}{Locked='ASP.NET Core Runtime'}{Locked='.NET Windows Desktop Runtime'}" -->La instalación se ha realizado correctamente.
 
 Se han instalado los siguientes productos:
     • .NET SDK [DOTNETSDKVERSION]
@@ -64,8 +64,8 @@ Recursos
     • Documentación del SDK https://aka.ms/dotnet-sdk-docs
     • Notas de la versión https://aka.ms/dotnet[VERSIONMAJOR]-release-notes
     • Tutoriales https://aka.ms/dotnet-tutorials</String>
-  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeHeaderMessage">SDK de .NET</String>
-  <String _locComment="{Locked='.NET SDK'}" Id="WelcomeDescription">
+  <String Id="WelcomeHeaderMessage"><!--_locComment="{Locked='.NET SDK'}"-->SDK de .NET</String>
+  <String Id="WelcomeDescription"><!--_locComment="{Locked='.NET SDK'}"-->
     El SDK de .NET se utiliza para crear, ejecutar y probar aplicaciones .NET. Puede elegir entre varios lenguajes, editores y herramientas de desarrollo, y aprovechar un amplio ecosistema de bibliotecas para crear aplicaciones para web, móvil, escritorio, juegos e IoT. Esperamos que lo disfrutes.</String>
   <String Id="LearnMoreTitle">Más información sobre .NET</String>
   <String Id="ResourcesHeader">Recursos</String>
@@ -77,7 +77,7 @@ Recursos
   <String Id="InstallationNoteTitle">Nota de instalación</String>
   <String Id="InstallationNote">Se ejecutará un comando durante el proceso de instalación que mejorará la velocidad de restauración del proyecto y permitirá el acceso sin conexión. La operación tardará hasta un minuto en completarse.
   </String>
-  <String _locComment="{Locked='Visual Studio'}" Id="VisualStudioWarning">Si tiene previsto utilizar .NET [VERSIONMAJOR].[VERSIONMINOR] con Visual Studio, necesitará Visual Studio 2022 [MINIMUMVSVERSION] o una versión más reciente. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Learn more&lt;/A&gt;.
+  <String  Id="VisualStudioWarning"><!--_locComment="{Locked='Visual Studio'}"-->Si tiene previsto utilizar .NET [VERSIONMAJOR].[VERSIONMINOR] con Visual Studio, necesitará Visual Studio 2022 [MINIMUMVSVERSION] o una versión más reciente. &lt;A HREF="https://aka.ms/dotnet[VERSIONMAJOR]-release-notes"&gt;Learn more&lt;/A&gt;.
   </String>
   <String Id="LicenseAssent">Al hacer clic en Instalar, acepta los siguientes términos:</String>
   <String Id="InstallPathx64x86">La ruta de instalación para las instalaciones del SDK x64: "[DOTNETHOME_X64]" no puede ser la misma que para las instalaciones del SDK x86: "[DOTNETHOME_X86]"</String>


### PR DESCRIPTION
This is for all of the windows installer strings. I'll need @cristianosuzuki77's help to understand how to update the mac lci file to exclude these.