### PR TITLE
Update debpkg leg to use the Ubuntu 22.04-based image

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -237,7 +237,7 @@ stages:
       parameters:
         agentOs: Linux
         jobName: Build_Linux_Portable_Deb_Release_x64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-debpkg'
+        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg'
         buildConfiguration: Release
         buildArchitecture: x64
         # Do not publish zips and tarballs. The linux-x64 binaries are


### PR DESCRIPTION
- Please add description for changes you are making.
- If there is an issue related to this PR, please add the reference.

Move the debpkg leg to use the Ubuntu 22.04 image from the Ubuntu 18.04 image to keep us on updated base OS versions.

I've validated locally that this image works with dotnet/installer and will not break the official build.