### PR TITLE
patch VMR-incompatable license in source-build-externals

### DIFF
--- a/src/SourceBuild/patches/source-build-externals/0001-remove-comment-2671.patch
+++ b/src/SourceBuild/patches/source-build-externals/0001-remove-comment-2671.patch
@@ -1,0 +1,32 @@
+From 7ce38a6434c502213e2652dc15afa5cf392a60f3 Mon Sep 17 00:00:00 2001
+From: Timothy Mothra <tilee@microsoft.com>
+Date: Tue, 6 Sep 2022 11:38:11 -0700
+Subject: [PATCH] remove comment (#2671)
+
+Backport: https://github.com/microsoft/ApplicationInsights-dotnet/pull/2671
+
+The patch in question removes a licensing declaration that is incompatable with the VMR.
+If the patch would be applied in source-build-externals directly, the change would be made onto
+the inner source-build (i.e. the package produced), while the VMR entry for it would still be
+affected.
+
+This can be removed once a new release version of the package is available and used by the .NET repos.
+---
+ src/application-insights/LOGGING/test/Shared/CustomTelemetryChannel.cs | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/src/application-insights/LOGGING/test/Shared/CustomTelemetryChannel.cs b/src/application-insights/LOGGING/test/Shared/CustomTelemetryChannel.cs
+index 807da59c..0a95bce9 100644
+--- a/src/application-insights/LOGGING/test/Shared/CustomTelemetryChannel.cs
++++ b/src/application-insights/LOGGING/test/Shared/CustomTelemetryChannel.cs
+@@ -1,7 +1,6 @@
+ ﻿//-----------------------------------------------------------------------------------
+ // <copyright file='CustomTelemetryChannel.cs' company='Microsoft Corporation'>
+ //     Copyright (c) Microsoft Corporation. All Rights Reserved.
+-//     Information Contained Herein is Proprietary and Confidential.
+ // </copyright>
+ //-----------------------------------------------------------------------------------
+ 
+-- 
+2.25.1
+

--- a/src/SourceBuild/patches/source-build-externals/0001-remove-comment-2671.patch
+++ b/src/SourceBuild/patches/source-build-externals/0001-remove-comment-2671.patch
@@ -10,7 +10,8 @@ If the patch would be applied in source-build-externals directly, the change wou
 the inner source-build (i.e. the package produced), while the VMR entry for it would still be
 affected.
 
-This can be removed once a new release version of the package is available and used by the .NET repos.
+This can be removed once a new release version of the package is available and used by the .NET repos:
+https://github.com/microsoft/ApplicationInsights-dotnet/issues/2792
 ---
  src/application-insights/LOGGING/test/Shared/CustomTelemetryChannel.cs | 1 -
  1 file changed, 1 deletion(-)


### PR DESCRIPTION
Resolves https://github.com/dotnet/source-build/issues/3529
