### PR TITLE
Update poison-usage baseline

### DIFF
--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/PoisonUsage.txt
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/PoisonUsage.txt
@@ -20,15 +20,6 @@
   <File Path="dotnet-sdk-x.y.z/sdk/x.y.z/Sdks/Microsoft.NET.ILLink.Tasks/tools/net472/System.Reflection.Metadata.dll">
     <Type>AssemblyAttribute</Type>
   </File>
-  <File Path="Microsoft.CodeAnalysis.RulesetToEditorconfigConverter.x.y.z/RulesetToEditorconfigConverter/System.Reflection.Metadata.dll">
-    <Type>AssemblyAttribute</Type>
-  </File>
-  <File Path="Microsoft.CodeAnalysis.RulesetToEditorconfigConverter.x.y.z/RulesetToEditorconfigConverter/System.Reflection.Metadata.dll">
-    <Type>AssemblyAttribute</Type>
-  </File>
-  <File Path="Microsoft.CodeAnalysis.RulesetToEditorconfigConverter.x.y.z/RulesetToEditorconfigConverter/System.Reflection.Metadata.dll">
-    <Type>AssemblyAttribute</Type>
-  </File>
   <File Path="Microsoft.DotNet.Arcade.Sdk.x.y.z/tools/net472/Microsoft.Bcl.AsyncInterfaces.dll">
     <Type>AssemblyAttribute</Type>
   </File>


### PR DESCRIPTION
Removing entries from poison-usage baseline that do not show up anymore: https://dev.azure.com/dnceng/internal/_build/results?buildId=2204877&view=logs&j=144317aa-cfc8-5d2a-3b5c-6cf453becae7&t=cfb1978d-ceae-5a3a-7a83-939f4538436f&l=82

```
      <File Path="dotnet-sdk-x.y.z/sdk/x.y.z/Sdks/Microsoft.NET.ILLink.Tasks/tools/net472/System.Reflection.Metadata.dll">
        <Type>AssemblyAttribute</Type>
      </File>
   -  <File Path="Microsoft.CodeAnalysis.RulesetToEditorconfigConverter.x.y.z/RulesetToEditorconfigConverter/System.Reflection.Metadata.dll">
   -    <Type>AssemblyAttribute</Type>
   -  </File>
   -  <File Path="Microsoft.CodeAnalysis.RulesetToEditorconfigConverter.x.y.z/RulesetToEditorconfigConverter/System.Reflection.Metadata.dll">
   -    <Type>AssemblyAttribute</Type>
   -  </File>
   -  <File Path="Microsoft.CodeAnalysis.RulesetToEditorconfigConverter.x.y.z/RulesetToEditorconfigConverter/System.Reflection.Metadata.dll">
   -    <Type>AssemblyAttribute</Type>
   -  </File>
      <File Path="Microsoft.DotNet.Arcade.Sdk.x.y.z/tools/net472/Microsoft.Bcl.AsyncInterfaces.dll">
        <Type>AssemblyAttribute</Type>
```