### PR TITLE
include version in other locales, too

### DIFF
--- a/src/redist/targets/BundledManifests.targets
+++ b/src/redist/targets/BundledManifests.targets
@@ -97,7 +97,7 @@
 
       <ManifestContent Include="%(BundledManifests.RestoredNupkgContentPath)\data\localize\*"
                        Condition="Exists('%(RestoredNupkgContentPath)\data\localize')"
-                       DestinationPath="%(BundledManifests.FeatureBand)/$([MSBuild]::ValueOrDefault('%(Identity)', '').ToLower())/%(Version)/localize"/>
+                       DestinationPath="%(BundledManifests.FeatureBand)/$([MSBuild]::ValueOrDefault('%(Identity)', '').ToLower())/%(BundledManifests.Version)/localize"/>
     </ItemGroup>
 
     <Error Text="No workload manifest content found." Condition="'@(ManifestContent->Count())' == '0'" />

--- a/src/redist/targets/BundledManifests.targets
+++ b/src/redist/targets/BundledManifests.targets
@@ -97,7 +97,7 @@
 
       <ManifestContent Include="%(BundledManifests.RestoredNupkgContentPath)\data\localize\*"
                        Condition="Exists('%(RestoredNupkgContentPath)\data\localize')"
-                       DestinationPath="%(BundledManifests.FeatureBand)/$([MSBuild]::ValueOrDefault('%(Identity)', '').ToLower())/localize"/>
+                       DestinationPath="%(BundledManifests.FeatureBand)/$([MSBuild]::ValueOrDefault('%(Identity)', '').ToLower())/%(Version)/localize"/>
     </ItemGroup>
 
     <Error Text="No workload manifest content found." Condition="'@(ManifestContent->Count())' == '0'" />


### PR DESCRIPTION
This may be the root of some of our CI difficulties recently. When I added versions to make the manifests install side-by-side, I only tested on an English machine, which meant they weren't using the locales. This should fix that. (Unit test failures may or may not be needed, since I've still only tested on an English machine.)