### PR TITLE
Rename symbols packages

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -127,7 +127,7 @@ jobs:
       artifact: ${{ parameters.reuseBuildArtifactsFrom }}_${{ parameters.architecture }}_Artifacts
       patterns: |
         **/Private.SourceBuilt.Artifacts.*.tar.gz
-        **/dotnet-sdk-+([0-9]).+([0-9]).+([0-9])*.tar.gz
+        **/dotnet-sdk-*.tar.gz
       displayName: Download Previous Build
 
     - task: CopyFiles@2

--- a/src/SourceBuild/content/build.proj
+++ b/src/SourceBuild/content/build.proj
@@ -92,7 +92,7 @@
             DiscoverSymbolsTarballs;
             ExtractSymbolsTarballs">
     <PropertyGroup>
-      <UnifiedSymbolsTarball>$(OutputPath)dotnet-symbols-$(MicrosoftSourceBuildIntermediateInstallerVersion)-$(TargetRid).tar.gz</UnifiedSymbolsTarball>
+      <UnifiedSymbolsTarball>$(OutputPath)dotnet-symbols-all-$(MicrosoftSourceBuildIntermediateInstallerVersion)-$(TargetRid).tar.gz</UnifiedSymbolsTarball>
     </PropertyGroup>
 
     <Exec Command="tar --numeric-owner -czf $(UnifiedSymbolsTarball) *"
@@ -106,13 +106,12 @@
           AfterTargets="Build"
           DependsOnTargets="RepackageSymbols">
     <ItemGroup>
-      <SdkTarballItem Include="$(OutputPath)dotnet-sdk-*$(TarBallExtension)"
-                      Exclude="$(OutputPath)dotnet-sdk-symbols-*$(TarBallExtension)" />
+      <SdkTarballItem Include="$(OutputPath)dotnet-sdk-*$(TarBallExtension)" />
     </ItemGroup>
 
     <PropertyGroup>
       <SdkSymbolsLayout>$(ArtifactsTmpDir)SdkSymbols</SdkSymbolsLayout>
-      <SdkSymbolsTarball>$(OutputPath)dotnet-sdk-symbols-$(MicrosoftSourceBuildIntermediateInstallerVersion)-$(TargetRid).tar.gz</SdkSymbolsTarball>
+      <SdkSymbolsTarball>$(OutputPath)dotnet-symbols-sdk-$(MicrosoftSourceBuildIntermediateInstallerVersion)-$(TargetRid).tar.gz</SdkSymbolsTarball>
       <SdkLayout>$(ArtifactsTmpDir)Sdk</SdkLayout>
       <SdkTarball>%(SdkTarballItem.Identity)</SdkTarball>
     </PropertyGroup>
@@ -183,8 +182,7 @@
 
   <Target Name="RunSmokeTest">
     <ItemGroup>
-      <SdkTarballItem Include="$(SourceBuiltTarBallPath)**/dotnet-sdk*$(TarBallExtension)"
-                      Exclude="$(SourceBuiltTarBallPath)**/dotnet-sdk-symbols*$(TarBallExtension)" />
+      <SdkTarballItem Include="$(SourceBuiltTarBallPath)**/dotnet-sdk*$(TarBallExtension)" />
       <SourceBuiltArtifactsItem Include="$(SourceBuiltTarBallPath)**/Private.SourceBuilt.Artifacts.*$(TarBallExtension)" />
     </ItemGroup>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/3621

Previously fixed with https://github.com/dotnet/installer/pull/17454

This PR updates the naming of two source-built produced symbols packages, `all-symbols package` and `sdk symbols package`.

New naming would help easily distinguish the sdk package, and enable file pattern use. New names:
```
dotnet-symbols-sdk-8.0.100-rtm.23477.1-fedora.38-x64.tar.gz
dotnet-symbols-all-8.0.100-rtm.23477.1-fedora.38-x64.tar.gz
```

cc @tmds @omajid 