### PR TITLE
Format tests should be skipped on Alpine

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -40,9 +40,6 @@ parameters:
 - name: excludeOmniSharpTests
   type: boolean
 
-- name: excludeDotnetFormatTests
-  type: boolean
-
 - name: enablePoison
   type: boolean
 
@@ -221,7 +218,7 @@ jobs:
       set -x
 
       dockerVolumeArgs="-v $(sourcesPath):/vmr"
-      dockerEnvArgs="-e SMOKE_TESTS_EXCLUDE_OMNISHARP=${{ parameters.excludeOmniSharpTests }} -e SMOKE_TESTS_EXCLUDE_DOTNETFORMAT=${{ parameters.excludeDotnetFormatTests }} -e SMOKE_TESTS_WARN_SDK_CONTENT_DIFFS=true -e SMOKE_TESTS_RUNNING_IN_CI=true"
+      dockerEnvArgs="-e SMOKE_TESTS_EXCLUDE_OMNISHARP=${{ parameters.excludeOmniSharpTests }} -e SMOKE_TESTS_WARN_SDK_CONTENT_DIFFS=true -e SMOKE_TESTS_RUNNING_IN_CI=true"
       poisonArg=''
 
       if [[ '${{ parameters.enablePoison }}' == 'True' ]]; then

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -83,7 +83,6 @@ stages:
       buildFromArchive: false            # 🚫
       enablePoison: false                # 🚫
       excludeOmniSharpTests: true        # ✅
-      excludeDotnetFormatTests: false    # 🚫
       runOnline: true                    # ✅
       useMonoRuntime: false              # 🚫
       withPreviousSDK: false             # 🚫
@@ -102,7 +101,6 @@ stages:
       buildFromArchive: true             # ✅
       enablePoison: false                # 🚫
       excludeOmniSharpTests: true        # ✅
-      excludeDotnetFormatTests: false    # 🚫
       runOnline: false                   # 🚫
       useMonoRuntime: false              # 🚫
       withPreviousSDK: false             # 🚫
@@ -125,7 +123,6 @@ stages:
         buildFromArchive: false            # ✅
         enablePoison: false                # 🚫
         excludeOmniSharpTests: true        # ✅
-        excludeDotnetFormatTests: true     # ✅ - https://github.com/dotnet/format/issues/1945
         runOnline: false                   # 🚫
         useMonoRuntime: false              # 🚫
         withPreviousSDK: false             # 🚫
@@ -144,7 +141,6 @@ stages:
         buildFromArchive: false            # 🚫
         enablePoison: false                # 🚫
         excludeOmniSharpTests: true        # ✅
-        excludeDotnetFormatTests: false    # 🚫
         runOnline: true                    # ✅
         useMonoRuntime: false              # 🚫
         withPreviousSDK: true              # ✅
@@ -163,7 +159,6 @@ stages:
         buildFromArchive: false            # 🚫
         enablePoison: false                # 🚫
         excludeOmniSharpTests: true        # ✅
-        excludeDotnetFormatTests: false    # 🚫
         runOnline: false                   # 🚫
         useMonoRuntime: false              # 🚫
         withPreviousSDK: true              # ✅
@@ -182,7 +177,6 @@ stages:
         buildFromArchive: true             # ✅
         enablePoison: false                # 🚫
         excludeOmniSharpTests: true        # ✅
-        excludeDotnetFormatTests: false    # 🚫
         runOnline: false                   # 🚫
         useMonoRuntime: true               # ✅
         withPreviousSDK: false             # 🚫
@@ -201,7 +195,6 @@ stages:
         buildFromArchive: true             # ✅
         enablePoison: false                # 🚫
         excludeOmniSharpTests: false       # 🚫
-        excludeDotnetFormatTests: false    # 🚫
         runOnline: false                   # 🚫
         useMonoRuntime: false              # 🚫
         withPreviousSDK: false             # 🚫
@@ -220,7 +213,6 @@ stages:
         buildFromArchive: true             # ✅
         enablePoison: true                 # ✅
         excludeOmniSharpTests: false       # 🚫
-        excludeDotnetFormatTests: false    # 🚫
         runOnline: false                   # 🚫
         useMonoRuntime: false              # 🚫
         withPreviousSDK: false             # 🚫
@@ -239,7 +231,6 @@ stages:
         buildFromArchive: false            # 🚫
         enablePoison: false                # 🚫
         excludeOmniSharpTests: false       # 🚫
-        excludeDotnetFormatTests: false    # 🚫
         runOnline: false                   # 🚫
         useMonoRuntime: false              # 🚫
         withPreviousSDK: false             # 🚫
@@ -258,7 +249,6 @@ stages:
         buildFromArchive: false            # 🚫
         enablePoison: false                # 🚫
         excludeOmniSharpTests: false       # 🚫
-        excludeDotnetFormatTests: false    # 🚫
         runOnline: false                   # 🚫
         useMonoRuntime: false              # 🚫
         withPreviousSDK: false             # 🚫
@@ -279,7 +269,6 @@ stages:
         buildFromArchive: false            # 🚫
         enablePoison: false                # 🚫
         excludeOmniSharpTests: true        # ✅
-        excludeDotnetFormatTests: false    # 🚫
         runOnline: false                   # 🚫
         useMonoRuntime: false              # 🚫
         withPreviousSDK: false             # 🚫
@@ -299,7 +288,6 @@ stages:
         buildFromArchive: false            # 🚫
         enablePoison: false                # 🚫
         excludeOmniSharpTests: false       # 🚫
-        excludeDotnetFormatTests: false    # 🚫
         runOnline: false                   # 🚫
         useMonoRuntime: false              # 🚫
         withPreviousSDK: false             # 🚫

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/Config.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/Config.cs
@@ -10,7 +10,6 @@ namespace Microsoft.DotNet.SourceBuild.SmokeTests;
 internal static class Config
 {
     public const string DotNetDirectoryEnv = "SMOKE_TESTS_DOTNET_DIR";
-    public const string ExcludeDotnetFormatEnv = "SMOKE_TESTS_EXCLUDE_DOTNETFORMAT";
     public const string ExcludeOmniSharpEnv = "SMOKE_TESTS_EXCLUDE_OMNISHARP";
     public const string MsftSdkTarballPathEnv = "SMOKE_TESTS_MSFT_SDK_TARBALL_PATH";
     public const string PoisonReportPathEnv = "SMOKE_TESTS_POISON_REPORT_PATH";

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetFormatTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetFormatTests.cs
@@ -19,9 +19,15 @@ public class DotNetFormatTests : SmokeTests
     /// <Summary>
     /// Format an unformatted project and verify that the output matches the pre-computed solution.
     /// </Summary>
-    [SkippableFact(Config.ExcludeDotnetFormatEnv, skipOnTrueEnv: true)]
+    [Fact]
     public void FormatProject()
     {
+        if (Config.TargetRid.Contains("alpine"))
+        {
+            // Skipping this test on Alpine due to https://github.com/dotnet/format/issues/1945
+            return;
+        }
+
         string unformattedCsFilePath = Path.Combine(BaselineHelper.GetAssetsDirectory(), UnformattedFileName);
 
         string projectDirectory = DotNetHelper.ExecuteNew("console", nameof(FormatProject), "C#");


### PR DESCRIPTION
The following PR enabled skipping Format tests on Alpine, if an environment variable is set: https://github.com/dotnet/installer/pull/17247

However, this is not a good experience for anyone building and testing on Alpine. See this for more context: https://github.com/dotnet/installer/pull/17247#discussion_r1304409661

A better experience is to not execute the test on Alpine, by utilizing `Config.TargetRid` and return from test method early. This would mark the test as `Passed`.

Even better experience would be to really skip the test dynamically, however we do not support XUnit v3, which provides `SkipWhen` method: https://github.com/xunit/xunit/blob/main/src/xunit.v3.assert.tests/Asserts/SkipAssertsTests.cs
