### PR TITLE
Remove manual Windows SDK KnownFrameworkReference items

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -559,45 +559,6 @@ Copyright (c) .NET Foundation. All rights reserved.
                               RuntimePackExcludedRuntimeIdentifiers="android%3Blinux-bionic"
                               />
 
-    <KnownFrameworkReference Include="Microsoft.Windows.SDK.NET.Ref"
-                              TargetFramework="net8.0-windows10.0.17763.0"
-                              RuntimeFrameworkName="Microsoft.Windows.SDK.NET.Ref"
-                              DefaultRuntimeFrameworkVersion="$(MicrosoftWindowsSDKNETRef10_0_17763PackageVersion)"
-                              LatestRuntimeFrameworkVersion="$(MicrosoftWindowsSDKNETRef10_0_17763PackageVersion)"
-                              TargetingPackName="Microsoft.Windows.SDK.NET.Ref"
-                              TargetingPackVersion="$(MicrosoftWindowsSDKNETRef10_0_17763PackageVersion)"
-                              RuntimePackAlwaysCopyLocal="true"
-                              RuntimePackNamePatterns="Microsoft.Windows.SDK.NET.Ref"
-                              RuntimePackRuntimeIdentifiers="any"
-                              IsWindowsOnly="true"
-                              />
-
-    <KnownFrameworkReference Include="Microsoft.Windows.SDK.NET.Ref"
-                              TargetFramework="net8.0-windows10.0.18362.0"
-                              RuntimeFrameworkName="Microsoft.Windows.SDK.NET.Ref"
-                              DefaultRuntimeFrameworkVersion="$(MicrosoftWindowsSDKNETRef10_0_18362PackageVersion)"
-                              LatestRuntimeFrameworkVersion="$(MicrosoftWindowsSDKNETRef10_0_18362PackageVersion)"
-                              TargetingPackName="Microsoft.Windows.SDK.NET.Ref"
-                              TargetingPackVersion="$(MicrosoftWindowsSDKNETRef10_0_18362PackageVersion)"
-                              RuntimePackAlwaysCopyLocal="true"
-                              RuntimePackNamePatterns="Microsoft.Windows.SDK.NET.Ref"
-                              RuntimePackRuntimeIdentifiers="any"
-                              IsWindowsOnly="true"
-                              />
-
-    <KnownFrameworkReference Include="Microsoft.Windows.SDK.NET.Ref"
-                              TargetFramework="net8.0-windows10.0.19041.0"
-                              RuntimeFrameworkName="Microsoft.Windows.SDK.NET.Ref"
-                              DefaultRuntimeFrameworkVersion="$(MicrosoftWindowsSDKNETRef10_0_19041PackageVersion)"
-                              LatestRuntimeFrameworkVersion="$(MicrosoftWindowsSDKNETRef10_0_19041PackageVersion)"
-                              TargetingPackName="Microsoft.Windows.SDK.NET.Ref"
-                              TargetingPackVersion="$(MicrosoftWindowsSDKNETRef10_0_19041PackageVersion)"
-                              RuntimePackAlwaysCopyLocal="true"
-                              RuntimePackNamePatterns="Microsoft.Windows.SDK.NET.Ref"
-                              RuntimePackRuntimeIdentifiers="any"
-                              IsWindowsOnly="true"
-                              />
-
     <!-- .NET 7.0 -->
     <KnownFrameworkReference Include="Microsoft.NETCore.App"
                               TargetFramework="net7.0"
@@ -699,45 +660,6 @@ Copyright (c) .NET Foundation. All rights reserved.
                               RuntimePackExcludedRuntimeIdentifiers="android"
                               />
 
-    <KnownFrameworkReference Include="Microsoft.Windows.SDK.NET.Ref"
-                              TargetFramework="net7.0-windows10.0.17763.0"
-                              RuntimeFrameworkName="Microsoft.Windows.SDK.NET.Ref"
-                              DefaultRuntimeFrameworkVersion="$(MicrosoftWindowsSDKNETRef10_0_17763PackageVersion)"
-                              LatestRuntimeFrameworkVersion="$(MicrosoftWindowsSDKNETRef10_0_17763PackageVersion)"
-                              TargetingPackName="Microsoft.Windows.SDK.NET.Ref"
-                              TargetingPackVersion="$(MicrosoftWindowsSDKNETRef10_0_17763PackageVersion)"
-                              RuntimePackAlwaysCopyLocal="true"
-                              RuntimePackNamePatterns="Microsoft.Windows.SDK.NET.Ref"
-                              RuntimePackRuntimeIdentifiers="any"
-                              IsWindowsOnly="true"
-                              />
-
-    <KnownFrameworkReference Include="Microsoft.Windows.SDK.NET.Ref"
-                              TargetFramework="net7.0-windows10.0.18362.0"
-                              RuntimeFrameworkName="Microsoft.Windows.SDK.NET.Ref"
-                              DefaultRuntimeFrameworkVersion="$(MicrosoftWindowsSDKNETRef10_0_18362PackageVersion)"
-                              LatestRuntimeFrameworkVersion="$(MicrosoftWindowsSDKNETRef10_0_18362PackageVersion)"
-                              TargetingPackName="Microsoft.Windows.SDK.NET.Ref"
-                              TargetingPackVersion="$(MicrosoftWindowsSDKNETRef10_0_18362PackageVersion)"
-                              RuntimePackAlwaysCopyLocal="true"
-                              RuntimePackNamePatterns="Microsoft.Windows.SDK.NET.Ref"
-                              RuntimePackRuntimeIdentifiers="any"
-                              IsWindowsOnly="true"
-                              />
-
-    <KnownFrameworkReference Include="Microsoft.Windows.SDK.NET.Ref"
-                              TargetFramework="net7.0-windows10.0.19041.0"
-                              RuntimeFrameworkName="Microsoft.Windows.SDK.NET.Ref"
-                              DefaultRuntimeFrameworkVersion="$(MicrosoftWindowsSDKNETRef10_0_19041PackageVersion)"
-                              LatestRuntimeFrameworkVersion="$(MicrosoftWindowsSDKNETRef10_0_19041PackageVersion)"
-                              TargetingPackName="Microsoft.Windows.SDK.NET.Ref"
-                              TargetingPackVersion="$(MicrosoftWindowsSDKNETRef10_0_19041PackageVersion)"
-                              RuntimePackAlwaysCopyLocal="true"
-                              RuntimePackNamePatterns="Microsoft.Windows.SDK.NET.Ref"
-                              RuntimePackRuntimeIdentifiers="any"
-                              IsWindowsOnly="true"
-                              />
-
     <!-- .NET 6.0 -->
     <KnownFrameworkReference Include="Microsoft.NETCore.App"
                               TargetFramework="net6.0"
@@ -831,45 +753,6 @@ Copyright (c) .NET Foundation. All rights reserved.
                               RuntimePackRuntimeIdentifiers="@(AspNetCore60RuntimePackRids, '%3B')"
                               />
 
-    <KnownFrameworkReference Include="Microsoft.Windows.SDK.NET.Ref"
-                              TargetFramework="net6.0-windows10.0.17763.0"
-                              RuntimeFrameworkName="Microsoft.Windows.SDK.NET.Ref"
-                              DefaultRuntimeFrameworkVersion="$(MicrosoftWindowsSDKNETRef10_0_17763PackageVersion)"
-                              LatestRuntimeFrameworkVersion="$(MicrosoftWindowsSDKNETRef10_0_17763PackageVersion)"
-                              TargetingPackName="Microsoft.Windows.SDK.NET.Ref"
-                              TargetingPackVersion="$(MicrosoftWindowsSDKNETRef10_0_17763PackageVersion)"
-                              RuntimePackAlwaysCopyLocal="true"
-                              RuntimePackNamePatterns="Microsoft.Windows.SDK.NET.Ref"
-                              RuntimePackRuntimeIdentifiers="any"
-                              IsWindowsOnly="true"
-                              />
-
-    <KnownFrameworkReference Include="Microsoft.Windows.SDK.NET.Ref"
-                              TargetFramework="net6.0-windows10.0.18362.0"
-                              RuntimeFrameworkName="Microsoft.Windows.SDK.NET.Ref"
-                              DefaultRuntimeFrameworkVersion="$(MicrosoftWindowsSDKNETRef10_0_18362PackageVersion)"
-                              LatestRuntimeFrameworkVersion="$(MicrosoftWindowsSDKNETRef10_0_18362PackageVersion)"
-                              TargetingPackName="Microsoft.Windows.SDK.NET.Ref"
-                              TargetingPackVersion="$(MicrosoftWindowsSDKNETRef10_0_18362PackageVersion)"
-                              RuntimePackAlwaysCopyLocal="true"
-                              RuntimePackNamePatterns="Microsoft.Windows.SDK.NET.Ref"
-                              RuntimePackRuntimeIdentifiers="any"
-                              IsWindowsOnly="true"
-                              />
-
-    <KnownFrameworkReference Include="Microsoft.Windows.SDK.NET.Ref"
-                              TargetFramework="net6.0-windows10.0.19041.0"
-                              RuntimeFrameworkName="Microsoft.Windows.SDK.NET.Ref"
-                              DefaultRuntimeFrameworkVersion="$(MicrosoftWindowsSDKNETRef10_0_19041PackageVersion)"
-                              LatestRuntimeFrameworkVersion="$(MicrosoftWindowsSDKNETRef10_0_19041PackageVersion)"
-                              TargetingPackName="Microsoft.Windows.SDK.NET.Ref"
-                              TargetingPackVersion="$(MicrosoftWindowsSDKNETRef10_0_19041PackageVersion)"
-                              RuntimePackAlwaysCopyLocal="true"
-                              RuntimePackNamePatterns="Microsoft.Windows.SDK.NET.Ref"
-                              RuntimePackRuntimeIdentifiers="any"
-                              IsWindowsOnly="true"
-                              />
-
     <!-- .NET 5.0 -->
     <KnownFrameworkReference Include="Microsoft.NETCore.App"
                               TargetFramework="net5.0"
@@ -948,45 +831,6 @@ Copyright (c) .NET Foundation. All rights reserved.
                               TargetingPackVersion="$(_AspNet50TargetingPackVersion)"
                               RuntimePackNamePatterns="Microsoft.AspNetCore.App.Runtime.**RID**"
                               RuntimePackRuntimeIdentifiers="@(AspNetCore50RuntimePackRids, '%3B')"
-                              />
-
-    <KnownFrameworkReference Include="Microsoft.Windows.SDK.NET.Ref"
-                              TargetFramework="net5.0-windows10.0.17763.0"
-                              RuntimeFrameworkName="Microsoft.Windows.SDK.NET.Ref"
-                              DefaultRuntimeFrameworkVersion="$(MicrosoftWindowsSDKNETRef10_0_17763PackageVersion)"
-                              LatestRuntimeFrameworkVersion="$(MicrosoftWindowsSDKNETRef10_0_17763PackageVersion)"
-                              TargetingPackName="Microsoft.Windows.SDK.NET.Ref"
-                              TargetingPackVersion="$(MicrosoftWindowsSDKNETRef10_0_17763PackageVersion)"
-                              RuntimePackAlwaysCopyLocal="true"
-                              RuntimePackNamePatterns="Microsoft.Windows.SDK.NET.Ref"
-                              RuntimePackRuntimeIdentifiers="any"
-                              IsWindowsOnly="true"
-                              />
-
-    <KnownFrameworkReference Include="Microsoft.Windows.SDK.NET.Ref"
-                              TargetFramework="net5.0-windows10.0.18362.0"
-                              RuntimeFrameworkName="Microsoft.Windows.SDK.NET.Ref"
-                              DefaultRuntimeFrameworkVersion="$(MicrosoftWindowsSDKNETRef10_0_18362PackageVersion)"
-                              LatestRuntimeFrameworkVersion="$(MicrosoftWindowsSDKNETRef10_0_18362PackageVersion)"
-                              TargetingPackName="Microsoft.Windows.SDK.NET.Ref"
-                              TargetingPackVersion="$(MicrosoftWindowsSDKNETRef10_0_18362PackageVersion)"
-                              RuntimePackAlwaysCopyLocal="true"
-                              RuntimePackNamePatterns="Microsoft.Windows.SDK.NET.Ref"
-                              RuntimePackRuntimeIdentifiers="any"
-                              IsWindowsOnly="true"
-                              />
-
-    <KnownFrameworkReference Include="Microsoft.Windows.SDK.NET.Ref"
-                              TargetFramework="net5.0-windows10.0.19041.0"
-                              RuntimeFrameworkName="Microsoft.Windows.SDK.NET.Ref"
-                              DefaultRuntimeFrameworkVersion="$(MicrosoftWindowsSDKNETRef10_0_19041PackageVersion)"
-                              LatestRuntimeFrameworkVersion="$(MicrosoftWindowsSDKNETRef10_0_19041PackageVersion)"
-                              TargetingPackName="Microsoft.Windows.SDK.NET.Ref"
-                              TargetingPackVersion="$(MicrosoftWindowsSDKNETRef10_0_19041PackageVersion)"
-                              RuntimePackAlwaysCopyLocal="true"
-                              RuntimePackNamePatterns="Microsoft.Windows.SDK.NET.Ref"
-                              RuntimePackRuntimeIdentifiers="any"
-                              IsWindowsOnly="true"
                               />
 
     <!-- .NET Core 3.1  -->


### PR DESCRIPTION
These items are always removed by the SDK targets and the correct KnownFrameworkReference items for the target TFM are added in the AddWindowsSdkKnownFrameworkReferences target.
