### PR TITLE
Update source-build prebuilts

### DIFF
--- a/src/SourceBuild/content/eng/Versions.props
+++ b/src/SourceBuild/content/eng/Versions.props
@@ -19,7 +19,7 @@
       prep.sh and pipeline scripts, outside of MSBuild.
     -->
     <PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Artifacts.8.0.100-preview.4.23260.1.centos.8-x64.tar.gz</PrivateSourceBuiltArtifactsUrl>
-    <PrivateSourceBuiltPrebuiltsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Prebuilts.0.1.0-8.0.100-32.centos.8-x64.tar.gz</PrivateSourceBuiltPrebuiltsUrl>
+    <PrivateSourceBuiltPrebuiltsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Prebuilts.0.1.0-8.0.100-33.centos.8-x64.tar.gz</PrivateSourceBuiltPrebuiltsUrl>
     <PrivateSourceBuiltSdkUrl_CentOS8Stream>https://dotnetcli.azureedge.net/source-built-artifacts/sdks/dotnet-sdk-8.0.100-preview.4.23260.1-centos.8-x64.tar.gz</PrivateSourceBuiltSdkUrl_CentOS8Stream>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/3259

Update the checked in prebuilts tarball to remove the following packages which are no longer referenced:

microsoft.aspnetcore.app.ref.7.0.2.nupkg
Microsoft.NETCore.App.Host.centos.8-x64.7.0.2.nupkg
Microsoft.NETCore.App.Host.centos.8-x64.7.0.5.nupkg
Microsoft.NETCore.App.Host.fedora.36-x64.7.0.2.nupkg
Microsoft.NETCore.App.Host.fedora.36-x64.7.0.5.nupkg
microsoft.netcore.app.host.linux-arm64.7.0.2.nupkg
microsoft.netcore.app.host.linux-arm64.7.0.5.nupkg
microsoft.netcore.app.host.linux-x64.7.0.2.nupkg
microsoft.netcore.app.host.linux-x64.7.0.5.nupkg
microsoft.netcore.app.ref.7.0.2.nupkg

There are only two remaining prebuilts:

microsoft.aspnetcore.app.ref.7.0.5.nupkg
microsoft.netcore.app.ref.7.0.5.nupkg
