### PR TITLE
Patch for roslyn ref-pack prebuilts

### DIFF
--- a/src/SourceBuild/patches/roslyn/0002-Do-not-specify-ref-pack-versions.patch
+++ b/src/SourceBuild/patches/roslyn/0002-Do-not-specify-ref-pack-versions.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nikola Milosavljevic <nikolam@microsoft.com>
+Date: Fri, 19 May 2023 21:54:50 +0000
+Subject: [PATCH] Do not specify ref-pack versions
+
+---
+ eng/targets/Imports.BeforeArcade.targets | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/eng/targets/Imports.BeforeArcade.targets b/eng/targets/Imports.BeforeArcade.targets
+index 968ecd42a6e..aeb820317be 100644
+--- a/eng/targets/Imports.BeforeArcade.targets
++++ b/eng/targets/Imports.BeforeArcade.targets
+@@ -17,11 +17,9 @@
+   <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
+     <KnownFrameworkReference Update="Microsoft.NETCore.App">
+       <TargetingPackVersion Condition="'%(TargetFramework)' == 'net6.0'">6.0.0</TargetingPackVersion>
+-      <TargetingPackVersion Condition="'%(TargetFramework)' == 'net8.0'">8.0.0-preview.3.23165.3</TargetingPackVersion>
+     </KnownFrameworkReference>
+     <KnownFrameworkReference Update="Microsoft.AspNetCore.App">
+       <TargetingPackVersion Condition="'%(TargetFramework)' == 'net6.0'">6.0.0</TargetingPackVersion>
+-      <TargetingPackVersion Condition="'%(TargetFramework)' == 'net8.0'">8.0.0-preview.3.23164.14</TargetingPackVersion>
+     </KnownFrameworkReference>
+   </ItemGroup>
+ 

--- a/src/SourceBuild/patches/roslyn/0002-Do-not-specify-ref-pack-versions.patch
+++ b/src/SourceBuild/patches/roslyn/0002-Do-not-specify-ref-pack-versions.patch
@@ -3,6 +3,7 @@ From: Nikola Milosavljevic <nikolam@microsoft.com>
 Date: Fri, 19 May 2023 21:54:50 +0000
 Subject: [PATCH] Do not specify ref-pack versions
 
+Backport: https://github.com/dotnet/roslyn/pull/67895
 ---
  eng/targets/Imports.BeforeArcade.targets | 2 --
  1 file changed, 2 deletions(-)


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/3468

Backport of https://github.com/dotnet/roslyn/pull/67895

This patch ensures that we don't ship 2 prebuilts introduced by `roslyn`:
```
    <Usage Id="Microsoft.AspNetCore.App.Ref" Version="8.0.0-preview.3.23164.14" />
    <Usage Id="Microsoft.NETCore.App.Ref" Version="8.0.0-preview.3.23165.3" />
```