### PR TITLE
Fix case sensitive comparison issue and optimize WritePrebuiltUsageData

### DIFF
--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -628,24 +628,23 @@
       DataFile="$(PackageReportDataFile)"
       ProjectAssetsJsonArchiveFile="$(ProjectAssetsJsonArchiveFile)" />
 
-    <!-- Copy all restored packages to resulting prebuilt folder -->
+    <!-- Copy packages detected as prebuilts to the artifacts prebuilt folder -->
     <ItemGroup>
-      <UsedPrebuiltPackageFiles Include="@(AllRestoredPackageFiles)" />
+      <AllowedPackageFiles Include="@(TarballPrebuiltPackageFile)" />
+      <AllowedPackageFiles Include="@(SourceBuiltPackageFiles)" />
+      <AllowedPackageFiles Include="@(ReferencePackageFiles)" />
+      <AllowedPackageFiles>
+        <LCFilename>$([System.String]::Copy(%(Filename)).ToLower())</LCFilename>
+      </AllowedPackageFiles>
+
+      <PrebuiltPackageFiles Include="@(AllRestoredPackageFiles)" >
+        <LCFilename>$([System.String]::Copy(%(Filename)).ToLower())</LCFilename>
+      </PrebuiltPackageFiles>
+      <PrebuiltPackageFiles Remove="@(AllowedPackageFiles)" MatchOnMetadata="LCFilename" />
     </ItemGroup>
     <Copy
-      SourceFiles="@(UsedPrebuiltPackageFiles)"
+      SourceFiles="@(PrebuiltPackageFiles)"
       DestinationFolder="$(ResultingPrebuiltPackagesDir)" />
-
-    <!-- Remove packages that are known to be built -->
-    <ItemGroup>
-      <BuiltPackageFiles Include="@(TarballPrebuiltPackageFile)" />
-      <BuiltPackageFiles Include="@(SourceBuiltPackageFiles)" />
-      <BuiltPackageFiles Include="@(ReferencePackageFiles)" />
-      <BuiltPackageFiles>
-        <LCFilename>$([System.String]::Copy(%(Filename)).ToLower())</LCFilename>
-      </BuiltPackageFiles>
-    </ItemGroup>
-    <Delete Files="@(BuiltPackageFiles->'$(ResultingPrebuiltPackagesDir)%(LCFilename)%(Extension)')" />
 
     <WriteLinesToFile File="$(RepoCompletedSemaphorePath)WritePrebuiltUsageData.complete" Overwrite="true" />
   </Target>


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/2989

This issue was caused by a simple case-insensitive path comparison in the WritePrebuiltUsageData logic.  While fixing this, I took the opportunity to make the logic more efficient to avoid coping all referenced packages and then deleting the known good packages.  The now logic builds up the list of prebuilts and only copies them.

