### PR TITLE
Fix syntax for allowed lss binaries

### DIFF
--- a/src/VirtualMonoRepo/allowed-binaries.txt
+++ b/src/VirtualMonoRepo/allowed-binaries.txt
@@ -20,7 +20,7 @@
 **/TestCert*.pfx
 **/tests/*
 
-src/*/eng/common/loc/*.lss # UTF16-LE text files
+**/eng/common/loc/*.lss # UTF16-LE text files
 
 src/aspnetcore/**/samples/*
 src/aspnetcore/**/TestCertificates/*


### PR DESCRIPTION
The changes in https://github.com/dotnet/installer/pull/17028 didn't work properly. The lss file is still being detected. This is because the [logic in the scanner](https://github.com/dotnet/arcade-services/blob/26c95087390ac3cb03d80c8b4054482551f23c81/src/Microsoft.DotNet.Darc/DarcLib/VirtualMonoRepo/VmrScanner.cs#L92) doesn't support wildcards for repo names. Instead, I've adjusted it to use a global pattern.