### PR TITLE
Find the releases dll in the correct path

### DIFF
--- a/src/redist/targets/GenerateMSBuildExtensions.targets
+++ b/src/redist/targets/GenerateMSBuildExtensions.targets
@@ -45,7 +45,7 @@
                                   Exclude="$(NETStandardLibraryNETFrameworkNuPkgPath)\build\**\*.props;$(NETStandardLibraryNETFrameworkNuPkgPath)\build\**\*.targets"
                                   DeploymentSubpath="msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/" />
 
-      <VSMSBuildExtensionsContent Include="$(DotNetDeploymentReleasesPkgPath)\lib\net452\**\*.*"
+      <VSMSBuildExtensionsContent Include="$(DotNetDeploymentReleasesPkgPath)\lib\netstandard2.0\**\*.*"
                                   DeploymentSubpath="MSBuildSdkResolver/" />
 
       <VSMSBuildExtensionsContent Include="$(SdkResolverLayoutPath)/**/*"


### PR DESCRIPTION
@joeloff this broke because you changed the TFM for the releases dll. The reason that other branches weren't affected was because only main got updated to the preview 6 version of the releases dll. That's why this file was missing from the swr file and nupkg for VS insertions of the 8.0 msbuildsdkresolver.

Should we have updated the downlevel versions as well or is main sufficient?