### PR TITLE
Fix System.Text.Json poison instances

### DIFF
--- a/src/SourceBuild/tarball/patches/format/0002-Add-explicit-System.Text.Json-dependency.patch
+++ b/src/SourceBuild/tarball/patches/format/0002-Add-explicit-System.Text.Json-dependency.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add explicit System.Text.Json dependency
 Adding an excplicit System.Text.Json dependency to prevent transitive dependency to be picked up
 from PSB, via Microsoft.Build package.
 
-Backport: https://github.com/dotnet/source-build/issues/3540
+Backport: https://github.com/dotnet/format/pull/1887
 ---
  Directory.Packages.props | 1 +
  eng/Version.Details.xml  | 4 ++++

--- a/src/SourceBuild/tarball/patches/format/0002-Add-explicit-System.Text.Json-dependency.patch
+++ b/src/SourceBuild/tarball/patches/format/0002-Add-explicit-System.Text.Json-dependency.patch
@@ -1,0 +1,73 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nikola Milosavljevic <nikolam@microsoft.com>
+Date: Mon, 26 Jun 2023 23:46:46 +0000
+Subject: [PATCH] Add explicit System.Text.Json dependency
+
+Adding an excplicit System.Text.Json dependency to prevent transitive dependency to be picked up
+from PSB, via Microsoft.Build package.
+
+Backport: https://github.com/dotnet/source-build/issues/3540
+---
+ Directory.Packages.props | 1 +
+ eng/Version.Details.xml  | 4 ++++
+ eng/Versions.props       | 2 ++
+ src/dotnet-format.csproj | 6 ++++++
+ 4 files changed, 13 insertions(+)
+
+diff --git a/Directory.Packages.props b/Directory.Packages.props
+index 6b628c22..c9f86593 100644
+--- a/Directory.Packages.props
++++ b/Directory.Packages.props
+@@ -36,5 +36,6 @@
+     <PackageVersion Include="NuGet.Versioning" Version="$(NuGetVersion)" />
+     <PackageVersion Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
+     <PackageVersion Include="System.CommandLine.Rendering" Version="$(SystemCommandLineRenderingVersion)" />
++    <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
+   </ItemGroup>
+ </Project>
+\ No newline at end of file
+diff --git a/eng/Version.Details.xml b/eng/Version.Details.xml
+index cdfa5f5e..86f02b44 100644
+--- a/eng/Version.Details.xml
++++ b/eng/Version.Details.xml
+@@ -13,6 +13,10 @@
+       <Uri>https://github.com/dotnet/command-line-api</Uri>
+       <Sha>82273cb56c83b589e8e5b63da0ac9745ffc6e105</Sha>
+     </Dependency>
++    <Dependency Name="System.Text.Json" Version="6.0.8">
++      <Uri>https://github.com/dotnet/runtime</Uri>
++      <Sha>3241df7f2b0f3e2dada8d07229723c79fdbe4991</Sha>
++    </Dependency>
+   </ProductDependencies>
+   <ToolsetDependencies>
+     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="7.0.0-beta.21524.1">
+diff --git a/eng/Versions.props b/eng/Versions.props
+index 27582078..bccaf176 100644
+--- a/eng/Versions.props
++++ b/eng/Versions.props
+@@ -20,6 +20,8 @@
+     <!-- Dependencies from https://github.com/dotnet/command-line-api -->
+     <SystemCommandLineVersion>2.0.0-beta1.21473.1</SystemCommandLineVersion>
+     <SystemCommandLineRenderingVersion>0.3.0-alpha.21473.1</SystemCommandLineRenderingVersion>
++    <!-- Dependencies from https://github.com/dotnet/runtime -->
++    <SystemTextJsonVersion>6.0.8</SystemTextJsonVersion>
+   </PropertyGroup>
+   <!--
+     Other Dependency versions
+diff --git a/src/dotnet-format.csproj b/src/dotnet-format.csproj
+index 5f691e6e..d812f06b 100644
+--- a/src/dotnet-format.csproj
++++ b/src/dotnet-format.csproj
+@@ -54,6 +54,12 @@
+     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
+     <PackageReference Include="Microsoft.Extensions.Logging" />
++
++    <!--
++      Explicit System.Text.Json package reference is required for source-build to pick up the live package.
++      Avoids picking up an old version via transitive dependency from Microsoft.Build or Microsoft.CodeAnalysis.Workspaces.MSBuild.
++    -->
++    <PackageReference Include="System.Text.Json"  Condition=" '$(DotnetBuildFromSource)' == 'true'" />
+   </ItemGroup>
+ 
+   <ItemGroup>

--- a/src/SourceBuild/tarball/patches/sdk/0001-Add-explicit-System.Text.Json-dependency.patch
+++ b/src/SourceBuild/tarball/patches/sdk/0001-Add-explicit-System.Text.Json-dependency.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nikola Milosavljevic <nikolam@microsoft.com>
+Date: Mon, 26 Jun 2023 23:02:20 +0000
+Subject: [PATCH] Add explicit System.Text.Json dependency
+
+Adding an excplicit System.Text.Json dependency to prevent transitive dependency to be picked up
+from PSB, via Microsoft.Build package.
+
+Backport: https://github.com/dotnet/source-build/issues/3540
+---
+ src/BuiltInTools/dotnet-watch/dotnet-watch.csproj | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj b/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj
+index 065f750f72..13d2c1ed99 100644
+--- a/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj
++++ b/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj
+@@ -23,6 +23,13 @@
+     <PackageReference Include="Microsoft.Build.Locator" Version="$(MicrosoftBuildLocatorPackageVersion)" />
+     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="$(MicrosoftCodeAnalysisCSharpFeaturesPackageVersion)" />
+     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="$(MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion)" />
++
++    <!--
++      Explicit System.Text.Json package reference is required for source-build to pick up the live package.
++      Avoids picking up an old version via transitive dependency from Microsoft.Build or Microsoft.CodeAnalysis.Workspaces.MSBuild.
++    -->
++    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" Condition="'$(DotnetBuildFromSource)' == 'true'" />
++
+     <Compile Include="$(RepoRoot)src\Common\PathUtilities.cs" LinkBase="Common" />
+   </ItemGroup>
+ 

--- a/src/SourceBuild/tarball/patches/sdk/0001-Add-explicit-System.Text.Json-dependency.patch
+++ b/src/SourceBuild/tarball/patches/sdk/0001-Add-explicit-System.Text.Json-dependency.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add explicit System.Text.Json dependency
 Adding an excplicit System.Text.Json dependency to prevent transitive dependency to be picked up
 from PSB, via Microsoft.Build package.
 
-Backport: https://github.com/dotnet/source-build/issues/3540
+Backport: https://github.com/dotnet/sdk/pull/33618
 ---
  src/BuiltInTools/dotnet-watch/dotnet-watch.csproj | 7 +++++++
  1 file changed, 7 insertions(+)


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/3540

`Microsoft.Build` package dependency is pulling a transitive `System.Text.Json` dependency from PSB. The fix is to simply add an explicit `System.Text.Json` dependency.

I'm not 100% sure if changes in `eng/Version.Details.xml` (`format` patch) are necessary.