### PR TITLE
update snapcraft auth for june releases

### DIFF
--- a/src/snaps/dotnet-sdk-6.0/snap/snapcraft.yaml
+++ b/src/snaps/dotnet-sdk-6.0/snap/snapcraft.yaml
@@ -1,30 +1,28 @@
 name: dotnet-sdk
-version: 6.0.408
+version: 6.0.410
 summary: Cross-Platform .NET Core SDK
 description: |
   .NET Core SDK. https://dot.net/core.
 
+architectures:
+  - build-on: amd64
+    run-on: amd64
+
 grade: stable
 confinement: classic
-
-apps:
-  dotnet:
-    command: dotnet
-
-base: core18
+base: core20
 
 parts:
   dotnet-sdk:
       plugin: dump
-      source: https://download.visualstudio.microsoft.com/download/pr/dd7d2255-c9c1-4c6f-b8ad-6e853d6bb574/c8e1b5f47bf17b317a84487491915178/dotnet-sdk-6.0.408-linux-x64.tar.gz
-      source-checksum: sha512/d5eed37ce6c07546aa217d6e786f3b67be2b6d97c23d5888d9ee5d5398e8a9bfc06202b14e3529245f7ec78f4036778caf69bdbe099de805fe1f566277e8440e
-      stage-packages:
-      - libicu60
-      - libc6
+      source: https://download.visualstudio.microsoft.com/download/pr/ac5809b0-7930-4ae9-9005-58f2fd7912f3/4cf0cb18d22a162b33149b1f28a8e045/dotnet-sdk-6.0.410-linux-x64.tar.gz
+      source-checksum: sha512/8c85f5b10eb786c8cf31bf268131a2345a295d88d318310dc8457d831f0a587ec1600e43beb7f55aec2248483b9a95e905a468b592f0c910443b4aaa9baeb2e3
+      stage-packages:      
+      - libicu66
       - libgcc1
       - libstdc++6
-      - libssl1.0.0
-      - libcurl3
+      - libssl1.1
+      - libcurl4
       - libgssapi-krb5-2
       - zlib1g
       - lldb
@@ -37,5 +35,7 @@ parts:
       plugin: dump
       source: .
 
-
+apps:
+  dotnet:
+    command: dotnet
 

--- a/src/snaps/dotnet-sdk-7.0/snap/snapcraft.yaml
+++ b/src/snaps/dotnet-sdk-7.0/snap/snapcraft.yaml
@@ -1,30 +1,28 @@
 name: dotnet-sdk
-version: 7.0.203
+version: 7.0.304
 summary: Cross-Platform .NET Core SDK
 description: |
   .NET Core SDK. https://dot.net/core.
 
+architectures:
+  - build-on: amd64
+    run-on: amd64
+
 grade: stable
 confinement: classic
-
-apps:
-  dotnet:
-    command: dotnet
-
-base: core18
+base: core20
 
 parts:
   dotnet-sdk:
       plugin: dump
-      source: https://download.visualstudio.microsoft.com/download/pr/ebfd0bf8-79bd-480a-9e81-0b217463738d/9adc6bf0614ce02670101e278a2d8555/dotnet-sdk-7.0.203-linux-x64.tar.gz
-      source-checksum: sha512/ed1ae7cd88591ec52e1515c4a25d9a832eca29e8a0889549fea35a320e6e356e3806a17289f71fc0b04c36b006ae74446c53771d976c170fcbe5977ac7db1cb6
+      source: https://download.visualstudio.microsoft.com/download/pr/9c86d7b4-acb2-4be4-8a89-d13bc3c3f28f/1d044c7c29df018e8f2837bb343e8a84/dotnet-sdk-7.0.304-linux-x64.tar.gz
+      source-checksum: sha512/f4b7d0cde432bd37f445363b3937ad483e5006794886941e43124de051475925b3cd11313b73d2cae481ee9b8f131394df0873451f6088ffdbe73f150b1ed727
       stage-packages:
-      - libicu60
-      - libc6
+      - libicu66
       - libgcc1
       - libstdc++6
-      - libssl1.0.0
-      - libcurl3
+      - libssl1.1
+      - libcurl4
       - libgssapi-krb5-2
       - zlib1g
       - lldb
@@ -37,5 +35,8 @@ parts:
       plugin: dump
       source: .
 
+apps:
+  dotnet:
+    command: dotnet
 
 

--- a/src/snaps/dotnet-sdk-8.0/snap/snapcraft.yaml
+++ b/src/snaps/dotnet-sdk-8.0/snap/snapcraft.yaml
@@ -1,30 +1,28 @@
 name: dotnet-sdk
-version: 8.0.100-preview.3.23178.7
+version: 8.0.100-preview.5.23303.2
 summary: Cross-Platform .NET Core SDK
 description: |
   .NET Core SDK. https://dot.net/core.
 
+architectures:
+  - build-on: amd64
+    run-on: amd64
+
 grade: stable
 confinement: classic
-
-apps:
-  dotnet:
-    command: dotnet
-
-base: core18
+base: core20
 
 parts:
   dotnet-sdk:
       plugin: dump
-      source: https://download.visualstudio.microsoft.com/download/pr/103d5e2c-d5c4-4101-bb6e-b82bc73a7d93/284a5cdccbc995f39806a3ba2dc17b93/dotnet-sdk-8.0.100-preview.3.23178.7-linux-x64.tar.gz
-      source-checksum: sha512/3b5d72979831256b9340a01db23d3b2dca801672546eeed04385949ed5f4363d3c731f31477ec82c7200ce88502dc45e03986c8acc8f2fc611b0343af5f1c488
+      source: https://download.visualstudio.microsoft.com/download/pr/07b027f8-4ef8-48cb-becc-132652c625bb/441ef662adfe931013745df24d53b26d/dotnet-sdk-8.0.100-preview.5.23303.2-linux-x64.tar.gz
+      source-checksum: sha512/dfe2085a92854a5cee84cb7be9344368f5dcb6333c4ca215375a34b862f3a3ee66c953b9957f7b46f6cd710992ee038f6b4c2bd16464b4a216a1785868e86f7c
       stage-packages:
-      - libicu60
-      - libc6
+      - libicu66
       - libgcc1
       - libstdc++6
-      - libssl1.0.0
-      - libcurl3
+      - libssl1.1
+      - libcurl4
       - libgssapi-krb5-2
       - zlib1g
       - lldb
@@ -37,5 +35,6 @@ parts:
       plugin: dump
       source: .
 
-
-
+apps:
+  dotnet:
+    command: dotnet


### PR DESCRIPTION
Changes include upgrading to Core20, updated libs and removing explicit glibc6 reference. These changes seem to have resolved some fundamental issues when running on newer OS versions (e.g. Ubuntu 22+ and Fedora 36+). Critically, segfaults when creating a new project and other cli operations have been resolved.

/cc @ashnaga 

resolves https://github.com/dotnet/installer/issues/13004, https://github.com/dotnet/core/issues/8254, https://github.com/dotnet/core/issues/7291, https://github.com/dotnet/core/issues/8499

partially resolve https://github.com/dotnet/core/issues/7776, https://github.com/dotnet/docs/pull/31045, https://github.com/dotnet/core/issues/7112