### PR TITLE
Flow Microsoft.CodeAnalysis version to aspnetcore

### DIFF
--- a/src/SourceBuild/content/repo-projects/aspnetcore.proj
+++ b/src/SourceBuild/content/repo-projects/aspnetcore.proj
@@ -39,6 +39,7 @@
     -->
     <ExtraPackageVersionPropsPackageInfo Include="Analyzer_MicrosoftCodeAnalysisCSharpVersion" Version="%24(MicrosoftCodeAnalysisCSharpVersion)" />
     <ExtraPackageVersionPropsPackageInfo Include="Analyzer_MicrosoftCodeAnalysisCSharpWorkspacesVersion" Version="%24(MicrosoftCodeAnalysisCSharpWorkspacesVersion)" />
+    <ExtraPackageVersionPropsPackageInfo Include="MicrosoftCodeAnalysisVersion_LatestVS" Version="%24(MicrosoftCodeAnalysisCommonVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The following prebuilts were introduced by https://github.com/dotnet/aspnetcore/pull/49245 and https://github.com/dotnet/aspnetcore/pull/48817.

The issue is that aspnetcore is pinned to a Microsoft.CodeAnalysis version (4.7.0) via a property named `MicrosoftCodeAnalysisVersion_LatestVS` in Version.props and so is not getting the source-built version of 4.8.0. 

```
/vmr/repo-projects/Directory.Build.targets(688,5): warning : 3 new packages used not in baseline! See report at /vmr/artifacts/prebuilt-report/baseline-comparison.xml for more information. Package IDs are: [/vmr/repo-projects/dotnet.proj]
/vmr/repo-projects/Directory.Build.targets(688,5): warning : Microsoft.CodeAnalysis.Analyzers.3.3.4 [/vmr/repo-projects/dotnet.proj]
/vmr/repo-projects/Directory.Build.targets(688,5): warning : Microsoft.CodeAnalysis.Common.4.7.0-3.23314.3 [/vmr/repo-projects/dotnet.proj]
/vmr/repo-projects/Directory.Build.targets(688,5): warning : Microsoft.CodeAnalysis.CSharp.4.7.0-3.23314.3 [/vmr/repo-projects/dotnet.proj]
```

This is fixed by explicitly overriding that property to flow in the live version of Microsoft.CodeAnalysis. This follows the [same pattern that is already used for runtime](https://github.com/dotnet/installer/blob/42d2b84779be1f33e0193f789ebcd569737120eb/src/SourceBuild/content/repo-projects/runtime.proj#L49).

Fixes dotnet/source-build#3557