### PR TITLE
Pin OmniSharp version used for testing

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/OmniSharpTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/OmniSharpTests.cs
@@ -18,6 +18,9 @@ namespace Microsoft.DotNet.SourceBuild.SmokeTests;
 /// </summary>
 public class OmniSharpTests : SmokeTests
 {
+    // Update version as new releases become available: https://github.com/OmniSharp/omnisharp-roslyn/releases
+    private const string OmniSharpReleaseVersion = "1.39.8";
+
     private string OmniSharpDirectory { get; } = Path.Combine(Directory.GetCurrentDirectory(), "omnisharp");
 
     public OmniSharpTests(ITestOutputHelper outputHelper) : base(outputHelper) { }
@@ -61,12 +64,11 @@ public class OmniSharpTests : SmokeTests
         {
             using HttpClient client = new();
             string omniSharpTarballFile = $"omnisharp-linux-{Config.TargetArchitecture}.tar.gz";
-            Uri omniSharpTarballUrl = new($"https://github.com/OmniSharp/omnisharp-roslyn/releases/latest/download/{omniSharpTarballFile}");
+            Uri omniSharpTarballUrl = new($"https://github.com/OmniSharp/omnisharp-roslyn/releases/download/v{OmniSharpReleaseVersion}/{omniSharpTarballFile}");
             await client.DownloadFileAsync(omniSharpTarballUrl, omniSharpTarballFile, OutputHelper);
 
             Directory.CreateDirectory(OmniSharpDirectory);
             Utilities.ExtractTarball(omniSharpTarballFile, OmniSharpDirectory, OutputHelper);
-            ExecuteHelper.ExecuteProcessValidateExitCode("chmod", $"+x {OmniSharpDirectory}/run", OutputHelper);
             
             // Ensure the run script is executable (see https://github.com/OmniSharp/omnisharp-roslyn/issues/2547)
             File.SetUnixFileMode($"{OmniSharpDirectory}/run", UnixFileMode.UserRead | UnixFileMode.UserExecute);


### PR DESCRIPTION
This helps protected the smoke tests from unexpected changes to OmniSharp that may cause the test to break. It pins the version of OmniSharp that is downloaded to use a specific version. This will need to be manually updated as new releases become available.

Also removed a redundant command to set the permissions of the OmniSharp `run` script. This was mistakenly merged in from servicing branches.

Fixes dotnet/source-build#3536