### PR TITLE
Update 7.0 ILLink version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -24,6 +24,9 @@
     <VersionFeature50>17</VersionFeature50>
     <VersionFeature60>16</VersionFeature60>
     <VersionFeature70>5</VersionFeature70>
+    <!-- Should be kept in sync with VersionFeature70. It should match the version of Microsoft.NET.ILLink.Tasks
+         referenced by the same 7.0 SDK that references the 7.0.VersionFeature70 runtime pack. -->
+    <_NET70ILLinkPackVersion>7.0.100-1.23211.1</_NET70ILLinkPackVersion>
   </PropertyGroup>
   <!-- Restore feeds -->
   <PropertyGroup Label="Restore feeds">

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -78,7 +78,6 @@
 
       <_NET70RuntimePackVersion>7.0.$(VersionFeature70)</_NET70RuntimePackVersion>
       <_NET70TargetingPackVersion>7.0.$(VersionFeature70)</_NET70TargetingPackVersion>
-      <_NET70ILLinkPackVersion>7.0.100-1.23062.2</_NET70ILLinkPackVersion>
       <_NET70WebAssemblyPackVersion>$(MicrosoftNETCoreAppRuntimePackageVersion)</_NET70WebAssemblyPackVersion>
       <_WindowsDesktop70RuntimePackVersion>7.0.$(VersionFeature70)</_WindowsDesktop70RuntimePackVersion>
       <_WindowsDesktop70TargetingPackVersion>7.0.$(VersionFeature70)</_WindowsDesktop70TargetingPackVersion>


### PR DESCRIPTION
Update to latest version of ILLink referenced by the 7.0 SDK (taken from https://github.com/dotnet/sdk/blob/17013a3c5efd16be267ead83381a14924c99780f/eng/Versions.props#L89).