### PR TITLE
Source-build symbols repackaging

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -127,7 +127,7 @@ jobs:
       artifact: ${{ parameters.reuseBuildArtifactsFrom }}_${{ parameters.architecture }}_Artifacts
       patterns: |
         **/Private.SourceBuilt.Artifacts.*.tar.gz
-        **/dotnet-sdk-*.tar.gz
+        **/dotnet-sdk-+([0-9]).+([0-9]).+([0-9])*.tar.gz
       displayName: Download Previous Build
 
     - task: CopyFiles@2

--- a/src/SourceBuild/content/build.proj
+++ b/src/SourceBuild/content/build.proj
@@ -92,7 +92,7 @@
             DiscoverSymbolsTarballs;
             ExtractSymbolsTarballs">
     <PropertyGroup>
-      <UnifiedSymbolsTarball>$(OutputPath)dotnet-sourcebuilt-symbols-$(MicrosoftSourceBuildIntermediateInstallerVersion)-$(TargetRid).tar.gz</UnifiedSymbolsTarball>
+      <UnifiedSymbolsTarball>$(OutputPath)dotnet-symbols-$(MicrosoftSourceBuildIntermediateInstallerVersion)-$(TargetRid).tar.gz</UnifiedSymbolsTarball>
     </PropertyGroup>
 
     <Exec Command="tar --numeric-owner -czf $(UnifiedSymbolsTarball) *"

--- a/src/SourceBuild/content/build.proj
+++ b/src/SourceBuild/content/build.proj
@@ -4,6 +4,7 @@
   <UsingTask AssemblyFile="$(LeakDetectionTasksAssembly)" TaskName="CheckForPoison" />
   <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="WriteUsageBurndownData" />
   <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="ReplaceTextInFile" />
+  <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="CreateSdkSymbolsLayout" />
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
@@ -57,6 +58,82 @@
     <MSBuild Projects="$(RepoProjectsDir)$(RootRepo).proj" Targets="WritePrebuiltUsageData;ReportPrebuiltUsage" />
   </Target>
 
+  <Target Name="DiscoverSymbolsTarballs"
+          AfterTargets="Build">
+    <ItemGroup>
+      <SymbolsTarball Include="$(OutputPath)Symbols.*.tar.gz" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="ExtractSymbolsTarballs"
+          AfterTargets="Build"
+          Outputs="%(SymbolsTarball.Identity)">
+    <PropertyGroup>
+      <Filename>$([System.IO.Path]::GetFileName('%(SymbolsTarball.Identity)'))</Filename>
+      <RepositoryName>$(Filename.Split('.')[1])</RepositoryName>
+      <UnifiedSymbolsLayout>$(ArtifactsTmpDir)Symbols</UnifiedSymbolsLayout>
+      <DestinationFolder>$(UnifiedSymbolsLayout)/$(RepositoryName)</DestinationFolder>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(DestinationFolder)" />
+    <Exec Command="tar -xzf %(SymbolsTarball.Identity) -C $(DestinationFolder)"
+          WorkingDirectory="$(SymbolsRoot)" />
+
+    <Delete Files="%(SymbolsTarball.Identity)" />
+  </Target>
+
+  <!-- After building, repackage symbols into a single tarball. -->
+  <Target Name="RepackageSymbols"
+          AfterTargets="Build"
+          DependsOnTargets="
+            DetermineMicrosoftSourceBuildIntermediateInstallerVersion;
+            DiscoverSymbolsTarballs;
+            ExtractSymbolsTarballs">
+    <PropertyGroup>
+      <UnifiedSymbolsTarball>$(OutputPath)sourcebuilt-symbols-$(MicrosoftSourceBuildIntermediateInstallerVersion)-$(TargetRid).tar.gz</UnifiedSymbolsTarball>
+    </PropertyGroup>
+
+    <Exec Command="tar --numeric-owner -czf $(UnifiedSymbolsTarball) *"
+          WorkingDirectory="$(UnifiedSymbolsLayout)" />
+
+    <Message Importance="High" Text="Packaged all symbols in '$(UnifiedSymbolsTarball)'" />
+  </Target>
+
+  <!-- After building, create the sdk symbols tarball. -->
+  <Target Name="CreateSdkSymbolsTarball"
+          AfterTargets="Build"
+          DependsOnTargets="RepackageSymbols">
+    <ItemGroup>
+      <SdkTarballItem Include="$(OutputPath)dotnet-sdk-*$(TarBallExtension)"
+                      Exclude="$(OutputPath)dotnet-sdk-symbols-*$(TarBallExtension)" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <SdkSymbolsLayout>$(ArtifactsTmpDir)SdkSymbols</SdkSymbolsLayout>
+      <SdkSymbolsTarball>$(OutputPath)dotnet-sdk-symbols-$(MicrosoftSourceBuildIntermediateInstallerVersion)-$(TargetRid).tar.gz</SdkSymbolsTarball>
+      <SdkLayout>$(ArtifactsTmpDir)Sdk</SdkLayout>
+      <SdkTarballPath>%(SdkTarballItem.Identity)</SdkTarballPath>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(SdkLayout)" />
+    <Exec Command="tar -xzf $(SdkTarballPath) -C $(SdkLayout)"
+          WorkingDirectory="$(OutputPath)" />
+
+    <CreateSdkSymbolsLayout SdkLayoutPath="$(SdkLayout)"
+                            AllSymbolsPath="$(UnifiedSymbolsLayout)"
+                            SdkSymbolsLayoutPath="$(SdkSymbolsLayout)"
+                            FailOnMissingPDBs="true" />
+
+    <Exec Command="tar --numeric-owner -czf $(SdkSymbolsTarball) *"
+          WorkingDirectory="$(SdkSymbolsLayout)" />
+
+    <Message Importance="High" Text="Packaged sdk symbols in '$(SdkSymbolsTarball)'" />
+
+    <RemoveDir Directories="$(UnifiedSymbolsLayout)" />
+    <RemoveDir Directories="$(SdkSymbolsLayout)" />
+    <RemoveDir Directories="$(SdkLayout)" />
+  </Target>
+
   <!--
     Dev scenario: rewrite a prebuilt-report. This makes it easy to add data to an existing
     prebuilt report without performing another full build. This doesn't reevalutate which packages
@@ -104,7 +181,8 @@
 
   <Target Name="RunSmokeTest">
     <ItemGroup>
-      <SdkTarballItem Include="$(SourceBuiltTarBallPath)**/dotnet-sdk*$(TarBallExtension)" />
+      <SdkTarballItem Include="$(SourceBuiltTarBallPath)**/dotnet-sdk*$(TarBallExtension)"
+                      Exclude="$(SourceBuiltTarBallPath)**/dotnet-sdk-symbols*$(TarBallExtension)" />
       <SourceBuiltArtifactsItem Include="$(SourceBuiltTarBallPath)**/Private.SourceBuilt.Artifacts.*$(TarBallExtension)" />
     </ItemGroup>
 

--- a/src/SourceBuild/content/build.proj
+++ b/src/SourceBuild/content/build.proj
@@ -67,7 +67,9 @@
 
   <Target Name="ExtractSymbolsTarballs"
           AfterTargets="Build"
+          DependsOnTargets="DiscoverSymbolsTarballs"
           Outputs="%(SymbolsTarball.Identity)">
+
     <PropertyGroup>
       <Filename>$([System.IO.Path]::GetFileName('%(SymbolsTarball.Identity)'))</Filename>
       <RepositoryName>$(Filename.Split('.')[1])</RepositoryName>
@@ -90,7 +92,7 @@
             DiscoverSymbolsTarballs;
             ExtractSymbolsTarballs">
     <PropertyGroup>
-      <UnifiedSymbolsTarball>$(OutputPath)sourcebuilt-symbols-$(MicrosoftSourceBuildIntermediateInstallerVersion)-$(TargetRid).tar.gz</UnifiedSymbolsTarball>
+      <UnifiedSymbolsTarball>$(OutputPath)dotnet-sourcebuilt-symbols-$(MicrosoftSourceBuildIntermediateInstallerVersion)-$(TargetRid).tar.gz</UnifiedSymbolsTarball>
     </PropertyGroup>
 
     <Exec Command="tar --numeric-owner -czf $(UnifiedSymbolsTarball) *"

--- a/src/SourceBuild/content/build.proj
+++ b/src/SourceBuild/content/build.proj
@@ -114,11 +114,11 @@
       <SdkSymbolsLayout>$(ArtifactsTmpDir)SdkSymbols</SdkSymbolsLayout>
       <SdkSymbolsTarball>$(OutputPath)dotnet-sdk-symbols-$(MicrosoftSourceBuildIntermediateInstallerVersion)-$(TargetRid).tar.gz</SdkSymbolsTarball>
       <SdkLayout>$(ArtifactsTmpDir)Sdk</SdkLayout>
-      <SdkTarballPath>%(SdkTarballItem.Identity)</SdkTarballPath>
+      <SdkTarball>%(SdkTarballItem.Identity)</SdkTarball>
     </PropertyGroup>
 
     <MakeDir Directories="$(SdkLayout)" />
-    <Exec Command="tar -xzf $(SdkTarballPath) -C $(SdkLayout)"
+    <Exec Command="tar -xzf $(SdkTarball) -C $(SdkLayout)"
           WorkingDirectory="$(OutputPath)" />
 
     <CreateSdkSymbolsLayout SdkLayoutPath="$(SdkLayout)"

--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/CreateSdkSymbolsLayout.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/CreateSdkSymbolsLayout.cs
@@ -149,7 +149,7 @@ namespace Microsoft.DotNet.Build.Tasks
                         allPdbGuids.Add(guid, file);
                     }
                 }
-                catch(Exception)
+                catch (Exception)
                 {
                     // ignore symbols that could not be indexed
                 }

--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/CreateSdkSymbolsLayout.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/CreateSdkSymbolsLayout.cs
@@ -1,0 +1,165 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    // Creates a symbols layout that matches the SDK layout
+    public class CreateSdkSymbolsLayout : Task
+    {
+        private Hashtable AllPdbGuids;
+
+        /// <summary>
+        /// Path to SDK layout.
+        /// </summary>
+        [Required]
+        public string SdkLayoutPath { get; set; }
+
+        /// <summary>
+        /// Path to all source-built symbols, flat or with folder hierarchy.
+        /// </summary>
+        [Required]
+        public string AllSymbolsPath { get; set; }
+
+        /// <summary>
+        /// Path to SDK symbols layout - will be created if it doesn't exist.
+        /// </summary>
+        [Required]
+        public string SdkSymbolsLayoutPath { get; set; }
+
+        /// <summary>
+        /// If true, fails the build if any PDBs are missing.
+        /// </summary>
+        public bool FailOnMissingPDBs { get; set; }
+
+        public override bool Execute()
+        {
+            IndexAllSymbols(AllSymbolsPath);
+            IList<string> filesWithoutPDBs = GenerateSymbolsLayout(SdkLayoutPath, SdkSymbolsLayoutPath);
+            if (filesWithoutPDBs.Count > 0)
+            {
+                LogErrorOrWarning(FailOnMissingPDBs, $"Did not find PDBs for the following SDK files:");
+                foreach (string file in filesWithoutPDBs)
+                {
+                    LogErrorOrWarning(FailOnMissingPDBs, file);
+                }
+           }
+
+            return !Log.HasLoggedErrors;
+        }
+
+        private void LogErrorOrWarning(bool isError, string message)
+        {
+            if (FailOnMissingPDBs)
+            {
+                Log.LogError(message);
+            }
+            else
+            {
+                Log.LogWarning(message);
+            }
+        }
+
+        private IList<string> GenerateSymbolsLayout(string sdkRoot, string destinationRoot)
+        {
+            List<string> filesWithoutPDBs = new List<string>();
+
+            if (Directory.Exists(destinationRoot))
+            {
+                Directory.Delete(destinationRoot, true);
+            }
+
+            foreach (string file in Directory.GetFiles(sdkRoot, "*", SearchOption.AllDirectories))
+            {
+                if (file.EndsWith(".dll", StringComparison.InvariantCultureIgnoreCase) &&
+                    !file.EndsWith(".resources.dll", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    string guid = string.Empty;
+                    using var pdbStream = File.OpenRead(file);
+                    using var peReader = new PEReader(pdbStream);
+                    try
+                    {
+                        // Check if pdb is embedded
+                        if (peReader.ReadDebugDirectory().Any(entry => entry.Type == DebugDirectoryEntryType.EmbeddedPortablePdb))
+                        {
+                            continue;
+                        }
+
+                        var debugDirectory = peReader.ReadDebugDirectory().First(entry => entry.Type == DebugDirectoryEntryType.CodeView);
+                        var codeViewData = peReader.ReadCodeViewDebugDirectoryData(debugDirectory);
+                        guid = $"{codeViewData.Guid.ToString("N").Replace("-", string.Empty)}";
+                    }
+                    catch (Exception)
+                    {
+                        // Ignore binaries without debug info
+                        continue;
+                    }
+
+                    if (guid != string.Empty)
+                    {
+                        if (!AllPdbGuids.ContainsKey(guid))
+                        {
+                            filesWithoutPDBs.Add(file.Substring(sdkRoot.Length + 1));
+                        }
+                        else
+                        {
+                            // Copy matching pdb to symbols path, preserving sdk binary's hierarchy
+                            string sourcePath = (string)AllPdbGuids[guid]!;
+                            string destinationPath =
+                                file.Replace(sdkRoot, destinationRoot)
+                                    .Replace(Path.GetFileName(file), Path.GetFileName(sourcePath));
+
+                            Directory.CreateDirectory(Path.GetDirectoryName(destinationPath)!);
+                            File.Copy(sourcePath, destinationPath, true);
+                        }
+                    }
+                }
+            }
+
+            return filesWithoutPDBs;
+        }
+
+        public void IndexAllSymbols(string path)
+        {
+            AllPdbGuids = new Hashtable();
+
+            foreach (string file in Directory.GetFiles(path, "*.pdb", SearchOption.AllDirectories))
+            {
+                try
+                {
+                    using var pdbFileStream = File.OpenRead(file);
+                    var metadataProvider = MetadataReaderProvider.FromPortablePdbStream(pdbFileStream);
+                    var metadataReader = metadataProvider.GetMetadataReader();
+                    if (metadataReader.DebugMetadataHeader == null)
+                    {
+                        continue;
+                    }
+
+                    var id = new BlobContentId(metadataReader.DebugMetadataHeader.Id);
+                    string guid = $"{id.Guid:N}";
+                    if (!string.IsNullOrEmpty(guid))
+                    {
+                        if (!AllPdbGuids.ContainsKey(guid))
+                        {
+                            AllPdbGuids.Add(guid, file);
+                        }
+                    }
+                }
+                catch(Exception)
+                {
+                    // ignore symbols that could not be indexed
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/3621

Also adds a new symbols package for SDK, that contains PDBs in proper folder hierarchy - https://github.com/dotnet/source-build/issues/3621#issuecomment-1724946897

Instead of 20 `Symbols.<repo>.*` tarballs, we'll have the following 2:
```
dotnet-sdk-symbols-8.0.100-rtm.23477.1-fedora.38-x64.tar.gz
sourcebuilt-symbols-8.0.100-rtm.23477.1-fedora.38-x64.tar.gz
```

First tarball contains SDK symbols that match those binaries. It enables developers to extract `dotnet-sdk` and `dotnet-sdk-symbols` tarballs to the same destination folder, and be able to debug every single .NET assembly, as PDBs will be placed right next to binaries.

Second tarball contains all symbols from all repos. This tarball introduces new naming schema for artifacts produced by `source-build` infra. In 9.0 we should use the new naming schema for all other source-build artifacts, i.e. various `Private.Sourcebuilt.*` tarballs.