### PR TITLE
[release/8.0.1xx-rc1] Propagate RID properties set in source-build to sdk repo

### DIFF
--- a/src/SourceBuild/content/repo-projects/sdk.proj
+++ b/src/SourceBuild/content/repo-projects/sdk.proj
@@ -7,6 +7,12 @@
     <BuildCommandArgs>$(BuildCommandArgs) /p:PackageProjectUrl=https://github.com/dotnet/sdk</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:PublishCompressedFilesPathPrefix=$(SourceBuiltToolsetDir)</BuildCommandArgs>
 
+    <!-- Propagate RID set in source-build to sdk repo -->
+    <_platformIndex>$(NETCoreSdkPortableRuntimeIdentifier.LastIndexOf('-'))</_platformIndex>
+    <_baseOS>$(NETCoreSdkPortableRuntimeIdentifier.Substring(0, $(_platformIndex)))</_baseOS>
+    <BuildCommandArgs>$(BuildCommandArgs) /p:PortableRid=$(_baseOS)-$(Platform)</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) /p:TargetRid=$(TargetRid)</BuildCommandArgs>
+
     <!-- Just like mono, arm does not support NativeAot -->
     <BuildCommandArgs Condition="'$(BuildArchitecture)' == 'arm'">$(BuildCommandArgs) /p:NativeAotSupported=false</BuildCommandArgs>
 


### PR DESCRIPTION
Port of https://github.com/dotnet/installer/pull/17197

The sdk repo needs the RID from source-build so that it can update its trimmed down RID graph with the non-portable RID. This propagates the required information to sdk during source builds.

Issue: https://github.com/dotnet/source-build/issues/3584