### PR TITLE
Globally copy VMR build asset outputs

### DIFF
--- a/src/SourceBuild/content/build.proj
+++ b/src/SourceBuild/content/build.proj
@@ -34,6 +34,27 @@
     <RemoveDir Directories="$(BaseOutputPath)" />
   </Target>
 
+  <!-- Copies the output assets of the builds to the output path. -->
+  <Target Name="CopyBinariesToBinFolder"
+          AfterTargets="Build"
+          Inputs="$(MSBuildProjectFullPath)"
+          Outputs="$(CompletedSemaphorePath)CopyBinariesToBinFolder.complete">
+    <ItemGroup>
+      <_builtSymbolPackages Include="$(SourceBuiltAssetsDir)*.symbols.nupkg" />
+      <_builtSymbolPackages>
+        <TransformedFileName>$([System.String]::Copy('%(FileName)').Replace('symbols', 'nupkg'))</TransformedFileName>
+      </_builtSymbolPackages>
+      <BinariesToCopy Include="$(SourceBuiltAssetsDir)*.*" Exclude="$(SourceBuiltAssetsDir)*.nupkg;$(SourceBuiltAssetsDir)*.requires_nupkg_signing" />
+      <BinariesToCopy Include="@(_builtSymbolPackages->'$(SourceBuiltPackagesPath)%(TransformedFileName)')" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(BinariesToCopy)"
+          DestinationFolder="$(OutputPath)"
+          Condition="'@(BinariesToCopy)'!=''" />
+
+    <WriteLinesToFile File="$(CompletedSemaphorePath)CopyBinariesToBinFolder.complete" Overwrite="true" />
+  </Target>
+
   <!-- After building, generate a prebuilt usage report. -->
   <Target Name="ReportPrebuiltUsage"
           AfterTargets="Build"

--- a/src/SourceBuild/content/build.proj
+++ b/src/SourceBuild/content/build.proj
@@ -40,12 +40,7 @@
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(CompletedSemaphorePath)CopyBinariesToBinFolder.complete">
     <ItemGroup>
-      <_builtSymbolPackages Include="$(SourceBuiltAssetsDir)*.symbols.nupkg" />
-      <_builtSymbolPackages>
-        <TransformedFileName>$([System.String]::Copy('%(FileName)').Replace('symbols', 'nupkg'))</TransformedFileName>
-      </_builtSymbolPackages>
       <BinariesToCopy Include="$(SourceBuiltAssetsDir)*.*" Exclude="$(SourceBuiltAssetsDir)*.nupkg;$(SourceBuiltAssetsDir)*.requires_nupkg_signing" />
-      <BinariesToCopy Include="@(_builtSymbolPackages->'$(SourceBuiltPackagesPath)%(TransformedFileName)')" />
     </ItemGroup>
 
     <Copy SourceFiles="@(BinariesToCopy)"

--- a/src/SourceBuild/content/repo-projects/installer.proj
+++ b/src/SourceBuild/content/repo-projects/installer.proj
@@ -82,26 +82,5 @@
     <EnvironmentVariables Include="CLIBUILD_SKIP_BUNDLEDDOTNETTOOLS=true" />
   </ItemGroup>
 
-  <Target Name="CopyTarBall"
-          AfterTargets="ExtractIntermediatePackages"
-          Inputs="$(MSBuildProjectFullPath)"
-          Outputs="$(RepoCompletedSemaphorePath)CopyTarBall.complete">
-
-    <PropertyGroup>
-      <TarBallPath>$(SourceBuiltAssetsDir)dotnet-sdk-*$(TarBallExtension)</TarBallPath>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <TarBall Include="$(TarBallPath)" />
-    </ItemGroup>
-
-    <Error Condition="'@(TarBall)' == ''" Text="'$(TarBallPath)' does not exist." />
-
-    <Copy SourceFiles="@(TarBall)"
-          DestinationFolder="$(SourceBuiltTarBallPath)" />
-
-    <WriteLinesToFile File="$(RepoCompletedSemaphorePath)CopyTarBall.complete" Overwrite="true" />
-  </Target>
-
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/SourceBuild/content/repo-projects/runtime.proj
+++ b/src/SourceBuild/content/repo-projects/runtime.proj
@@ -78,25 +78,5 @@
                          Rid="$(TargetRid)-$(Platform)" />
   </Target>
 
-  <Target Name="CopyBinariesToBinFolder"
-          AfterTargets="ExtractIntermediatePackages"
-          Inputs="$(MSBuildProjectFullPath)"
-          Outputs="$(RepoCompletedSemaphorePath)CopyBinariesToBinFolder.complete">
-    <ItemGroup>
-      <_builtRuntimePackages Include="$(SourceBuiltAssetsDir)*.symbols.nupkg" />
-      <_builtRuntimePackages>
-        <TransformedFileName>$([System.String]::Copy('%(FileName)').Replace('symbols', 'nupkg'))</TransformedFileName>
-      </_builtRuntimePackages>
-      <BinariesToCopy Include="$(SourceBuiltAssetsDir)*.*" Exclude="$(SourceBuiltAssetsDir)*.nupkg;$(SourceBuiltAssetsDir)*.requires_nupkg_signing" />
-      <BinariesToCopy Include="@(_builtRuntimePackages->'$(SourceBuiltPackagesPath)%(TransformedFileName)')" />
-    </ItemGroup>
-
-    <Copy SourceFiles="@(BinariesToCopy)"
-          DestinationFolder="$(OutputPath)runtime"
-          Condition="'@(BinariesToCopy)'!=''" />
-
-    <WriteLinesToFile File="$(RepoCompletedSemaphorePath)CopyBinariesToBinFolder.complete" Overwrite="true" />
-  </Target>
-
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>


### PR DESCRIPTION
Instead of relying on individual targets in runtime.proj, installer.proj, etc, copy all files at the end of the build to the VMR build output. This results in non-runtime/installer archives being included in the output.

Resolves https://github.com/dotnet/source-build/issues/3579
