### PR TITLE
Revert "Exclude vstest licenses directory from VMR (#17023)"

### DIFF
--- a/src/VirtualMonoRepo/source-mappings.json
+++ b/src/VirtualMonoRepo/source-mappings.json
@@ -171,12 +171,7 @@
         },
         {
             "name": "vstest",
-            "defaultRemote": "https://github.com/microsoft/vstest",
-            "exclude": [
-                // These license files are for the nuget packages that vstest produces which include additional files built in
-                // different repositories and have different licensing. See https://github.com/microsoft/vstest/issues/4574
-                "src/package/licenses/**/*"
-            ]
+            "defaultRemote": "https://github.com/microsoft/vstest"
         },
         {
             "name": "xdt",


### PR DESCRIPTION
This reverts commit ffb1fa4dde21b3b5d6bb5c93d57df52a68c0440c from https://github.com/dotnet/installer/pull/17023.  The corresponding changes in https://github.com/dotnet/dotnet/pull/32 didn't catch that this would cause a build break.

cc @nohwnd, @premun 


