### PR TITLE
Propagate RID properties set in source-build to sdk repo

### DIFF
--- a/src/SourceBuild/content/repo-projects/sdk.proj
+++ b/src/SourceBuild/content/repo-projects/sdk.proj
@@ -7,6 +7,10 @@
     <BuildCommandArgs>$(BuildCommandArgs) /p:PackageProjectUrl=https://github.com/dotnet/sdk</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:PublishCompressedFilesPathPrefix=$(SourceBuiltToolsetDir)</BuildCommandArgs>
 
+    <!-- Propagate RID set in source-build to sdk repo -->
+    <BuildCommandArgs>$(BuildCommandArgs) /p:PortableRid=$(PortableRid)</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) /p:TargetRid=$(TargetRid)</BuildCommandArgs>
+
     <!-- Just like mono, arm does not support NativeAot -->
     <BuildCommandArgs Condition="'$(BuildArchitecture)' == 'arm'">$(BuildCommandArgs) /p:NativeAotSupported=false</BuildCommandArgs>
 

--- a/src/SourceBuild/content/repo-projects/sdk.proj
+++ b/src/SourceBuild/content/repo-projects/sdk.proj
@@ -8,7 +8,9 @@
     <BuildCommandArgs>$(BuildCommandArgs) /p:PublishCompressedFilesPathPrefix=$(SourceBuiltToolsetDir)</BuildCommandArgs>
 
     <!-- Propagate RID set in source-build to sdk repo -->
-    <BuildCommandArgs>$(BuildCommandArgs) /p:PortableRid=$(PortableRid)</BuildCommandArgs>
+    <_platformIndex>$(NETCoreSdkPortableRuntimeIdentifier.LastIndexOf('-'))</_platformIndex>
+    <_baseOS>$(NETCoreSdkPortableRuntimeIdentifier.Substring(0, $(_platformIndex)))</_baseOS>
+    <BuildCommandArgs>$(BuildCommandArgs) /p:PortableRid=$(_baseOS)-$(Platform)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:TargetRid=$(TargetRid)</BuildCommandArgs>
 
     <!-- Just like mono, arm does not support NativeAot -->


### PR DESCRIPTION
The sdk repo needs the RID from source-build so that it can update its trimmed down RID graph with the non-portable RID. This propagates the `TargetRid` and `PortableRid` properties to sdk during source builds.

Contributes to https://github.com/dotnet/source-build/issues/3584

cc @dsplaisted @tmds 