### PR TITLE
Patch for Microsoft.VisualStudioEng.MicroBuild.Core prebuilt

### DIFF
--- a/src/SourceBuild/patches/nuget-client/0001-Do-not-use-Microsoft.VisualStudioEng.MicroBuild.Core.patch
+++ b/src/SourceBuild/patches/nuget-client/0001-Do-not-use-Microsoft.VisualStudioEng.MicroBuild.Core.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nikola Milosavljevic <nikolam@microsoft.com>
+Date: Fri, 19 May 2023 17:07:26 +0000
+Subject: [PATCH] Do not use Microsoft.VisualStudioEng.MicroBuild.Core package
+ in source-build
+
+Backport: https://github.com/NuGet/NuGet.Client/pull/5175
+---
+ Directory.Packages.props | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Directory.Packages.props b/Directory.Packages.props
+index 526d86ede..a3fb0ea79 100644
+--- a/Directory.Packages.props
++++ b/Directory.Packages.props
+@@ -126,7 +126,7 @@
+ 
+   <ItemGroup>
+     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" Condition="'$(Shipping)' == 'true' AND '$(IsXPlat)' != 'true'" />
+-    <GlobalPackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" version="1.0.0" />
++    <GlobalPackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" version="1.0.0" Condition="'$(DotNetBuildFromSource)' != 'true'" />
+   </ItemGroup>
+ 
+   <ItemGroup Condition=" '$(UsePublicApiAnalyzer)' == 'true' ">


### PR DESCRIPTION
Backport of https://github.com/NuGet/NuGet.Client/pull/5175

This patch ensures that we don't ship the prebuilt in Preview 5.
