### PR TITLE
Ignore CS9169 for runtime repo

### DIFF
--- a/src/SourceBuild/content/repo-projects/runtime.proj
+++ b/src/SourceBuild/content/repo-projects/runtime.proj
@@ -26,6 +26,9 @@
     <BuildCommandArgs>$(BuildCommandArgs) /p:SourceBuildNonPortable=true</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:UsingToolMicrosoftNetCompilers=false</BuildCommandArgs>
     <BuildCommand>$(StandardSourceBuildCommand) $(BuildCommandArgs)</BuildCommand>
+
+    <!-- CS9169 - Invalid inline array fields (https://github.com/dotnet/runtime/issues/88141) -->
+    <RepoNoWarns>CS9169</RepoNoWarns>
   </PropertyGroup>
 
   <!-- SDK Overrides -->


### PR DESCRIPTION
SB bootstrap stage 2 builds are failing with the following error:

```
/vmr/src/runtime/artifacts/source-build/self/src/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBase.cs(314,38): error CS9169: Inline array struct must declare one and only one instance field which must not be a ref field. [/vmr/src/runtime/artifacts/source-build/self/src/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj]
```

This change resolves the issue by configuring the runtime repo to ignore that error.

Related to https://github.com/dotnet/runtime/issues/88141