### PR TITLE
[release/6.01xx] Update source-build CI to Fedora 38

### DIFF
--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build.yml
@@ -14,7 +14,7 @@ parameters:
   centOSStream9Container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9-20220107135047-4cd394c
   debian9Container: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-20211001171226-047508b
   debian9Arm64Container: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-arm64v8-20220405201138-a251961
-  fedora33Container: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-33-20210222183538-031e7d2
+  fedora38Container: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-38-20230609193134-47458d2
   ubuntu1804Container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-20210924170306-047508b
   poolInternalAmd64:
     name: NetCore1ESPool-Svc-Internal
@@ -62,9 +62,9 @@ jobs:
           _EnablePoison: false
           _ExcludeOmniSharpTests: false
           _RunOnline: false
-        Fedora33-Offline:
+        Fedora38-Offline:
           _BootstrapPrep: false
-          _Container: ${{ parameters.fedora33Container }}
+          _Container: ${{ parameters.fedora38Container }}
           _EnablePoison: true
           _ExcludeOmniSharpTests: false
           _RunOnline: false
@@ -111,9 +111,9 @@ jobs:
       excludeSdkContentTests: true
       installerBuildResourceId: ${{ parameters.installerBuildResourceId }}
       matrix:
-        Fedora33-Offline:
-          _PreviousSourceBuildArtifact: Build_Tarball_x64 Fedora33-Offline_Artifacts
-          _Container: ${{ parameters.fedora33Container }}
+        Fedora38-Offline:
+          _PreviousSourceBuildArtifact: Build_Tarball_x64 Fedora38-Offline_Artifacts
+          _Container: ${{ parameters.fedora38Container }}
           _EnablePoison: false
           _ExcludeOmniSharpTests: false
           _RunOnline: false


### PR DESCRIPTION
Fedora versions up to 36 are already EOL:
https://docs.fedoraproject.org/en-US/releases/eol/