### PR TITLE
Allow .lss binaries for all repos

### DIFF
--- a/src/VirtualMonoRepo/allowed-binaries.txt
+++ b/src/VirtualMonoRepo/allowed-binaries.txt
@@ -20,6 +20,8 @@
 **/TestCert*.pfx
 **/tests/*
 
+src/*/eng/common/loc/*.lss # UTF16-LE text files
+
 src/aspnetcore/**/samples/*
 src/aspnetcore/**/TestCertificates/*
 src/aspnetcore/src/*.eot
@@ -30,8 +32,6 @@ src/aspnetcore/src/*.woff2
 src/aspnetcore/src/Components/Web.JS/dist/Release/blazor.*.js # JavaScript files with a null bytes
 src/aspnetcore/src/ProjectTemplates/Web.ProjectTemplates/**/app.db
 src/aspnetcore/src/submodules/spa-templates/**/app.db
-
-src/emsdk/eng/common/loc/*.lss # UTF16-LE text files
 
 src/fsharp/**/signedtests/*
 src/fsharp/src/fsi/fsi.res # Icon


### PR DESCRIPTION
The `Scan for binaries` job for the VMR is detecting a binary in the msbuild repo:

```
src/msbuild/eng/common/loc/P22DotNetHtmlLocalization.lss
```

This was introduced by https://github.com/dotnet/msbuild/pull/8672.

We already have an allowance for this for the `emsdk` repo. So I've generalized this to be applicable for all repos.