### PR TITLE
[release/8.0.1xx] When laying out the PKG contents copy only aspnet shared framework

### DIFF
--- a/src/redist/targets/GeneratePKG.targets
+++ b/src/redist/targets/GeneratePKG.targets
@@ -156,7 +156,8 @@
       
       <!-- Copy ASP.NET runtime and targeting pack to internal layout, as we don't currently chain that in with a pkg dependency -->
       <ExtractArchiveToDirectory SourceArchive="$(DownloadsFolder)$(AspNetCoreSharedFxArchiveFileName)"
-                                 DestinationDirectory="$(SdkInternalLayoutPath)" />
+                                 DestinationDirectory="$(SdkInternalLayoutPath)"
+                                 DirectoriesToCopy="shared/Microsoft.AspNetCore.App" />
       <ExtractArchiveToDirectory SourceArchive="$(DownloadsFolder)$(AspNetTargetingPackArchiveFileName)"
                                  DestinationDirectory="$(SdkInternalLayoutPath)" />
 


### PR DESCRIPTION
When switching to using the full archives rather than the now-removed aspnet internal archive, this place should have been changed along with GenerateLayout.targets. Because we failed to do so, we appear to be double-distributing .NET runtime and host in the PKGs. The runtime should simply be chained in via a dependent PKG.
