### PR TITLE
SDK diff - exclude runtime components in roslyn layout

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkDiffExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkDiffExclusions.txt
@@ -89,3 +89,8 @@ msft,./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/System.Windows.Extensions.dll
 msft,./sdk/x.y.z/runtimes/win/lib/netx.y/Microsoft.Win32.SystemEvents.dll
 msft,./sdk/x.y.z/runtimes/win/lib/netx.y/System.Drawing.Common.dll
 msft,./sdk/x.y.z/runtimes/win/lib/netx.y/System.Windows.Extensions.dll
+
+# runtime components in roslyn layout - https://github.com/dotnet/source-build/issues/3286
+# Expected - build is filtering components present in target platform.
+msft,./sdk/x.y.z/Roslyn/bincore/System.Collections.Immutable.dll
+msft,./sdk/x.y.z/Roslyn/bincore/System.Reflection.Metadata.dll

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdk.diff
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdk.diff
@@ -449,15 +449,6 @@ index ------------
  ./sdk/x.y.z/Microsoft.VisualStudio.TestPlatform.Common.dll
  ./sdk/x.y.z/Microsoft.VisualStudio.TestPlatform.ObjectModel.dll
 @@ ------------ @@
- ./sdk/x.y.z/Roslyn/bincore/ru/Microsoft.CodeAnalysis.CSharp.resources.dll
- ./sdk/x.y.z/Roslyn/bincore/ru/Microsoft.CodeAnalysis.resources.dll
- ./sdk/x.y.z/Roslyn/bincore/ru/Microsoft.CodeAnalysis.VisualBasic.resources.dll
--./sdk/x.y.z/Roslyn/bincore/System.Collections.Immutable.dll
--./sdk/x.y.z/Roslyn/bincore/System.Reflection.Metadata.dll
- ./sdk/x.y.z/Roslyn/bincore/tr/
- ./sdk/x.y.z/Roslyn/bincore/tr/Microsoft.CodeAnalysis.CSharp.resources.dll
- ./sdk/x.y.z/Roslyn/bincore/tr/Microsoft.CodeAnalysis.resources.dll
-@@ ------------ @@
  ./sdk/x.y.z/runtimes/win/
  ./sdk/x.y.z/runtimes/win/lib/
  ./sdk/x.y.z/runtimes/win/lib/netx.y/


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/3286

These files are not present in source-built SDK due to filtering of platform components from project output - see more in the issue discussion: https://github.com/dotnet/source-build/issues/3286#issuecomment-1603063699

Fixing this by adding the following entries to sdk diff exclusion list, so the diffing will ignore the files in Microsoft-built SDK.
```
msft,./sdk/x.y.z/Roslyn/bincore/System.Collections.Immutable.dll
msft,./sdk/x.y.z/Roslyn/bincore/System.Reflection.Metadata.dll
```