### PR TITLE
Disable SCM queries for build

### DIFF
--- a/src/SourceBuild/content/Directory.Build.props
+++ b/src/SourceBuild/content/Directory.Build.props
@@ -4,6 +4,7 @@
     <ImportNetSdkFromRepoToolset>false</ImportNetSdkFromRepoToolset>
     <_SuppressSdkImports>true</_SuppressSdkImports>
     <Configuration Condition="$(Configuration) == ''">Release</Configuration>
+    <EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
   </PropertyGroup>
 
   <Import Condition="'$(SkipArcadeSdkImport)' != 'true'" Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SourceBuiltArtifactsTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SourceBuiltArtifactsTests.cs
@@ -17,8 +17,7 @@ public class SourceBuiltArtifactsTests : SmokeTests
 {
     public SourceBuiltArtifactsTests(ITestOutputHelper outputHelper) : base(outputHelper) { }
 
-    // Disabling due to https://github.com/dotnet/source-build/issues/3426
-    //[Fact]
+    [Fact]
     public void VerifyVersionFile()
     {
         string outputDir = Path.Combine(Directory.GetCurrentDirectory(), "sourcebuilt-artifacts");


### PR DESCRIPTION
The SB smoke tests are failing due to the `.version` file in the SB artifacts tarball not having the correct content. It doesn't contain the repo commit but does have the version. The MSBuild property that's used to input the repo commit is `$(RepositoryCommit)`. Looking at the binlog shows that this property is not set for the `package-source-build` project.

This is caused by source-link being bundled with the SDK in https://github.com/dotnet/sdk/pull/31632. Because of that [`EnableSourceControlManagerQueries` gets defaulted to `true`](https://github.com/dotnet/sourcelink/blob/be19eed7910611c4219b50cd2a89af87698ba34d/src/SourceLink.Common/build/Microsoft.SourceLink.Common.props#L13). And because `EnableSourceControlManagerQueries` is `true`, it causes [`RepositoryCommit` to not be set](https://github.com/dotnet/arcade/blob/769f8b16f6b2385bfef62753fb9f04885f158492/src/Microsoft.DotNet.Arcade.Sdk/tools/RepositoryInfo.targets#L26-L29).

This is fixed by explicitly disabling `EnableSourceControlManagerQueries`.

Fixes https://github.com/dotnet/source-build/issues/3426