### PR TITLE
.NET Source-Build 7.0.112 October 2023 Updates

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -215,8 +215,8 @@
       or minor release, prebuilts may be needed. When the release is mature, prebuilts are not
       necessary, and this property is removed from the file.
     -->
-    <PrivateSourceBuiltSDKVersion>7.0.111</PrivateSourceBuiltSDKVersion>
-    <PrivateSourceBuiltArtifactsPackageVersion>7.0.111</PrivateSourceBuiltArtifactsPackageVersion>
+    <PrivateSourceBuiltSDKVersion>7.0.112</PrivateSourceBuiltSDKVersion>
+    <PrivateSourceBuiltArtifactsPackageVersion>7.0.112</PrivateSourceBuiltArtifactsPackageVersion>
   </PropertyGroup>
   <!-- Workload manifest package versions -->
   <PropertyGroup>

--- a/src/SourceBuild/tarball/content/global.json
+++ b/src/SourceBuild/tarball/content/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "7.0.111"
+    "dotnet": "7.0.112"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.1",


### PR DESCRIPTION
Source-build updates for the .NET 7.0.12 / 7.0.112 October 2023 release.