### PR TITLE
Upgrade SB build leg from Ubuntu 20.04 to Ubuntu 22.04

### DIFF
--- a/eng/pipelines/source-build-sdk-diff-tests.yml
+++ b/eng/pipelines/source-build-sdk-diff-tests.yml
@@ -43,8 +43,8 @@ jobs:
 
 - template: templates/jobs/sdk-diff-tests.yml
   parameters:
-    buildName: Ubuntu2004_Offline_MsftSdk
-    targetRid: ubuntu.20.04-x64
+    buildName: Ubuntu2204_Offline_MsftSdk
+    targetRid: ubuntu.22.04-x64
     architecture: x64
     dotnetDotnetRunId: ${{ parameters.dotnetDotnetRunId }}
 

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -17,7 +17,7 @@ parameters:
   centOSStream8Container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8
   centOSStream9Container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9
   fedora38Container: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-38
-  ubuntu2004Container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04
+  ubuntu2204Container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04
   ubuntu2204ArmContainer: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-arm64
 
   # Internal builds
@@ -194,14 +194,14 @@ stages:
 
     - template: ../jobs/vmr-build.yml
       parameters:
-        buildName: Ubuntu2004_Offline_MsftSdk
+        buildName: Ubuntu2204_Offline_MsftSdk
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
         vmrBranch: ${{ variables.VmrBranch }}
         architecture: x64
         pool:
           name: ${{ variables.defaultPoolName }}
           demands: ${{ variables.defaultPoolDemands }}
-        container: ${{ parameters.ubuntu2004Container }}
+        container: ${{ parameters.ubuntu2204Container }}
         buildFromArchive: false            # 🚫
         enablePoison: false                # 🚫
         excludeOmniSharpTests: false       # 🚫

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -71,6 +71,7 @@ stages:
 
   - template: ../jobs/vmr-build.yml
     parameters:
+      # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
       buildName: CentOSStream8_Online_MsftSdk
       isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
       vmrBranch: ${{ variables.VmrBranch }}
@@ -88,6 +89,7 @@ stages:
 
   - template: ../jobs/vmr-build.yml
     parameters:
+      # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
       buildName: CentOSStream8_Offline_MsftSdk
       isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
       vmrBranch: ${{ variables.VmrBranch }}
@@ -109,6 +111,7 @@ stages:
 
     - template: ../jobs/vmr-build.yml
       parameters:
+        # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
         buildName: Alpine317_Offline_MsftSdk
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
         vmrBranch: ${{ variables.VmrBranch }}
@@ -126,6 +129,7 @@ stages:
 
     - template: ../jobs/vmr-build.yml
       parameters:
+        # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
         buildName: CentOSStream8_Online_PreviousSourceBuiltSdk
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
         vmrBranch: ${{ variables.VmrBranch }}
@@ -143,6 +147,7 @@ stages:
 
     - template: ../jobs/vmr-build.yml
       parameters:
+        # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
         buildName: CentOSStream8_Mono_Offline_MsftSdk
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
         vmrBranch: ${{ variables.VmrBranch }}
@@ -160,6 +165,7 @@ stages:
 
     - template: ../jobs/vmr-build.yml
       parameters:
+        # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
         buildName: CentOSStream9_Offline_MsftSdk
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
         vmrBranch: ${{ variables.VmrBranch }}
@@ -177,6 +183,7 @@ stages:
 
     - template: ../jobs/vmr-build.yml
       parameters:
+        # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
         buildName: Fedora38_Offline_MsftSdk
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
         vmrBranch: ${{ variables.VmrBranch }}
@@ -194,6 +201,7 @@ stages:
 
     - template: ../jobs/vmr-build.yml
       parameters:
+        # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
         buildName: Ubuntu2204_Offline_MsftSdk
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
         vmrBranch: ${{ variables.VmrBranch }}
@@ -213,6 +221,7 @@ stages:
 
     - template: ../jobs/vmr-build.yml
       parameters:
+        # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
         buildName: Ubuntu2204Arm64_Offline_MsftSdk
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
         vmrBranch: ${{ variables.VmrBranch }}
@@ -230,6 +239,7 @@ stages:
 
     - template: ../jobs/vmr-build.yml
       parameters:
+        # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
         buildName: CentOSStream8_Online_CurrentSourceBuiltSdk
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
         vmrBranch: ${{ variables.VmrBranch }}
@@ -248,6 +258,7 @@ stages:
 
     - template: ../jobs/vmr-build.yml
       parameters:
+        # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
         buildName: Fedora38_Offline_CurrentSourceBuiltSdk
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
         vmrBranch: ${{ variables.VmrBranch }}


### PR DESCRIPTION
The runtime repo is failing to build in the Ubuntu 20.04 leg of the VMR due to this error:

```
Commencing build of "install" target in "CoreCLR component" for linux.x64.Release in /vmr/src/runtime/artifacts/source-build/self/src/artifacts/obj/coreclr/linux.x64.Release
Invoking "/vmr/src/runtime/artifacts/source-build/self/src/eng/native/gen-buildsys.sh" "/vmr/src/runtime/artifacts/source-build/self/src/src/coreclr" "/vmr/src/runtime/artifacts/source-build/self/src/artifacts/obj/coreclr/linux.x64.Release" x64 linux clang Release ""  -DCLR_CMAKE_PGO_INSTRUMENT=0 -DCLR_CMAKE_OPTDATA_PATH= -DCLR_CMAKE_PGO_OPTIMIZE=0 -DCLI_CMAKE_FALLBACK_OS="ubuntu.20.04" -DFEATURE_DISTRO_AGNOSTIC_SSL=0  -DCLR_CMAKE_KEEP_NATIVE_SYMBOLS=true
/vmr/src/runtime/artifacts/source-build/self/src/artifacts/obj/coreclr/linux.x64.Release /vmr/src/runtime/artifacts/source-build/self/src/src/coreclr
Not searching for unused variables given on the command line.
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  CMake 3.20 or higher is required.  You are running version 3.16.3
```

This happens because the [minimum required version of CMake has been upgraded to 3.20](https://github.com/dotnet/runtime/pull/86530). But the CMake version in Ubuntu 20.04 is at 3.16.3.

Fixing this by upgrading the version to Ubuntu 22.04 which has the required CMake version.