### PR TITLE
Pull in msbuild fixes to eliminate source-build prebuilts

### DIFF
--- a/src/SourceBuild/content/eng/Versions.props
+++ b/src/SourceBuild/content/eng/Versions.props
@@ -15,11 +15,22 @@
       Building .NET from source depends on several archives, depending on the branch's current
       source-buildability status.
 
+      PrivateSourceBuiltArtifactsUrl is a tar.gz of .NET build outputs from a previous
+      build needed to build the current version of .NET. This is always defined, because .NET needs
+      to be bootstrappable at any point in time.
+
+      PrivateSourceBuiltPrebuiltsUrl is a tar.gz of assets downloaded from the internet
+      that are needed to build the current version of .NET. Early in the lifecycle of a .NET major
+      or minor release, prebuilts may be needed. When the release is mature, prebuilts are not
+      necessary, and this property is removed from the file.
+
+      PrivateSourceBuiltSdkUrl_<abc> is a tar.gz of the source build .NET SDK from the previous release
+      for a particular OS. It is used by CI to validate that the current release can be built with it.
+
       These URLs can't be composed from their base URL and version as we read them from the
       prep.sh and pipeline scripts, outside of MSBuild.
     -->
     <PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Artifacts.8.0.100-preview.5.23303.1.centos.8-x64.tar.gz</PrivateSourceBuiltArtifactsUrl>
-    <PrivateSourceBuiltPrebuiltsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Prebuilts.0.1.0-8.0.100-33.centos.8-x64.tar.gz</PrivateSourceBuiltPrebuiltsUrl>
     <PrivateSourceBuiltSdkUrl_CentOS8Stream>https://dotnetcli.azureedge.net/source-built-artifacts/sdks/dotnet-sdk-8.0.100-preview.5.23303.1-centos.8-x64.tar.gz</PrivateSourceBuiltSdkUrl_CentOS8Stream>
   </PropertyGroup>
 </Project>

--- a/src/SourceBuild/patches/msbuild/0001-Use-NetCurrent-to-pull-target-.NET-version-from-Arca.patch
+++ b/src/SourceBuild/patches/msbuild/0001-Use-NetCurrent-to-pull-target-.NET-version-from-Arca.patch
@@ -1,0 +1,54 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Rainer Sigwald <raines@microsoft.com>
+Date: Fri, 16 Jun 2023 09:41:18 -0500
+Subject: [PATCH] Use NetCurrent to pull target .NET version from Arcade
+
+This is required for source-build in .NET 8 now, so that we target 8
+in the sourcebuilt builds, even when the product must target 7.
+
+Backport: https://github.com/dotnet/msbuild/pull/8865
+---
+ Directory.Build.props     | 6 +++++-
+ src/Directory.Build.props | 4 ++--
+ 2 files changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/Directory.Build.props b/Directory.Build.props
+index ea3e227d6..ae75c21fe 100644
+--- a/Directory.Build.props
++++ b/Directory.Build.props
+@@ -24,8 +24,12 @@
+           scripts/Deploy-MSBuild.ps1
+           src/Framework/README.md
+           src/Utilities/README.md
++
++        Special-case while MSBuild uses Arcade 6 to build: 17.7 should
++        continue to target .NET 7, so bump a 6 here to 7.
+      -->
+-    <LatestDotNetCoreForMSBuild>net7.0</LatestDotNetCoreForMSBuild>
++    <LatestDotNetCoreForMSBuild>$(NetCurrent)</LatestDotNetCoreForMSBuild>
++    <LatestDotNetCoreForMSBuild Condition=" '$(NetCurrent)' == 'net6.0' ">net7.0</LatestDotNetCoreForMSBuild>
+   </PropertyGroup>
+ 
+   <PropertyGroup>
+diff --git a/src/Directory.Build.props b/src/Directory.Build.props
+index f6809d2e4..fd9dc2a59 100644
+--- a/src/Directory.Build.props
++++ b/src/Directory.Build.props
+@@ -15,7 +15,7 @@
+     <!-- Ensure that compiler errors emit full paths so that files
+          can be correctly annotated in GitHub. -->
+     <GenerateFullPaths>true</GenerateFullPaths>
+-    
++
+     <!-- https://github.com/NuGet/Home/issues/8684 -->
+     <NoWarn>$(NoWarn);NU5131</NoWarn>
+ 
+@@ -36,7 +36,7 @@
+     <PlatformTarget>AnyCPU</PlatformTarget>
+ 
+     <!-- Target frameworks for Exe and unit test projects (ie projects with runtime output) -->
+-    <RuntimeOutputTargetFrameworks>net7.0</RuntimeOutputTargetFrameworks>
++    <RuntimeOutputTargetFrameworks>$(LatestDotNetCoreForMSBuild)</RuntimeOutputTargetFrameworks>
+     <RuntimeOutputTargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(FullFrameworkTFM);$(RuntimeOutputTargetFrameworks)</RuntimeOutputTargetFrameworks>
+     <RuntimeOutputTargetFrameworks Condition="'$(MonoBuild)' == 'true'">$(FullFrameworkTFM)</RuntimeOutputTargetFrameworks>
+ 

--- a/src/SourceBuild/patches/sdk/0002-MSBuild-SourceBuild-TF-is-NetCurrent.patch
+++ b/src/SourceBuild/patches/sdk/0002-MSBuild-SourceBuild-TF-is-NetCurrent.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Rainer Sigwald <raines@microsoft.com>
+Date: Wed, 21 Jun 2023 12:31:49 +0000
+Subject: [PATCH] MSBuild: SourceBuild TF is NetCurrent
+
+Backport: https://github.com/dotnet/sdk/pull/33188
+---
+ .../Microsoft.DotNet.Cli.Utils.csproj                         | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj b/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
+index 345b986a81..da79ba61e7 100644
+--- a/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
++++ b/src/Cli/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
+@@ -23,10 +23,10 @@
+   <Target Name="VerifyMSBuildDependency" BeforeTargets="ResolveAssemblyReferences" Condition="'$([MSBuild]::GetTargetFrameworkIdentifier($(TargetFramework)))' == '.NETCoreApp'">
+     <!-- We explicitly reference an older version of MSBuild here to support VS
+     for Mac and other VS scenarios. During source-build, we only have access to
+-    the latest version, which targets net7.0. -->
++    the latest version, which targets NetCurrent. -->
+     <PropertyGroup>
+       <MSBuildPathInPackage>$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net7.0\MSBuild.dll</MSBuildPathInPackage>
+-      <MSBuildPathInPackage Condition="'$(DotNetBuildFromSource)' == 'true'">$(PkgMicrosoft_Build_Runtime)\contentFiles\any\net7.0\MSBuild.dll</MSBuildPathInPackage>
++      <MSBuildPathInPackage Condition="'$(DotNetBuildFromSource)' == 'true'">$(PkgMicrosoft_Build_Runtime)\contentFiles\any\$(NetCurrent)\MSBuild.dll</MSBuildPathInPackage>
+     </PropertyGroup>
+     <Error Condition="!Exists('$(MSBuildPathInPackage)')" Text="Something moved around in Microsoft.Build.Runtime, adjust code here accordingly." />
+     <ItemGroup>


### PR DESCRIPTION
Pulling in these changes gets source-build to be prebuilt clean.
