### PR TITLE
Exclude Windows components from sdk diff

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkDiffExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkDiffExclusions.txt
@@ -84,3 +84,8 @@ msft,./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/Microsoft.Win32.SystemEvents.dll
 msft,./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/System.Drawing.Common.dll
 msft,./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/System.Security.Cryptography.ProtectedData.dll
 msft,./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/System.Windows.Extensions.dll
+
+# windows components - https://github.com/dotnet/source-build/issues/3526
+msft,./sdk/x.y.z/runtimes/win/lib/netx.y/Microsoft.Win32.SystemEvents.dll
+msft,./sdk/x.y.z/runtimes/win/lib/netx.y/System.Drawing.Common.dll
+msft,./sdk/x.y.z/runtimes/win/lib/netx.y/System.Windows.Extensions.dll

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdk.diff
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdk.diff
@@ -462,16 +462,9 @@ index ------------
  ./sdk/x.y.z/runtimes/win/lib/
  ./sdk/x.y.z/runtimes/win/lib/netx.y/
 -./sdk/x.y.z/runtimes/win/lib/netx.y/
--./sdk/x.y.z/runtimes/win/lib/netx.y/Microsoft.Win32.SystemEvents.dll
  ./sdk/x.y.z/runtimes/win/lib/netx.y/System.Diagnostics.EventLog.dll
  ./sdk/x.y.z/runtimes/win/lib/netx.y/System.Diagnostics.EventLog.Messages.dll
--./sdk/x.y.z/runtimes/win/lib/netx.y/System.Drawing.Common.dll
  ./sdk/x.y.z/runtimes/win/lib/netx.y/System.Security.Cryptography.Pkcs.dll
- ./sdk/x.y.z/runtimes/win/lib/netx.y/System.ServiceProcess.ServiceController.dll
--./sdk/x.y.z/runtimes/win/lib/netx.y/System.Windows.Extensions.dll
- ./sdk/x.y.z/SDKPrecomputedAssemblyReferences.cache
- ./sdk/x.y.z/SdkResolvers/
- ./sdk/x.y.z/SdkResolvers/Microsoft.Build.NuGetSdkResolver/
 @@ ------------ @@
  ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WebAssembly/tools/
  ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WebAssembly/tools/netx.y/


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/3526

This PR adds 3 Windows components to the exclusion list, as they are ignorable. This also removes them from SDK diff baseline. Baseline is only meant to contain the differences that aren't well understood or temporary diffs that have pending changes in contributing repos.