### PR TITLE
Add known RID platforms to generated BundledVersions props

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -325,7 +325,6 @@
       <WindowsDesktop50RuntimePackRids Include="@(WindowsDesktop31RuntimePackRids);win-arm64" />
       <WindowsDesktopRuntimePackRids Include="@(WindowsDesktop50RuntimePackRids)" />
 
-      <_KnownRuntimeIdentiferPlatforms Include="$(ProductMonikerRid.Substring(0, $(Rid.LastIndexOf('-'))))" Condition="'$(DotNetBuildFromSource)' == 'true'" />
       <_KnownRuntimeIdentiferPlatforms Include="any;aot;freebsd;illumos;solaris;unix" />
       <_ExcludedKnownRuntimeIdentiferPlatforms Include="rhel.6;tizen.4.0.0;tizen.5.0.0" Condition="'$(DotNetBuildFromSource)' != 'true'" />
       <_ExcludedKnownRuntimeIdentiferPlatforms Include="rhel.6" Condition="'$(DotNetBuildFromSource)' == 'true' and !$(ProductMonikerRid.StartsWith('rhel.6-'))" />

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -324,6 +324,10 @@
       <WindowsDesktop31RuntimePackRids Include="@(WindowsDesktop30RuntimePackRids)" />
       <WindowsDesktop50RuntimePackRids Include="@(WindowsDesktop31RuntimePackRids);win-arm64" />
       <WindowsDesktopRuntimePackRids Include="@(WindowsDesktop50RuntimePackRids)" />
+
+      <_KnownRuntimeIdentiferPlatforms Include="$(ProductMonikerRid.Substring(0, $(Rid.LastIndexOf('-'))))" Condition="'$(DotNetBuildFromSource)' == 'true'" />
+      <_KnownRuntimeIdentiferPlatforms Include="any;freebsd;illumos;linux;linux-bionic;linux-musl;osx;solaris;unix;win" />
+      <_KnownRuntimeIdentiferPlatforms Include="android;aot;browser;ios;iossimulator;maccatalyst;tvos;tvossimulator" />
     </ItemGroup>
 
     <!--
@@ -1130,6 +1134,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <WindowsSdkSupportedTargetPlatformVersion Include="8.0" />
     <WindowsSdkSupportedTargetPlatformVersion Include="7.0" />
 
+    <_KnownRuntimeIdentiferPlatforms Include="@(_KnownRuntimeIdentiferPlatforms, '%3B')" />
   </ItemGroup>
 </Project>
 ]]>

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -1137,15 +1137,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <WindowsSdkSupportedTargetPlatformVersion Include="8.0" />
     <WindowsSdkSupportedTargetPlatformVersion Include="7.0" />
 
-    <_KnownRuntimeIdentifersForTfm Include="%40(KnownRuntimePack->WithMetadataValue('TargetFramework', %24(TargetFramework))->Metadata('RuntimePackRuntimeIdentifiers'))" />
-    <_KnownRuntimeIdentifersForTfm Include="%40(KnownFrameworkReference->WithMetadataValue('TargetFramework', %24(TargetFramework))->Metadata('RuntimePackRuntimeIdentifiers'))" />
-    <_KnownRuntimeIdentifersForTfmWithPlatform Include="%40(_KnownRuntimeIdentifersForTfm->ClearMetadata()->Distinct())">
-      <Platform Condition="%24([System.String]::new('%25(Identity)').LastIndexOf('-')) == -1">%25(Identity)</Platform>
-      <Platform Condition="%24([System.String]::new('%25(Identity)').LastIndexOf('-')) != -1">%24([System.String]::new('%25(Identity)').Substring(0, %24([System.String]::new('%25(Identity)').LastIndexOf('-'))))</Platform>
-    </_KnownRuntimeIdentifersForTfmWithPlatform>
-
     <_KnownRuntimeIdentiferPlatforms Include="@(_KnownRuntimeIdentiferPlatforms, '%3B')" />
-    <_KnownRuntimeIdentiferPlatforms Include="%40(_KnownRuntimeIdentifersForTfmWithPlatform->Metadata('Platform')->ClearMetadata()->Distinct())" Exclude="@(_ExcludedKnownRuntimeIdentiferPlatforms, '%3B')" />
+    <_ExcludedKnownRuntimeIdentiferPlatforms Include="@(_ExcludedKnownRuntimeIdentiferPlatforms, '%3B')" />
   </ItemGroup>
 </Project>
 ]]>

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -326,8 +326,11 @@
       <WindowsDesktopRuntimePackRids Include="@(WindowsDesktop50RuntimePackRids)" />
 
       <_KnownRuntimeIdentiferPlatforms Include="$(ProductMonikerRid.Substring(0, $(Rid.LastIndexOf('-'))))" Condition="'$(DotNetBuildFromSource)' == 'true'" />
-      <_KnownRuntimeIdentiferPlatforms Include="any;freebsd;illumos;linux;linux-bionic;linux-musl;osx;solaris;unix;win" />
-      <_KnownRuntimeIdentiferPlatforms Include="android;aot;browser;ios;iossimulator;maccatalyst;tvos;tvossimulator" />
+      <_KnownRuntimeIdentiferPlatforms Include="any;aot;freebsd;illumos;solaris;unix" />
+      <_ExcludedKnownRuntimeIdentiferPlatforms Include="rhel.6;tizen.4.0.0;tizen.5.0.0" Condition="'$(DotNetBuildFromSource)' != 'true'" />
+      <_ExcludedKnownRuntimeIdentiferPlatforms Include="rhel.6" Condition="'$(DotNetBuildFromSource)' == 'true' and !$(ProductMonikerRid.StartsWith('rhel.6-'))" />
+      <_ExcludedKnownRuntimeIdentiferPlatforms Include="tizen.4.0.0" Condition="'$(DotNetBuildFromSource)' == 'true' and !$(ProductMonikerRid.StartsWith('tizen.4.0.0-'))" />
+      <_ExcludedKnownRuntimeIdentiferPlatforms Include="tizen.5.0.0" Condition="'$(DotNetBuildFromSource)' == 'true' and !$(ProductMonikerRid.StartsWith('tizen.5.0.0-'))" />
     </ItemGroup>
 
     <!--
@@ -1134,7 +1137,15 @@ Copyright (c) .NET Foundation. All rights reserved.
     <WindowsSdkSupportedTargetPlatformVersion Include="8.0" />
     <WindowsSdkSupportedTargetPlatformVersion Include="7.0" />
 
+    <_KnownRuntimeIdentifersForTfm Include="%40(KnownRuntimePack->WithMetadataValue('TargetFramework', %24(TargetFramework))->Metadata('RuntimePackRuntimeIdentifiers'))" />
+    <_KnownRuntimeIdentifersForTfm Include="%40(KnownFrameworkReference->WithMetadataValue('TargetFramework', %24(TargetFramework))->Metadata('RuntimePackRuntimeIdentifiers'))" />
+    <_KnownRuntimeIdentifersForTfmWithPlatform Include="%40(_KnownRuntimeIdentifersForTfm->ClearMetadata()->Distinct())">
+      <Platform Condition="%24([System.String]::new('%25(Identity)').LastIndexOf('-')) == -1">%25(Identity)</Platform>
+      <Platform Condition="%24([System.String]::new('%25(Identity)').LastIndexOf('-')) != -1">%24([System.String]::new('%25(Identity)').Substring(0, %24([System.String]::new('%25(Identity)').LastIndexOf('-'))))</Platform>
+    </_KnownRuntimeIdentifersForTfmWithPlatform>
+
     <_KnownRuntimeIdentiferPlatforms Include="@(_KnownRuntimeIdentiferPlatforms, '%3B')" />
+    <_KnownRuntimeIdentiferPlatforms Include="%40(_KnownRuntimeIdentifersForTfmWithPlatform->Metadata('Platform')->ClearMetadata()->Distinct())" Exclude="@(_ExcludedKnownRuntimeIdentiferPlatforms, '%3B')" />
   </ItemGroup>
 </Project>
 ]]>


### PR DESCRIPTION
Update generated BundledVersions props to include a list of known RID platforms. This will be used by https://github.com/dotnet/sdk/pull/32970. 