### PR TITLE
Add System.CommandLine dependency to control version in VMR

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -191,6 +191,15 @@
       <Sha>2c8079e2e8e78c0cd11ac75a32014756136ecdb9</Sha>
       <SourceBuild RepoName="symreader" ManagedOnly="true" />
     </Dependency>
+    <Dependency Name="System.CommandLine" Version="2.0.0-beta4.22564.1" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Uri>https://github.com/dotnet/command-line-api</Uri>
+      <Sha>8374d5fca634a93458c84414b1604c12f765d1ab</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.command-line-api" Version="0.1.356401" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Uri>https://github.com/dotnet/command-line-api</Uri>
+      <Sha>8374d5fca634a93458c84414b1604c12f765d1ab</Sha>
+      <SourceBuild RepoName="command-line-api" ManagedOnly="true" />
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.23307.2">


### PR DESCRIPTION
Currently the runtime controls which version of System.CommandLine is in the VMR.  This is because installer doesn't have a direct dependency.  The arcade-services logic walks the version.details.xml graph and which every reference is found first wins.  Since runtime appears before the sdk in the installer's version.details.xml file, it controls the version of System.CommandLine in the VMR.  This doesn't feel correct, the sdk repo should control this.  Adding an explicitly dependency in installer to control this.
