### PR TITLE
Move disabling of EnableSourceControlManagerQueries to package-source-build

### DIFF
--- a/src/SourceBuild/content/Directory.Build.props
+++ b/src/SourceBuild/content/Directory.Build.props
@@ -4,7 +4,6 @@
     <ImportNetSdkFromRepoToolset>false</ImportNetSdkFromRepoToolset>
     <_SuppressSdkImports>true</_SuppressSdkImports>
     <Configuration Condition="$(Configuration) == ''">Release</Configuration>
-    <EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
   </PropertyGroup>
 
   <Import Condition="'$(SkipArcadeSdkImport)' != 'true'" Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />

--- a/src/SourceBuild/content/repo-projects/package-source-build.proj
+++ b/src/SourceBuild/content/repo-projects/package-source-build.proj
@@ -5,6 +5,7 @@
     <ProjectDirectory>$(SubmoduleDirectory)$(RepositoryName)/</ProjectDirectory>
     <SkipEnsurePackagesCreated>true</SkipEnsurePackagesCreated>
     <IncludedPackageVersionPropsFile>$(CurrentSourceBuiltPackageVersionPropsPath)</IncludedPackageVersionPropsFile>
+    <EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
 
     <!--
       The default PackageVersionPropsFlowType behavior (DependenciesOnly) triggers logic that looks for a Version.Details.xml file.


### PR DESCRIPTION
The `EnableSourceControlManagerQueries` property doesn't need to be placed at the scope it is because it's not actually flowed to product repo builds. It's only needed for the package-source-build project.

Based on feedback from https://github.com/dotnet/installer/pull/17157#pullrequestreview-1570369602