### PR TITLE
Avoid attempting to download from exteranl URIs in Product Source Build mode

### DIFF
--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -373,16 +373,24 @@
         <ShouldDownload>%(ComponentToDownload.ShouldDownload)</ShouldDownload>
         <DownloadDestination>%(ComponentToDownload.DownloadDestination)</DownloadDestination>
       </UrisToDownload>
-      <UrisToDownload Include="$([System.String]::Copy('%(ComponentToDownload.BaseUrl)').Replace($(PublicBaseURL), 'https://dotnetbuilds.blob.core.windows.net/public/'))/%(ComponentToDownload.DownloadFileName)" Condition="'%(ComponentToDownload.ShouldDownload)' == 'true'">
+      <!-- If building in product source build mode, there is no need to attempt the external URIs. These are not desired,
+           and won't work anyway because the source build file URI doesn't use the same structure as the storage accounts.
+           For example, the dotnetbuilds uri for 'file:///vmr/dotnet2/artifacts/obj/x64/Release/blob-feed/assets//aspnetcore_base_runtime.version'
+           would end up 'https://dotnetbuilds.blob.core.windows.net/public//dotnet-runtime-8.0.0-rc.1.23381.3-centos.8-x64.tar.gz'. This is
+           missing the runtime version number directory. -->
+      <UrisToDownload Include="$([System.String]::Copy('%(ComponentToDownload.BaseUrl)').Replace($(PublicBaseURL), 'https://dotnetbuilds.blob.core.windows.net/public/'))/%(ComponentToDownload.DownloadFileName)"
+                      Condition="'%(ComponentToDownload.ShouldDownload)' == 'true' AND '$(DotNetBuildFromSourceFlavor)' != 'Product'">
         <ShouldDownload>%(ComponentToDownload.ShouldDownload)</ShouldDownload>
         <DownloadDestination>%(ComponentToDownload.DownloadDestination)</DownloadDestination>
       </UrisToDownload>
-      <UrisToDownload Include="%(ComponentToDownload.PrivateBaseUrl)/%(ComponentToDownload.DownloadFileName)" Condition="'%(ComponentToDownload.ShouldDownload)' == 'true' and '$(DotNetRuntimeSourceFeedKey)' != ''">
+      <UrisToDownload Include="%(ComponentToDownload.PrivateBaseUrl)/%(ComponentToDownload.DownloadFileName)"
+                      Condition="'%(ComponentToDownload.ShouldDownload)' == 'true' and '$(DotNetRuntimeSourceFeedKey)' != '' and '$(DotNetBuildFromSourceFlavor)' != 'Product'">
         <ShouldDownload>%(ComponentToDownload.ShouldDownload)</ShouldDownload>
         <DownloadDestination>%(ComponentToDownload.DownloadDestination)</DownloadDestination>
         <token>$(DotNetRuntimeSourceFeedKey)</token>
       </UrisToDownload>
-      <UrisToDownload Include="$([System.String]::Copy('%(ComponentToDownload.PrivateBaseUrl)').Replace($(InternalBaseURL), 'https://dotnetbuilds.blob.core.windows.net/internal/'))/%(ComponentToDownload.DownloadFileName)" Condition="'%(ComponentToDownload.ShouldDownload)' == 'true' and '$(DotNetRuntimeSourceFeedKey)' != ''">
+      <UrisToDownload Include="$([System.String]::Copy('%(ComponentToDownload.PrivateBaseUrl)').Replace($(InternalBaseURL), 'https://dotnetbuilds.blob.core.windows.net/internal/'))/%(ComponentToDownload.DownloadFileName)"
+                      Condition="'%(ComponentToDownload.ShouldDownload)' == 'true' and '$(DotNetRuntimeSourceFeedKey)' != '' and '$(DotNetBuildFromSourceFlavor)' != 'Product'">
         <ShouldDownload>%(ComponentToDownload.ShouldDownload)</ShouldDownload>
         <DownloadDestination>%(ComponentToDownload.DownloadDestination)</DownloadDestination>
         <token>$(dotnetbuilds-internal-container-read-token-base64)</token>

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -373,30 +373,33 @@
         <ShouldDownload>%(ComponentToDownload.ShouldDownload)</ShouldDownload>
         <DownloadDestination>%(ComponentToDownload.DownloadDestination)</DownloadDestination>
       </UrisToDownload>
-      <!-- If building in product source build mode, there is no need to attempt the external URIs. These are not desired,
-           and won't work anyway because the source build file URI doesn't use the same structure as the storage accounts.
-           For example, the dotnetbuilds uri for 'file:///vmr/dotnet2/artifacts/obj/x64/Release/blob-feed/assets//aspnetcore_base_runtime.version'
-           would end up 'https://dotnetbuilds.blob.core.windows.net/public//dotnet-runtime-8.0.0-rc.1.23381.3-centos.8-x64.tar.gz'. This is
-           missing the runtime version number directory. -->
+    </ItemGroup>
+
+    <!-- If building in product source build mode, there is no need to attempt the external URIs. These are not desired,
+            and won't work anyway because the source build file URI doesn't use the same structure as the storage accounts.
+            For example, the dotnetbuilds uri for 'file:///vmr/dotnet2/artifacts/obj/x64/Release/blob-feed/assets//aspnetcore_base_runtime.version'
+            would end up 'https://dotnetbuilds.blob.core.windows.net/public//dotnet-runtime-8.0.0-rc.1.23381.3-centos.8-x64.tar.gz'. This is
+            missing the runtime version number directory. -->
+    <ItemGroup Condition="'$(DotNetBuildFromSourceFlavor)' != 'Product'">
       <UrisToDownload Include="$([System.String]::Copy('%(ComponentToDownload.BaseUrl)').Replace($(PublicBaseURL), 'https://dotnetbuilds.blob.core.windows.net/public/'))/%(ComponentToDownload.DownloadFileName)"
-                      Condition="'%(ComponentToDownload.ShouldDownload)' == 'true' AND '$(DotNetBuildFromSourceFlavor)' != 'Product'">
+                      Condition="'%(ComponentToDownload.ShouldDownload)' == 'true'">
         <ShouldDownload>%(ComponentToDownload.ShouldDownload)</ShouldDownload>
         <DownloadDestination>%(ComponentToDownload.DownloadDestination)</DownloadDestination>
       </UrisToDownload>
       <UrisToDownload Include="%(ComponentToDownload.PrivateBaseUrl)/%(ComponentToDownload.DownloadFileName)"
-                      Condition="'%(ComponentToDownload.ShouldDownload)' == 'true' and '$(DotNetRuntimeSourceFeedKey)' != '' and '$(DotNetBuildFromSourceFlavor)' != 'Product'">
+                      Condition="'%(ComponentToDownload.ShouldDownload)' == 'true' and '$(DotNetRuntimeSourceFeedKey)' != ''">
         <ShouldDownload>%(ComponentToDownload.ShouldDownload)</ShouldDownload>
         <DownloadDestination>%(ComponentToDownload.DownloadDestination)</DownloadDestination>
         <token>$(DotNetRuntimeSourceFeedKey)</token>
       </UrisToDownload>
       <UrisToDownload Include="$([System.String]::Copy('%(ComponentToDownload.PrivateBaseUrl)').Replace($(InternalBaseURL), 'https://dotnetbuilds.blob.core.windows.net/internal/'))/%(ComponentToDownload.DownloadFileName)"
-                      Condition="'%(ComponentToDownload.ShouldDownload)' == 'true' and '$(DotNetRuntimeSourceFeedKey)' != '' and '$(DotNetBuildFromSourceFlavor)' != 'Product'">
+                      Condition="'%(ComponentToDownload.ShouldDownload)' == 'true' and '$(DotNetRuntimeSourceFeedKey)' != ''">
         <ShouldDownload>%(ComponentToDownload.ShouldDownload)</ShouldDownload>
         <DownloadDestination>%(ComponentToDownload.DownloadDestination)</DownloadDestination>
         <token>$(dotnetbuilds-internal-container-read-token-base64)</token>
       </UrisToDownload>
     </ItemGroup>
-    
+
     <DownloadFile Condition=" '@(UrisToDownload)' != '' and %(ShouldDownload)"
                   Uris="@(UrisToDownload)"
                   DestinationPath="%(DownloadDestination)" />

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -368,7 +368,7 @@
            with shared metadata DownloadDestination and potentially the encoded key token for the private url.
            Then use task batching to send batched itemgroups to the DownloadFile task that have the same
            DownloadDestination. -->
-      
+
       <UrisToDownload Include="%(ComponentToDownload.BaseUrl)/%(ComponentToDownload.DownloadFileName)" Condition="'%(ComponentToDownload.ShouldDownload)' == 'true'">
         <ShouldDownload>%(ComponentToDownload.ShouldDownload)</ShouldDownload>
         <DownloadDestination>%(ComponentToDownload.DownloadDestination)</DownloadDestination>
@@ -391,12 +391,6 @@
         <ShouldDownload>%(ComponentToDownload.ShouldDownload)</ShouldDownload>
         <DownloadDestination>%(ComponentToDownload.DownloadDestination)</DownloadDestination>
         <token>$(DotNetRuntimeSourceFeedKey)</token>
-      </UrisToDownload>
-      <UrisToDownload Include="$([System.String]::Copy('%(ComponentToDownload.PrivateBaseUrl)').Replace($(InternalBaseURL), 'https://dotnetbuilds.blob.core.windows.net/internal/'))/%(ComponentToDownload.DownloadFileName)"
-                      Condition="'%(ComponentToDownload.ShouldDownload)' == 'true' and '$(DotNetRuntimeSourceFeedKey)' != ''">
-        <ShouldDownload>%(ComponentToDownload.ShouldDownload)</ShouldDownload>
-        <DownloadDestination>%(ComponentToDownload.DownloadDestination)</DownloadDestination>
-        <token>$(dotnetbuilds-internal-container-read-token-base64)</token>
       </UrisToDownload>
     </ItemGroup>
 


### PR DESCRIPTION
When in product source build mode, there is no need to attempt to download from dotnetbuilds/*. The generated URI will be incorrect (missing a version number) anyway.