### PR TITLE
Add Microsoft.CodeAnalysis.AnalyzerUtilities.dll to poison baseline

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -219,8 +219,14 @@ jobs:
 
       dockerVolumeArgs="-v $(sourcesPath):/vmr"
       dockerEnvArgs="-e SMOKE_TESTS_EXCLUDE_OMNISHARP=${{ parameters.excludeOmniSharpTests }} -e SMOKE_TESTS_WARN_SDK_CONTENT_DIFFS=true -e SMOKE_TESTS_RUNNING_IN_CI=true"
+      poisonArg=''
 
-      docker run --rm $dockerVolumeArgs -w /vmr $dockerEnvArgs ${{ parameters.container }} ./build.sh --run-smoke-test $(additionalBuildArgs) -- -p:SmokeTestConsoleVerbosity=detailed
+      if [[ '${{ parameters.enablePoison }}' == 'True' ]]; then
+        poisonArg='--poison'
+        dockerEnvArgs+=" -e SMOKE_TESTS_WARN_POISON_DIFFS=true"
+      fi
+
+      docker run --rm $dockerVolumeArgs -w /vmr $dockerEnvArgs ${{ parameters.container }} ./build.sh $poisonArg --run-smoke-test $(additionalBuildArgs) -- -p:SmokeTestConsoleVerbosity=detailed
     displayName: Run Tests
 
   # Don't use CopyFiles@2 as it encounters permissions issues because it indexes all files in the source directory graph.

--- a/src/SourceBuild/content/build.proj
+++ b/src/SourceBuild/content/build.proj
@@ -70,8 +70,7 @@
                     HashCatalogFilePath="$(PoisonReportDataFile)"
                     MarkerFileName="$(PoisonMarkerFile)"
                     PoisonReportOutputFilePath="$(PoisonUsageReportFile)"
-                    NonShippingPackagesListFiles="@(NonShippingPackagesList)"
-                    FailOnPoisonFound="true" />
+                    NonShippingPackagesListFiles="@(NonShippingPackagesList)" />
 
     <WriteLinesToFile File="$(CompletedSemaphorePath)ReportPoisonUsage.complete" Overwrite="true" />
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Done checking for poison." />
@@ -94,6 +93,7 @@
     </ItemGroup>
 
     <PropertyGroup>
+      <CustomTestEnvVars Condition="'$(EnablePoison)' == 'true'">SMOKE_TESTS_POISON_REPORT_PATH=$(PoisonUsageReportFile);</CustomTestEnvVars>
       <SdkTarballPath>%(SdkTarballItem.Identity)</SdkTarballPath>
       <SourceBuiltArtifactsPath>%(SourceBuiltArtifactsItem.Identity)</SourceBuiltArtifactsPath>
       <SmokeTestConsoleVerbosity Condition="'$(SmokeTestConsoleVerbosity)' == ''">normal</SmokeTestConsoleVerbosity>

--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection/CheckForPoison.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection/CheckForPoison.cs
@@ -160,6 +160,11 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.LeakDetection
             {
                 Log.LogWarning($"{poisons.Count()} marked files leaked to output.  See complete report '{PoisonReportOutputFilePath}' for details.");
             }
+            else
+            {
+                Log.LogError($"No leaked files found in output.  Either something is broken or it is the future and we have fixed all leaks - please verify and remove this error if so (and default {nameof(FailOnPoisonFound)} to true).");
+                return false;
+            }
 
             return !Log.HasLoggedErrors;
         }

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/Config.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/Config.cs
@@ -12,18 +12,21 @@ internal static class Config
     public const string DotNetDirectoryEnv = "SMOKE_TESTS_DOTNET_DIR";
     public const string ExcludeOmniSharpEnv = "SMOKE_TESTS_EXCLUDE_OMNISHARP";
     public const string MsftSdkTarballPathEnv = "SMOKE_TESTS_MSFT_SDK_TARBALL_PATH";
+    public const string PoisonReportPathEnv = "SMOKE_TESTS_POISON_REPORT_PATH";
     public const string PortableRidEnv = "SMOKE_TESTS_PORTABLE_RID";
     public const string PrereqsPathEnv = "SMOKE_TESTS_PREREQS_PATH";
     public const string CustomPackagesPathEnv = "SMOKE_TESTS_CUSTOM_PACKAGES_PATH";
     public const string SdkTarballPathEnv = "SMOKE_TESTS_SDK_TARBALL_PATH";
     public const string SourceBuiltArtifactsPathEnv = "SMOKE_TESTS_SOURCEBUILT_ARTIFACTS_PATH";
     public const string TargetRidEnv = "SMOKE_TESTS_TARGET_RID";
+    public const string WarnPoisonDiffsEnv = "SMOKE_TESTS_WARN_POISON_DIFFS";
     public const string WarnSdkContentDiffsEnv = "SMOKE_TESTS_WARN_SDK_CONTENT_DIFFS";
     public const string RunningInCIEnv = "SMOKE_TESTS_RUNNING_IN_CI";
 
     public static string DotNetDirectory { get; } =
         Environment.GetEnvironmentVariable(DotNetDirectoryEnv) ?? Path.Combine(Directory.GetCurrentDirectory(), ".dotnet");
     public static string? MsftSdkTarballPath { get; } = Environment.GetEnvironmentVariable(MsftSdkTarballPathEnv);
+    public static string? PoisonReportPath { get; } = Environment.GetEnvironmentVariable(PoisonReportPathEnv);
     public static string PortableRid { get; } = Environment.GetEnvironmentVariable(PortableRidEnv) ??
         throw new InvalidOperationException($"'{Config.PortableRidEnv}' must be specified");
     public static string? PrereqsPath { get; } = Environment.GetEnvironmentVariable(PrereqsPathEnv);
@@ -34,6 +37,8 @@ internal static class Config
     public static string TargetRid { get; } = Environment.GetEnvironmentVariable(TargetRidEnv) ??
         throw new InvalidOperationException($"'{Config.TargetRidEnv}' must be specified");
     public static string TargetArchitecture { get; } = TargetRid.Split('-')[1];
+    public static bool WarnOnPoisonDiffs { get; } =
+        bool.TryParse(Environment.GetEnvironmentVariable(WarnPoisonDiffsEnv), out bool excludeOnlineTests) && excludeOnlineTests;
     public static bool WarnOnSdkContentDiffs { get; } =
         bool.TryParse(Environment.GetEnvironmentVariable(WarnSdkContentDiffsEnv), out bool excludeOnlineTests) && excludeOnlineTests;
 

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/PoisonTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/PoisonTests.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.SourceBuild.SmokeTests
+{
+    public class PoisonTests : SmokeTests
+    {
+        public PoisonTests(ITestOutputHelper outputHelper) : base(outputHelper) { }
+
+        [SkippableFact(Config.PoisonReportPathEnv, skipOnNullOrWhiteSpace: true)]
+        public void VerifyUsage()
+        {
+            if (!File.Exists(Config.PoisonReportPath))
+            {
+                throw new InvalidOperationException($"Poison report '{Config.PoisonReportPath}' does not exist.");
+            }
+
+            string currentPoisonReport = File.ReadAllText(Config.PoisonReportPath);
+            currentPoisonReport = RemoveHashes(currentPoisonReport);
+            currentPoisonReport = BaselineHelper.RemoveRids(currentPoisonReport);
+            currentPoisonReport = BaselineHelper.RemoveRids(currentPoisonReport, true);
+            currentPoisonReport = BaselineHelper.RemoveVersions(currentPoisonReport);
+
+            BaselineHelper.CompareContents("PoisonUsage.txt", currentPoisonReport, OutputHelper, Config.WarnOnPoisonDiffs);
+        }
+
+        private static string RemoveHashes(string source) => Regex.Replace(source, "^\\s*<Hash>.*</Hash>(\r\n?|\n)", string.Empty, RegexOptions.Multiline);
+    }
+}

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/PoisonUsage.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/PoisonUsage.txt
@@ -1,0 +1,11 @@
+<PrebuiltLeakReport>
+  <File Path="dotnet-format.x.y.z/tools/netx.y/any/Microsoft.CodeAnalysis.AnalyzerUtilities.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="dotnet-sdk-x.y.z-banana-rid.tar/sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.CodeAnalysis.AnalyzerUtilities.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="dotnet-sdk-x.y.z-banana-rid.tar/sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Microsoft.CodeAnalysis.AnalyzerUtilities.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+</PrebuiltLeakReport>


### PR DESCRIPTION
Recently, [Microsoft.CodeAnalysis.AnalyzerUtilities.dll has showed up as a SB poison leak](https://github.com/dotnet/source-build/issues/3556) in the VMR build. For now, we're going to need to allow this for .NET 8 Preview 7 release. Since poison leaks currently break the build as error, we need to disable that and instead use poison tests with a baseline that includes this file. This will allow for passing builds. These changes revert most of the changes that were made in https://github.com/dotnet/installer/pull/16631 which got rid of the poison tests.