### PR TITLE
Disable warnings for aspnetcore, cleanup NoWarns

### DIFF
--- a/src/SourceBuild/content/repo-projects/aspnetcore.proj
+++ b/src/SourceBuild/content/repo-projects/aspnetcore.proj
@@ -24,18 +24,11 @@
 
     <LogVerbosityOptOut>true</LogVerbosityOptOut>
     <PackageVersionPropsFlowType>DependenciesOnly</PackageVersionPropsFlowType>
-
-    <!-- CA1512 - Use 'ArgumentOutOfRangeException.ThrowIfEqual'
-                  Requires https://github.com/dotnet/aspnetcore/issues/47673 -->
-    <!-- CA1822 - Mark members as static
-                  https://github.com/dotnet/aspnetcore/pull/48551 -->
-    <!-- CA1854 - Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
-                  https://github.com/dotnet/aspnetcore/issues/48052 -->
-    <!-- IDE0005 - Using directive is unnecessary: https://github.com/dotnet/aspnetcore/issues/47932 -->
-    <!-- IDE0059 - Unnecessary assignment of a value: https://github.com/dotnet/aspnetcore/pull/47931 -->
-    <!-- NETSDK1206 - Non-portable RID detected: https://github.com/dotnet/aspnetcore/issues/48842 -->
-    <RepoNoWarns>CA1512;CA1822;CA1854;IDE0005;IDE0059;NETSDK1206</RepoNoWarns>
   </PropertyGroup>
+
+  <ItemGroup>
+    <EnvironmentVariables Include="warn_as_error=false" />
+  </ItemGroup>
 
   <ItemGroup>
     <!--

--- a/src/SourceBuild/content/repo-projects/format.proj
+++ b/src/SourceBuild/content/repo-projects/format.proj
@@ -3,10 +3,6 @@
 
   <PropertyGroup>
     <BuildCommand>$(ProjectDirectory)eng\common\build$(ShellExtension) $(StandardSourceBuildArgs)</BuildCommand>
-
-    <!-- CS9057 - Caused by incoherency of analyzer assemblies during pre-release builds. -->
-    <RepoNoWarns>CS9057</RepoNoWarns>
-
     <PackageVersionPropsFlowType>DependenciesOnly</PackageVersionPropsFlowType>
   </PropertyGroup>
 

--- a/src/SourceBuild/content/repo-projects/installer.proj
+++ b/src/SourceBuild/content/repo-projects/installer.proj
@@ -44,9 +44,6 @@
     <BuildCommand>$(StandardSourceBuildCommand) $(BuildCommandArgs)</BuildCommand>
 
     <PackageVersionPropsFlowType>DependenciesOnly</PackageVersionPropsFlowType>
-
-    <!-- CS9057 - Caused by incoherency of analyzer assemblies during pre-release builds. -->
-    <RepoNoWarns>CS9057</RepoNoWarns>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SourceBuild/content/repo-projects/nuget-client.proj
+++ b/src/SourceBuild/content/repo-projects/nuget-client.proj
@@ -5,7 +5,7 @@
     <NuGetKeyFilePath>$(KeysDir)NuGet.Client.snk</NuGetKeyFilePath>
     <DeterministicBuildOptOut>true</DeterministicBuildOptOut>
     <!-- SYSLIB0051 - Type or member is obsolete: https://github.com/NuGet/Home/issues/12626 -->
-    <RepoNoWarns>CS9057;SYSLIB0051</RepoNoWarns>
+    <RepoNoWarns>SYSLIB0051</RepoNoWarns>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SourceBuild/content/repo-projects/razor.proj
+++ b/src/SourceBuild/content/repo-projects/razor.proj
@@ -4,10 +4,6 @@
   <PropertyGroup>
     <PackageVersionPropsFlowType>DependenciesOnly</PackageVersionPropsFlowType>
     <BuildCommand>$(StandardSourceBuildCommand) $(StandardSourceBuildArgs)</BuildCommand>
-
-    <!-- NU1507 - https://github.com/dotnet/razor-compiler/issues/242
-                  Occurs when using NuGet central package management without defining any Package Source Mappings. -->
-    <RepoNoWarns>NU1507</RepoNoWarns>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SourceBuild/content/repo-projects/vstest.proj
+++ b/src/SourceBuild/content/repo-projects/vstest.proj
@@ -5,13 +5,7 @@
     <BuildCommandArgs>$(StandardSourceBuildArgs)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:SemanticVersioningV1=true</BuildCommandArgs>
     <BuildCommand>$(ProjectDirectory)\eng\common\build$(ShellExtension) $(BuildCommandArgs)</BuildCommand>
-
     <DeterministicBuildOptOut>true</DeterministicBuildOptOut>
-
-    <!-- IDE0059 - Unnecessary assignment of a value: https://github.com/microsoft/vstest/issues/4424 -->
-    <!-- SYSLIB0051 - Type or member is obsolete: https://github.com/microsoft/vstest/pull/4425 -->
-    <RepoNoWarns>IDE0059;SYSLIB0051</RepoNoWarns>
-
     <PackageVersionPropsFlowType>DependenciesOnly</PackageVersionPropsFlowType>
   </PropertyGroup>
 


### PR DESCRIPTION
The aspnetcore repo had NETSDK1206 warnings which the changes in https://github.com/dotnet/installer/pull/16699 didn't fully address (see https://github.com/dotnet/source-build/issues/3515#issuecomment-1601726848). So to mitigate the issue, this disables warnings for the entire aspnetcore repo.

Also cleans up `NoWarn` entries for other repos.

Fixes dotnet/source-build#3515