### PR TITLE
Add System.IO.Pipelines to assembly version diff exclusions

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkAssemblyVersionDiffExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkAssemblyVersionDiffExclusions.txt
@@ -32,6 +32,7 @@
 ./sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.CodeAnalysis.*
 ./sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.DiaSymReader.dll
 ./sdk/x.y.z/DotnetTools/dotnet-format/System.Composition.*
+./sdk/x.y.z/DotnetTools/dotnet-format/System.IO.Pipelines.dll
 ./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Humanizer.dll
 ./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Microsoft.Build.Locator.dll
 ./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Microsoft.CodeAnalysis.AnalyzerUtilities.dll


### PR DESCRIPTION
The following showed up in the SB assembly version diff:

```diff
-sdk/x.y.z/DotnetTools/dotnet-format/System.IO.Pipelines.dll - 7.0.0
+sdk/x.y.z/DotnetTools/dotnet-format/System.IO.Pipelines.dll - 8.0.0
```

This is a result of the change in https://github.com/dotnet/roslyn/pull/69719 to update System.IO.Pipelines to the live version. It is expected that this diff occurs. I've added this to the exclusion file.