### PR TITLE
Re-enable format tests

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetFormatTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetFormatTests.cs
@@ -19,7 +19,7 @@ public class DotNetFormatTests : SmokeTests
     /// <Summary>
     /// Format an unformatted project and verify that the output matches the pre-computed solution.
     /// </Summary>
-    //[Fact] - Re-enable once https://github.com/dotnet/sdk/issues/27332 is resolved.  Tracking - https://github.com/dotnet/source-build/issues/3004
+    [Fact]
     public void FormatProject()
     {
         string unformattedCsFilePath = Path.Combine(BaselineHelper.GetAssetsDirectory(), UnformattedFileName);

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetHelper.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetHelper.cs
@@ -126,7 +126,7 @@ internal class DotNetHelper
         }
     }
 
-    public static void ConfigureProcess(Process process, string? workingDirectory, bool setPath = false)
+    public static void ConfigureProcess(Process process, string? workingDirectory, bool setPath = true)
     {
         if (workingDirectory != null)
         {

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetHelper.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetHelper.cs
@@ -126,7 +126,7 @@ internal class DotNetHelper
         }
     }
 
-    public static void ConfigureProcess(Process process, string? workingDirectory, bool setPath = true)
+    public static void ConfigureProcess(Process process, string? workingDirectory)
     {
         if (workingDirectory != null)
         {
@@ -137,11 +137,7 @@ internal class DotNetHelper
         process.StartInfo.EnvironmentVariables["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "1";
         process.StartInfo.EnvironmentVariables["DOTNET_ROOT"] = Config.DotNetDirectory;
         process.StartInfo.EnvironmentVariables["NUGET_PACKAGES"] = PackagesDirectory;
-
-        if (setPath)
-        {
-            process.StartInfo.EnvironmentVariables["PATH"] = $"{Config.DotNetDirectory}:{Environment.GetEnvironmentVariable("PATH")}";
-        }
+        process.StartInfo.EnvironmentVariables["PATH"] = $"{Config.DotNetDirectory}:{Environment.GetEnvironmentVariable("PATH")}";
     }
 
     public void ExecuteBuild(string projectName) =>

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/OmniSharpTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/OmniSharpTests.cs
@@ -51,7 +51,7 @@ public class OmniSharpTests : SmokeTests
             OutputHelper,
             logOutput: true,
             millisecondTimeout: 5000,
-            configureCallback: (process) => DotNetHelper.ConfigureProcess(process, projectDirectory, setPath: true));
+            configureCallback: (process) => DotNetHelper.ConfigureProcess(process, projectDirectory));
 
         Assert.NotEqual(0, executeResult.Process.ExitCode);
         Assert.DoesNotContain("ERROR", executeResult.StdOut);


### PR DESCRIPTION
Format tests were broken due to 2 missing package dependencies - those were added recently with https://github.com/dotnet/format/pull/1930, which flowed to `installer` yesterday.

Additionally, `dotnet-format` tool is currently broken on machines that have `DOTNET_ROOT` set, but do not have .NET root in the environment's `PATH` variable - this issue is being tracked with: https://github.com/dotnet/format/issues/1925

This PR changes the default for all .NET tests to add .NET path to `PATH`. This is already used for OmniSharp tests.

I believe we should keep this optional argument, `setPath` and also continue to set `DOTNET_ROOT` environment variable.