### PR TITLE
Fix casing of Microsoft.DotNet.ILCompiler for SB artifact bootstrapping

### DIFF
--- a/src/SourceBuild/content/eng/bootstrap/buildBootstrapPreviouslySB.csproj
+++ b/src/SourceBuild/content/eng/bootstrap/buildBootstrapPreviouslySB.csproj
@@ -32,7 +32,7 @@
     <RuntimePack Include="Microsoft.NETCore.App.Host" Version="[$(MicrosoftNETCoreAppHostPackageVersion)]" />
     <RuntimePack Include="Microsoft.NETCore.App.Runtime" Version="[$(MicrosoftNETCoreAppRuntimeVersion)]" />
 
-    <PortablePackage Include="Microsoft.DotNet.IlCompiler" Version="[$(MicrosoftDotNetIlCompilerVersion)]" />
+    <PortablePackage Include="Microsoft.DotNet.ILCompiler" Version="[$(MicrosoftDotNetILCompilerVersion)]" />
     <PortablePackage Include="Microsoft.NETCore.DotNetAppHost" Version="[$(MicrosoftNETCoreDotNetAppHostVersion)]" />
     <PortablePackage Include="Microsoft.NETCore.DotNetHost" Version="[$(MicrosoftNETCoreDotNetHostVersion)]" />
     <PortablePackage Include="Microsoft.NETCore.DotNetHostPolicy" Version="[$(MicrosoftNETCoreDotNetHostPolicyVersion)]" />


### PR DESCRIPTION
The casing of the `Microsoft.DotNet.ILCompiler` package name is incorrect in the project configuration which handles source-build artifact bootstrapping. Because Linux is case-sensitive, this causes two versions of the `Microsoft.DotNet.ILCompiler` to exist in the `previously-source-built` local package feed:

* `Microsoft.DotNet.ILCompiler`: This is the original package that came from the source built artifacts tarball.
* `Microsoft.DotNet.IlCompiler`: This is the "bootstrapped" package that was pulled from nuget.org.

The contents of these two packages are different. But from the perspective of NuGet, whose implementation is not case-sensitive with respect to NuGet package names, they have the same name and version. Because of non-deterministic behavior in NuGet you may get one package or the other, leading to unpredictable results in the build (see https://github.com/dotnet/runtime/issues/83695#issuecomment-1560313360 and https://github.com/dotnet/runtime/issues/83695#issuecomment-1579443829).