### PR TITLE
Fix SDK version of source-build global.json

### DIFF
--- a/src/SourceBuild/tarball/content/global.json
+++ b/src/SourceBuild/tarball/content/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "6.0.118"
+    "dotnet": "6.0.119"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.1",

--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MissingXmlDoc.txt
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MissingXmlDoc.txt
@@ -1,7 +1,6 @@
 Microsoft.AspNetCore.App.Ref/analyzers/dotnet/cs/Microsoft.AspNetCore.App.Analyzers.xml
 Microsoft.AspNetCore.App.Ref/analyzers/dotnet/cs/Microsoft.AspNetCore.App.CodeFixes.xml
 Microsoft.AspNetCore.App.Ref/analyzers/dotnet/roslyn4.0/cs/Microsoft.Extensions.Logging.Generators.xml
-Microsoft.AspNetCore.App.Ref/ref/netx.y/System.Runtime.CompilerServices.Unsafe.xml
 Microsoft.NETCore.App.Ref/analyzers/dotnet/cs/System.Text.Json.SourceGeneration.xml
 Microsoft.NETCore.App.Ref/ref/netx.y/Microsoft.VisualBasic.xml
 Microsoft.NETCore.App.Ref/ref/netx.y/mscorlib.xml


### PR DESCRIPTION
This change was missed in https://github.com/dotnet/installer/pull/16670.