### PR TITLE
Add sourcelink tests

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/Config.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/Config.cs
@@ -11,7 +11,6 @@ internal static class Config
 {
     public const string DotNetDirectoryEnv = "SMOKE_TESTS_DOTNET_DIR";
     public const string ExcludeOmniSharpEnv = "SMOKE_TESTS_EXCLUDE_OMNISHARP";
-    public const string ExcludeSourcelinkEnv = "SMOKE_TESTS_EXCLUDE_SOURCELINK";
     public const string MsftSdkTarballPathEnv = "SMOKE_TESTS_MSFT_SDK_TARBALL_PATH";
     public const string PoisonReportPathEnv = "SMOKE_TESTS_POISON_REPORT_PATH";
     public const string PortableRidEnv = "SMOKE_TESTS_PORTABLE_RID";

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/Config.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/Config.cs
@@ -11,6 +11,7 @@ internal static class Config
 {
     public const string DotNetDirectoryEnv = "SMOKE_TESTS_DOTNET_DIR";
     public const string ExcludeOmniSharpEnv = "SMOKE_TESTS_EXCLUDE_OMNISHARP";
+    public const string ExcludeSourcelinkEnv = "SMOKE_TESTS_EXCLUDE_SOURCELINK";
     public const string MsftSdkTarballPathEnv = "SMOKE_TESTS_MSFT_SDK_TARBALL_PATH";
     public const string PoisonReportPathEnv = "SMOKE_TESTS_POISON_REPORT_PATH";
     public const string PortableRidEnv = "SMOKE_TESTS_PORTABLE_RID";

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/ExecuteHelper.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/ExecuteHelper.cs
@@ -17,11 +17,11 @@ internal static class ExecuteHelper
         string args,
         ITestOutputHelper outputHelper,
         bool logOutput = false,
-        bool logInfo = true,
+        bool excludeInfo = false,
         Action<Process>? configureCallback = null,
         int millisecondTimeout = -1)
     {
-        if (logInfo)
+        if (!excludeInfo)
         {
             outputHelper.WriteLine($"Executing: {fileName} {args}");
         }

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/ExecuteHelper.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/ExecuteHelper.cs
@@ -17,10 +17,14 @@ internal static class ExecuteHelper
         string args,
         ITestOutputHelper outputHelper,
         bool logOutput = false,
+        bool logInfo = true,
         Action<Process>? configureCallback = null,
         int millisecondTimeout = -1)
     {
-        outputHelper.WriteLine($"Executing: {fileName} {args}");
+        if (logInfo)
+        {
+            outputHelper.WriteLine($"Executing: {fileName} {args}");
+        }
 
         Process process = new()
         {

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/OmniSharpTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/OmniSharpTests.cs
@@ -21,7 +21,7 @@ public class OmniSharpTests : SmokeTests
     // Update version as new releases become available: https://github.com/OmniSharp/omnisharp-roslyn/releases
     private const string OmniSharpReleaseVersion = "1.39.8";
 
-    private string OmniSharpDirectory { get; } = Path.Combine(Directory.GetCurrentDirectory(), "omnisharp");
+    private string OmniSharpDirectory { get; } = Path.Combine(Directory.GetCurrentDirectory(), nameof(OmniSharpTests));
 
     public OmniSharpTests(ITestOutputHelper outputHelper) : base(outputHelper) { }
 

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SourcelinkTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SourcelinkTests.cs
@@ -1,0 +1,134 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.SourceBuild.SmokeTests;
+
+public class SourcelinkTests : SmokeTests
+{
+    private static string SourcelinkRoot { get; } = Path.Combine(Directory.GetCurrentDirectory(), "sourcelink");
+
+    private string sourcelinkToolPath;
+    private ConcurrentBag<string> failedFiles = new ConcurrentBag<string>();
+
+    public SourcelinkTests(ITestOutputHelper outputHelper) : base(outputHelper) { }
+
+    /// <summary>
+    /// Verifies that all symbols have valid sourcelinks.
+    /// </summary>
+    [SkippableFact(Config.ExcludeSourcelinkEnv, skipOnTrueEnv: true)]
+    public void VerifySourcelinks()
+    {
+        if (Directory.Exists(SourcelinkRoot))
+        {
+            Directory.Delete(SourcelinkRoot, true);
+        }
+        Directory.CreateDirectory(SourcelinkRoot);
+
+        sourcelinkToolPath = GetSourcelinkToolPath();
+
+        ValidateAllFiles(ExtractPackages(GetAllSymbolsPackages()));
+
+        foreach (string file in failedFiles)
+        {
+            OutputHelper.WriteLine($"Failed sourcelink verification: {file}");
+        }
+
+        Assert.True(failedFiles.Count == 0);
+    }
+
+    /// <summary>
+    /// Gets the path to sourcelink binary.
+    /// Extracts the dotnet-sourcelink tool package from PSB arhive.
+    /// </summary>
+    /// <returns>Path to sourcelink tool binary.</returns>
+    private string GetSourcelinkToolPath()
+    {
+        string sourcelinkToolPackageNamePattern = "dotnet-sourcelink*nupkg";
+        string sourcelinkToolBinaryFilenamePattern = "dotnet-sourcelink.dll";
+
+        string sourcelinkRoot = Directory.CreateDirectory(Path.Combine(SourcelinkRoot, "sourcelink-tool")).FullName;
+        Utilities.ExtractTarball(Config.SourceBuiltArtifactsPath, sourcelinkRoot, sourcelinkToolPackageNamePattern);
+        string[] files = Directory.GetFiles(sourcelinkRoot, sourcelinkToolPackageNamePattern, SearchOption.AllDirectories);
+        Assert.True(files.Length > 0, "Did not find sourcelink tool package in PSB Artifacts archive");
+
+        string extractedToolPath = Directory.CreateDirectory(Path.Combine(sourcelinkRoot, "extracted")).FullName;
+        Utilities.ExtractNupkg(files[0], extractedToolPath);
+
+        files = Directory.GetFiles(extractedToolPath, sourcelinkToolBinaryFilenamePattern, SearchOption.AllDirectories);
+        Assert.True(files.Length > 0, $"Did not find sourcelink tool binary with expected filename pattern: {sourcelinkToolBinaryFilenamePattern}");
+
+        return files[0];
+    }
+
+    private IEnumerable<string> GetAllSymbolsPackages()
+    {
+        /*
+            At the moment we validate sourcelinks from runtime symbols package.
+            The plan is to make symbols, from all repos, available in source-build artifacts.
+            Once that's available, this code will be modified to validate all available symbols.
+            Tracking issue: https://github.com/dotnet/source-build/issues/3612
+        */
+
+        // Runtime symbols package lives in the same directory as PSB artifacts.
+        // i.e. <repo-root>/artifacts/x64/Release/runtime/dotnet-runtime-symbols-fedora.36-x64-8.0.0-preview.7.23355.7.tar.gz
+        string runtimeSymbolsPackageNamePattern = "dotnet-runtime-symbols-*.tar.gz";
+        string[] files = Directory.GetFiles(Path.GetDirectoryName(Config.SourceBuiltArtifactsPath), runtimeSymbolsPackageNamePattern, SearchOption.AllDirectories);
+        Assert.True(files.Length > 0, "Did not find runtime symbols archive");
+
+        yield return files[0];
+    }
+
+    /// <summary>
+    /// Extracts packages to subdirectories of the common symbols root directory.
+    /// </summary>
+    /// <returns>Path to common symbols root directory.</returns>
+    private string ExtractPackages(IEnumerable<string> packages)
+    {
+        string symbolsRoot = Directory.CreateDirectory(Path.Combine(SourcelinkRoot, "symbols")).FullName;
+
+        foreach (string package in packages)
+        {
+            Assert.True(package.EndsWith(".tar.gz"), $"Package extension is not supported: {package}");
+            DirectoryInfo targetDirInfo = Directory.CreateDirectory(Path.Combine(symbolsRoot, Path.GetFileNameWithoutExtension(package)));
+            Utilities.ExtractTarball(package, targetDirInfo.FullName, OutputHelper);
+        }
+
+        return symbolsRoot;
+    }
+
+    private void ValidateAllFiles(string path)
+    {
+        Assert.True(Directory.Exists(path), $"Path, with symbol files to validate, does not exist: {path}");
+
+        IEnumerable<string> allFiles = Directory.GetFiles(path, "*.pdb", SearchOption.AllDirectories);
+        Parallel.ForEach(allFiles, file =>
+        {
+            (Process Process, string StdOut, string StdErr) executeResult = ExecuteHelper.ExecuteProcess(
+                DotNetHelper.DotNetPath,
+                $"{sourcelinkToolPath} test --offline {file}",
+                OutputHelper,
+                logOutput: false,
+                logInfo: false, // Do not log process cmd line, as there can be 1,000+
+                millisecondTimeout: 5000,
+                configureCallback: (process) => DotNetHelper.ConfigureProcess(process, null));
+
+            if (executeResult.Process.ExitCode != 0)
+            {
+                failedFiles.Add(file);
+            }
+        });
+
+        Assert.True(allFiles.Count() > 0, $"Did not find any symbols for sourcelink verification in {path}");
+    }
+}

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SourcelinkTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SourcelinkTests.cs
@@ -58,18 +58,11 @@ public class SourcelinkTests : SmokeTests
 
         string toolPackageDir = Directory.CreateDirectory(Path.Combine(SourcelinkRoot, "sourcelink-tool")).FullName;
         Utilities.ExtractTarball(Config.SourceBuiltArtifactsPath, toolPackageDir, SourcelinkToolPackageNamePattern);
-        string[] files = Directory.GetFiles(toolPackageDir, SourcelinkToolPackageNamePattern, SearchOption.AllDirectories);
-        Assert.False(files.Length > 1, "Unexpected - PSB Artifacts archive should contain only one sourcelink tool package.");
-        Assert.False(files.Length == 0, "Did not find sourcelink tool package in PSB Artifacts archive.");
 
         string extractedToolPath = Directory.CreateDirectory(Path.Combine(toolPackageDir, "extracted")).FullName;
-        Utilities.ExtractNupkg(files[0], extractedToolPath);
+        Utilities.ExtractNupkg(Utilities.GetFile(toolPackageDir, SourcelinkToolPackageNamePattern), extractedToolPath);
 
-        files = Directory.GetFiles(extractedToolPath, SourcelinkToolBinaryFilename, SearchOption.AllDirectories);
-        Assert.False(files.Length > 1, $"Unexpected - found more than one sourcelink tool binary: {SourcelinkToolBinaryFilename}");
-        Assert.False(files.Length == 0, $"Did not find sourcelink tool binary: {SourcelinkToolBinaryFilename}");
-
-        return files[0];
+        return Utilities.GetFile(extractedToolPath, SourcelinkToolBinaryFilename);
     }
 
     private IEnumerable<string> GetAllSymbolsPackages()
@@ -83,12 +76,7 @@ public class SourcelinkTests : SmokeTests
 
         // Runtime symbols package lives in the same directory as PSB artifacts.
         // i.e. <repo-root>/artifacts/x64/Release/runtime/dotnet-runtime-symbols-fedora.36-x64-8.0.0-preview.7.23355.7.tar.gz
-        string runtimeSymbolsPackageNamePattern = "dotnet-runtime-symbols-*.tar.gz";
-        string[] files = Directory.GetFiles(Path.GetDirectoryName(Config.SourceBuiltArtifactsPath), runtimeSymbolsPackageNamePattern, SearchOption.AllDirectories);
-        Assert.False(files.Length > 1, "Unexpected - found more than one runtime symbols archives.");
-        Assert.False(files.Length == 0, "Did not find runtime symbols archive.");
-
-        yield return files[0];
+        yield return Utilities.GetFile(Path.GetDirectoryName(Config.SourceBuiltArtifactsPath), "dotnet-runtime-symbols-*.tar.gz");
     }
 
     /// <summary>

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/Utilities.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/Utilities.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Threading;
 using System.Threading.Tasks;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.SourceBuild.SmokeTests;
@@ -116,5 +117,13 @@ public static class Utilities
             Thread.Sleep(TimeSpan.FromSeconds(waitTime));
             exception = await executor();
         }
+    }
+
+    public static string GetFile(string path, string pattern)
+    {
+        string[] files = Directory.GetFiles(path, pattern, SearchOption.AllDirectories);
+        Assert.False(files.Length > 1, $"Found multiple files matching the pattern {pattern}: {Environment.NewLine}{string.Join(Environment.NewLine, files)}");
+        Assert.False(files.Length == 0, $"Did not find any files matching the pattern {pattern}");
+        return files[0];
     }
 }

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/Utilities.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/Utilities.cs
@@ -60,6 +60,21 @@ public static class Utilities
         }
     }
 
+    public static void ExtractNupkg(string package, string outputDir)
+    {
+        Directory.CreateDirectory(outputDir);
+
+        using (ZipArchive zip = ZipFile.OpenRead(package))
+        {
+            foreach (ZipArchiveEntry entry in zip.Entries)
+            {
+                string outputPath = Path.Combine(outputDir, entry.FullName);
+                Directory.CreateDirectory(Path.GetDirectoryName(outputPath));
+                entry.ExtractToFile(outputPath);
+            }
+        }
+    }
+
     public static async Task RetryAsync(Func<Task> executor, ITestOutputHelper outputHelper)
     {
         await Utilities.RetryAsync(

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/Utilities.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/Utilities.cs
@@ -64,14 +64,12 @@ public static class Utilities
     {
         Directory.CreateDirectory(outputDir);
 
-        using (ZipArchive zip = ZipFile.OpenRead(package))
+        using ZipArchive zip = ZipFile.OpenRead(package);
+        foreach (ZipArchiveEntry entry in zip.Entries)
         {
-            foreach (ZipArchiveEntry entry in zip.Entries)
-            {
-                string outputPath = Path.Combine(outputDir, entry.FullName);
-                Directory.CreateDirectory(Path.GetDirectoryName(outputPath));
-                entry.ExtractToFile(outputPath);
-            }
+            string outputPath = Path.Combine(outputDir, entry.FullName);
+            Directory.CreateDirectory(Path.GetDirectoryName(outputPath));
+            entry.ExtractToFile(outputPath);
         }
     }
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/3052

For now, we process just the runtime symbols as they are available in source-build artifacts. After PDB work is done, we'll modify the code in `GetAllSymbolsPackages()` to discover all symbols archives. That work is tracked with: https://github.com/dotnet/source-build/issues/3612

PDB work has the following related issues: https://github.com/dotnet/source-build/issues/3547, https://github.com/dotnet/source-build/issues/3609, https://github.com/dotnet/source-build/issues/3610