### PR TITLE
Stabilize branding

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -10,6 +10,7 @@
     <add key="darc-pub-DotNet-msbuild-Trusted-5785ed5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-DotNet-msbuild-Trusted-5785ed5c/nuget/v3/index.json" />
     <!--  End: Package sources from DotNet-msbuild-Trusted -->
     <!--  Begin: Package sources from dotnet-aspnetcore -->
+    <add key="darc-pub-dotnet-aspnetcore-c993061" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspnetcore-c9930616/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-aspnetcore -->
     <!--  Begin: Package sources from dotnet-emsdk -->
     <!--  End: Package sources from dotnet-emsdk -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,20 +10,20 @@
     <VersionSDKMinor>4</VersionSDKMinor>
     <VersionFeature>00</VersionFeature>
     <VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionSDKMinor)$(VersionFeature)</VersionPrefix>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>
     </PreReleaseVersionIteration>
     <MajorMinorVersion>$(VersionMajor).$(VersionMinor)</MajorMinorVersion>
     <CliProductBandVersion>$(MajorMinorVersion).$(VersionSDKMinor)</CliProductBandVersion>
     <!-- Enable to remove prerelease label. -->
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
   </PropertyGroup>
   <PropertyGroup>
     <VersionFeature21>30</VersionFeature21>
     <VersionFeature31>32</VersionFeature31>
     <VersionFeature50>17</VersionFeature50>
-    <VersionFeature60>19</VersionFeature60>
+    <VersionFeature60>$([MSBuild]::Add($(VersionFeature), 20))</VersionFeature60>
   </PropertyGroup>
   <!-- Restore feeds -->
   <PropertyGroup Label="Restore feeds">


### PR DESCRIPTION
7.0.4xx will be shipping its final preview next week and so putting out the PR to stabilize branding in preparation for GA release. Update the implicit version to be automatic. This PR should wait till the runtime in SDK has been updated to 7.0.9 on Tuesday I think. 

I believe some tests will need to be disabled with the implicit version update.

- Please add description for changes you are making.
- If there is an issue related to this PR, please add the reference.
