### PR TITLE
aspnetcore patch to exclude WasmLinkerTest project from build

### DIFF
--- a/src/SourceBuild/patches/aspnetcore/0001-Ensure-WasmLinkerTest-project-is-not-included-in-bui.patch
+++ b/src/SourceBuild/patches/aspnetcore/0001-Ensure-WasmLinkerTest-project-is-not-included-in-bui.patch
@@ -3,7 +3,7 @@ From: Matt Thalman <mthalman@microsoft.com>
 Date: Wed, 2 Aug 2023 08:06:29 -0500
 Subject: [PATCH] Ensure WasmLinkerTest project is not included in build
 
-https://github.com/dotnet/aspnetcore/issues/49774
+Backport: https://github.com/dotnet/aspnetcore/issues/49774
 ---
  eng/Build.props | 3 +--
  1 file changed, 1 insertion(+), 2 deletions(-)

--- a/src/SourceBuild/patches/aspnetcore/0001-Ensure-WasmLinkerTest-project-is-not-included-in-bui.patch
+++ b/src/SourceBuild/patches/aspnetcore/0001-Ensure-WasmLinkerTest-project-is-not-included-in-bui.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matt Thalman <mthalman@microsoft.com>
+Date: Wed, 2 Aug 2023 08:06:29 -0500
+Subject: [PATCH] Ensure WasmLinkerTest project is not included in build
+
+https://github.com/dotnet/aspnetcore/issues/49774
+---
+ eng/Build.props | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/eng/Build.props b/eng/Build.props
+index d61fcb6e58..f2e7334cfd 100644
+--- a/eng/Build.props
++++ b/eng/Build.props
+@@ -31,8 +31,7 @@
+       Include="$(RepoRoot)src\**\testassets\**\*.*proj;
+                @(RequiresDelayedBuild);
+                "
+-      Exclude="$(RepoRoot)src\Components\WebAssembly\testassets\WasmLinkerTest\*.*proj;
+-               $(RepoRoot)src\Components\WebView\Samples\PhotinoPlatform\testassets\PhotinoTestApp\*.*proj;
++      Exclude="$(RepoRoot)src\Components\WebView\Samples\PhotinoPlatform\testassets\PhotinoTestApp\*.*proj;
+                $(RepoRoot)src\Http\Routing\test\testassets\RoutingSandbox\*.*proj;
+                $(RepoRoot)src\Security\Authentication\Negotiate\test\testassets\Negotiate.Client\*.*proj;
+                $(RepoRoot)src\Security\Authentication\Negotiate\test\testassets\Negotiate.Server\*.*proj;


### PR DESCRIPTION
This is a workaround for https://github.com/dotnet/aspnetcore/issues/49774. This is a test asset project and not needed for source-build.