### PR TITLE
Update scripts to set distro RID and properties to use it as TargetRid

### DIFF
--- a/run-build.sh
+++ b/run-build.sh
@@ -63,4 +63,8 @@ while [[ $# > 0 ]]; do
     shift
 done
 
+source $REPOROOT/eng/common/native/init-os-and-arch.sh
+source $REPOROOT/eng/common/native/init-distro-rid.sh
+initDistroRidGlobal "$os" "$arch" ""
+
 . "$REPOROOT/eng/common/build.sh" --build --restore "${args[@]}"

--- a/src/SourceBuild/content/Directory.Build.props
+++ b/src/SourceBuild/content/Directory.Build.props
@@ -168,10 +168,11 @@
     <TargetOS Condition="'$(TargetOS)' == '' AND $([MSBuild]::IsOSPlatform('LINUX'))">Linux</TargetOS>
     <TargetOS Condition="'$(TargetOS)' == '' AND $([MSBuild]::IsOSPlatform('FREEBSD'))">FreeBSD</TargetOS>
 
-    <PortableRid Condition="'$(TargetOS)' == 'FreeBSD'">freebsd-$(Platform)</PortableRid>
-    <PortableRid Condition="'$(TargetOS)' == 'OSX'">osx-$(Platform)</PortableRid>
-    <PortableRid Condition="'$(TargetOS)' == 'Linux'">linux-$(Platform)</PortableRid>
-    <PortableRid Condition="'$(TargetOS)' == 'Windows_NT'">win-$(Platform)</PortableRid>
+    <PortableRid Condition="'$(__PortableTargetOS)' != ''">$(__PortableTargetOS)-$(Platform)</PortableRid>
+    <PortableRid Condition="'$(PortableRid)' == '' AND '$(TargetOS)' == 'FreeBSD'">freebsd-$(Platform)</PortableRid>
+    <PortableRid Condition="'$(PortableRid)' == '' AND '$(TargetOS)' == 'OSX'">osx-$(Platform)</PortableRid>
+    <PortableRid Condition="'$(PortableRid)' == '' AND '$(TargetOS)' == 'Linux'">linux-$(Platform)</PortableRid>
+    <PortableRid Condition="'$(PortableRid)' == '' AND '$(TargetOS)' == 'Windows_NT'">win-$(Platform)</PortableRid>
     <TargetRid Condition="'$(PortableBuild)' == 'true' AND '$(PortableRid)' != ''">$(PortableRid)</TargetRid>
   </PropertyGroup>
 

--- a/src/SourceBuild/content/Directory.Build.props
+++ b/src/SourceBuild/content/Directory.Build.props
@@ -159,6 +159,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <!-- Use current machine distro RID if set. Otherwise, fall back to RuntimeInformation.RuntimeIdentifier -->
+    <TargetRid Condition="'$(TargetRid)' == ''">$(__DistroRid)</TargetRid>
     <TargetRid Condition="'$(TargetRid)' == ''">$([System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier)</TargetRid>
 
     <TargetOS Condition="'$(TargetOS)' == '' AND $([MSBuild]::IsOSPlatform('WINDOWS'))">Windows_NT</TargetOS>

--- a/src/SourceBuild/content/build.sh
+++ b/src/SourceBuild/content/build.sh
@@ -247,6 +247,10 @@ echo "Found bootstrap SDK $SDK_VERSION, bootstrap Arcade $ARCADE_BOOTSTRAP_VERSI
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
 export NUGET_PACKAGES=$packagesRestoredDir/
 
+source $SCRIPT_ROOT/eng/common/native/init-os-and-arch.sh
+source $SCRIPT_ROOT/eng/common/native/init-distro-rid.sh
+initDistroRidGlobal "$os" "$arch" ""
+
 LogDateStamp=$(date +"%m%d%H%M%S")
 
 "$CLI_ROOT/dotnet" build-server shutdown

--- a/src/redist/targets/GetRuntimeInformation.targets
+++ b/src/redist/targets/GetRuntimeInformation.targets
@@ -1,6 +1,8 @@
 <Project>
   <Target Name="GetCurrentRuntimeInformation">
     <PropertyGroup>
+      <!-- Use current machine distro RID if set. Otherwise, fall back to RuntimeInformation.RuntimeIdentifier -->
+      <HostRid Condition="'$(HostRid)' == '' and '$(MSBuildRuntimeType)' == 'core'">$(__DistroRid)</HostRid>
       <HostRid Condition="'$(HostRid)' == '' and '$(MSBuildRuntimeType)' == 'core'">$([System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier)</HostRid>
       <HostRid Condition="'$(HostRid)' == '' and '$(MSBuildRuntimeType)' != 'core'">win-$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant)</HostRid>
 


### PR DESCRIPTION
This updates installer and source-build to call shared scripts for determining the distro RID and use that value as the `TargetRid`.

cc @dsplaisted @tmds 

Fixes https://github.com/dotnet/source-build/issues/3578