### PR TITLE
Update poison baseline

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/PoisonUsage.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/PoisonUsage.txt
@@ -5,20 +5,4 @@
   <File Path="dotnet-sdk-x.y.z-banana-rid.tar/sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Razor/source-generators/System.Collections.Immutable.dll">
     <Type>AssemblyAttribute</Type>
   </File>
-  <File Path="Microsoft.DotNet.ILCompiler.x.y.z/tools/netstandard/System.Collections.Immutable.dll">
-    <Type>AssemblyAttribute</Type>
-  </File>
-  <File Path="Microsoft.DotNet.ILCompiler.x.y.z/tools/netstandard/System.Reflection.Metadata.dll">
-    <Type>AssemblyAttribute</Type>
-  </File>
-  <File Path="Microsoft.TestPlatform.CLI.x.y.z/contentFiles/any/netx.y/System.ComponentModel.Composition.dll">
-    <Type>Hash, AssemblyAttribute</Type>
-    <Match Package="/vmr/prereqs/packages/prebuilt/microsoft.internal.testplatform.remote.x.y.z.297.nupkg" PackageId="Microsoft.Internal.TestPlatform.Remote" PackageVersion="x.y.z.297" File="tools/netstandard/Extensions/System.ComponentModel.Composition.dll" />
-  </File>
-  <File Path="runtime.banana-rid.Microsoft.DotNet.ILCompiler.x.y.z/tools/netstandard/System.Collections.Immutable.dll">
-    <Type>AssemblyAttribute</Type>
-  </File>
-  <File Path="runtime.banana-rid.Microsoft.DotNet.ILCompiler.x.y.z/tools/netstandard/System.Reflection.Metadata.dll">
-    <Type>AssemblyAttribute</Type>
-  </File>
 </PrebuiltLeakReport>


### PR DESCRIPTION
The latest build indicates a diff in the poison usage baseline due to certain files no longer showing up as leaks. I've removed them from the baseline.