### PR TITLE
Update SB SDK diff pipeline job name refs

### DIFF
--- a/eng/pipelines/source-build-sdk-diff-tests.yml
+++ b/eng/pipelines/source-build-sdk-diff-tests.yml
@@ -36,8 +36,8 @@ jobs:
 
 - template: templates/jobs/sdk-diff-tests.yml
   parameters:
-    buildName: Fedora36_Offline_MsftSdk
-    targetRid: fedora.36-x64
+    buildName: Fedora38_Offline_MsftSdk
+    targetRid: fedora.38-x64
     architecture: x64
     dotnetDotnetRunId: ${{ parameters.dotnetDotnetRunId }}
 
@@ -50,7 +50,7 @@ jobs:
 
 - template: templates/jobs/sdk-diff-tests.yml
   parameters:
-    buildName: Debian11_Offline_MsftSdk
-    targetRid: debian.11-arm64
+    buildName: Ubuntu2204Arm64_Offline_MsftSdk
+    targetRid: ubuntu.22.04-arm64
     architecture: arm64
     dotnetDotnetRunId: ${{ parameters.dotnetDotnetRunId }}


### PR DESCRIPTION
The [source-build-sdk-diff-tests pipeline](https://github.com/dotnet/installer/blob/main/eng/pipelines/source-build-sdk-diff-tests.yml) is failing in the `Fedora36_Offline_MsftSdk_x64` and `Debian11_Offline_MsftSdk_arm64` jobs with an error like:

```
##[error]Artifact Fedora36_Offline_MsftSdk_x64_Artifacts was not found for build 2213558.
```

This is because these two referenced jobs have had their names changed in the VMR build.

Fixed by updating the referenced job names to be based on the changes that were made in https://github.com/dotnet/installer/pull/16774 and https://github.com/dotnet/installer/pull/16756.