### PR TITLE
Update SDK diff baseline

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkFileDiffExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkFileDiffExclusions.txt
@@ -78,6 +78,11 @@ msft,./sdk/x.y.z/DotnetTools/dotnet-format/System.Security.Cryptography.Protecte
 msft,./sdk/x.y.z/DotnetTools/dotnet-format/System.Security.Permissions.dll
 msft,./sdk/x.y.z/DotnetTools/dotnet-format/System.Windows.Extensions.dll
 
+# https://github.com/dotnet/source-build/issues/3632
+msft,./sdk/x.y.z/DotnetTools/dotnet-format/*/Microsoft.CodeAnalysis.Workspaces.MSBuild.resources.dll
+sb,./sdk/x.y.z/DotnetTools/dotnet-format/*/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.resources.dll
+sb,./sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.dll
+
 # netfx runtimes for fsharp - https://github.com/dotnet/source-build/issues/3290
 msft,./sdk/x.y.z/FSharp/Microsoft.VisualStudio.Setup.Configuration.Interop.dll
 msft,./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/Microsoft.Win32.SystemEvents.dll

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdkFiles.diff
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdkFiles.diff
@@ -45,8 +45,8 @@ index ------------
  ./packs/Microsoft.NETCore.App.Ref/x.y.z/
  ./packs/Microsoft.NETCore.App.Ref/x.y.z/analyzers/
 @@ ------------ @@
+ ./packs/NETStandard.Library.Ref/x.y.z/ref/netstandard2.1/System.Xml.XPath.XDocument.dll
  ./sdk-manifests/
- ./sdk-manifests/x.y.z/
  ./sdk-manifests/x.y.z/
 -./sdk-manifests/x.y.z/
  ./sdk-manifests/x.y.z/microsoft.net.workload.emscripten.current/


### PR DESCRIPTION
Removal of an extra version from the sdk-manifests directory in the Microsoft-built SDK.

Added exclusions due to https://github.com/dotnet/source-build/issues/3632.