### PR TITLE
Do not try to restore ASP.NET on linux-bionic

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -494,7 +494,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                               TargetingPackVersion="$(MicrosoftAspNetCoreAppRefPackageVersion)"
                               RuntimePackNamePatterns="Microsoft.AspNetCore.App.Runtime.**RID**"
                               RuntimePackRuntimeIdentifiers="@(AspNetCoreRuntimePackRids, '%3B')"
-                              RuntimePackExcludedRuntimeIdentifiers="android"
+                              RuntimePackExcludedRuntimeIdentifiers="android;linux-bionic"
                               />
 
     <KnownFrameworkReference Include="Microsoft.Windows.SDK.NET.Ref"


### PR DESCRIPTION
```
dotnet new console --aot -o NAotHello
cd NAotHello
dotnet publish -r linux-bionic-x64 /p:DisableUnsupportedError=true /p:PublishAotUsingRuntimePack=true
```

Currently fails with

```
c:\net8\sdk\8.0.100-preview.6.23280.8\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.RuntimeIdentifierInference.targets
(314,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [C:\N
AotHello\NAotHello.csproj]
c:\net8\sdk\8.0.100-preview.6.23280.8\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.FrameworkReferenceResolution.t
argets(479,5): error NETSDK1082: There was no runtime pack for Microsoft.NETCore.App available for the specified Runt
imeIdentifier 'linux-bionic-x64'. [C:\NAotHello\NAotHello.csproj]
```

It doesn't look related to this change, but the ASP.NET reference is triggering this.

With this change we get much further and I believe all the remaining fixes are on the dotnet/runtime repo side.

Cc @dotnet/ilc-contrib 