### PR TITLE
Build sourcelink after command-line-api

### DIFF
--- a/src/SourceBuild/content/repo-projects/arcade.proj
+++ b/src/SourceBuild/content/repo-projects/arcade.proj
@@ -30,9 +30,5 @@
     <ExtraPackageVersionPropsPackageInfo Include="NuGetVersion" Version="%24(NuGetPackagingVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <RepositoryReference Include="sourcelink" />
-  </ItemGroup>
-
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/SourceBuild/content/repo-projects/dotnet.proj
+++ b/src/SourceBuild/content/repo-projects/dotnet.proj
@@ -13,11 +13,11 @@
   <ItemGroup>
     <!-- Toolsets -->
     <RepositoryReference Include="source-build-reference-packages" />
-    <RepositoryReference Include="sourcelink" />
     <RepositoryReference Include="arcade" />
 
     <!-- Product Repos -->
     <RepositoryReference Include="command-line-api" />
+    <RepositoryReference Include="sourcelink" />
     <RepositoryReference Include="diagnostics" />
     <RepositoryReference Include="emsdk" />
     <RepositoryReference Include="xliff-tasks" />

--- a/src/SourceBuild/content/repo-projects/sourcelink.proj
+++ b/src/SourceBuild/content/repo-projects/sourcelink.proj
@@ -5,13 +5,14 @@
     <BuildCommand>$(StandardSourceBuildCommand) $(StandardSourceBuildArgs)</BuildCommand>
 
     <LogVerbosityOptOut>true</LogVerbosityOptOut>
-
-    <!-- SourceLink builds before Arcade so it also needs the bootstrap Arcade version -->
-    <UseBootstrapArcade>true</UseBootstrapArcade>
   </PropertyGroup>
 
   <ItemGroup>
     <ExtraPackageVersionPropsPackageInfo Include="MicrosoftSourceLinkVersion" Version="$(SOURCE_LINK_BOOTSTRAP_VERSION)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <RepositoryReference Include="command-line-api" />
   </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />


### PR DESCRIPTION
Contributes to:
- Response for sourcelink being bundled in the SDK: https://github.com/dotnet/source-build/issues/3439
- Building dotnet-sourcelink in source-build: https://github.com/dotnet/sourcelink/issues/1028
- Running sourcelink-specific source-build tests: https://github.com/dotnet/source-build/issues/3052
