### PR TITLE
Disable format tests on Alpine

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -40,6 +40,9 @@ parameters:
 - name: excludeOmniSharpTests
   type: boolean
 
+- name: excludeDotnetFormatTests
+  type: boolean
+
 - name: enablePoison
   type: boolean
 
@@ -218,7 +221,7 @@ jobs:
       set -x
 
       dockerVolumeArgs="-v $(sourcesPath):/vmr"
-      dockerEnvArgs="-e SMOKE_TESTS_EXCLUDE_OMNISHARP=${{ parameters.excludeOmniSharpTests }} -e SMOKE_TESTS_WARN_SDK_CONTENT_DIFFS=true -e SMOKE_TESTS_RUNNING_IN_CI=true"
+      dockerEnvArgs="-e SMOKE_TESTS_EXCLUDE_OMNISHARP=${{ parameters.excludeOmniSharpTests }} -e SMOKE_TESTS_EXCLUDE_DOTNETFORMAT=${{ parameters.excludeDotnetFormatTests }} -e SMOKE_TESTS_WARN_SDK_CONTENT_DIFFS=true -e SMOKE_TESTS_RUNNING_IN_CI=true"
       poisonArg=''
 
       if [[ '${{ parameters.enablePoison }}' == 'True' ]]; then

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -83,6 +83,7 @@ stages:
       buildFromArchive: false            # 🚫
       enablePoison: false                # 🚫
       excludeOmniSharpTests: true        # ✅
+      excludeDotnetFormatTests: false    # 🚫
       runOnline: true                    # ✅
       useMonoRuntime: false              # 🚫
       withPreviousSDK: false             # 🚫
@@ -101,6 +102,7 @@ stages:
       buildFromArchive: true             # ✅
       enablePoison: false                # 🚫
       excludeOmniSharpTests: true        # ✅
+      excludeDotnetFormatTests: false    # 🚫
       runOnline: false                   # 🚫
       useMonoRuntime: false              # 🚫
       withPreviousSDK: false             # 🚫
@@ -123,6 +125,7 @@ stages:
         buildFromArchive: false            # ✅
         enablePoison: false                # 🚫
         excludeOmniSharpTests: true        # ✅
+        excludeDotnetFormatTests: true     # ✅ - https://github.com/dotnet/format/issues/1945
         runOnline: false                   # 🚫
         useMonoRuntime: false              # 🚫
         withPreviousSDK: false             # 🚫
@@ -141,6 +144,7 @@ stages:
         buildFromArchive: false            # 🚫
         enablePoison: false                # 🚫
         excludeOmniSharpTests: true        # ✅
+        excludeDotnetFormatTests: false    # 🚫
         runOnline: true                    # ✅
         useMonoRuntime: false              # 🚫
         withPreviousSDK: true              # ✅
@@ -159,6 +163,7 @@ stages:
         buildFromArchive: false            # 🚫
         enablePoison: false                # 🚫
         excludeOmniSharpTests: true        # ✅
+        excludeDotnetFormatTests: false    # 🚫
         runOnline: false                   # 🚫
         useMonoRuntime: false              # 🚫
         withPreviousSDK: true              # ✅
@@ -177,6 +182,7 @@ stages:
         buildFromArchive: true             # ✅
         enablePoison: false                # 🚫
         excludeOmniSharpTests: true        # ✅
+        excludeDotnetFormatTests: false    # 🚫
         runOnline: false                   # 🚫
         useMonoRuntime: true               # ✅
         withPreviousSDK: false             # 🚫
@@ -195,6 +201,7 @@ stages:
         buildFromArchive: true             # ✅
         enablePoison: false                # 🚫
         excludeOmniSharpTests: false       # 🚫
+        excludeDotnetFormatTests: false    # 🚫
         runOnline: false                   # 🚫
         useMonoRuntime: false              # 🚫
         withPreviousSDK: false             # 🚫
@@ -213,6 +220,7 @@ stages:
         buildFromArchive: true             # ✅
         enablePoison: true                 # ✅
         excludeOmniSharpTests: false       # 🚫
+        excludeDotnetFormatTests: false    # 🚫
         runOnline: false                   # 🚫
         useMonoRuntime: false              # 🚫
         withPreviousSDK: false             # 🚫
@@ -231,6 +239,7 @@ stages:
         buildFromArchive: false            # 🚫
         enablePoison: false                # 🚫
         excludeOmniSharpTests: false       # 🚫
+        excludeDotnetFormatTests: false    # 🚫
         runOnline: false                   # 🚫
         useMonoRuntime: false              # 🚫
         withPreviousSDK: false             # 🚫
@@ -249,6 +258,7 @@ stages:
         buildFromArchive: false            # 🚫
         enablePoison: false                # 🚫
         excludeOmniSharpTests: false       # 🚫
+        excludeDotnetFormatTests: false    # 🚫
         runOnline: false                   # 🚫
         useMonoRuntime: false              # 🚫
         withPreviousSDK: false             # 🚫
@@ -269,6 +279,7 @@ stages:
         buildFromArchive: false            # 🚫
         enablePoison: false                # 🚫
         excludeOmniSharpTests: true        # ✅
+        excludeDotnetFormatTests: false    # 🚫
         runOnline: false                   # 🚫
         useMonoRuntime: false              # 🚫
         withPreviousSDK: false             # 🚫
@@ -288,6 +299,7 @@ stages:
         buildFromArchive: false            # 🚫
         enablePoison: false                # 🚫
         excludeOmniSharpTests: false       # 🚫
+        excludeDotnetFormatTests: false    # 🚫
         runOnline: false                   # 🚫
         useMonoRuntime: false              # 🚫
         withPreviousSDK: false             # 🚫

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/Config.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/Config.cs
@@ -10,6 +10,7 @@ namespace Microsoft.DotNet.SourceBuild.SmokeTests;
 internal static class Config
 {
     public const string DotNetDirectoryEnv = "SMOKE_TESTS_DOTNET_DIR";
+    public const string ExcludeDotnetFormatEnv = "SMOKE_TESTS_EXCLUDE_DOTNETFORMAT";
     public const string ExcludeOmniSharpEnv = "SMOKE_TESTS_EXCLUDE_OMNISHARP";
     public const string MsftSdkTarballPathEnv = "SMOKE_TESTS_MSFT_SDK_TARBALL_PATH";
     public const string PoisonReportPathEnv = "SMOKE_TESTS_POISON_REPORT_PATH";

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetFormatTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetFormatTests.cs
@@ -19,7 +19,7 @@ public class DotNetFormatTests : SmokeTests
     /// <Summary>
     /// Format an unformatted project and verify that the output matches the pre-computed solution.
     /// </Summary>
-    [Fact]
+    [SkippableFact(Config.ExcludeDotnetFormatEnv, skipOnTrue: true)]
     public void FormatProject()
     {
         string unformattedCsFilePath = Path.Combine(BaselineHelper.GetAssetsDirectory(), UnformattedFileName);


### PR DESCRIPTION
Format tests were enabled with https://github.com/dotnet/installer/pull/17238 That PR uncovered the issues with dotnet-format on Alpine that is tracked with https://github.com/dotnet/format/issues/1945

This change allows skipping of dotnet-format tests on Alpine and disables them in Alpine CI leg.