### PR TITLE
Remove logging of error for no poison leaks

### DIFF
--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection/CheckForPoison.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection/CheckForPoison.cs
@@ -160,11 +160,6 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.LeakDetection
             {
                 Log.LogWarning($"{poisons.Count()} marked files leaked to output.  See complete report '{PoisonReportOutputFilePath}' for details.");
             }
-            else
-            {
-                Log.LogError($"No leaked files found in output.  Either something is broken or it is the future and we have fixed all leaks - please verify and remove this error if so (and default {nameof(FailOnPoisonFound)} to true).");
-                return false;
-            }
 
             return !Log.HasLoggedErrors;
         }

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/PoisonUsage.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/PoisonUsage.txt
@@ -1,11 +1,1 @@
-<PrebuiltLeakReport>
-  <File Path="dotnet-format.x.y.z/tools/netx.y/any/Microsoft.CodeAnalysis.AnalyzerUtilities.dll">
-    <Type>AssemblyAttribute</Type>
-  </File>
-  <File Path="dotnet-sdk-x.y.z-banana-rid.tar/sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.CodeAnalysis.AnalyzerUtilities.dll">
-    <Type>AssemblyAttribute</Type>
-  </File>
-  <File Path="dotnet-sdk-x.y.z-banana-rid.tar/sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Microsoft.CodeAnalysis.AnalyzerUtilities.dll">
-    <Type>AssemblyAttribute</Type>
-  </File>
-</PrebuiltLeakReport>
+<PrebuiltLeakReport />


### PR DESCRIPTION
The poison leak identified in https://github.com/dotnet/source-build/issues/3556 is no longer occurring after the 8.0 Preview 7 release. This is causing the VMR build in the Fedora job, which enables poison leak detection, to fail with this error:

```
/vmr/build.proj(69,5): error : No leaked files found in output.  Either something is broken or it is the future and we have fixed all leaks - please verify and remove this error if so (and default FailOnPoisonFound to true).
```

This is fixed by removing the logic which fails the build. The action specified in the error is no longer relevant as we have already decided to not fail the build on leak detection and instead report that as a test failure.

This allows updates the poison baseline to reflect that there are no leaks.