### PR TITLE
Add VMR exclusion for non-OSS VS specific license

### DIFF
--- a/src/VirtualMonoRepo/source-mappings.json
+++ b/src/VirtualMonoRepo/source-mappings.json
@@ -172,7 +172,11 @@
         },
         {
             "name": "vstest",
-            "defaultRemote": "https://github.com/microsoft/vstest"
+            "defaultRemote": "https://github.com/microsoft/vstest",
+            "exclude": [
+                // Non-OSS license used in VS specific build configurations.
+                "src/package/licenses/LICENSE_VS.txt"
+            ]
         },
         {
             "name": "xdt",


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/3538.  

Will open auxiliary PR to remove the file from the VMR.

This is a second attempt.  The other license which caused this first fix attempt to break is being removed in https://github.com/microsoft/vstest/pull/4658
