### PR TITLE
Exclude vstest licenses directory from VMR

### DIFF
--- a/src/VirtualMonoRepo/source-mappings.json
+++ b/src/VirtualMonoRepo/source-mappings.json
@@ -171,7 +171,12 @@
         },
         {
             "name": "vstest",
-            "defaultRemote": "https://github.com/microsoft/vstest"
+            "defaultRemote": "https://github.com/microsoft/vstest",
+            "exclude": [
+                // These license files are for the nuget packages that vstest produces which include additional files built in
+                // different repositories and have different licensing. See https://github.com/microsoft/vstest/issues/4574
+                "src/package/licenses/**/*"
+            ]
         },
         {
             "name": "xdt",


### PR DESCRIPTION
https://github.com/dotnet/source-build/issues/3538 and https://github.com/microsoft/vstest/issues/4574
