### PR TITLE
Patch for ILMerge prebuilt in source-build

### DIFF
--- a/src/SourceBuild/content/eng/Versions.props
+++ b/src/SourceBuild/content/eng/Versions.props
@@ -19,7 +19,7 @@
       prep.sh and pipeline scripts, outside of MSBuild.
     -->
     <PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Artifacts.8.0.100-preview.4.23260.1.centos.8-x64.tar.gz</PrivateSourceBuiltArtifactsUrl>
-    <PrivateSourceBuiltPrebuiltsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Prebuilts.0.1.0-8.0.100-31.centos.8-x64.tar.gz</PrivateSourceBuiltPrebuiltsUrl>
+    <PrivateSourceBuiltPrebuiltsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Prebuilts.0.1.0-8.0.100-32.centos.8-x64.tar.gz</PrivateSourceBuiltPrebuiltsUrl>
     <PrivateSourceBuiltSdkUrl_CentOS8Stream>https://dotnetcli.azureedge.net/source-built-artifacts/sdks/dotnet-sdk-8.0.100-preview.4.23260.1-centos.8-x64.tar.gz</PrivateSourceBuiltSdkUrl_CentOS8Stream>
   </PropertyGroup>
 </Project>

--- a/src/SourceBuild/patches/nuget-client/0002-Do-not-restore-ILMerge-in-source-build.patch
+++ b/src/SourceBuild/patches/nuget-client/0002-Do-not-restore-ILMerge-in-source-build.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nikola Milosavljevic <nikolam@microsoft.com>
+Date: Tue, 23 May 2023 21:15:50 +0000
+Subject: [PATCH] Do not restore ILMerge in source-build
+
+Backport of ILMerge changes in https://github.com/NuGet/NuGet.Client/pull/5178
+---
+ .../NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj        | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+index 7940ac1d1..ff3627e00 100644
+--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
++++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+@@ -37,7 +37,7 @@
+   </ItemGroup>
+ 
+   <ItemGroup>
+-    <PackageReference Include="ILMerge" PrivateAssets="All" />
++    <PackageReference Include="ILMerge" PrivateAssets="All" Condition="'$(DotNetBuildFromSource)' != 'true'" />
+   </ItemGroup>
+ 
+   <ItemGroup Condition=" '$(IsCore)' == 'true' ">

--- a/src/SourceBuild/patches/nuget-client/0002-Do-not-restore-ILMerge-in-source-build.patch
+++ b/src/SourceBuild/patches/nuget-client/0002-Do-not-restore-ILMerge-in-source-build.patch
@@ -3,7 +3,7 @@ From: Nikola Milosavljevic <nikolam@microsoft.com>
 Date: Tue, 23 May 2023 21:15:50 +0000
 Subject: [PATCH] Do not restore ILMerge in source-build
 
-Backport of ILMerge changes in https://github.com/NuGet/NuGet.Client/pull/5178
+Backport: https://github.com/NuGet/NuGet.Client/pull/5178
 ---
  .../NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj        | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)


### PR DESCRIPTION
- Removes the usage of ILMerge package in nuget.client build
- Updates prebuilts tarball reference - the only change in v.32 is removal of ILMerge package