### PR TITLE
Ignore `.lss` binaries in VMR's `eng/common`

### DIFF
--- a/src/VirtualMonoRepo/allowed-binaries.txt
+++ b/src/VirtualMonoRepo/allowed-binaries.txt
@@ -20,6 +20,7 @@
 **/TestCert*.pfx
 **/tests/*
 
+eng/common/loc/*.lss # UTF16-LE text files
 **/eng/common/loc/*.lss # UTF16-LE text files
 
 src/aspnetcore/**/samples/*


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/3589