### PR TITLE
Remove SHA1 workarounds from VMR build

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -47,12 +47,6 @@ parameters:
 - name: buildFromArchive
   type: boolean
 
-# Some distros like CentOS Stream 9 use OpenSSL 3.0 which disables SHA1 signing.
-# This option overrides that default configuration and enables it. See https://github.com/dotnet/installer/pull/15289
-- name: overrideDistroDisablingSha1
-  type: boolean
-  default: false
-
 # Use the previous version's SDK to build the current one
 - name: withPreviousSDK
   type: boolean
@@ -202,11 +196,6 @@ jobs:
         customBuildArgs='--online'
       else
         customRunArgs="$customRunArgs --network none"
-      fi
-
-      # See https://github.com/dotnet/source-build/issues/3202
-      if [[ '${{ parameters.overrideDistroDisablingSha1 }}' == 'True' ]]; then
-        customRunArgs="$customRunArgs -e OPENSSL_ENABLE_SHA1_SIGNATURES=1"
       fi
 
       if [[ '${{ parameters.enablePoison }}' == 'True' ]]; then

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -82,7 +82,6 @@ stages:
       buildFromArchive: false            # 🚫
       enablePoison: false                # 🚫
       excludeOmniSharpTests: true        # ✅
-      overrideDistroDisablingSha1: false # 🚫
       runOnline: true                    # ✅
       useMonoRuntime: false              # 🚫
       withPreviousSDK: false             # 🚫
@@ -104,7 +103,6 @@ stages:
         buildFromArchive: false            # ✅
         enablePoison: false                # 🚫
         excludeOmniSharpTests: true        # ✅
-        overrideDistroDisablingSha1: false # 🚫
         runOnline: false                   # 🚫
         useMonoRuntime: false              # 🚫
         withPreviousSDK: false             # 🚫
@@ -122,7 +120,6 @@ stages:
         buildFromArchive: false            # 🚫
         enablePoison: false                # 🚫
         excludeOmniSharpTests: true        # ✅
-        overrideDistroDisablingSha1: false # 🚫
         runOnline: true                    # ✅
         useMonoRuntime: false              # 🚫
         withPreviousSDK: true              # ✅
@@ -140,7 +137,6 @@ stages:
         buildFromArchive: true             # ✅
         enablePoison: false                # 🚫
         excludeOmniSharpTests: true        # ✅
-        overrideDistroDisablingSha1: false # 🚫
         runOnline: false                   # 🚫
         useMonoRuntime: false              # 🚫
         withPreviousSDK: false             # 🚫
@@ -158,7 +154,6 @@ stages:
         buildFromArchive: true             # ✅
         enablePoison: false                # 🚫
         excludeOmniSharpTests: true        # ✅
-        overrideDistroDisablingSha1: false # 🚫
         runOnline: false                   # 🚫
         useMonoRuntime: true               # ✅
         withPreviousSDK: false             # 🚫
@@ -176,7 +171,6 @@ stages:
         buildFromArchive: true             # ✅
         enablePoison: false                # 🚫
         excludeOmniSharpTests: false       # 🚫
-        overrideDistroDisablingSha1: true  # ✅
         runOnline: false                   # 🚫
         useMonoRuntime: false              # 🚫
         withPreviousSDK: false             # 🚫
@@ -194,7 +188,6 @@ stages:
         buildFromArchive: true             # ✅
         enablePoison: true                 # ✅
         excludeOmniSharpTests: false       # 🚫
-        overrideDistroDisablingSha1: false # 🚫
         runOnline: false                   # 🚫
         useMonoRuntime: false              # 🚫
         withPreviousSDK: false             # 🚫
@@ -212,7 +205,6 @@ stages:
         buildFromArchive: false            # 🚫
         enablePoison: false                # 🚫
         excludeOmniSharpTests: false       # 🚫
-        overrideDistroDisablingSha1: false # 🚫
         runOnline: false                   # 🚫
         useMonoRuntime: false              # 🚫
         withPreviousSDK: false             # 🚫
@@ -230,7 +222,6 @@ stages:
         buildFromArchive: false            # 🚫
         enablePoison: false                # 🚫
         excludeOmniSharpTests: false       # 🚫
-        overrideDistroDisablingSha1: false # 🚫
         runOnline: false                   # 🚫
         useMonoRuntime: false              # 🚫
         withPreviousSDK: false             # 🚫
@@ -250,7 +241,6 @@ stages:
         buildFromArchive: false            # 🚫
         enablePoison: false                # 🚫
         excludeOmniSharpTests: true        # ✅
-        overrideDistroDisablingSha1: false # 🚫
         runOnline: false                   # 🚫
         useMonoRuntime: false              # 🚫
         withPreviousSDK: false             # 🚫
@@ -269,7 +259,6 @@ stages:
         buildFromArchive: false            # 🚫
         enablePoison: false                # 🚫
         excludeOmniSharpTests: false       # 🚫
-        overrideDistroDisablingSha1: false # 🚫
         runOnline: false                   # 🚫
         useMonoRuntime: false              # 🚫
         withPreviousSDK: false             # 🚫


### PR DESCRIPTION
These are no longer needed since https://github.com/dotnet/arcade/pull/12940

Fixes: https://github.com/dotnet/source-build/issues/3458