### PR TITLE
Do not set BuildInParallel globally to false in runtime source build

### DIFF
--- a/src/SourceBuild/content/repo-projects/runtime.proj
+++ b/src/SourceBuild/content/repo-projects/runtime.proj
@@ -38,11 +38,6 @@
     <UseSourceBuiltSdkOverride Include="@(ArcadeSharedFrameworkSdkOverride)" />
   </ItemGroup>
 
-  <!-- Environment Variables -->
-  <ItemGroup>
-    <EnvironmentVariables Include="BuildInParallel=false" />
-  </ItemGroup>
-
   <ItemGroup>
     <ExtraPackageVersionPropsPackageInfo Include="MicrosoftCodeAnalysisVersion_4_X" Version="%24(MicrosoftCodeAnalysisVersion)" />
     <ExtraPackageVersionPropsPackageInfo Include="MicrosoftCodeAnalysisVersion_4_4" Version="%24(MicrosoftCodeAnalysisVersion)" />


### PR DESCRIPTION
This environment variable was added in the distant past. It's not set explicitly in repo-level source build in the runtime repo.
