### PR TITLE
Set OmniSharp run script to be executable

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/OmniSharpTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/OmniSharpTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
+using System.Security.AccessControl;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -66,6 +67,9 @@ public class OmniSharpTests : SmokeTests
 
             Directory.CreateDirectory(OmniSharpDirectory);
             Utilities.ExtractTarball(omniSharpTarballFile, OmniSharpDirectory, OutputHelper);
+
+            // Ensure the run script is executable (see https://github.com/OmniSharp/omnisharp-roslyn/issues/2547)
+            File.SetUnixFileMode($"{OmniSharpDirectory}/run", UnixFileMode.UserRead | UnixFileMode.UserExecute);
         }
     }
 }


### PR DESCRIPTION
The latest release of OmniSharp has a `run` script which is not set to be executable by default. This causes a permission error when attempting to execute it. This change ensures the file is set to be executable.

Fixes dotnet/source-build#3527