### PR TITLE
Do not auto-generate symbol packages

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -8,8 +8,11 @@
   <PropertyGroup>
     <Product>Sdk</Product>
     <BlobStoragePartialRelativePath>$(Product)</BlobStoragePartialRelativePath>
-
     <PublishBinariesAndBadge Condition=" '$(PublishBinariesAndBadge)' == '' ">true</PublishBinariesAndBadge>
+    <!-- Installer doesn't produce any interesting binaries that need a symbol package generated in
+         parallel to the regular package. This avoids creating VS.*.symbols.nupkg packages that
+         are identical to the original package. -->
+    <AutoGenerateSymbolPackages>false</AutoGenerateSymbolPackages>
   </PropertyGroup>
 
   <!-- Pulled from arcade's publish.proj see https://github.com/dotnet/arcade/issues/5790 for


### PR DESCRIPTION
Arcade will auto 'generate' symbol packages by default if they do not exist. This is just a copy of the original package to .symbols.nupkg, assuming that the original package has symbols init. For installer, all this amounts to is copying the VS.Redist packages to a new file, wasting space.
