### PR TITLE
Fail source build tests when there is a poison leak

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -223,7 +223,6 @@ jobs:
 
       if [[ '${{ parameters.enablePoison }}' == 'True' ]]; then
         poisonArg='--poison'
-        dockerEnvArgs+=" -e SMOKE_TESTS_WARN_POISON_DIFFS=true"
       fi
 
       docker run --rm $dockerVolumeArgs -w /vmr $dockerEnvArgs ${{ parameters.container }} ./build.sh $poisonArg --run-smoke-test $(additionalBuildArgs) -- -p:SmokeTestConsoleVerbosity=detailed

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/Config.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/Config.cs
@@ -19,7 +19,6 @@ internal static class Config
     public const string SdkTarballPathEnv = "SMOKE_TESTS_SDK_TARBALL_PATH";
     public const string SourceBuiltArtifactsPathEnv = "SMOKE_TESTS_SOURCEBUILT_ARTIFACTS_PATH";
     public const string TargetRidEnv = "SMOKE_TESTS_TARGET_RID";
-    public const string WarnPoisonDiffsEnv = "SMOKE_TESTS_WARN_POISON_DIFFS";
     public const string WarnSdkContentDiffsEnv = "SMOKE_TESTS_WARN_SDK_CONTENT_DIFFS";
     public const string RunningInCIEnv = "SMOKE_TESTS_RUNNING_IN_CI";
 
@@ -37,10 +36,8 @@ internal static class Config
     public static string TargetRid { get; } = Environment.GetEnvironmentVariable(TargetRidEnv) ??
         throw new InvalidOperationException($"'{Config.TargetRidEnv}' must be specified");
     public static string TargetArchitecture { get; } = TargetRid.Split('-')[1];
-    public static bool WarnOnPoisonDiffs { get; } =
-        bool.TryParse(Environment.GetEnvironmentVariable(WarnPoisonDiffsEnv), out bool excludeOnlineTests) && excludeOnlineTests;
     public static bool WarnOnSdkContentDiffs { get; } =
-        bool.TryParse(Environment.GetEnvironmentVariable(WarnSdkContentDiffsEnv), out bool excludeOnlineTests) && excludeOnlineTests;
+        bool.TryParse(Environment.GetEnvironmentVariable(WarnSdkContentDiffsEnv), out bool warnOnSdkContentDiffs) && warnOnSdkContentDiffs;
 
     // Indicates whether the tests are being run in the context of a CI pipeline
     public static bool RunningInCI { get; } =

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/PoisonTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/PoisonTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.SourceBuild.SmokeTests
             currentPoisonReport = BaselineHelper.RemoveRids(currentPoisonReport, true);
             currentPoisonReport = BaselineHelper.RemoveVersions(currentPoisonReport);
 
-            BaselineHelper.CompareContents("PoisonUsage.txt", currentPoisonReport, OutputHelper, Config.WarnOnPoisonDiffs);
+            BaselineHelper.CompareContents("PoisonUsage.txt", currentPoisonReport, OutputHelper);
         }
 
         private static string RemoveHashes(string source) => Regex.Replace(source, "^\\s*<Hash>.*</Hash>(\r\n?|\n)", string.Empty, RegexOptions.Multiline);


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/3561.

Test build - https://dev.azure.com/dnceng/internal/_build/results?buildId=2226906&view=results (Microsoft internal link)
