### PR TITLE
Fix bionic exclusion for ASP.NET

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -527,7 +527,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                               TargetingPackVersion="$(MicrosoftAspNetCoreAppRefPackageVersion)"
                               RuntimePackNamePatterns="Microsoft.AspNetCore.App.Runtime.**RID**"
                               RuntimePackRuntimeIdentifiers="@(AspNetCoreRuntimePackRids, '%3B')"
-                              RuntimePackExcludedRuntimeIdentifiers="android;linux-bionic"
+                              RuntimePackExcludedRuntimeIdentifiers="android%3Blinux-bionic"
                               />
 
     <KnownFrameworkReference Include="Microsoft.Windows.SDK.NET.Ref"


### PR DESCRIPTION
Fixes a problem I introduced in #16529. Because obviously, a semicolon in this file means a newline.

This time I built the repo and checked the output and there is indeed a semicolon. Previously I just hacked my NuGet cache.