### PR TITLE
Patch for MSBuild reference of System.Security.Permissions

### DIFF
--- a/src/SourceBuild/patches/msbuild/0001-Flow-live-version-of-System.Security.Permissions-for.patch
+++ b/src/SourceBuild/patches/msbuild/0001-Flow-live-version-of-System.Security.Permissions-for.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matt Thalman <mthalman@microsoft.com>
+Date: Wed, 23 Aug 2023 16:20:02 -0500
+Subject: [PATCH] Flow live version of System.Security.Permissions for
+ source-build
+
+Backport: https://github.com/dotnet/msbuild/pull/9158
+---
+ eng/Version.Details.xml | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/eng/Version.Details.xml b/eng/Version.Details.xml
+index 244fed20fb..91137a797c 100644
+--- a/eng/Version.Details.xml
++++ b/eng/Version.Details.xml
+@@ -37,6 +37,11 @@
+       <Uri>https://github.com/dotnet/runtime</Uri>
+       <Sha>d099f075e45d2aa6007a22b71b45a08758559f80</Sha>
+     </Dependency>
++    <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
++    <Dependency Name="System.Security.Permissions" Version="7.0.0">
++      <Uri>https://github.com/dotnet/runtime</Uri>
++      <Sha>d099f075e45d2aa6007a22b71b45a08758559f80</Sha>
++    </Dependency>
+     <Dependency Name="System.Text.Json" Version="7.0.3">
+       <Uri>https://github.com/dotnet/runtime</Uri>
+       <Sha>5b20af47d99620150c53eaf5db8636fdf730b126</Sha>


### PR DESCRIPTION
Patch for https://github.com/dotnet/msbuild/pull/9158

Fixes https://github.com/dotnet/source-build/issues/3571