### PR TITLE
[main] Re-enable R2R tests in source-build

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/BasicScenarioTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/BasicScenarioTests.cs
@@ -34,8 +34,7 @@ public class BasicScenarioTests : SmokeTests
         {
             yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.Console,
                 // R2R is not supported on Mono (see https://github.com/dotnet/runtime/issues/88419#issuecomment-1623762676)
-                // Disable R2R tests due to https://github.com/dotnet/source-build/issues/3591
-                DotNetActions.Build | DotNetActions.Run | DotNetActions.PublishComplex);
+                DotNetActions.Build | DotNetActions.Run | DotNetActions.PublishComplex | (helper.IsMonoRuntime ? DotNetActions.None : DotNetActions.PublishR2R));
             yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.ClassLib, DotNetActions.Build | DotNetActions.Publish);
             yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.XUnit,    DotNetActions.Test);
             yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.NUnit,    DotNetActions.Test);


### PR DESCRIPTION
Re-enables the R2R tests that were disabled by https://github.com/dotnet/installer/pull/17118. The underlying issue is fixed by https://github.com/dotnet/sdk/pull/34650 and can't be merged until those changes have flowed into installer.