### PR TITLE
SDK diff - fix for vstest and fsharp

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkDiffExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkDiffExclusions.txt
@@ -33,16 +33,11 @@ msft,./sdk/x.y.z/Sdks/Microsoft.SourceLink.GitLab/tools/net472/*
 
 # vstest localization is disabled in Linux builds - https://github.com/dotnet/source-build/issues/3517
 msft,./sdk/x.y.z/*?/Microsoft.CodeCoverage.IO.resources.dll
-msft,./sdk/x.y.z/*?/Microsoft.TestPlatform.*?.resources.dll
-msft,./sdk/x.y.z/*?/Microsoft.VisualStudio.TestPlatform.*?.resources.dll
-msft,./sdk/x.y.z/*?/Test.Utility.resources.dll
-msft,./sdk/x.y.z/*?/vstest.console.resources.dll
-msft,./sdk/x.y.z/Extensions/*?/Microsoft.TestPlatform.*?.resources.dll
-msft,./sdk/x.y.z/Extensions/*?/Microsoft.VisualStudio.TestPlatform.*?.resources.dll
 
 # nuget localization is not available for Linux builds - https://github.com/NuGet/Home/issues/12440
 msft,./sdk/x.y.z/*?/NuGet.*?.resources.dll
 msft,./sdk/x.y.z/*?/Microsoft.Build.NuGetSdkResolver.resources.dll
+msft,./sdk/x.y.z/*?/Test.Utility.resources.dll
 
 # ILMerge is not supported in Linux builds - excluding the whole NuGet.Build.Tasks.Pack directory, to avoid a noisy diff
 msft,./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/*?
@@ -82,3 +77,10 @@ msft,./sdk/x.y.z/DotnetTools/dotnet-format/System.Drawing.Common.dll
 msft,./sdk/x.y.z/DotnetTools/dotnet-format/System.Security.Cryptography.ProtectedData.dll
 msft,./sdk/x.y.z/DotnetTools/dotnet-format/System.Security.Permissions.dll
 msft,./sdk/x.y.z/DotnetTools/dotnet-format/System.Windows.Extensions.dll
+
+# netfx runtimes for fsharp - https://github.com/dotnet/source-build/issues/3290
+msft,./sdk/x.y.z/FSharp/Microsoft.VisualStudio.Setup.Configuration.Interop.dll
+msft,./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/Microsoft.Win32.SystemEvents.dll
+msft,./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/System.Drawing.Common.dll
+msft,./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/System.Security.Cryptography.ProtectedData.dll
+msft,./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/System.Windows.Extensions.dll

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdk.diff
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdk.diff
@@ -428,108 +428,10 @@ index ------------
 -./sdk/x.y.z/Containers/tasks/netx.y/runtimes/win/lib/netx.y/System.Drawing.Common.dll
  ./sdk/x.y.z/Containers/tasks/netx.y/runtimes/win/lib/netx.y/System.Security.Cryptography.Pkcs.dll
 -./sdk/x.y.z/Containers/tasks/netx.y/runtimes/win/lib/netx.y/System.Security.Cryptography.ProtectedData.dll
- ./sdk/x.y.z/Containers/tasks/netx.y/runtimes/win/lib/netx.y/System.Windows.Extensions.dll
+-./sdk/x.y.z/Containers/tasks/netx.y/runtimes/win/lib/netx.y/System.Windows.Extensions.dll
  ./sdk/x.y.z/Containers/tasks/netx.y/System.CommandLine.dll
  ./sdk/x.y.z/Containers/tasks/netx.y/System.Configuration.ConfigurationManager.dll
-@@ ------------ @@
- ./sdk/x.y.z/cs/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
- ./sdk/x.y.z/cs/Microsoft.TemplateEngine.Utils.resources.dll
- ./sdk/x.y.z/cs/Microsoft.TemplateSearch.Common.resources.dll
-+./sdk/x.y.z/cs/Microsoft.TestPlatform.Build.resources.dll
- ./sdk/x.y.z/cs/MSBuild.resources.dll
- ./sdk/x.y.z/cs/System.CommandLine.resources.dll
- ./sdk/x.y.z/Current/
-@@ ------------ @@
- ./sdk/x.y.z/de/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
- ./sdk/x.y.z/de/Microsoft.TemplateEngine.Utils.resources.dll
- ./sdk/x.y.z/de/Microsoft.TemplateSearch.Common.resources.dll
-+./sdk/x.y.z/de/Microsoft.TestPlatform.Build.resources.dll
- ./sdk/x.y.z/de/MSBuild.resources.dll
- ./sdk/x.y.z/de/System.CommandLine.resources.dll
- ./sdk/x.y.z/dotnet.deps.json
-@@ ------------ @@
- ./sdk/x.y.z/es/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
- ./sdk/x.y.z/es/Microsoft.TemplateEngine.Utils.resources.dll
- ./sdk/x.y.z/es/Microsoft.TemplateSearch.Common.resources.dll
-+./sdk/x.y.z/es/Microsoft.TestPlatform.Build.resources.dll
- ./sdk/x.y.z/es/MSBuild.resources.dll
- ./sdk/x.y.z/es/System.CommandLine.resources.dll
- ./sdk/x.y.z/Extensions/
--./sdk/x.y.z/Extensions/cs/
--./sdk/x.y.z/Extensions/de/
--./sdk/x.y.z/Extensions/es/
--./sdk/x.y.z/Extensions/fr/
--./sdk/x.y.z/Extensions/it/
--./sdk/x.y.z/Extensions/ja/
--./sdk/x.y.z/Extensions/ko/
- ./sdk/x.y.z/Extensions/Microsoft.Diagnostics.NETCore.Client.dll
- ./sdk/x.y.z/Extensions/Microsoft.TestPlatform.Extensions.BlameDataCollector.dll
- ./sdk/x.y.z/Extensions/Microsoft.TestPlatform.Extensions.EventLogCollector.dll
- ./sdk/x.y.z/Extensions/Microsoft.TestPlatform.TestHostRuntimeProvider.dll
- ./sdk/x.y.z/Extensions/Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.dll
- ./sdk/x.y.z/Extensions/Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.dll
--./sdk/x.y.z/Extensions/pl/
--./sdk/x.y.z/Extensions/pt-BR/
--./sdk/x.y.z/Extensions/ru/
--./sdk/x.y.z/Extensions/tr/
--./sdk/x.y.z/Extensions/zh-Hans/
--./sdk/x.y.z/Extensions/zh-Hant/
- ./sdk/x.y.z/fr/
- ./sdk/x.y.z/fr/dotnet.resources.dll
- ./sdk/x.y.z/fr/Microsoft.Build.resources.dll
-@@ ------------ @@
- ./sdk/x.y.z/fr/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
- ./sdk/x.y.z/fr/Microsoft.TemplateEngine.Utils.resources.dll
- ./sdk/x.y.z/fr/Microsoft.TemplateSearch.Common.resources.dll
-+./sdk/x.y.z/fr/Microsoft.TestPlatform.Build.resources.dll
- ./sdk/x.y.z/fr/MSBuild.resources.dll
- ./sdk/x.y.z/fr/System.CommandLine.resources.dll
- ./sdk/x.y.z/FSharp/
-@@ ------------ @@
- ./sdk/x.y.z/FSharp/Microsoft.FSharp.Targets
- ./sdk/x.y.z/FSharp/Microsoft.NET.StringTools.dll
- ./sdk/x.y.z/FSharp/Microsoft.Portable.FSharp.Targets
--./sdk/x.y.z/FSharp/Microsoft.VisualStudio.Setup.Configuration.Interop.dll
- ./sdk/x.y.z/FSharp/Microsoft.Win32.SystemEvents.dll
- ./sdk/x.y.z/FSharp/pl/
- ./sdk/x.y.z/FSharp/pl/FSharp.Build.resources.dll
-@@ ------------ @@
- ./sdk/x.y.z/FSharp/runtimes/win/
- ./sdk/x.y.z/FSharp/runtimes/win/lib/
- ./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/
--./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/Microsoft.Win32.SystemEvents.dll
- ./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/System.Diagnostics.EventLog.dll
- ./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/System.Diagnostics.EventLog.Messages.dll
--./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/System.Drawing.Common.dll
- ./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/System.Security.Cryptography.Pkcs.dll
--./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/System.Security.Cryptography.ProtectedData.dll
- ./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/System.Windows.Extensions.dll
- ./sdk/x.y.z/FSharp/System.CodeDom.dll
- ./sdk/x.y.z/FSharp/System.Configuration.ConfigurationManager.dll
-@@ ------------ @@
- ./sdk/x.y.z/it/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
- ./sdk/x.y.z/it/Microsoft.TemplateEngine.Utils.resources.dll
- ./sdk/x.y.z/it/Microsoft.TemplateSearch.Common.resources.dll
-+./sdk/x.y.z/it/Microsoft.TestPlatform.Build.resources.dll
- ./sdk/x.y.z/it/MSBuild.resources.dll
- ./sdk/x.y.z/it/System.CommandLine.resources.dll
- ./sdk/x.y.z/ja/
-@@ ------------ @@
- ./sdk/x.y.z/ja/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
- ./sdk/x.y.z/ja/Microsoft.TemplateEngine.Utils.resources.dll
- ./sdk/x.y.z/ja/Microsoft.TemplateSearch.Common.resources.dll
-+./sdk/x.y.z/ja/Microsoft.TestPlatform.Build.resources.dll
- ./sdk/x.y.z/ja/MSBuild.resources.dll
- ./sdk/x.y.z/ja/System.CommandLine.resources.dll
- ./sdk/x.y.z/KnownWorkloadManifests.txt
-@@ ------------ @@
- ./sdk/x.y.z/ko/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
- ./sdk/x.y.z/ko/Microsoft.TemplateEngine.Utils.resources.dll
- ./sdk/x.y.z/ko/Microsoft.TemplateSearch.Common.resources.dll
-+./sdk/x.y.z/ko/Microsoft.TestPlatform.Build.resources.dll
- ./sdk/x.y.z/ko/MSBuild.resources.dll
- ./sdk/x.y.z/ko/System.CommandLine.resources.dll
- ./sdk/x.y.z/Microsoft.ApplicationInsights.dll
+ ./sdk/x.y.z/Containers/tasks/netx.y/System.Diagnostics.EventLog.dll
 @@ ------------ @@
  ./sdk/x.y.z/Microsoft.Build.NuGetSdkResolver.dll
  ./sdk/x.y.z/Microsoft.Build.Tasks.Core.dll
@@ -547,22 +449,6 @@ index ------------
  ./sdk/x.y.z/Microsoft.VisualStudio.TestPlatform.Common.dll
  ./sdk/x.y.z/Microsoft.VisualStudio.TestPlatform.ObjectModel.dll
 @@ ------------ @@
- ./sdk/x.y.z/pl/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
- ./sdk/x.y.z/pl/Microsoft.TemplateEngine.Utils.resources.dll
- ./sdk/x.y.z/pl/Microsoft.TemplateSearch.Common.resources.dll
-+./sdk/x.y.z/pl/Microsoft.TestPlatform.Build.resources.dll
- ./sdk/x.y.z/pl/MSBuild.resources.dll
- ./sdk/x.y.z/pl/System.CommandLine.resources.dll
- ./sdk/x.y.z/pt-BR/
-@@ ------------ @@
- ./sdk/x.y.z/pt-BR/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
- ./sdk/x.y.z/pt-BR/Microsoft.TemplateEngine.Utils.resources.dll
- ./sdk/x.y.z/pt-BR/Microsoft.TemplateSearch.Common.resources.dll
-+./sdk/x.y.z/pt-BR/Microsoft.TestPlatform.Build.resources.dll
- ./sdk/x.y.z/pt-BR/MSBuild.resources.dll
- ./sdk/x.y.z/pt-BR/System.CommandLine.resources.dll
- ./sdk/x.y.z/ref/
-@@ ------------ @@
  ./sdk/x.y.z/Roslyn/bincore/ru/Microsoft.CodeAnalysis.CSharp.resources.dll
  ./sdk/x.y.z/Roslyn/bincore/ru/Microsoft.CodeAnalysis.resources.dll
  ./sdk/x.y.z/Roslyn/bincore/ru/Microsoft.CodeAnalysis.VisualBasic.resources.dll
@@ -572,24 +458,20 @@ index ------------
  ./sdk/x.y.z/Roslyn/bincore/tr/Microsoft.CodeAnalysis.CSharp.resources.dll
  ./sdk/x.y.z/Roslyn/bincore/tr/Microsoft.CodeAnalysis.resources.dll
 @@ ------------ @@
- ./sdk/x.y.z/ru/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
- ./sdk/x.y.z/ru/Microsoft.TemplateEngine.Utils.resources.dll
- ./sdk/x.y.z/ru/Microsoft.TemplateSearch.Common.resources.dll
-+./sdk/x.y.z/ru/Microsoft.TestPlatform.Build.resources.dll
- ./sdk/x.y.z/ru/MSBuild.resources.dll
- ./sdk/x.y.z/ru/System.CommandLine.resources.dll
- ./sdk/x.y.z/RuntimeIdentifierGraph.json
-@@ ------------ @@
  ./sdk/x.y.z/runtimes/win/
  ./sdk/x.y.z/runtimes/win/lib/
  ./sdk/x.y.z/runtimes/win/lib/netx.y/
+-./sdk/x.y.z/runtimes/win/lib/netx.y/
 -./sdk/x.y.z/runtimes/win/lib/netx.y/Microsoft.Win32.SystemEvents.dll
  ./sdk/x.y.z/runtimes/win/lib/netx.y/System.Diagnostics.EventLog.dll
  ./sdk/x.y.z/runtimes/win/lib/netx.y/System.Diagnostics.EventLog.Messages.dll
 -./sdk/x.y.z/runtimes/win/lib/netx.y/System.Drawing.Common.dll
  ./sdk/x.y.z/runtimes/win/lib/netx.y/System.Security.Cryptography.Pkcs.dll
  ./sdk/x.y.z/runtimes/win/lib/netx.y/System.ServiceProcess.ServiceController.dll
- ./sdk/x.y.z/runtimes/win/lib/netx.y/System.Windows.Extensions.dll
+-./sdk/x.y.z/runtimes/win/lib/netx.y/System.Windows.Extensions.dll
+ ./sdk/x.y.z/SDKPrecomputedAssemblyReferences.cache
+ ./sdk/x.y.z/SdkResolvers/
+ ./sdk/x.y.z/SdkResolvers/Microsoft.Build.NuGetSdkResolver/
 @@ ------------ @@
  ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WebAssembly/tools/
  ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WebAssembly/tools/netx.y/
@@ -606,27 +488,3 @@ index ------------
  ./sdk/x.y.z/tr/
  ./sdk/x.y.z/tr/dotnet.resources.dll
  ./sdk/x.y.z/tr/Microsoft.Build.resources.dll
-@@ ------------ @@
- ./sdk/x.y.z/tr/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
- ./sdk/x.y.z/tr/Microsoft.TemplateEngine.Utils.resources.dll
- ./sdk/x.y.z/tr/Microsoft.TemplateSearch.Common.resources.dll
-+./sdk/x.y.z/tr/Microsoft.TestPlatform.Build.resources.dll
- ./sdk/x.y.z/tr/MSBuild.resources.dll
- ./sdk/x.y.z/tr/System.CommandLine.resources.dll
- ./sdk/x.y.z/trustedroots/
-@@ ------------ @@
- ./sdk/x.y.z/zh-Hans/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
- ./sdk/x.y.z/zh-Hans/Microsoft.TemplateEngine.Utils.resources.dll
- ./sdk/x.y.z/zh-Hans/Microsoft.TemplateSearch.Common.resources.dll
-+./sdk/x.y.z/zh-Hans/Microsoft.TestPlatform.Build.resources.dll
- ./sdk/x.y.z/zh-Hans/MSBuild.resources.dll
- ./sdk/x.y.z/zh-Hans/System.CommandLine.resources.dll
- ./sdk/x.y.z/zh-Hant/
-@@ ------------ @@
- ./sdk/x.y.z/zh-Hant/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.resources.dll
- ./sdk/x.y.z/zh-Hant/Microsoft.TemplateEngine.Utils.resources.dll
- ./sdk/x.y.z/zh-Hant/Microsoft.TemplateSearch.Common.resources.dll
-+./sdk/x.y.z/zh-Hant/Microsoft.TestPlatform.Build.resources.dll
- ./sdk/x.y.z/zh-Hant/MSBuild.resources.dll
- ./sdk/x.y.z/zh-Hant/System.CommandLine.resources.dll
- ./shared/

--- a/src/SourceBuild/patches/vstest/0001-Consume-localized-resources-in-source-build.patch
+++ b/src/SourceBuild/patches/vstest/0001-Consume-localized-resources-in-source-build.patch
@@ -1,0 +1,217 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nikola Milosavljevic <nikolam@microsoft.com>
+Date: Mon, 19 Jun 2023 22:28:26 +0000
+Subject: [PATCH] Consume localized resources in source-build
+
+Backport: https://github.com/microsoft/vstest/pull/4564
+---
+ ...rosoft.TestPlatform.CLI.sourcebuild.nuspec | 197 ++++++++++++++++++
+ 1 file changed, 197 insertions(+)
+
+diff --git a/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.sourcebuild.nuspec b/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.sourcebuild.nuspec
+index 39dd437c..4de0d6f8 100644
+--- a/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.sourcebuild.nuspec
++++ b/src/package/Microsoft.TestPlatform.CLI/Microsoft.TestPlatform.CLI.sourcebuild.nuspec
+@@ -61,5 +61,202 @@
+     <file src="$SourceBuildTfm$\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions" />
+     <file src="$SourceBuildTfm$\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions" />
+ 
++    <!-- Resources -->
++    <file src="$SourceBuildTfm$\cs\Microsoft.TestPlatform.CommunicationUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\cs" />
++    <file src="$SourceBuildTfm$\de\Microsoft.TestPlatform.CommunicationUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\de" />
++    <file src="$SourceBuildTfm$\es\Microsoft.TestPlatform.CommunicationUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\es" />
++    <file src="$SourceBuildTfm$\fr\Microsoft.TestPlatform.CommunicationUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\fr" />
++    <file src="$SourceBuildTfm$\it\Microsoft.TestPlatform.CommunicationUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\it" />
++    <file src="$SourceBuildTfm$\ja\Microsoft.TestPlatform.CommunicationUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ja" />
++    <file src="$SourceBuildTfm$\ko\Microsoft.TestPlatform.CommunicationUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ko" />
++    <file src="$SourceBuildTfm$\pl\Microsoft.TestPlatform.CommunicationUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\pl" />
++    <file src="$SourceBuildTfm$\pt-BR\Microsoft.TestPlatform.CommunicationUtilities.resources.dll"   target="contentFiles\any\$SourceBuildTfm$\pt-BR" />
++    <file src="$SourceBuildTfm$\ru\Microsoft.TestPlatform.CommunicationUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ru" />
++    <file src="$SourceBuildTfm$\tr\Microsoft.TestPlatform.CommunicationUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\tr" />
++    <file src="$SourceBuildTfm$\zh-Hans\Microsoft.TestPlatform.CommunicationUtilities.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hans" />
++    <file src="$SourceBuildTfm$\zh-Hant\Microsoft.TestPlatform.CommunicationUtilities.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hant" />
++
++    <file src="$SourceBuildTfm$\cs\Microsoft.TestPlatform.CoreUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\cs" />
++    <file src="$SourceBuildTfm$\de\Microsoft.TestPlatform.CoreUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\de" />
++    <file src="$SourceBuildTfm$\es\Microsoft.TestPlatform.CoreUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\es" />
++    <file src="$SourceBuildTfm$\fr\Microsoft.TestPlatform.CoreUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\fr" />
++    <file src="$SourceBuildTfm$\it\Microsoft.TestPlatform.CoreUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\it" />
++    <file src="$SourceBuildTfm$\ja\Microsoft.TestPlatform.CoreUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ja" />
++    <file src="$SourceBuildTfm$\ko\Microsoft.TestPlatform.CoreUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ko" />
++    <file src="$SourceBuildTfm$\pl\Microsoft.TestPlatform.CoreUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\pl" />
++    <file src="$SourceBuildTfm$\pt-BR\Microsoft.TestPlatform.CoreUtilities.resources.dll"   target="contentFiles\any\$SourceBuildTfm$\pt-BR" />
++    <file src="$SourceBuildTfm$\ru\Microsoft.TestPlatform.CoreUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ru" />
++    <file src="$SourceBuildTfm$\tr\Microsoft.TestPlatform.CoreUtilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\tr" />
++    <file src="$SourceBuildTfm$\zh-Hans\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hans" />
++    <file src="$SourceBuildTfm$\zh-Hant\Microsoft.TestPlatform.CoreUtilities.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hant" />
++
++    <file src="$SourceBuildTfm$\cs\Microsoft.TestPlatform.CrossPlatEngine.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\cs" />
++    <file src="$SourceBuildTfm$\de\Microsoft.TestPlatform.CrossPlatEngine.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\de" />
++    <file src="$SourceBuildTfm$\es\Microsoft.TestPlatform.CrossPlatEngine.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\es" />
++    <file src="$SourceBuildTfm$\fr\Microsoft.TestPlatform.CrossPlatEngine.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\fr" />
++    <file src="$SourceBuildTfm$\it\Microsoft.TestPlatform.CrossPlatEngine.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\it" />
++    <file src="$SourceBuildTfm$\ja\Microsoft.TestPlatform.CrossPlatEngine.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ja" />
++    <file src="$SourceBuildTfm$\ko\Microsoft.TestPlatform.CrossPlatEngine.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ko" />
++    <file src="$SourceBuildTfm$\pl\Microsoft.TestPlatform.CrossPlatEngine.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\pl" />
++    <file src="$SourceBuildTfm$\pt-BR\Microsoft.TestPlatform.CrossPlatEngine.resources.dll"   target="contentFiles\any\$SourceBuildTfm$\pt-BR" />
++    <file src="$SourceBuildTfm$\ru\Microsoft.TestPlatform.CrossPlatEngine.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ru" />
++    <file src="$SourceBuildTfm$\tr\Microsoft.TestPlatform.CrossPlatEngine.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\tr" />
++    <file src="$SourceBuildTfm$\zh-Hans\Microsoft.TestPlatform.CrossPlatEngine.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hans" />
++    <file src="$SourceBuildTfm$\zh-Hant\Microsoft.TestPlatform.CrossPlatEngine.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hant" />
++
++    <file src="$SourceBuildTfm$\cs\Microsoft.TestPlatform.Utilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\cs" />
++    <file src="$SourceBuildTfm$\de\Microsoft.TestPlatform.Utilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\de" />
++    <file src="$SourceBuildTfm$\es\Microsoft.TestPlatform.Utilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\es" />
++    <file src="$SourceBuildTfm$\fr\Microsoft.TestPlatform.Utilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\fr" />
++    <file src="$SourceBuildTfm$\it\Microsoft.TestPlatform.Utilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\it" />
++    <file src="$SourceBuildTfm$\ja\Microsoft.TestPlatform.Utilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ja" />
++    <file src="$SourceBuildTfm$\ko\Microsoft.TestPlatform.Utilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ko" />
++    <file src="$SourceBuildTfm$\pl\Microsoft.TestPlatform.Utilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\pl" />
++    <file src="$SourceBuildTfm$\pt-BR\Microsoft.TestPlatform.Utilities.resources.dll"   target="contentFiles\any\$SourceBuildTfm$\pt-BR" />
++    <file src="$SourceBuildTfm$\ru\Microsoft.TestPlatform.Utilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ru" />
++    <file src="$SourceBuildTfm$\tr\Microsoft.TestPlatform.Utilities.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\tr" />
++    <file src="$SourceBuildTfm$\zh-Hans\Microsoft.TestPlatform.Utilities.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hans" />
++    <file src="$SourceBuildTfm$\zh-Hant\Microsoft.TestPlatform.Utilities.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hant" />
++
++    <file src="$SourceBuildTfm$\cs\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="contentFiles\any\$SourceBuildTfm$\cs" />
++    <file src="$SourceBuildTfm$\de\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="contentFiles\any\$SourceBuildTfm$\de" />
++    <file src="$SourceBuildTfm$\es\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="contentFiles\any\$SourceBuildTfm$\es" />
++    <file src="$SourceBuildTfm$\fr\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="contentFiles\any\$SourceBuildTfm$\fr" />
++    <file src="$SourceBuildTfm$\it\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="contentFiles\any\$SourceBuildTfm$\it" />
++    <file src="$SourceBuildTfm$\ja\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="contentFiles\any\$SourceBuildTfm$\ja" />
++    <file src="$SourceBuildTfm$\ko\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="contentFiles\any\$SourceBuildTfm$\ko" />
++    <file src="$SourceBuildTfm$\pl\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="contentFiles\any\$SourceBuildTfm$\pl" />
++    <file src="$SourceBuildTfm$\pt-BR\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="contentFiles\any\$SourceBuildTfm$\pt-BR" />
++    <file src="$SourceBuildTfm$\ru\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="contentFiles\any\$SourceBuildTfm$\ru" />
++    <file src="$SourceBuildTfm$\tr\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="contentFiles\any\$SourceBuildTfm$\tr" />
++    <file src="$SourceBuildTfm$\zh-Hans\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hans" />
++    <file src="$SourceBuildTfm$\zh-Hant\Microsoft.TestPlatform.VsTestConsole.TranslationLayer.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hant" />
++
++    <file src="$SourceBuildTfm$\cs\Microsoft.VisualStudio.TestPlatform.Client.resources.dll" target="contentFiles\any\$SourceBuildTfm$\cs" />
++    <file src="$SourceBuildTfm$\de\Microsoft.VisualStudio.TestPlatform.Client.resources.dll" target="contentFiles\any\$SourceBuildTfm$\de" />
++    <file src="$SourceBuildTfm$\es\Microsoft.VisualStudio.TestPlatform.Client.resources.dll" target="contentFiles\any\$SourceBuildTfm$\es" />
++    <file src="$SourceBuildTfm$\fr\Microsoft.VisualStudio.TestPlatform.Client.resources.dll" target="contentFiles\any\$SourceBuildTfm$\fr" />
++    <file src="$SourceBuildTfm$\it\Microsoft.VisualStudio.TestPlatform.Client.resources.dll" target="contentFiles\any\$SourceBuildTfm$\it" />
++    <file src="$SourceBuildTfm$\ja\Microsoft.VisualStudio.TestPlatform.Client.resources.dll" target="contentFiles\any\$SourceBuildTfm$\ja" />
++    <file src="$SourceBuildTfm$\ko\Microsoft.VisualStudio.TestPlatform.Client.resources.dll" target="contentFiles\any\$SourceBuildTfm$\ko" />
++    <file src="$SourceBuildTfm$\pl\Microsoft.VisualStudio.TestPlatform.Client.resources.dll" target="contentFiles\any\$SourceBuildTfm$\pl" />
++    <file src="$SourceBuildTfm$\pt-BR\Microsoft.VisualStudio.TestPlatform.Client.resources.dll" target="contentFiles\any\$SourceBuildTfm$\pt-BR" />
++    <file src="$SourceBuildTfm$\ru\Microsoft.VisualStudio.TestPlatform.Client.resources.dll" target="contentFiles\any\$SourceBuildTfm$\ru" />
++    <file src="$SourceBuildTfm$\tr\Microsoft.VisualStudio.TestPlatform.Client.resources.dll" target="contentFiles\any\$SourceBuildTfm$\tr" />
++    <file src="$SourceBuildTfm$\zh-Hans\Microsoft.VisualStudio.TestPlatform.Client.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hans" />
++    <file src="$SourceBuildTfm$\zh-Hant\Microsoft.VisualStudio.TestPlatform.Client.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hant" />
++
++    <file src="$SourceBuildTfm$\cs\Microsoft.VisualStudio.TestPlatform.Common.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\cs" />
++    <file src="$SourceBuildTfm$\de\Microsoft.VisualStudio.TestPlatform.Common.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\de" />
++    <file src="$SourceBuildTfm$\es\Microsoft.VisualStudio.TestPlatform.Common.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\es" />
++    <file src="$SourceBuildTfm$\fr\Microsoft.VisualStudio.TestPlatform.Common.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\fr" />
++    <file src="$SourceBuildTfm$\it\Microsoft.VisualStudio.TestPlatform.Common.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\it" />
++    <file src="$SourceBuildTfm$\ja\Microsoft.VisualStudio.TestPlatform.Common.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ja" />
++    <file src="$SourceBuildTfm$\ko\Microsoft.VisualStudio.TestPlatform.Common.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ko" />
++    <file src="$SourceBuildTfm$\pl\Microsoft.VisualStudio.TestPlatform.Common.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\pl" />
++    <file src="$SourceBuildTfm$\pt-BR\Microsoft.VisualStudio.TestPlatform.Common.resources.dll"   target="contentFiles\any\$SourceBuildTfm$\pt-BR" />
++    <file src="$SourceBuildTfm$\ru\Microsoft.VisualStudio.TestPlatform.Common.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ru" />
++    <file src="$SourceBuildTfm$\tr\Microsoft.VisualStudio.TestPlatform.Common.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\tr" />
++    <file src="$SourceBuildTfm$\zh-Hans\Microsoft.VisualStudio.TestPlatform.Common.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hans" />
++    <file src="$SourceBuildTfm$\zh-Hant\Microsoft.VisualStudio.TestPlatform.Common.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hant" />
++
++    <file src="$SourceBuildTfm$\cs\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\cs" />
++    <file src="$SourceBuildTfm$\de\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\de" />
++    <file src="$SourceBuildTfm$\es\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\es" />
++    <file src="$SourceBuildTfm$\fr\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\fr" />
++    <file src="$SourceBuildTfm$\it\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\it" />
++    <file src="$SourceBuildTfm$\ja\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ja" />
++    <file src="$SourceBuildTfm$\ko\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ko" />
++    <file src="$SourceBuildTfm$\pl\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\pl" />
++    <file src="$SourceBuildTfm$\pt-BR\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll"   target="contentFiles\any\$SourceBuildTfm$\pt-BR" />
++    <file src="$SourceBuildTfm$\ru\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\ru" />
++    <file src="$SourceBuildTfm$\tr\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll"      target="contentFiles\any\$SourceBuildTfm$\tr" />
++    <file src="$SourceBuildTfm$\zh-Hans\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hans" />
++    <file src="$SourceBuildTfm$\zh-Hant\Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hant" />
++
++    <file src="$SourceBuildTfm$\cs\vstest.console.resources.dll" target="contentFiles\any\$SourceBuildTfm$\cs" />
++    <file src="$SourceBuildTfm$\de\vstest.console.resources.dll" target="contentFiles\any\$SourceBuildTfm$\de" />
++    <file src="$SourceBuildTfm$\es\vstest.console.resources.dll" target="contentFiles\any\$SourceBuildTfm$\es" />
++    <file src="$SourceBuildTfm$\fr\vstest.console.resources.dll" target="contentFiles\any\$SourceBuildTfm$\fr" />
++    <file src="$SourceBuildTfm$\it\vstest.console.resources.dll" target="contentFiles\any\$SourceBuildTfm$\it" />
++    <file src="$SourceBuildTfm$\ja\vstest.console.resources.dll" target="contentFiles\any\$SourceBuildTfm$\ja" />
++    <file src="$SourceBuildTfm$\ko\vstest.console.resources.dll" target="contentFiles\any\$SourceBuildTfm$\ko" />
++    <file src="$SourceBuildTfm$\pl\vstest.console.resources.dll" target="contentFiles\any\$SourceBuildTfm$\pl" />
++    <file src="$SourceBuildTfm$\pt-BR\vstest.console.resources.dll" target="contentFiles\any\$SourceBuildTfm$\pt-BR" />
++    <file src="$SourceBuildTfm$\ru\vstest.console.resources.dll" target="contentFiles\any\$SourceBuildTfm$\ru" />
++    <file src="$SourceBuildTfm$\tr\vstest.console.resources.dll" target="contentFiles\any\$SourceBuildTfm$\tr" />
++    <file src="$SourceBuildTfm$\zh-Hans\vstest.console.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hans" />
++    <file src="$SourceBuildTfm$\zh-Hant\vstest.console.resources.dll" target="contentFiles\any\$SourceBuildTfm$\zh-Hant" />
++
++    <file src="$SourceBuildTfm$\cs\Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\cs" />
++    <file src="$SourceBuildTfm$\de\Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\de" />
++    <file src="$SourceBuildTfm$\es\Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\es" />
++    <file src="$SourceBuildTfm$\fr\Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\fr" />
++    <file src="$SourceBuildTfm$\it\Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\it" />
++    <file src="$SourceBuildTfm$\ja\Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\ja" />
++    <file src="$SourceBuildTfm$\ko\Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\ko" />
++    <file src="$SourceBuildTfm$\pl\Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\pl" />
++    <file src="$SourceBuildTfm$\pt-BR\Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\pt-BR" />
++    <file src="$SourceBuildTfm$\ru\Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\ru" />
++    <file src="$SourceBuildTfm$\tr\Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\tr" />
++    <file src="$SourceBuildTfm$\zh-Hans\Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\zh-Hans" />
++    <file src="$SourceBuildTfm$\zh-Hant\Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\zh-Hant" />
++
++    <file src="$SourceBuildTfm$\cs\Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\cs" />
++    <file src="$SourceBuildTfm$\de\Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\de" />
++    <file src="$SourceBuildTfm$\es\Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\es" />
++    <file src="$SourceBuildTfm$\fr\Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\fr" />
++    <file src="$SourceBuildTfm$\it\Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\it" />
++    <file src="$SourceBuildTfm$\ja\Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\ja" />
++    <file src="$SourceBuildTfm$\ko\Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\ko" />
++    <file src="$SourceBuildTfm$\pl\Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\pl" />
++    <file src="$SourceBuildTfm$\pt-BR\Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\pt-BR" />
++    <file src="$SourceBuildTfm$\ru\Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\ru" />
++    <file src="$SourceBuildTfm$\tr\Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\tr" />
++    <file src="$SourceBuildTfm$\zh-Hans\Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\zh-Hans" />
++    <file src="$SourceBuildTfm$\zh-Hant\Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\zh-Hant" />
++
++    <file src="$SourceBuildTfm$\cs\Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\cs" />
++    <file src="$SourceBuildTfm$\de\Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\de" />
++    <file src="$SourceBuildTfm$\es\Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\es" />
++    <file src="$SourceBuildTfm$\fr\Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\fr" />
++    <file src="$SourceBuildTfm$\it\Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\it" />
++    <file src="$SourceBuildTfm$\ja\Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\ja" />
++    <file src="$SourceBuildTfm$\ko\Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\ko" />
++    <file src="$SourceBuildTfm$\pl\Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\pl" />
++    <file src="$SourceBuildTfm$\pt-BR\Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\pt-BR" />
++    <file src="$SourceBuildTfm$\ru\Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\ru" />
++    <file src="$SourceBuildTfm$\tr\Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\tr" />
++    <file src="$SourceBuildTfm$\zh-Hans\Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\zh-Hans" />
++    <file src="$SourceBuildTfm$\zh-Hant\Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\zh-Hant" />
++
++    <file src="$SourceBuildTfm$\cs\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\cs" />
++    <file src="$SourceBuildTfm$\de\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\de" />
++    <file src="$SourceBuildTfm$\es\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\es" />
++    <file src="$SourceBuildTfm$\fr\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\fr" />
++    <file src="$SourceBuildTfm$\it\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\it" />
++    <file src="$SourceBuildTfm$\ja\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\ja" />
++    <file src="$SourceBuildTfm$\ko\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\ko" />
++    <file src="$SourceBuildTfm$\pl\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\pl" />
++    <file src="$SourceBuildTfm$\pt-BR\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\pt-BR" />
++    <file src="$SourceBuildTfm$\ru\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\ru" />
++    <file src="$SourceBuildTfm$\tr\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\tr" />
++    <file src="$SourceBuildTfm$\zh-Hans\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\zh-Hans" />
++    <file src="$SourceBuildTfm$\zh-Hant\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\zh-Hant" />
++
++    <file src="$SourceBuildTfm$\cs\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\cs" />
++    <file src="$SourceBuildTfm$\de\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\de" />
++    <file src="$SourceBuildTfm$\es\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\es" />
++    <file src="$SourceBuildTfm$\fr\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\fr" />
++    <file src="$SourceBuildTfm$\it\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\it" />
++    <file src="$SourceBuildTfm$\ja\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\ja" />
++    <file src="$SourceBuildTfm$\ko\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\ko" />
++    <file src="$SourceBuildTfm$\pl\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\pl" />
++    <file src="$SourceBuildTfm$\pt-BR\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\pt-BR" />
++    <file src="$SourceBuildTfm$\ru\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\ru" />
++    <file src="$SourceBuildTfm$\tr\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\tr" />
++    <file src="$SourceBuildTfm$\zh-Hans\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\zh-Hans" />
++    <file src="$SourceBuildTfm$\zh-Hant\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll" target="contentFiles\any\$SourceBuildTfm$\Extensions\zh-Hant" />
++
+   </files>
+ </package>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/3290, https://github.com/dotnet/source-build/issues/3517

VSTest localization was enabled on Linux recently - this PR includes a patch for inclusion of localized resources in the CLI package: https://github.com/microsoft/vstest/pull/4564

FSharp binaries are all Windows components or transitive dependencies of those components - adding to the exclusion list, as this difference is now understood.
 
Also moving the following exclusion entry to the correct section (NuGet):
```
msft,./sdk/x.y.z/*?/Test.Utility.resources.dll
```
