### PR TITLE
Fix known maccatalyst-arm64/x64 packages

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -230,7 +230,7 @@
           tvossimulator-arm64;
           tvossimulator-x64;
           maccatalyst-x64;
-          maccatalyst-arm64;                                      
+          maccatalyst-arm64;
           android-arm64;
           android-arm;
           android-x64;

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -162,8 +162,6 @@
       <Net60RuntimePackRids Include="
           @(Net50RuntimePackRids);
           osx-arm64;
-          maccatalyst-x64;
-          maccatalyst-arm64;
           linux-s390x;
           " />
 
@@ -231,6 +229,8 @@
           tvos-arm64;
           tvossimulator-arm64;
           tvossimulator-x64;
+          maccatalyst-x64;
+          maccatalyst-arm64;                                      
           android-arm64;
           android-arm;
           android-x64;


### PR DESCRIPTION
There are no Microsoft.NETCore.App.Runtime.maccatalyst-arm64/x64 packages. Only the Mono and NativeAOT ones exist. The split was done in the net6.0 timeframe in PR #10222 before the plan to use CoreCLR for MacCatalyst was abandoned.

