### PR TITLE
Enable source-build pvp flow for installer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,7 @@
 # See https://help.github.com/articles/about-code-owners/
 
 /.devcontainer/ @dotnet/source-build-internal
+/src/eng/SourceBuild* @dotnet/source-build-internal
 /src/snaps/ @rbhanda
 /src/SourceBuild/ @dotnet/source-build-internal
 /src/VirtualMonoRepo/ @dotnet/product-construction

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 # See https://help.github.com/articles/about-code-owners/
 
 /.devcontainer/ @dotnet/source-build-internal
-/src/eng/SourceBuild* @dotnet/source-build-internal
+/eng/SourceBuild* @dotnet/source-build-internal
 /src/snaps/ @rbhanda
 /src/SourceBuild/ @dotnet/source-build-internal
 /src/VirtualMonoRepo/ @dotnet/product-construction

--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -1,3 +1,5 @@
+<!-- Whenever altering this or other Source Build files, please include @dotnet/source-build-internal as a reviewer. -->
+
 <Project>
 
   <PropertyGroup>

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,3 +1,6 @@
+<!-- Whenever altering this or other Source Build files, please include @dotnet/source-build-internal as a reviewer. -->
+<!-- See aka.ms/dotnet/prebuilts for guidance on what pre-builts are and how to eliminate them. -->
+
 <UsageData>
   <IgnorePatterns>
     <UsagePattern IdentityGlob="Microsoft.SourceBuild.Intermediate.*/*" />
@@ -5,19 +8,8 @@
     <!--
       Temporary exclusion for NuGet packages, since NuGet is not producing source-build intermediate package,
       see: https://github.com/NuGet/Home/issues/11059
-
-      Once that's fixed, NuGet package version should be updated to newest, and intermediate product dependency
-      added to Version.Details.xml
     -->
-    <UsagePattern IdentityGlob="NuGet.Common/*5.8.0*" />
-    <UsagePattern IdentityGlob="NuGet.Configuration/*5.8.0*" />
-    <UsagePattern IdentityGlob="NuGet.Frameworks/*5.8.0*" />
-    <UsagePattern IdentityGlob="NuGet.Packaging/*5.8.0*" />
-    <UsagePattern IdentityGlob="NuGet.Versioning/*5.8.0*" />
-
-    <!-- Referenced by NuGet.Packaging.5.8.0 - could be resolved when version of NuGet packages gets updated. -->
-    <UsagePattern IdentityGlob="System.Security.Cryptography.Cng/5.0.0-preview.3.20214.6" />
-    <UsagePattern IdentityGlob="System.Security.Cryptography.Pkcs/5.0.0-preview.3.20214.6" />
+    <UsagePattern IdentityGlob="NuGet.*/*" />
 
     <!-- These are coming in via runtime but the source-build infra isn't able to automatically pick up the right intermediate. -->
     <UsagePattern IdentityGlob="Microsoft.NETCore.App.Crossgen2.linux-x64/*8.0.*" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -156,14 +156,10 @@
       <Sha>d4c4d1ec77e88a9abcb229f3d86413fa0b2a57e1</Sha>
       <SourceBuild RepoName="msbuild" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="NuGet.Packaging" Version="6.7.0-preview.2.50" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="NuGet.Build.Tasks" Version="6.7.0-preview.2.50" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/nuget/nuget.client</Uri>
       <Sha>a6fff16af6f44927a83851448a99beb1d2801600</Sha>
       <SourceBuildTarball RepoName="nuget-client" ManagedOnly="true" />
-    </Dependency>
-    <Dependency Name="NuGet.Versioning" Version="6.7.0-preview.2.50" CoherentParentDependency="Microsoft.NET.Sdk">
-      <Uri>https://github.com/nuget/nuget.client</Uri>
-      <Sha>a6fff16af6f44927a83851448a99beb1d2801600</Sha>
     </Dependency>
     <Dependency Name="Microsoft.ApplicationInsights" Version="2.0.0">
       <Uri>https://github.com/Microsoft/ApplicationInsights-dotnet</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -156,10 +156,14 @@
       <Sha>d4c4d1ec77e88a9abcb229f3d86413fa0b2a57e1</Sha>
       <SourceBuild RepoName="msbuild" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="NuGet.Build.Tasks" Version="6.7.0-preview.2.50" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="NuGet.Packaging" Version="6.7.0-preview.2.50" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/nuget/nuget.client</Uri>
       <Sha>a6fff16af6f44927a83851448a99beb1d2801600</Sha>
       <SourceBuildTarball RepoName="nuget-client" ManagedOnly="true" />
+    </Dependency>
+    <Dependency Name="NuGet.Versioning" Version="6.7.0-preview.2.50" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Uri>https://github.com/nuget/nuget.client</Uri>
+      <Sha>a6fff16af6f44927a83851448a99beb1d2801600</Sha>
     </Dependency>
     <Dependency Name="Microsoft.ApplicationInsights" Version="2.0.0">
       <Uri>https://github.com/Microsoft/ApplicationInsights-dotnet</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -120,7 +120,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/NuGet/NuGet.Client -->
-    <NuGetBuildTasksPackageVersion>6.7.0-preview.2.50</NuGetBuildTasksPackageVersion>
+    <NuGetBuildTasksPackageVersion>6.7.0-preview.2.51</NuGetBuildTasksPackageVersion>
   </PropertyGroup>
   <!-- Dependencies from https://github.com/dotnet/deployment-tools -->
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -120,8 +120,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/NuGet/NuGet.Client -->
-    <NuGetPackagingPackageVersion>6.7.0-preview.2.50</NuGetPackagingPackageVersion>
-    <NuGetVersioningPackageVersion>6.7.0-preview.2.50</NuGetVersioningPackageVersion>
+    <NuGetBuildTasksPackageVersion>6.7.0-preview.2.50</NuGetBuildTasksPackageVersion>
   </PropertyGroup>
   <!-- Dependencies from https://github.com/dotnet/deployment-tools -->
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -120,7 +120,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/NuGet/NuGet.Client -->
-    <NuGetVersioningPackageVersion>5.8.0</NuGetVersioningPackageVersion>
+    <NuGetPackagingPackageVersion>6.7.0-preview.2.50</NuGetPackagingPackageVersion>
+    <NuGetVersioningPackageVersion>6.7.0-preview.2.50</NuGetVersioningPackageVersion>
   </PropertyGroup>
   <!-- Dependencies from https://github.com/dotnet/deployment-tools -->
   <PropertyGroup>

--- a/src/SourceBuild/content/repo-projects/installer.proj
+++ b/src/SourceBuild/content/repo-projects/installer.proj
@@ -43,6 +43,8 @@
 
     <BuildCommand>$(StandardSourceBuildCommand) $(BuildCommandArgs)</BuildCommand>
 
+    <PackageVersionPropsFlowType>DependenciesOnly</PackageVersionPropsFlowType>
+
     <!-- CS9057 - Caused by incoherency of analyzer assemblies during pre-release builds. -->
     <RepoNoWarns>CS9057</RepoNoWarns>
   </PropertyGroup>

--- a/src/core-sdk-tasks/core-sdk-tasks.csproj
+++ b/src/core-sdk-tasks/core-sdk-tasks.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.7.179" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NuGet.Versioning" Version="$(NuGetVersioningPackageVersion)" />
-    <PackageReference Include="NuGet.Packaging" Version="$(NuGetVersioningPackageVersion)" />
+    <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackagingPackageVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.4.2" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" Condition="'$(DotNetBuildFromSource)' != 'true'" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/src/core-sdk-tasks/core-sdk-tasks.csproj
+++ b/src/core-sdk-tasks/core-sdk-tasks.csproj
@@ -12,8 +12,8 @@
     <PackageReference Include="Microsoft.Build" Version="15.7.179" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.7.179" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="NuGet.Versioning" Version="$(NuGetVersioningPackageVersion)" />
-    <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackagingPackageVersion)" />
+    <PackageReference Include="NuGet.Versioning" Version="$(NuGetBuildTasksPackageVersion)" />
+    <PackageReference Include="NuGet.Packaging" Version="$(NuGetBuildTasksPackageVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.4.2" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" Condition="'$(DotNetBuildFromSource)' != 'true'" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/3043

This PR contains a number of related changes:

1. Enabled the source-build per repo pvp flow for the installer repo.
2. With the per repo pvp flow enabled it surfaced the nuget prebuilts already included in the prebuilt baseline.  To fix this, I modified the nuget dependency to be a live/latest dependency.
3. Refactored the source-build baseline because of the nuget dependency update.
4. Since I was touching the source-build prebuilt baseline, I updated a few source-build files to help ensure source-build-internal is included in reviewing changes.

If you feel I have overloaded this PR please let me know and I will break it apart.
