### PR TITLE
Fix poisoning issue with existing marker

### DIFF
--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection/MarkAndCatalogPackages.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection/MarkAndCatalogPackages.cs
@@ -155,6 +155,7 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.LeakDetection
                     }
                     File.Delete(p.ItemSpec);
                     File.Move(poisonedPackagePath, p.ItemSpec);
+                    Directory.Delete(packageTempPath, true);
                 }
             }
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/3657

Poisoning infra extracts each package to a temporary directory named after package identity. It does not clean this temporary directory after use. When there are 2 (or more) packages with the same identity, i.e. one PSB and one SBRP, we end up extracting second package to the same directory and finding the poison marker that we created during poisoning of the first package. Poison infra fails the build as it cannot add the poison marker - it assumes that all files in this directory are real package content, including the poison marker file.

The fix is easy - delete the temporary package directory after we're done using it.