### PR TITLE
Address all known SDK differences

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkDiffExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkDiffExclusions.txt
@@ -12,9 +12,24 @@
 # We do not want to filter-out folder entries, therefore, we should use: '?*' and not just '*'
 
 msft,./sdk/x.y.z/TestHostNetFramework/?*   # Intentional - MSFT build includes test-host that targets netcoreapp3.1
-msft,./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/?*   # Intentional - source-build includes SDK Publishing package that target latest .NET TFM
 msft,./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/?*   # Intentional - explicitly excluded from source-build
-sb,./sdk/x.y.z/TestHost/?*   # Intentional - source-build includes test-host that targets latest .NET TFM
+
+# netfx tooling and tasks, not building in source-build
+msft,./sdk/x.y.z/Sdks/Microsoft.Build.Tasks.Git/tools/net472/*
+msft,./sdk/x.y.z/Sdks/Microsoft.NET.Sdk/tools/net472/*
+msft,./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.BlazorWebAssembly/tools/net472/*
+msft,./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/*
+msft,./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Razor/tasks/net472/*
+msft,./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.StaticWebAssets/tasks/net472/*
+msft,./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Web/tools/net472/*
+msft,./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Web.ProjectSystem/tools/net472/*
+msft,./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WebAssembly/tools/net472/*
+msft,./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Worker/tools/net472/*
+msft,./sdk/x.y.z/Sdks/Microsoft.SourceLink.AzureRepos.Git/tools/net472/*
+msft,./sdk/x.y.z/Sdks/Microsoft.SourceLink.Bitbucket.Git/tools/net472/*
+msft,./sdk/x.y.z/Sdks/Microsoft.SourceLink.Common/tools/net472/*
+msft,./sdk/x.y.z/Sdks/Microsoft.SourceLink.GitHub/tools/net472/*
+msft,./sdk/x.y.z/Sdks/Microsoft.SourceLink.GitLab/tools/net472/*
 
 # vstest localization is disabled in Linux builds - https://github.com/microsoft/vstest/issues/4305
 msft,./sdk/x.y.z/*?/Microsoft.CodeCoverage.IO.resources.dll
@@ -40,3 +55,40 @@ msft,./sdk-manifests/x.y.z/microsoft.net.sdk.maccatalyst/*
 msft,./sdk-manifests/x.y.z/microsoft.net.sdk.macos/*
 msft,./sdk-manifests/x.y.z/microsoft.net.sdk.maui/*
 msft,./sdk-manifests/x.y.z/microsoft.net.sdk.tvos/*
+
+# linux runtimes are needed for self-contained apps - https://github.com/dotnet/source-build/issues/3507
+sb,./packs/Microsoft.AspNetCore.App.Runtime.*/*
+sb,./packs/Microsoft.NETCore.App.Runtime.*/*
+
+# netfx tooling - dumpminitool - https://github.com/dotnet/source-build/issues/3289
+msft,./sdk/x.y.z/Extensions/dump/*
+
+# netfx runtimes for dotnet-watch - https://github.com/dotnet/source-build/issues/3285
+msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Microsoft.CodeAnalysis.Elfie.dll
+msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Microsoft.Win32.SystemEvents.dll
+msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/runtimes/*
+msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Configuration.ConfigurationManager.dll
+msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Drawing.Common.dll
+msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Security.Cryptography.ProtectedData.dll
+msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Security.Permissions.dll
+msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Windows.Extensions.dll
+
+# netfx runtimes for dotnet-format - https://github.com/dotnet/source-build/issues/3509
+msft,./sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.CodeAnalysis.Elfie.dll
+msft,./sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.Win32.SystemEvents.dll
+msft,./sdk/x.y.z/DotnetTools/dotnet-format/runtimes/*
+msft,./sdk/x.y.z/DotnetTools/dotnet-format/System.Configuration.ConfigurationManager.dll
+msft,./sdk/x.y.z/DotnetTools/dotnet-format/System.Drawing.Common.dll
+msft,./sdk/x.y.z/DotnetTools/dotnet-format/System.Security.Cryptography.ProtectedData.dll
+msft,./sdk/x.y.z/DotnetTools/dotnet-format/System.Security.Permissions.dll
+msft,./sdk/x.y.z/DotnetTools/dotnet-format/System.Windows.Extensions.dll
+
+# netfx runtimes for containers - https://github.com/dotnet/source-build/issues/3510
+msft,./sdk/x.y.z/containerize.deps.json
+msft,./sdk/x.y.z/containerize.exe
+msft,./sdk/x.y.z/containerize.runtimeconfig.json
+msft,./sdk/x.y.z/Containers/containerize/*
+msft,./sdk/x.y.z/Containers/tasks/net472/*
+msft,./sdk/x.y.z/Containers/tasks/netx.y/Microsoft.VisualStudio.Setup.Configuration.Interop.dll
+msft,./sdk/x.y.z/Containers/tasks/netx.y/runtimes/*   # msft (netfx) runtimes
+sb,./sdk/x.y.z/Containers/tasks/netx.y/runtimes/*   # sb (.net) runtimes

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkDiffExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkDiffExclusions.txt
@@ -56,7 +56,7 @@ msft,./sdk-manifests/x.y.z/microsoft.net.sdk.macos/*
 msft,./sdk-manifests/x.y.z/microsoft.net.sdk.maui/*
 msft,./sdk-manifests/x.y.z/microsoft.net.sdk.tvos/*
 
-# linux runtimes are needed for self-contained apps - https://github.com/dotnet/source-build/issues/3507
+# linux runtimes are included in source-build for self-contained apps - https://github.com/dotnet/source-build/issues/3507
 sb,./packs/Microsoft.AspNetCore.App.Runtime.*/*
 sb,./packs/Microsoft.NETCore.App.Runtime.*/*
 

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkDiffExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkDiffExclusions.txt
@@ -14,7 +14,7 @@
 msft,./sdk/x.y.z/TestHostNetFramework/?*   # Intentional - MSFT build includes test-host that targets netcoreapp3.1
 msft,./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/?*   # Intentional - explicitly excluded from source-build
 
-# netfx tooling and tasks, not building in source-build
+# netfx tooling and tasks, not building in source-build - https://github.com/dotnet/source-build/issues/3514
 msft,./sdk/x.y.z/Sdks/Microsoft.Build.Tasks.Git/tools/net472/*
 msft,./sdk/x.y.z/Sdks/Microsoft.NET.Sdk/tools/net472/*
 msft,./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.BlazorWebAssembly/tools/net472/*

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkDiffExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkDiffExclusions.txt
@@ -31,7 +31,7 @@ msft,./sdk/x.y.z/Sdks/Microsoft.SourceLink.Common/tools/net472/*
 msft,./sdk/x.y.z/Sdks/Microsoft.SourceLink.GitHub/tools/net472/*
 msft,./sdk/x.y.z/Sdks/Microsoft.SourceLink.GitLab/tools/net472/*
 
-# vstest localization is disabled in Linux builds - https://github.com/microsoft/vstest/issues/4305
+# vstest localization is disabled in Linux builds - https://github.com/dotnet/source-build/issues/3517
 msft,./sdk/x.y.z/*?/Microsoft.CodeCoverage.IO.resources.dll
 msft,./sdk/x.y.z/*?/Microsoft.TestPlatform.*?.resources.dll
 msft,./sdk/x.y.z/*?/Microsoft.VisualStudio.TestPlatform.*?.resources.dll
@@ -82,13 +82,3 @@ msft,./sdk/x.y.z/DotnetTools/dotnet-format/System.Drawing.Common.dll
 msft,./sdk/x.y.z/DotnetTools/dotnet-format/System.Security.Cryptography.ProtectedData.dll
 msft,./sdk/x.y.z/DotnetTools/dotnet-format/System.Security.Permissions.dll
 msft,./sdk/x.y.z/DotnetTools/dotnet-format/System.Windows.Extensions.dll
-
-# netfx runtimes for containers - https://github.com/dotnet/source-build/issues/3510
-msft,./sdk/x.y.z/containerize.deps.json
-msft,./sdk/x.y.z/containerize.exe
-msft,./sdk/x.y.z/containerize.runtimeconfig.json
-msft,./sdk/x.y.z/Containers/containerize/*
-msft,./sdk/x.y.z/Containers/tasks/net472/*
-msft,./sdk/x.y.z/Containers/tasks/netx.y/Microsoft.VisualStudio.Setup.Configuration.Interop.dll
-msft,./sdk/x.y.z/Containers/tasks/netx.y/runtimes/*   # msft (netfx) runtimes
-sb,./sdk/x.y.z/Containers/tasks/netx.y/runtimes/*   # sb (.net) runtimes

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdk.diff
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdk.diff
@@ -45,132 +45,197 @@ index ------------
  ./packs/Microsoft.NETCore.App.Ref/x.y.z/
  ./packs/Microsoft.NETCore.App.Ref/x.y.z/analyzers/
 @@ ------------ @@
- ./sdk-manifests/x.y.z/microsoft.net.workload.mono.toolchain.current/localize/WorkloadManifest.zh-Hant.json
- ./sdk-manifests/x.y.z/microsoft.net.workload.mono.toolchain.current/WorkloadManifest.json
- ./sdk-manifests/x.y.z/microsoft.net.workload.mono.toolchain.current/WorkloadManifest.targets
-+./sdk-manifests/x.y.z/microsoft.net.workload.mono.toolchain.current/WorkloadManifest.Wasi.targets
- ./sdk-manifests/x.y.z/microsoft.net.workload.mono.toolchain.net6/
- ./sdk-manifests/x.y.z/microsoft.net.workload.mono.toolchain.net6/localize/
- ./sdk-manifests/x.y.z/microsoft.net.workload.mono.toolchain.net6/localize/WorkloadManifest.cs.json
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/Microsoft.CSharp.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/Microsoft.CSharp.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/Microsoft.VisualBasic.Core.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/Microsoft.VisualBasic.Core.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/Microsoft.VisualBasic.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/Microsoft.Win32.Primitives.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/Microsoft.Win32.Primitives.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/Microsoft.Win32.Registry.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/Microsoft.Win32.Registry.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/mscorlib.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/netstandard.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.AppContext.dll
 @@ ------------ @@
- ./sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.CodeAnalysis.CSharp.Features.dll
- ./sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.CodeAnalysis.CSharp.Workspaces.dll
- ./sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.CodeAnalysis.dll
--./sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.CodeAnalysis.Elfie.dll
- ./sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.CodeAnalysis.Features.dll
- ./sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.CodeAnalysis.Scripting.dll
- ./sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.CodeAnalysis.VisualBasic.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.ComponentModel.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Configuration.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Console.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Console.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Core.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Data.Common.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Data.Common.xml
 @@ ------------ @@
- ./sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.Extensions.Logging.dll
- ./sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.Extensions.Options.dll
- ./sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.Extensions.Primitives.dll
--./sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.Win32.SystemEvents.dll
- ./sdk/x.y.z/DotnetTools/dotnet-format/pl/
- ./sdk/x.y.z/DotnetTools/dotnet-format/pl/dotnet-format.resources.dll
- ./sdk/x.y.z/DotnetTools/dotnet-format/pl/Microsoft.CodeAnalysis.CSharp.Features.resources.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Diagnostics.DiagnosticSource.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Diagnostics.DiagnosticSource.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Diagnostics.FileVersionInfo.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Diagnostics.FileVersionInfo.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Diagnostics.Process.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Diagnostics.Process.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Diagnostics.StackTrace.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Diagnostics.StackTrace.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Diagnostics.TextWriterTraceListener.dll
 @@ ------------ @@
- ./sdk/x.y.z/DotnetTools/dotnet-format/ru/Microsoft.CodeAnalysis.Workspaces.MSBuild.resources.dll
- ./sdk/x.y.z/DotnetTools/dotnet-format/ru/Microsoft.CodeAnalysis.Workspaces.resources.dll
- ./sdk/x.y.z/DotnetTools/dotnet-format/ru/System.CommandLine.resources.dll
--./sdk/x.y.z/DotnetTools/dotnet-format/runtimes/
--./sdk/x.y.z/DotnetTools/dotnet-format/runtimes/unix/
--./sdk/x.y.z/DotnetTools/dotnet-format/runtimes/unix/lib/
--./sdk/x.y.z/DotnetTools/dotnet-format/runtimes/unix/lib/netx.y/
--./sdk/x.y.z/DotnetTools/dotnet-format/runtimes/unix/lib/netx.y/System.Drawing.Common.dll
--./sdk/x.y.z/DotnetTools/dotnet-format/runtimes/win/
--./sdk/x.y.z/DotnetTools/dotnet-format/runtimes/win/lib/
--./sdk/x.y.z/DotnetTools/dotnet-format/runtimes/win/lib/netx.y/
--./sdk/x.y.z/DotnetTools/dotnet-format/runtimes/win/lib/netx.y/Microsoft.Win32.SystemEvents.dll
--./sdk/x.y.z/DotnetTools/dotnet-format/runtimes/win/lib/netx.y/System.Drawing.Common.dll
--./sdk/x.y.z/DotnetTools/dotnet-format/runtimes/win/lib/netx.y/System.Security.Cryptography.ProtectedData.dll
--./sdk/x.y.z/DotnetTools/dotnet-format/runtimes/win/lib/netx.y/System.Windows.Extensions.dll
-+./sdk/x.y.z/DotnetTools/dotnet-format/System.Collections.Immutable.dll
- ./sdk/x.y.z/DotnetTools/dotnet-format/System.CommandLine.dll
- ./sdk/x.y.z/DotnetTools/dotnet-format/System.CommandLine.Rendering.dll
- ./sdk/x.y.z/DotnetTools/dotnet-format/System.Composition.AttributedModel.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Drawing.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Drawing.Primitives.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Drawing.Primitives.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Dynamic.Runtime.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Dynamic.Runtime.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Formats.Asn1.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Formats.Asn1.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Formats.Tar.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Formats.Tar.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Globalization.Calendars.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Globalization.Calendars.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Globalization.dll
 @@ ------------ @@
- ./sdk/x.y.z/DotnetTools/dotnet-format/System.Composition.Hosting.dll
- ./sdk/x.y.z/DotnetTools/dotnet-format/System.Composition.Runtime.dll
- ./sdk/x.y.z/DotnetTools/dotnet-format/System.Composition.TypedParts.dll
--./sdk/x.y.z/DotnetTools/dotnet-format/System.Configuration.ConfigurationManager.dll
--./sdk/x.y.z/DotnetTools/dotnet-format/System.Drawing.Common.dll
-+./sdk/x.y.z/DotnetTools/dotnet-format/System.Diagnostics.DiagnosticSource.dll
- ./sdk/x.y.z/DotnetTools/dotnet-format/System.IO.Pipelines.dll
--./sdk/x.y.z/DotnetTools/dotnet-format/System.Security.Cryptography.ProtectedData.dll
--./sdk/x.y.z/DotnetTools/dotnet-format/System.Security.Permissions.dll
--./sdk/x.y.z/DotnetTools/dotnet-format/System.Windows.Extensions.dll
-+./sdk/x.y.z/DotnetTools/dotnet-format/System.Reflection.Metadata.dll
-+./sdk/x.y.z/DotnetTools/dotnet-format/System.Text.Encoding.CodePages.dll
-+./sdk/x.y.z/DotnetTools/dotnet-format/System.Text.Encodings.Web.dll
-+./sdk/x.y.z/DotnetTools/dotnet-format/System.Text.Json.dll
-+./sdk/x.y.z/DotnetTools/dotnet-format/System.Threading.Channels.dll
- ./sdk/x.y.z/DotnetTools/dotnet-format/tr/
- ./sdk/x.y.z/DotnetTools/dotnet-format/tr/dotnet-format.resources.dll
- ./sdk/x.y.z/DotnetTools/dotnet-format/tr/Microsoft.CodeAnalysis.CSharp.Features.resources.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Globalization.Extensions.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Globalization.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.IO.Compression.Brotli.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.IO.Compression.Brotli.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.IO.Compression.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.IO.Compression.FileSystem.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.IO.Compression.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.IO.Compression.ZipFile.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.IO.Compression.ZipFile.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.IO.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.IO.FileSystem.AccessControl.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.IO.FileSystem.AccessControl.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.IO.FileSystem.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.IO.FileSystem.DriveInfo.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.IO.FileSystem.DriveInfo.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.IO.FileSystem.Primitives.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.IO.FileSystem.Primitives.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.IO.FileSystem.Watcher.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.IO.FileSystem.Watcher.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.IO.FileSystem.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.IO.IsolatedStorage.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.IO.IsolatedStorage.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.IO.MemoryMappedFiles.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.IO.MemoryMappedFiles.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.IO.Pipes.AccessControl.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.IO.Pipes.AccessControl.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.IO.Pipes.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.IO.Pipes.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.IO.UnmanagedMemoryStream.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.IO.UnmanagedMemoryStream.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.IO.xml
 @@ ------------ @@
- ./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Microsoft.CodeAnalysis.AnalyzerUtilities.dll
- ./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Microsoft.CodeAnalysis.CSharp.Features.dll
- ./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Microsoft.CodeAnalysis.CSharp.Workspaces.dll
--./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Microsoft.CodeAnalysis.Elfie.dll
- ./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Microsoft.CodeAnalysis.Features.dll
- ./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Microsoft.CodeAnalysis.Scripting.dll
- ./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Microsoft.CodeAnalysis.Workspaces.dll
- ./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Microsoft.CodeAnalysis.Workspaces.MSBuild.dll
- ./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Microsoft.DiaSymReader.dll
--./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Microsoft.Win32.SystemEvents.dll
- ./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/middleware/
- ./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/middleware/Microsoft.AspNetCore.Watch.BrowserRefresh.dll
- ./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/pl/
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.Http.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.Http.Json.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.Http.Json.xml
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.Http.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.HttpListener.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.HttpListener.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.Mail.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.Mail.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.NameResolution.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.NameResolution.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.NetworkInformation.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.NetworkInformation.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.Ping.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.Ping.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.Primitives.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.Primitives.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.Quic.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.Quic.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.Requests.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.Requests.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.Security.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.Security.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.ServicePoint.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.ServicePoint.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.Sockets.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.Sockets.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.WebClient.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.WebClient.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.WebHeaderCollection.dll
 @@ ------------ @@
- ./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/ru/Microsoft.CodeAnalysis.Workspaces.MSBuild.resources.dll
- ./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/ru/Microsoft.CodeAnalysis.Workspaces.resources.dll
- ./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/ru/System.CommandLine.resources.dll
--./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/runtimes/
--./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/runtimes/unix/
--./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/runtimes/unix/lib/
--./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/runtimes/unix/lib/netx.y/
--./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/runtimes/unix/lib/netx.y/System.Drawing.Common.dll
--./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/runtimes/win/
--./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/runtimes/win/lib/
--./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/runtimes/win/lib/netx.y/
--./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/runtimes/win/lib/netx.y/Microsoft.Win32.SystemEvents.dll
--./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/runtimes/win/lib/netx.y/System.Drawing.Common.dll
--./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/runtimes/win/lib/netx.y/System.Security.Cryptography.ProtectedData.dll
--./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/runtimes/win/lib/netx.y/System.Windows.Extensions.dll
- ./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.CommandLine.dll
- ./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Composition.AttributedModel.dll
- ./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Composition.Convention.dll
- ./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Composition.Hosting.dll
- ./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Composition.Runtime.dll
- ./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Composition.TypedParts.dll
--./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Configuration.ConfigurationManager.dll
--./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Drawing.Common.dll
--./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Security.Cryptography.ProtectedData.dll
--./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Security.Permissions.dll
--./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Windows.Extensions.dll
-+./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.IO.Pipelines.dll
- ./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/tr/
- ./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/tr/dotnet-watch.resources.dll
- ./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/tr/Microsoft.CodeAnalysis.CSharp.Features.resources.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.WebSockets.Client.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.WebSockets.Client.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.WebSockets.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Net.WebSockets.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Numerics.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Numerics.Vectors.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Numerics.Vectors.xml
 @@ ------------ @@
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Runtime.Serialization.Xml.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Runtime.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Security.AccessControl.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Security.AccessControl.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Security.Claims.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Security.Claims.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Security.Cryptography.Algorithms.dll
+@@ ------------ @@
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Security.Cryptography.Primitives.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Security.Cryptography.X509Certificates.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Security.Cryptography.X509Certificates.xml
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Security.Cryptography.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Security.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Security.Principal.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Security.Principal.Windows.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Security.Principal.Windows.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Security.Principal.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Security.SecureString.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Security.SecureString.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.ServiceModel.Web.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.ServiceProcess.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Text.Encoding.CodePages.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Text.Encoding.CodePages.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Text.Encoding.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Text.Encoding.Extensions.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Text.Encoding.Extensions.xml
+@@ ------------ @@
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Threading.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Transactions.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Transactions.Local.dll
++./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Transactions.Local.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.ValueTuple.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.ValueTuple.xml
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/System.Web.dll
+@@ ------------ @@
+ ./packs/NETStandard.Library.Ref/x.y.z/ref/netstandard2.1/System.Xml.XPath.XDocument.dll
+ ./sdk-manifests/
+ ./sdk-manifests/x.y.z/
+-./sdk-manifests/x.y.z/
+ ./sdk-manifests/x.y.z/microsoft.net.workload.emscripten.current/
+ ./sdk-manifests/x.y.z/microsoft.net.workload.emscripten.current/WorkloadManifest.json
+ ./sdk-manifests/x.y.z/microsoft.net.workload.emscripten.current/WorkloadManifest.targets
+@@ ------------ @@
+ ./sdk/x.y.z/cs/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
+ ./sdk/x.y.z/cs/Microsoft.TemplateEngine.Utils.resources.dll
+ ./sdk/x.y.z/cs/Microsoft.TemplateSearch.Common.resources.dll
++./sdk/x.y.z/cs/Microsoft.TestPlatform.Build.resources.dll
+ ./sdk/x.y.z/cs/MSBuild.resources.dll
+ ./sdk/x.y.z/cs/System.CommandLine.resources.dll
+ ./sdk/x.y.z/Current/
+@@ ------------ @@
+ ./sdk/x.y.z/de/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
+ ./sdk/x.y.z/de/Microsoft.TemplateEngine.Utils.resources.dll
+ ./sdk/x.y.z/de/Microsoft.TemplateSearch.Common.resources.dll
++./sdk/x.y.z/de/Microsoft.TestPlatform.Build.resources.dll
+ ./sdk/x.y.z/de/MSBuild.resources.dll
+ ./sdk/x.y.z/de/System.CommandLine.resources.dll
+ ./sdk/x.y.z/dotnet.deps.json
+@@ ------------ @@
+ ./sdk/x.y.z/es/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
+ ./sdk/x.y.z/es/Microsoft.TemplateEngine.Utils.resources.dll
+ ./sdk/x.y.z/es/Microsoft.TemplateSearch.Common.resources.dll
++./sdk/x.y.z/es/Microsoft.TestPlatform.Build.resources.dll
  ./sdk/x.y.z/es/MSBuild.resources.dll
  ./sdk/x.y.z/es/System.CommandLine.resources.dll
  ./sdk/x.y.z/Extensions/
 -./sdk/x.y.z/Extensions/cs/
 -./sdk/x.y.z/Extensions/de/
--./sdk/x.y.z/Extensions/dump/
--./sdk/x.y.z/Extensions/dump/DumpMinitool.arm64.exe
--./sdk/x.y.z/Extensions/dump/DumpMinitool.arm64.exe.config
--./sdk/x.y.z/Extensions/dump/DumpMinitool.exe
--./sdk/x.y.z/Extensions/dump/DumpMinitool.exe.config
--./sdk/x.y.z/Extensions/dump/DumpMinitool.x86.exe
--./sdk/x.y.z/Extensions/dump/DumpMinitool.x86.exe.config
 -./sdk/x.y.z/Extensions/es/
 -./sdk/x.y.z/Extensions/fr/
 -./sdk/x.y.z/Extensions/it/
 -./sdk/x.y.z/Extensions/ja/
 -./sdk/x.y.z/Extensions/ko/
--./sdk/x.y.z/Extensions/Microsoft.Diagnostics.NETCore.Client.dll
+ ./sdk/x.y.z/Extensions/Microsoft.Diagnostics.NETCore.Client.dll
  ./sdk/x.y.z/Extensions/Microsoft.TestPlatform.Extensions.BlameDataCollector.dll
  ./sdk/x.y.z/Extensions/Microsoft.TestPlatform.Extensions.EventLogCollector.dll
  ./sdk/x.y.z/Extensions/Microsoft.TestPlatform.TestHostRuntimeProvider.dll
@@ -186,36 +251,59 @@ index ------------
  ./sdk/x.y.z/fr/dotnet.resources.dll
  ./sdk/x.y.z/fr/Microsoft.Build.resources.dll
 @@ ------------ @@
- ./sdk/x.y.z/FSharp/ru/FSharp.Core.resources.dll
- ./sdk/x.y.z/FSharp/ru/FSharp.DependencyManager.Nuget.resources.dll
- ./sdk/x.y.z/FSharp/runtimes/
--./sdk/x.y.z/FSharp/runtimes/unix/
--./sdk/x.y.z/FSharp/runtimes/unix/lib/
--./sdk/x.y.z/FSharp/runtimes/unix/lib/netx.y/
--./sdk/x.y.z/FSharp/runtimes/unix/lib/netx.y/System.Drawing.Common.dll
+ ./sdk/x.y.z/fr/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
+ ./sdk/x.y.z/fr/Microsoft.TemplateEngine.Utils.resources.dll
+ ./sdk/x.y.z/fr/Microsoft.TemplateSearch.Common.resources.dll
++./sdk/x.y.z/fr/Microsoft.TestPlatform.Build.resources.dll
+ ./sdk/x.y.z/fr/MSBuild.resources.dll
+ ./sdk/x.y.z/fr/System.CommandLine.resources.dll
+ ./sdk/x.y.z/FSharp/
+@@ ------------ @@
+ ./sdk/x.y.z/FSharp/Microsoft.FSharp.Targets
+ ./sdk/x.y.z/FSharp/Microsoft.NET.StringTools.dll
+ ./sdk/x.y.z/FSharp/Microsoft.Portable.FSharp.Targets
+-./sdk/x.y.z/FSharp/Microsoft.VisualStudio.Setup.Configuration.Interop.dll
+ ./sdk/x.y.z/FSharp/Microsoft.Win32.SystemEvents.dll
+ ./sdk/x.y.z/FSharp/pl/
+ ./sdk/x.y.z/FSharp/pl/FSharp.Build.resources.dll
+@@ ------------ @@
  ./sdk/x.y.z/FSharp/runtimes/win/
  ./sdk/x.y.z/FSharp/runtimes/win/lib/
  ./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/
- ./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/Microsoft.Win32.SystemEvents.dll
+-./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/Microsoft.Win32.SystemEvents.dll
+ ./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/System.Diagnostics.EventLog.dll
+ ./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/System.Diagnostics.EventLog.Messages.dll
 -./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/System.Drawing.Common.dll
-+./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/System.Diagnostics.EventLog.dll
-+./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/System.Diagnostics.EventLog.Messages.dll
  ./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/System.Security.Cryptography.Pkcs.dll
 -./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/System.Security.Cryptography.ProtectedData.dll
  ./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/System.Windows.Extensions.dll
  ./sdk/x.y.z/FSharp/System.CodeDom.dll
  ./sdk/x.y.z/FSharp/System.Configuration.ConfigurationManager.dll
-+./sdk/x.y.z/FSharp/System.Diagnostics.EventLog.dll
- ./sdk/x.y.z/FSharp/System.Drawing.Common.dll
- ./sdk/x.y.z/FSharp/System.Resources.Extensions.dll
- ./sdk/x.y.z/FSharp/System.Security.Cryptography.Pkcs.dll
 @@ ------------ @@
+ ./sdk/x.y.z/it/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
+ ./sdk/x.y.z/it/Microsoft.TemplateEngine.Utils.resources.dll
+ ./sdk/x.y.z/it/Microsoft.TemplateSearch.Common.resources.dll
++./sdk/x.y.z/it/Microsoft.TestPlatform.Build.resources.dll
+ ./sdk/x.y.z/it/MSBuild.resources.dll
+ ./sdk/x.y.z/it/System.CommandLine.resources.dll
+ ./sdk/x.y.z/ja/
+@@ ------------ @@
+ ./sdk/x.y.z/ja/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
+ ./sdk/x.y.z/ja/Microsoft.TemplateEngine.Utils.resources.dll
+ ./sdk/x.y.z/ja/Microsoft.TemplateSearch.Common.resources.dll
++./sdk/x.y.z/ja/Microsoft.TestPlatform.Build.resources.dll
+ ./sdk/x.y.z/ja/MSBuild.resources.dll
+ ./sdk/x.y.z/ja/System.CommandLine.resources.dll
+ ./sdk/x.y.z/KnownWorkloadManifests.txt
+@@ ------------ @@
+ ./sdk/x.y.z/ko/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
+ ./sdk/x.y.z/ko/Microsoft.TemplateEngine.Utils.resources.dll
+ ./sdk/x.y.z/ko/Microsoft.TemplateSearch.Common.resources.dll
++./sdk/x.y.z/ko/Microsoft.TestPlatform.Build.resources.dll
+ ./sdk/x.y.z/ko/MSBuild.resources.dll
  ./sdk/x.y.z/ko/System.CommandLine.resources.dll
  ./sdk/x.y.z/Microsoft.ApplicationInsights.dll
- ./sdk/x.y.z/Microsoft.AspNetCore.DeveloperCertificates.XPlat.dll
-+./sdk/x.y.z/Microsoft.Bcl.AsyncInterfaces.dll
- ./sdk/x.y.z/Microsoft.Build.dll
- ./sdk/x.y.z/Microsoft.Build.Framework.dll
+@@ ------------ @@
  ./sdk/x.y.z/Microsoft.Build.NuGetSdkResolver.dll
  ./sdk/x.y.z/Microsoft.Build.Tasks.Core.dll
  ./sdk/x.y.z/Microsoft.Build.Utilities.Core.dll
@@ -224,35 +312,51 @@ index ------------
  ./sdk/x.y.z/Microsoft.Common.CurrentVersion.targets
  ./sdk/x.y.z/Microsoft.Common.overridetasks
 @@ ------------ @@
- ./sdk/x.y.z/Microsoft.TestPlatform.PlatformAbstractions.deps.json
- ./sdk/x.y.z/Microsoft.TestPlatform.PlatformAbstractions.dll
- ./sdk/x.y.z/Microsoft.TestPlatform.targets
-+./sdk/x.y.z/Microsoft.TestPlatform.TestHostRuntimeProvider.dll
- ./sdk/x.y.z/Microsoft.TestPlatform.Utilities.dll
- ./sdk/x.y.z/Microsoft.TestPlatform.VsTestConsole.TranslationLayer.dll
  ./sdk/x.y.z/Microsoft.VisualBasic.CrossTargeting.targets
  ./sdk/x.y.z/Microsoft.VisualBasic.CurrentVersion.targets
  ./sdk/x.y.z/Microsoft.VisualBasic.targets
 -./sdk/x.y.z/Microsoft.VisualStudio.Setup.Configuration.Interop.dll
  ./sdk/x.y.z/Microsoft.VisualStudio.TestPlatform.Client.dll
  ./sdk/x.y.z/Microsoft.VisualStudio.TestPlatform.Common.dll
-+./sdk/x.y.z/Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.dll
-+./sdk/x.y.z/Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.dll
- ./sdk/x.y.z/Microsoft.VisualStudio.TestPlatform.ObjectModel.deps.json
  ./sdk/x.y.z/Microsoft.VisualStudio.TestPlatform.ObjectModel.dll
- ./sdk/x.y.z/Microsoft.VisualStudioVersion.v11.Common.props
+@@ ------------ @@
+ ./sdk/x.y.z/pl/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
+ ./sdk/x.y.z/pl/Microsoft.TemplateEngine.Utils.resources.dll
+ ./sdk/x.y.z/pl/Microsoft.TemplateSearch.Common.resources.dll
++./sdk/x.y.z/pl/Microsoft.TestPlatform.Build.resources.dll
+ ./sdk/x.y.z/pl/MSBuild.resources.dll
+ ./sdk/x.y.z/pl/System.CommandLine.resources.dll
+ ./sdk/x.y.z/pt-BR/
+@@ ------------ @@
+ ./sdk/x.y.z/pt-BR/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
+ ./sdk/x.y.z/pt-BR/Microsoft.TemplateEngine.Utils.resources.dll
+ ./sdk/x.y.z/pt-BR/Microsoft.TemplateSearch.Common.resources.dll
++./sdk/x.y.z/pt-BR/Microsoft.TestPlatform.Build.resources.dll
+ ./sdk/x.y.z/pt-BR/MSBuild.resources.dll
+ ./sdk/x.y.z/pt-BR/System.CommandLine.resources.dll
+ ./sdk/x.y.z/ref/
 @@ ------------ @@
  ./sdk/x.y.z/Roslyn/bincore/ru/Microsoft.CodeAnalysis.CSharp.resources.dll
  ./sdk/x.y.z/Roslyn/bincore/ru/Microsoft.CodeAnalysis.resources.dll
  ./sdk/x.y.z/Roslyn/bincore/ru/Microsoft.CodeAnalysis.VisualBasic.resources.dll
-+./sdk/x.y.z/Roslyn/bincore/System.Collections.Immutable.dll
- ./sdk/x.y.z/Roslyn/bincore/System.Reflection.Metadata.dll
-+./sdk/x.y.z/Roslyn/bincore/System.Text.Encoding.CodePages.dll
+-./sdk/x.y.z/Roslyn/bincore/System.Collections.Immutable.dll
+-./sdk/x.y.z/Roslyn/bincore/System.Reflection.Metadata.dll
  ./sdk/x.y.z/Roslyn/bincore/tr/
  ./sdk/x.y.z/Roslyn/bincore/tr/Microsoft.CodeAnalysis.CSharp.resources.dll
  ./sdk/x.y.z/Roslyn/bincore/tr/Microsoft.CodeAnalysis.resources.dll
 @@ ------------ @@
- ./sdk/x.y.z/runtimes/win/lib/netx.y/Microsoft.Win32.SystemEvents.dll
+ ./sdk/x.y.z/ru/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
+ ./sdk/x.y.z/ru/Microsoft.TemplateEngine.Utils.resources.dll
+ ./sdk/x.y.z/ru/Microsoft.TemplateSearch.Common.resources.dll
++./sdk/x.y.z/ru/Microsoft.TestPlatform.Build.resources.dll
+ ./sdk/x.y.z/ru/MSBuild.resources.dll
+ ./sdk/x.y.z/ru/System.CommandLine.resources.dll
+ ./sdk/x.y.z/RuntimeIdentifierGraph.json
+@@ ------------ @@
+ ./sdk/x.y.z/runtimes/win/
+ ./sdk/x.y.z/runtimes/win/lib/
+ ./sdk/x.y.z/runtimes/win/lib/netx.y/
+-./sdk/x.y.z/runtimes/win/lib/netx.y/Microsoft.Win32.SystemEvents.dll
  ./sdk/x.y.z/runtimes/win/lib/netx.y/System.Diagnostics.EventLog.dll
  ./sdk/x.y.z/runtimes/win/lib/netx.y/System.Diagnostics.EventLog.Messages.dll
 -./sdk/x.y.z/runtimes/win/lib/netx.y/System.Drawing.Common.dll
@@ -260,95 +364,42 @@ index ------------
  ./sdk/x.y.z/runtimes/win/lib/netx.y/System.ServiceProcess.ServiceController.dll
  ./sdk/x.y.z/runtimes/win/lib/netx.y/System.Windows.Extensions.dll
 @@ ------------ @@
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.BlazorWebAssembly/tools/
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.BlazorWebAssembly/tools/net472/
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.BlazorWebAssembly/tools/net472/Microsoft.NET.Sdk.BlazorWebAssembly.Tasks.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.BlazorWebAssembly/tools/net472/Microsoft.NET.Sdk.BlazorWebAssembly.Tasks.dll.config
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.BlazorWebAssembly/tools/netx.y/
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.BlazorWebAssembly/tools/netx.y/Microsoft.NET.Sdk.BlazorWebAssembly.Tasks.dll
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.BlazorWebAssembly/tools/netx.y/Microsoft.NET.Sdk.BlazorWebAssembly.Tool.deps.json
-@@ ------------ @@
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/targets/TransformTargets/Transforms/EnvironmentNoLocation.transform
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/targets/TransformTargets/Transforms/EnvironmentWithLocation.transform
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/netx.y/
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/netx.y/cs/
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/netx.y/cs/Microsoft.NET.Sdk.Publish.Tasks.resources.dll
-@@ ------------ @@
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Razor/source-generators/
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Razor/source-generators/Microsoft.AspNetCore.Mvc.Razor.Extensions.dll
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Razor/source-generators/Microsoft.AspNetCore.Razor.Language.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Razor/source-generators/Microsoft.AspNetCore.Razor.LanguageSupport.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Razor/source-generators/Microsoft.AspNetCore.Razor.LanguageSupport.xml
-+./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Razor/source-generators/Microsoft.AspNetCore.Razor.Utilities.Shared.dll
-+./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Razor/source-generators/Microsoft.AspNetCore.Razor.Utilities.Shared.xml
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Razor/source-generators/Microsoft.CodeAnalysis.Razor.dll
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Razor/source-generators/Microsoft.NET.Sdk.Razor.SourceGenerators.deps.json
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Razor/source-generators/Microsoft.NET.Sdk.Razor.SourceGenerators.dll
-@@ ------------ @@
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Razor/tasks/net472/Microsoft.Bcl.AsyncInterfaces.dll
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Razor/tasks/net472/Microsoft.Extensions.FileSystemGlobbing.dll
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Razor/tasks/net472/Microsoft.NET.Sdk.Razor.Tasks.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Razor/tasks/net472/Microsoft.NET.Sdk.Razor.Tasks.dll.config
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Razor/tasks/net472/System.Buffers.dll
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Razor/tasks/net472/System.Collections.Immutable.dll
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Razor/tasks/net472/System.Memory.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Razor/tasks/net472/System.Numerics.Vectors.dll
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Razor/tasks/net472/System.Reflection.Metadata.dll
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Razor/tasks/net472/System.Runtime.CompilerServices.Unsafe.dll
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Razor/tasks/net472/System.Text.Encodings.Web.dll
-@@ ------------ @@
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Web/tools/net472/Microsoft.NET.Sdk.Web.Tasks.dll
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Web/tools/netx.y/
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Web/tools/netx.y/Microsoft.NET.Sdk.Web.Tasks.dll
+ ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WebAssembly/tools/
+ ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WebAssembly/tools/netx.y/
+ ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WebAssembly/tools/netx.y/Microsoft.NET.Sdk.WebAssembly.Tasks.dll
 -./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/
  ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Worker/
  ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Worker/Sdk/
  ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Worker/Sdk/Sdk.props
 @@ ------------ @@
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk/tools/net472/System.Buffers.dll
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk/tools/net472/System.Collections.Immutable.dll
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk/tools/net472/System.Memory.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk/tools/net472/System.Numerics.Vectors.dll
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk/tools/net472/System.Reflection.Metadata.dll
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk/tools/net472/System.Runtime.CompilerServices.Unsafe.dll
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk/tools/net472/System.Text.Encodings.Web.dll
-@@ ------------ @@
- ./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/
- ./sdk/x.y.z/System.CodeDom.dll
- ./sdk/x.y.z/System.CommandLine.dll
--./sdk/x.y.z/System.ComponentModel.Composition.dll
- ./sdk/x.y.z/System.Configuration.ConfigurationManager.dll
- ./sdk/x.y.z/System.Diagnostics.EventLog.dll
- ./sdk/x.y.z/System.Drawing.Common.dll
-@@ ------------ @@
- ./sdk/x.y.z/System.Security.Cryptography.Xml.dll
- ./sdk/x.y.z/System.Security.Permissions.dll
- ./sdk/x.y.z/System.ServiceProcess.ServiceController.dll
-+./sdk/x.y.z/System.Text.Encodings.Web.dll
- ./sdk/x.y.z/System.Windows.Extensions.dll
--./sdk/x.y.z/testhost-1.0.runtimeconfig.json
--./sdk/x.y.z/testhost-1.1.runtimeconfig.json
--./sdk/x.y.z/testhost-2.0.runtimeconfig.json
--./sdk/x.y.z/testhost-2.1.runtimeconfig.json
--./sdk/x.y.z/testhost-3.0.runtimeconfig.json
--./sdk/x.y.z/testhost-3.1.runtimeconfig.json
--./sdk/x.y.z/testhost-5.0.runtimeconfig.json
--./sdk/x.y.z/testhost-6.0.runtimeconfig.json
--./sdk/x.y.z/testhost-7.0.runtimeconfig.json
--./sdk/x.y.z/testhost-latest.runtimeconfig.json
+ ./sdk/x.y.z/testhost-latest.runtimeconfig.json
  ./sdk/x.y.z/testhost.deps.json
  ./sdk/x.y.z/testhost.dll
 -./sdk/x.y.z/TestHostNetFramework/
-+./sdk/x.y.z/testhost.dll.config
-+./sdk/x.y.z/testhost.runtimeconfig.json
-+./sdk/x.y.z/testhost.x86
-+./sdk/x.y.z/testhost.x86.deps.json
-+./sdk/x.y.z/testhost.x86.dll
-+./sdk/x.y.z/testhost.x86.dll.config
-+./sdk/x.y.z/testhost.x86.runtimeconfig.json
-+./sdk/x.y.z/TestHost/
  ./sdk/x.y.z/tr/
  ./sdk/x.y.z/tr/dotnet.resources.dll
  ./sdk/x.y.z/tr/Microsoft.Build.resources.dll
+@@ ------------ @@
+ ./sdk/x.y.z/tr/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
+ ./sdk/x.y.z/tr/Microsoft.TemplateEngine.Utils.resources.dll
+ ./sdk/x.y.z/tr/Microsoft.TemplateSearch.Common.resources.dll
++./sdk/x.y.z/tr/Microsoft.TestPlatform.Build.resources.dll
+ ./sdk/x.y.z/tr/MSBuild.resources.dll
+ ./sdk/x.y.z/tr/System.CommandLine.resources.dll
+ ./sdk/x.y.z/trustedroots/
+@@ ------------ @@
+ ./sdk/x.y.z/zh-Hans/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
+ ./sdk/x.y.z/zh-Hans/Microsoft.TemplateEngine.Utils.resources.dll
+ ./sdk/x.y.z/zh-Hans/Microsoft.TemplateSearch.Common.resources.dll
++./sdk/x.y.z/zh-Hans/Microsoft.TestPlatform.Build.resources.dll
+ ./sdk/x.y.z/zh-Hans/MSBuild.resources.dll
+ ./sdk/x.y.z/zh-Hans/System.CommandLine.resources.dll
+ ./sdk/x.y.z/zh-Hant/
+@@ ------------ @@
+ ./sdk/x.y.z/zh-Hant/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
+ ./sdk/x.y.z/zh-Hant/Microsoft.TemplateEngine.Utils.resources.dll
+ ./sdk/x.y.z/zh-Hant/Microsoft.TemplateSearch.Common.resources.dll
++./sdk/x.y.z/zh-Hant/Microsoft.TestPlatform.Build.resources.dll
+ ./sdk/x.y.z/zh-Hant/MSBuild.resources.dll
+ ./sdk/x.y.z/zh-Hant/System.CommandLine.resources.dll
+ ./shared/

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdk.diff
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdk.diff
@@ -205,6 +205,233 @@ index ------------
  ./sdk-manifests/x.y.z/microsoft.net.workload.emscripten.current/WorkloadManifest.json
  ./sdk-manifests/x.y.z/microsoft.net.workload.emscripten.current/WorkloadManifest.targets
 @@ ------------ @@
+ ./sdk/x.y.z/.version
+ ./sdk/x.y.z/AppHostTemplate/
+ ./sdk/x.y.z/AppHostTemplate/apphost
+-./sdk/x.y.z/containerize.deps.json
+-./sdk/x.y.z/containerize.exe
+-./sdk/x.y.z/containerize.runtimeconfig.json
+ ./sdk/x.y.z/Containers/
+ ./sdk/x.y.z/Containers/build/
+ ./sdk/x.y.z/Containers/build/Microsoft.NET.Build.Containers.props
+ ./sdk/x.y.z/Containers/build/Microsoft.NET.Build.Containers.targets
+-./sdk/x.y.z/Containers/containerize/
+-./sdk/x.y.z/Containers/containerize/containerize.deps.json
+-./sdk/x.y.z/Containers/containerize/containerize.dll
+-./sdk/x.y.z/Containers/containerize/containerize.exe
+-./sdk/x.y.z/Containers/containerize/containerize.runtimeconfig.json
+-./sdk/x.y.z/Containers/containerize/cs/
+-./sdk/x.y.z/Containers/containerize/cs/Microsoft.DotNet.Cli.Utils.resources.dll
+-./sdk/x.y.z/Containers/containerize/cs/Microsoft.NET.Build.Containers.resources.dll
+-./sdk/x.y.z/Containers/containerize/cs/System.CommandLine.resources.dll
+-./sdk/x.y.z/Containers/containerize/de/
+-./sdk/x.y.z/Containers/containerize/de/Microsoft.DotNet.Cli.Utils.resources.dll
+-./sdk/x.y.z/Containers/containerize/de/Microsoft.NET.Build.Containers.resources.dll
+-./sdk/x.y.z/Containers/containerize/de/System.CommandLine.resources.dll
+-./sdk/x.y.z/Containers/containerize/es/
+-./sdk/x.y.z/Containers/containerize/es/Microsoft.DotNet.Cli.Utils.resources.dll
+-./sdk/x.y.z/Containers/containerize/es/Microsoft.NET.Build.Containers.resources.dll
+-./sdk/x.y.z/Containers/containerize/es/System.CommandLine.resources.dll
+-./sdk/x.y.z/Containers/containerize/fr/
+-./sdk/x.y.z/Containers/containerize/fr/Microsoft.DotNet.Cli.Utils.resources.dll
+-./sdk/x.y.z/Containers/containerize/fr/Microsoft.NET.Build.Containers.resources.dll
+-./sdk/x.y.z/Containers/containerize/fr/System.CommandLine.resources.dll
+-./sdk/x.y.z/Containers/containerize/it/
+-./sdk/x.y.z/Containers/containerize/it/Microsoft.DotNet.Cli.Utils.resources.dll
+-./sdk/x.y.z/Containers/containerize/it/Microsoft.NET.Build.Containers.resources.dll
+-./sdk/x.y.z/Containers/containerize/it/System.CommandLine.resources.dll
+-./sdk/x.y.z/Containers/containerize/ja/
+-./sdk/x.y.z/Containers/containerize/ja/Microsoft.DotNet.Cli.Utils.resources.dll
+-./sdk/x.y.z/Containers/containerize/ja/Microsoft.NET.Build.Containers.resources.dll
+-./sdk/x.y.z/Containers/containerize/ja/System.CommandLine.resources.dll
+-./sdk/x.y.z/Containers/containerize/ko/
+-./sdk/x.y.z/Containers/containerize/ko/Microsoft.DotNet.Cli.Utils.resources.dll
+-./sdk/x.y.z/Containers/containerize/ko/Microsoft.NET.Build.Containers.resources.dll
+-./sdk/x.y.z/Containers/containerize/ko/System.CommandLine.resources.dll
+-./sdk/x.y.z/Containers/containerize/Microsoft.Build.dll
+-./sdk/x.y.z/Containers/containerize/Microsoft.Build.Framework.dll
+-./sdk/x.y.z/Containers/containerize/Microsoft.DotNet.Cli.Utils.dll
+-./sdk/x.y.z/Containers/containerize/Microsoft.Extensions.DependencyModel.dll
+-./sdk/x.y.z/Containers/containerize/Microsoft.NET.Build.Containers.dll
+-./sdk/x.y.z/Containers/containerize/Microsoft.NET.StringTools.dll
+-./sdk/x.y.z/Containers/containerize/Microsoft.Win32.SystemEvents.dll
+-./sdk/x.y.z/Containers/containerize/MSBuild.dll
+-./sdk/x.y.z/Containers/containerize/Newtonsoft.Json.dll
+-./sdk/x.y.z/Containers/containerize/NuGet.Common.dll
+-./sdk/x.y.z/Containers/containerize/NuGet.Configuration.dll
+-./sdk/x.y.z/Containers/containerize/NuGet.DependencyResolver.Core.dll
+-./sdk/x.y.z/Containers/containerize/NuGet.Frameworks.dll
+-./sdk/x.y.z/Containers/containerize/NuGet.LibraryModel.dll
+-./sdk/x.y.z/Containers/containerize/NuGet.Packaging.Core.dll
+-./sdk/x.y.z/Containers/containerize/NuGet.Packaging.dll
+-./sdk/x.y.z/Containers/containerize/NuGet.ProjectModel.dll
+-./sdk/x.y.z/Containers/containerize/NuGet.Protocol.dll
+-./sdk/x.y.z/Containers/containerize/NuGet.Versioning.dll
+-./sdk/x.y.z/Containers/containerize/pl/
+-./sdk/x.y.z/Containers/containerize/pl/Microsoft.DotNet.Cli.Utils.resources.dll
+-./sdk/x.y.z/Containers/containerize/pl/Microsoft.NET.Build.Containers.resources.dll
+-./sdk/x.y.z/Containers/containerize/pl/System.CommandLine.resources.dll
+-./sdk/x.y.z/Containers/containerize/pt-BR/
+-./sdk/x.y.z/Containers/containerize/pt-BR/Microsoft.DotNet.Cli.Utils.resources.dll
+-./sdk/x.y.z/Containers/containerize/pt-BR/Microsoft.NET.Build.Containers.resources.dll
+-./sdk/x.y.z/Containers/containerize/pt-BR/System.CommandLine.resources.dll
+-./sdk/x.y.z/Containers/containerize/ru/
+-./sdk/x.y.z/Containers/containerize/ru/Microsoft.DotNet.Cli.Utils.resources.dll
+-./sdk/x.y.z/Containers/containerize/ru/Microsoft.NET.Build.Containers.resources.dll
+-./sdk/x.y.z/Containers/containerize/ru/System.CommandLine.resources.dll
+-./sdk/x.y.z/Containers/containerize/runtimes/
+-./sdk/x.y.z/Containers/containerize/runtimes/win/
+-./sdk/x.y.z/Containers/containerize/runtimes/win/lib/
+-./sdk/x.y.z/Containers/containerize/runtimes/win/lib/netx.y/
+-./sdk/x.y.z/Containers/containerize/runtimes/win/lib/netx.y/Microsoft.Win32.SystemEvents.dll
+-./sdk/x.y.z/Containers/containerize/runtimes/win/lib/netx.y/System.Diagnostics.EventLog.dll
+-./sdk/x.y.z/Containers/containerize/runtimes/win/lib/netx.y/System.Diagnostics.EventLog.Messages.dll
+-./sdk/x.y.z/Containers/containerize/runtimes/win/lib/netx.y/System.Drawing.Common.dll
+-./sdk/x.y.z/Containers/containerize/runtimes/win/lib/netx.y/System.Security.Cryptography.Pkcs.dll
+-./sdk/x.y.z/Containers/containerize/runtimes/win/lib/netx.y/System.Security.Cryptography.ProtectedData.dll
+-./sdk/x.y.z/Containers/containerize/runtimes/win/lib/netx.y/System.Windows.Extensions.dll
+-./sdk/x.y.z/Containers/containerize/System.CommandLine.dll
+-./sdk/x.y.z/Containers/containerize/System.Configuration.ConfigurationManager.dll
+-./sdk/x.y.z/Containers/containerize/System.Diagnostics.EventLog.dll
+-./sdk/x.y.z/Containers/containerize/System.Drawing.Common.dll
+-./sdk/x.y.z/Containers/containerize/System.Reflection.MetadataLoadContext.dll
+-./sdk/x.y.z/Containers/containerize/System.Security.Cryptography.Pkcs.dll
+-./sdk/x.y.z/Containers/containerize/System.Security.Cryptography.ProtectedData.dll
+-./sdk/x.y.z/Containers/containerize/System.Security.Permissions.dll
+-./sdk/x.y.z/Containers/containerize/System.Windows.Extensions.dll
+-./sdk/x.y.z/Containers/containerize/tr/
+-./sdk/x.y.z/Containers/containerize/tr/Microsoft.DotNet.Cli.Utils.resources.dll
+-./sdk/x.y.z/Containers/containerize/tr/Microsoft.NET.Build.Containers.resources.dll
+-./sdk/x.y.z/Containers/containerize/tr/System.CommandLine.resources.dll
+-./sdk/x.y.z/Containers/containerize/Valleysoft.DockerCredsProvider.dll
+-./sdk/x.y.z/Containers/containerize/zh-Hans/
+-./sdk/x.y.z/Containers/containerize/zh-Hans/Microsoft.DotNet.Cli.Utils.resources.dll
+-./sdk/x.y.z/Containers/containerize/zh-Hans/Microsoft.NET.Build.Containers.resources.dll
+-./sdk/x.y.z/Containers/containerize/zh-Hans/System.CommandLine.resources.dll
+-./sdk/x.y.z/Containers/containerize/zh-Hant/
+-./sdk/x.y.z/Containers/containerize/zh-Hant/Microsoft.DotNet.Cli.Utils.resources.dll
+-./sdk/x.y.z/Containers/containerize/zh-Hant/Microsoft.NET.Build.Containers.resources.dll
+-./sdk/x.y.z/Containers/containerize/zh-Hant/System.CommandLine.resources.dll
+ ./sdk/x.y.z/Containers/tasks/
+-./sdk/x.y.z/Containers/tasks/net472/
+-./sdk/x.y.z/Containers/tasks/net472/cs/
+-./sdk/x.y.z/Containers/tasks/net472/cs/Microsoft.DotNet.Cli.Utils.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/cs/Microsoft.NET.Build.Containers.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/cs/System.CommandLine.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/de/
+-./sdk/x.y.z/Containers/tasks/net472/de/Microsoft.DotNet.Cli.Utils.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/de/Microsoft.NET.Build.Containers.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/de/System.CommandLine.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/es/
+-./sdk/x.y.z/Containers/tasks/net472/es/Microsoft.DotNet.Cli.Utils.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/es/Microsoft.NET.Build.Containers.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/es/System.CommandLine.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/fr/
+-./sdk/x.y.z/Containers/tasks/net472/fr/Microsoft.DotNet.Cli.Utils.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/fr/Microsoft.NET.Build.Containers.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/fr/System.CommandLine.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/it/
+-./sdk/x.y.z/Containers/tasks/net472/it/Microsoft.DotNet.Cli.Utils.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/it/Microsoft.NET.Build.Containers.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/it/System.CommandLine.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/ja/
+-./sdk/x.y.z/Containers/tasks/net472/ja/Microsoft.DotNet.Cli.Utils.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/ja/Microsoft.NET.Build.Containers.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/ja/System.CommandLine.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/ko/
+-./sdk/x.y.z/Containers/tasks/net472/ko/Microsoft.DotNet.Cli.Utils.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/ko/Microsoft.NET.Build.Containers.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/ko/System.CommandLine.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/Microsoft.Bcl.AsyncInterfaces.dll
+-./sdk/x.y.z/Containers/tasks/net472/Microsoft.Build.dll
+-./sdk/x.y.z/Containers/tasks/net472/Microsoft.Build.Framework.dll
+-./sdk/x.y.z/Containers/tasks/net472/Microsoft.DotNet.Cli.Utils.dll
+-./sdk/x.y.z/Containers/tasks/net472/Microsoft.DotNet.Cli.Utils.dll.config
+-./sdk/x.y.z/Containers/tasks/net472/Microsoft.Extensions.DependencyModel.dll
+-./sdk/x.y.z/Containers/tasks/net472/Microsoft.IO.Redist.dll
+-./sdk/x.y.z/Containers/tasks/net472/Microsoft.NET.Build.Containers.deps.json
+-./sdk/x.y.z/Containers/tasks/net472/Microsoft.NET.Build.Containers.dll
+-./sdk/x.y.z/Containers/tasks/net472/Microsoft.NET.Build.Containers.dll.config
+-./sdk/x.y.z/Containers/tasks/net472/Microsoft.NET.StringTools.dll
+-./sdk/x.y.z/Containers/tasks/net472/Microsoft.VisualStudio.Setup.Configuration.Interop.dll
+-./sdk/x.y.z/Containers/tasks/net472/Newtonsoft.Json.dll
+-./sdk/x.y.z/Containers/tasks/net472/NuGet.Common.dll
+-./sdk/x.y.z/Containers/tasks/net472/NuGet.Configuration.dll
+-./sdk/x.y.z/Containers/tasks/net472/NuGet.DependencyResolver.Core.dll
+-./sdk/x.y.z/Containers/tasks/net472/NuGet.Frameworks.dll
+-./sdk/x.y.z/Containers/tasks/net472/NuGet.LibraryModel.dll
+-./sdk/x.y.z/Containers/tasks/net472/NuGet.Packaging.Core.dll
+-./sdk/x.y.z/Containers/tasks/net472/NuGet.Packaging.dll
+-./sdk/x.y.z/Containers/tasks/net472/NuGet.ProjectModel.dll
+-./sdk/x.y.z/Containers/tasks/net472/NuGet.Protocol.dll
+-./sdk/x.y.z/Containers/tasks/net472/NuGet.Versioning.dll
+-./sdk/x.y.z/Containers/tasks/net472/pl/
+-./sdk/x.y.z/Containers/tasks/net472/pl/Microsoft.DotNet.Cli.Utils.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/pl/Microsoft.NET.Build.Containers.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/pl/System.CommandLine.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/pt-BR/
+-./sdk/x.y.z/Containers/tasks/net472/pt-BR/Microsoft.DotNet.Cli.Utils.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/pt-BR/Microsoft.NET.Build.Containers.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/pt-BR/System.CommandLine.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/ru/
+-./sdk/x.y.z/Containers/tasks/net472/ru/Microsoft.DotNet.Cli.Utils.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/ru/Microsoft.NET.Build.Containers.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/ru/System.CommandLine.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/System.Buffers.dll
+-./sdk/x.y.z/Containers/tasks/net472/System.Collections.Immutable.dll
+-./sdk/x.y.z/Containers/tasks/net472/System.CommandLine.dll
+-./sdk/x.y.z/Containers/tasks/net472/System.Configuration.ConfigurationManager.dll
+-./sdk/x.y.z/Containers/tasks/net472/System.Memory.dll
+-./sdk/x.y.z/Containers/tasks/net472/System.Numerics.Vectors.dll
+-./sdk/x.y.z/Containers/tasks/net472/System.Reflection.Metadata.dll
+-./sdk/x.y.z/Containers/tasks/net472/System.Reflection.MetadataLoadContext.dll
+-./sdk/x.y.z/Containers/tasks/net472/System.Runtime.CompilerServices.Unsafe.dll
+-./sdk/x.y.z/Containers/tasks/net472/System.Security.AccessControl.dll
+-./sdk/x.y.z/Containers/tasks/net472/System.Security.Permissions.dll
+-./sdk/x.y.z/Containers/tasks/net472/System.Security.Principal.Windows.dll
+-./sdk/x.y.z/Containers/tasks/net472/System.Text.Encodings.Web.dll
+-./sdk/x.y.z/Containers/tasks/net472/System.Text.Json.dll
+-./sdk/x.y.z/Containers/tasks/net472/System.Threading.Tasks.Dataflow.dll
+-./sdk/x.y.z/Containers/tasks/net472/System.Threading.Tasks.Extensions.dll
+-./sdk/x.y.z/Containers/tasks/net472/System.ValueTuple.dll
+-./sdk/x.y.z/Containers/tasks/net472/tr/
+-./sdk/x.y.z/Containers/tasks/net472/tr/Microsoft.DotNet.Cli.Utils.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/tr/Microsoft.NET.Build.Containers.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/tr/System.CommandLine.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/Valleysoft.DockerCredsProvider.dll
+-./sdk/x.y.z/Containers/tasks/net472/zh-Hans/
+-./sdk/x.y.z/Containers/tasks/net472/zh-Hans/Microsoft.DotNet.Cli.Utils.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/zh-Hans/Microsoft.NET.Build.Containers.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/zh-Hans/System.CommandLine.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/zh-Hant/
+-./sdk/x.y.z/Containers/tasks/net472/zh-Hant/Microsoft.DotNet.Cli.Utils.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/zh-Hant/Microsoft.NET.Build.Containers.resources.dll
+-./sdk/x.y.z/Containers/tasks/net472/zh-Hant/System.CommandLine.resources.dll
+ ./sdk/x.y.z/Containers/tasks/netx.y/
+ ./sdk/x.y.z/Containers/tasks/netx.y/cs/
+ ./sdk/x.y.z/Containers/tasks/netx.y/cs/Microsoft.DotNet.Cli.Utils.resources.dll
+@@ ------------ @@
+ ./sdk/x.y.z/Containers/tasks/netx.y/Microsoft.NET.Build.Containers.deps.json
+ ./sdk/x.y.z/Containers/tasks/netx.y/Microsoft.NET.Build.Containers.dll
+ ./sdk/x.y.z/Containers/tasks/netx.y/Microsoft.NET.StringTools.dll
+-./sdk/x.y.z/Containers/tasks/netx.y/Microsoft.VisualStudio.Setup.Configuration.Interop.dll
+ ./sdk/x.y.z/Containers/tasks/netx.y/Microsoft.Win32.SystemEvents.dll
+ ./sdk/x.y.z/Containers/tasks/netx.y/MSBuild.dll
+ ./sdk/x.y.z/Containers/tasks/netx.y/Newtonsoft.Json.dll
+@@ ------------ @@
+ ./sdk/x.y.z/Containers/tasks/netx.y/runtimes/win/
+ ./sdk/x.y.z/Containers/tasks/netx.y/runtimes/win/lib/
+ ./sdk/x.y.z/Containers/tasks/netx.y/runtimes/win/lib/netx.y/
+-./sdk/x.y.z/Containers/tasks/netx.y/runtimes/win/lib/netx.y/Microsoft.Win32.SystemEvents.dll
+ ./sdk/x.y.z/Containers/tasks/netx.y/runtimes/win/lib/netx.y/System.Diagnostics.EventLog.dll
+ ./sdk/x.y.z/Containers/tasks/netx.y/runtimes/win/lib/netx.y/System.Diagnostics.EventLog.Messages.dll
+-./sdk/x.y.z/Containers/tasks/netx.y/runtimes/win/lib/netx.y/System.Drawing.Common.dll
+ ./sdk/x.y.z/Containers/tasks/netx.y/runtimes/win/lib/netx.y/System.Security.Cryptography.Pkcs.dll
+-./sdk/x.y.z/Containers/tasks/netx.y/runtimes/win/lib/netx.y/System.Security.Cryptography.ProtectedData.dll
+ ./sdk/x.y.z/Containers/tasks/netx.y/runtimes/win/lib/netx.y/System.Windows.Extensions.dll
+ ./sdk/x.y.z/Containers/tasks/netx.y/System.CommandLine.dll
+ ./sdk/x.y.z/Containers/tasks/netx.y/System.Configuration.ConfigurationManager.dll
+@@ ------------ @@
  ./sdk/x.y.z/cs/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
  ./sdk/x.y.z/cs/Microsoft.TemplateEngine.Utils.resources.dll
  ./sdk/x.y.z/cs/Microsoft.TemplateSearch.Common.resources.dll


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/2573, https://github.com/dotnet/source-build/issues/3508, https://github.com/dotnet/source-build/issues/3507, https://github.com/dotnet/source-build/issues/3285, https://github.com/dotnet/source-build/issues/3509, https://github.com/dotnet/source-build/issues/3514, https://github.com/dotnet/source-build/issues/3289

These issues capture known and expected differences in Microsoft and source-build built SDKs. To simplify SDK diff, appropriate entries are being added to the SDK exclusion file.

I'm updating SDK baseline diff, to ensure we get clean smoke-tests, and enable us to detect future diff changes.

More SDK diff issues will be investigated and resolved in the coming days/weeks.