### PR TITLE
Do not publish wixpacks when postbuild sign is not true

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -76,7 +76,10 @@
     <SdkNonShippingAssetsToPublish Include="$(ArtifactsNonShippingPackagesDir)*.swr" />
     <SdkNonShippingAssetsToPublish Include="$(ArtifactsNonShippingPackagesDir)*.msi" />
     <SdkNonShippingAssetsToPublish Condition="'$(PublishBinariesAndBadge)' != 'false'" Include="$(ArtifactsNonShippingPackagesDir)*.tar.gz" />
+    <WixPacksToPublish Include="$(ArtifactsNonShippingPackagesDir)*.wixpack.zip" />
     <SdkNonShippingAssetsToPublish Condition="'$(PublishBinariesAndBadge)' != 'false'" Include="$(ArtifactsNonShippingPackagesDir)*.zip" />
+    <!-- Remove wixpacks if not doing post-build signing, since they are not needed -->
+    <SdkNonShippingAssetsToPublish Remove="@(WixPacksToPublish)" Condition="'$(PostBuildSign)' != 'true'" />
     <SdkNonShippingAssetsToPublish Include="$(ArtifactsNonShippingPackagesDir)*.pkg" />
     <CheckSumsToPublish Include="$(ArtifactsShippingPackagesDir)*.sha512" />
     <CheckSumsToPublish Remove="$(ArtifactsShippingPackagesDir)productCommit-*.txt.sha512" Condition=" '$(PublishBinariesAndBadge)' == 'false'" />


### PR DESCRIPTION
Removes about 1GB of artifacts.