### PR TITLE
Set portable RID architecture for SDK diff tests

### DIFF
--- a/eng/pipelines/templates/jobs/sdk-diff-tests.yml
+++ b/eng/pipelines/templates/jobs/sdk-diff-tests.yml
@@ -119,7 +119,7 @@ jobs:
       -e SMOKE_TESTS_WARN_SDK_CONTENT_DIFFS=false
       -e SMOKE_TESTS_RUNNING_IN_CI=true
       -e SMOKE_TESTS_TARGET_RID=${{ parameters.targetRid }}
-      -e SMOKE_TESTS_PORTABLE_RID=linux-x64
+      -e SMOKE_TESTS_PORTABLE_RID=linux-${{ parameters.architecture }}
       -e SMOKE_TESTS_CUSTOM_PACKAGES_PATH= 
     displayName: Run Tests
     workingDirectory: $(Build.SourcesDirectory)


### PR DESCRIPTION
The source-build SDK diff tests are failing with a diff in the Arm64 leg:

```diff
  ./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Security.Cryptography.Xml.xml
  ./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Threading.RateLimiting.dll
  ./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Threading.RateLimiting.xml
--./packs/Microsoft.NETCore.App.Host.portable-rid/
--./packs/Microsoft.NETCore.App.Host.portable-rid/x.y.z/
--./packs/Microsoft.NETCore.App.Host.portable-rid/x.y.z/runtimes/
--./packs/Microsoft.NETCore.App.Host.portable-rid/x.y.z/runtimes/portable-rid/
--./packs/Microsoft.NETCore.App.Host.portable-rid/x.y.z/runtimes/portable-rid/native/
--./packs/Microsoft.NETCore.App.Host.portable-rid/x.y.z/runtimes/portable-rid/native/apphost
--./packs/Microsoft.NETCore.App.Host.portable-rid/x.y.z/runtimes/portable-rid/native/coreclr_delegates.h
--./packs/Microsoft.NETCore.App.Host.portable-rid/x.y.z/runtimes/portable-rid/native/hostfxr.h
--./packs/Microsoft.NETCore.App.Host.portable-rid/x.y.z/runtimes/portable-rid/native/libnethost.a
--./packs/Microsoft.NETCore.App.Host.portable-rid/x.y.z/runtimes/portable-rid/native/libnethost.so
--./packs/Microsoft.NETCore.App.Host.portable-rid/x.y.z/runtimes/portable-rid/native/nethost.h
--./packs/Microsoft.NETCore.App.Host.portable-rid/x.y.z/runtimes/portable-rid/native/singlefilehost
+-./packs/Microsoft.NETCore.App.Host.linux-arm64/
+-./packs/Microsoft.NETCore.App.Host.linux-arm64/x.y.z/
+-./packs/Microsoft.NETCore.App.Host.linux-arm64/x.y.z/runtimes/
+-./packs/Microsoft.NETCore.App.Host.linux-arm64/x.y.z/runtimes/linux-arm64/
+-./packs/Microsoft.NETCore.App.Host.linux-arm64/x.y.z/runtimes/linux-arm64/native/
+-./packs/Microsoft.NETCore.App.Host.linux-arm64/x.y.z/runtimes/linux-arm64/native/apphost
+-./packs/Microsoft.NETCore.App.Host.linux-arm64/x.y.z/runtimes/linux-arm64/native/coreclr_delegates.h
+-./packs/Microsoft.NETCore.App.Host.linux-arm64/x.y.z/runtimes/linux-arm64/native/hostfxr.h
+-./packs/Microsoft.NETCore.App.Host.linux-arm64/x.y.z/runtimes/linux-arm64/native/libnethost.a
+-./packs/Microsoft.NETCore.App.Host.linux-arm64/x.y.z/runtimes/linux-arm64/native/libnethost.so
+-./packs/Microsoft.NETCore.App.Host.linux-arm64/x.y.z/runtimes/linux-arm64/native/nethost.h
+-./packs/Microsoft.NETCore.App.Host.linux-arm64/x.y.z/runtimes/linux-arm64/native/singlefilehost
 +./packs/Microsoft.NETCore.App.Host.banana-rid/
 +./packs/Microsoft.NETCore.App.Host.banana-rid/x.y.z/
 +./packs/Microsoft.NETCore.App.Host.banana-rid/x.y.z/runtimes/
```

This happens because the paths in the Arm64 are not correctly normalized. `linux-arm64` should be normalized as `portable-rid`. This doesn't happen because `linux-arm64` isn't set to be the portable RID in the test configuration. That's because it's been hardcoded to `linux-x64`.

Fixed this by injecting the architecture into the portable RID value.