### PR TITLE
Add VMR exclusion for non-OSS VS specific license

### DIFF
--- a/src/VirtualMonoRepo/source-mappings.json
+++ b/src/VirtualMonoRepo/source-mappings.json
@@ -172,7 +172,11 @@
         },
         {
             "name": "vstest",
-            "defaultRemote": "https://github.com/microsoft/vstest"
+            "defaultRemote": "https://github.com/microsoft/vstest",
+            "exclude": [
+                // Non-OSS license used in VS specific build configurations.
+                "src/package/licenses/LICENSE_VS.txt"
+            ]
         },
         {
             "name": "xdt",


### PR DESCRIPTION
Port of https://github.com/dotnet/installer/pull/17216 to rc1
