### PR TITLE
Skip BasicScenarioTests.cs and WebScenarioTests.cs for PublishComplex action

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/BasicScenarioTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/BasicScenarioTests.cs
@@ -34,7 +34,7 @@ public class BasicScenarioTests : SmokeTests
         {
             yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.Console,
                 // R2R is not supported on Mono (see https://github.com/dotnet/runtime/issues/88419#issuecomment-1623762676)
-                DotNetActions.Build | DotNetActions.Run | (DotNetHelper.ShouldPublishComplex() ? DotNetActions.PublishComplex : DotNetActions.None) | (helper.IsMonoRuntime ? DotNetActions.None : DotNetActions.PublishR2R));
+                DotNetActions.Build | DotNetActions.Run | (DotNetHelper.ShouldPublishComplex() ? DotNetActions.None : DotNetActions.PublishComplex) | (helper.IsMonoRuntime ? DotNetActions.None : DotNetActions.PublishR2R));
             yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.ClassLib, DotNetActions.Build | DotNetActions.Publish);
             yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.XUnit,    DotNetActions.Test);
             yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.NUnit,    DotNetActions.Test);

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/BasicScenarioTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/BasicScenarioTests.cs
@@ -34,7 +34,7 @@ public class BasicScenarioTests : SmokeTests
         {
             yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.Console,
                 // R2R is not supported on Mono (see https://github.com/dotnet/runtime/issues/88419#issuecomment-1623762676)
-                DotNetActions.Build | DotNetActions.Run | DotNetActions.PublishComplex | (helper.IsMonoRuntime ? DotNetActions.None : DotNetActions.PublishR2R));
+                DotNetActions.Build | DotNetActions.Run | (string.Equals(Config.TargetArchitecture,"ppc64le") || string.Equals(Config.TargetArchitecture,"s390x") ? DotNetActions.None : DotNetActions.PublishComplex) | (helper.IsMonoRuntime ? DotNetActions.None : DotNetActions.PublishR2R));
             yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.ClassLib, DotNetActions.Build | DotNetActions.Publish);
             yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.XUnit,    DotNetActions.Test);
             yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.NUnit,    DotNetActions.Test);

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/BasicScenarioTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/BasicScenarioTests.cs
@@ -34,7 +34,7 @@ public class BasicScenarioTests : SmokeTests
         {
             yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.Console,
                 // R2R is not supported on Mono (see https://github.com/dotnet/runtime/issues/88419#issuecomment-1623762676)
-                DotNetActions.Build | DotNetActions.Run | (helper.ShouldPublishComplex ? DotNetActions.PublishComplex : DotNetActions.None) | (helper.IsMonoRuntime ? DotNetActions.None : DotNetActions.PublishR2R));
+                DotNetActions.Build | DotNetActions.Run | (DotNetHelper.ShouldPublishComplex() ? DotNetActions.PublishComplex : DotNetActions.None) | (helper.IsMonoRuntime ? DotNetActions.None : DotNetActions.PublishR2R));
             yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.ClassLib, DotNetActions.Build | DotNetActions.Publish);
             yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.XUnit,    DotNetActions.Test);
             yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.NUnit,    DotNetActions.Test);

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/BasicScenarioTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/BasicScenarioTests.cs
@@ -34,7 +34,7 @@ public class BasicScenarioTests : SmokeTests
         {
             yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.Console,
                 // R2R is not supported on Mono (see https://github.com/dotnet/runtime/issues/88419#issuecomment-1623762676)
-                DotNetActions.Build | DotNetActions.Run | (helper.IsActionPublishComplex ? DotNetActions.PublishComplex : DotNetActions.None) | (helper.IsMonoRuntime ? DotNetActions.None : DotNetActions.PublishR2R));
+                DotNetActions.Build | DotNetActions.Run | (helper.ShouldPublishComplex ? DotNetActions.PublishComplex : DotNetActions.None) | (helper.IsMonoRuntime ? DotNetActions.None : DotNetActions.PublishR2R));
             yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.ClassLib, DotNetActions.Build | DotNetActions.Publish);
             yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.XUnit,    DotNetActions.Test);
             yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.NUnit,    DotNetActions.Test);

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/BasicScenarioTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/BasicScenarioTests.cs
@@ -34,7 +34,7 @@ public class BasicScenarioTests : SmokeTests
         {
             yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.Console,
                 // R2R is not supported on Mono (see https://github.com/dotnet/runtime/issues/88419#issuecomment-1623762676)
-                DotNetActions.Build | DotNetActions.Run | (string.Equals(Config.TargetArchitecture,"ppc64le") || string.Equals(Config.TargetArchitecture,"s390x") ? DotNetActions.None : DotNetActions.PublishComplex) | (helper.IsMonoRuntime ? DotNetActions.None : DotNetActions.PublishR2R));
+                DotNetActions.Build | DotNetActions.Run | (helper.IsActionPublishComplex ? DotNetActions.PublishComplex : DotNetActions.None) | (helper.IsMonoRuntime ? DotNetActions.None : DotNetActions.PublishR2R));
             yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.ClassLib, DotNetActions.Build | DotNetActions.Publish);
             yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.XUnit,    DotNetActions.Test);
             yield return new(nameof(BasicScenarioTests), language, DotNetTemplate.NUnit,    DotNetActions.Test);

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetHelper.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetHelper.cs
@@ -284,7 +284,7 @@ internal class DotNetHelper
         return File.Exists(Path.Combine(sharedFramework, "mono-gc.h"));
     }
 
-    public bool ShouldPublishComplex() {
+    public static bool ShouldPublishComplex() {
         if (string.Equals(Config.TargetArchitecture,"ppc64le") || string.Equals(Config.TargetArchitecture,"s390x"))
         {
             return false;

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetHelper.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetHelper.cs
@@ -284,7 +284,7 @@ internal class DotNetHelper
         return File.Exists(Path.Combine(sharedFramework, "mono-gc.h"));
     }
 
-    public bool IsActionPublishComplex() {
+    public bool ShouldPublishComplex() {
         if (string.Equals(Config.TargetArchitecture,"ppc64le") || string.Equals(Config.TargetArchitecture,"s390x"))
         {
             return false;

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetHelper.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetHelper.cs
@@ -284,16 +284,10 @@ internal class DotNetHelper
         return File.Exists(Path.Combine(sharedFramework, "mono-gc.h"));
     }
 
-    public static bool ShouldPublishComplex() {
-        if (string.Equals(Config.TargetArchitecture,"ppc64le") || string.Equals(Config.TargetArchitecture,"s390x"))
-        {
-            return false;
-        }
-        else
-            return true;
-    }
-
     private static string GetProjectDirectory(string projectName) => Path.Combine(ProjectsDirectory, projectName);
+
+    public static bool ShouldPublishComplex() =>
+        string.Equals(Config.TargetArchitecture,"ppc64le") || string.Equals(Config.TargetArchitecture,"s390x");
 
     private class WebAppValidator
     {

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetHelper.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetHelper.cs
@@ -284,6 +284,15 @@ internal class DotNetHelper
         return File.Exists(Path.Combine(sharedFramework, "mono-gc.h"));
     }
 
+    public bool IsActionPublishComplex() {
+        if (string.Equals(Config.TargetArchitecture,"ppc64le") || string.Equals(Config.TargetArchitecture,"s390x"))
+        {
+            return false;
+        }
+        else
+            return true;
+    }
+
     private static string GetProjectDirectory(string projectName) => Path.Combine(ProjectsDirectory, projectName);
 
     private class WebAppValidator

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/WebScenarioTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/WebScenarioTests.cs
@@ -30,7 +30,7 @@ public class WebScenarioTests : SmokeTests
     {
         foreach (DotNetLanguage language in new[] { DotNetLanguage.CSharp, DotNetLanguage.FSharp })
         {
-            yield return new(nameof(WebScenarioTests), language, DotNetTemplate.Web,    DotNetActions.Build | DotNetActions.Run | DotNetActions.PublishComplex);
+            yield return new(nameof(WebScenarioTests), language, DotNetTemplate.Web,    DotNetActions.Build | DotNetActions.Run | (string.Equals(Config.TargetArchitecture,"ppc64le") || string.Equals(Config.TargetArchitecture,"s390x") ? DotNetActions.None : DotNetActions.PublishComplex));
             yield return new(nameof(WebScenarioTests), language, DotNetTemplate.Mvc,    DotNetActions.Build | DotNetActions.Run | DotNetActions.Publish) { NoHttps = true };
             yield return new(nameof(WebScenarioTests), language, DotNetTemplate.WebApi, DotNetActions.Build | DotNetActions.Run | DotNetActions.Publish);
         }

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/WebScenarioTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/WebScenarioTests.cs
@@ -30,7 +30,7 @@ public class WebScenarioTests : SmokeTests
     {
         foreach (DotNetLanguage language in new[] { DotNetLanguage.CSharp, DotNetLanguage.FSharp })
         {
-            yield return new(nameof(WebScenarioTests), language, DotNetTemplate.Web,    DotNetActions.Build | DotNetActions.Run | (DotNetHelper.ShouldPublishComplex() ? DotNetActions.PublishComplex : DotNetActions.None));
+            yield return new(nameof(WebScenarioTests), language, DotNetTemplate.Web,    DotNetActions.Build | DotNetActions.Run | (DotNetHelper.ShouldPublishComplex() ? DotNetActions.None : DotNetActions.PublishComplex));
             yield return new(nameof(WebScenarioTests), language, DotNetTemplate.Mvc,    DotNetActions.Build | DotNetActions.Run | DotNetActions.Publish) { NoHttps = true };
             yield return new(nameof(WebScenarioTests), language, DotNetTemplate.WebApi, DotNetActions.Build | DotNetActions.Run | DotNetActions.Publish);
         }

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/WebScenarioTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/WebScenarioTests.cs
@@ -28,10 +28,9 @@ public class WebScenarioTests : SmokeTests
 
     private static IEnumerable<TestScenario> GetScenarios()
     {
-        DotNetHelper helper = new(new DebugTestOutputHelper());
         foreach (DotNetLanguage language in new[] { DotNetLanguage.CSharp, DotNetLanguage.FSharp })
         {
-            yield return new(nameof(WebScenarioTests), language, DotNetTemplate.Web,    DotNetActions.Build | DotNetActions.Run | (helper.ShouldPublishComplex() ? DotNetActions.PublishComplex : DotNetActions.None));
+            yield return new(nameof(WebScenarioTests), language, DotNetTemplate.Web,    DotNetActions.Build | DotNetActions.Run | (DotNetHelper.ShouldPublishComplex() ? DotNetActions.PublishComplex : DotNetActions.None));
             yield return new(nameof(WebScenarioTests), language, DotNetTemplate.Mvc,    DotNetActions.Build | DotNetActions.Run | DotNetActions.Publish) { NoHttps = true };
             yield return new(nameof(WebScenarioTests), language, DotNetTemplate.WebApi, DotNetActions.Build | DotNetActions.Run | DotNetActions.Publish);
         }

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/WebScenarioTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/WebScenarioTests.cs
@@ -31,7 +31,7 @@ public class WebScenarioTests : SmokeTests
         DotNetHelper helper = new(new DebugTestOutputHelper());
         foreach (DotNetLanguage language in new[] { DotNetLanguage.CSharp, DotNetLanguage.FSharp })
         {
-            yield return new(nameof(WebScenarioTests), language, DotNetTemplate.Web,    DotNetActions.Build | DotNetActions.Run | (helper.IsActionPublishComplex() ? DotNetActions.PublishComplex : DotNetActions.None));
+            yield return new(nameof(WebScenarioTests), language, DotNetTemplate.Web,    DotNetActions.Build | DotNetActions.Run | (helper.ShouldPublishComplex() ? DotNetActions.PublishComplex : DotNetActions.None));
             yield return new(nameof(WebScenarioTests), language, DotNetTemplate.Mvc,    DotNetActions.Build | DotNetActions.Run | DotNetActions.Publish) { NoHttps = true };
             yield return new(nameof(WebScenarioTests), language, DotNetTemplate.WebApi, DotNetActions.Build | DotNetActions.Run | DotNetActions.Publish);
         }

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/WebScenarioTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/WebScenarioTests.cs
@@ -28,9 +28,10 @@ public class WebScenarioTests : SmokeTests
 
     private static IEnumerable<TestScenario> GetScenarios()
     {
+        DotNetHelper helper = new(new DebugTestOutputHelper());
         foreach (DotNetLanguage language in new[] { DotNetLanguage.CSharp, DotNetLanguage.FSharp })
         {
-            yield return new(nameof(WebScenarioTests), language, DotNetTemplate.Web,    DotNetActions.Build | DotNetActions.Run | (string.Equals(Config.TargetArchitecture,"ppc64le") || string.Equals(Config.TargetArchitecture,"s390x") ? DotNetActions.None : DotNetActions.PublishComplex));
+            yield return new(nameof(WebScenarioTests), language, DotNetTemplate.Web,    DotNetActions.Build | DotNetActions.Run | (helper.IsActionPublishComplex() ? DotNetActions.PublishComplex : DotNetActions.None));
             yield return new(nameof(WebScenarioTests), language, DotNetTemplate.Mvc,    DotNetActions.Build | DotNetActions.Run | DotNetActions.Publish) { NoHttps = true };
             yield return new(nameof(WebScenarioTests), language, DotNetTemplate.WebApi, DotNetActions.Build | DotNetActions.Run | DotNetActions.Publish);
         }


### PR DESCRIPTION
Fixes [#3614](https://github.com/dotnet/source-build/issues/3614)
This PR is to skip BasicScenarioTests.cs and WebScenarioTests.cs test cases for ppc64le and s390x arch.

