### PR TITLE
Ignore warnings of IDE0090 for vstest

### DIFF
--- a/src/SourceBuild/content/repo-projects/vstest.proj
+++ b/src/SourceBuild/content/repo-projects/vstest.proj
@@ -6,6 +6,7 @@
     <BuildCommandArgs>$(BuildCommandArgs) /p:SemanticVersioningV1=true</BuildCommandArgs>
     <BuildCommand>$(ProjectDirectory)\eng\common\build$(ShellExtension) $(BuildCommandArgs)</BuildCommand>
     <DeterministicBuildOptOut>true</DeterministicBuildOptOut>
+    <RepoNoWarns>IDE0090</RepoNoWarns>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SourceBuild/content/repo-projects/vstest.proj
+++ b/src/SourceBuild/content/repo-projects/vstest.proj
@@ -6,6 +6,7 @@
     <BuildCommandArgs>$(BuildCommandArgs) /p:SemanticVersioningV1=true</BuildCommandArgs>
     <BuildCommand>$(ProjectDirectory)\eng\common\build$(ShellExtension) $(BuildCommandArgs)</BuildCommand>
     <DeterministicBuildOptOut>true</DeterministicBuildOptOut>
+    <!-- IDE0090: https://github.com/microsoft/vstest/pull/4674 -->
     <RepoNoWarns>IDE0090</RepoNoWarns>
   </PropertyGroup>
 


### PR DESCRIPTION
The following error is occurring in the stage 2 bootstrapping build of the VMR:

```
/vmr/src/vstest/artifacts/source-build/self/src/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/ProcessCodeMethods.cs(71,48): error IDE0090: 'new' expression can be simplified (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0090) [/vmr/src/vstest/artifacts/source-build/self/src/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Microsoft.TestPlatform.Extensions.BlameDataCollector.csproj::TargetFramework=net8.0]
```

This is fixed by ignoring the IDE0090 warning.

Related to https://github.com/microsoft/vstest/pull/4674