### PR TITLE
[source-build infra] Ensure unique keys for symbols hashtable

### DIFF
--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/CreateSdkSymbolsLayout.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/CreateSdkSymbolsLayout.cs
@@ -157,9 +157,7 @@ namespace Microsoft.DotNet.Build.Tasks
         /// Calculates a debug Id from debug guid and filename. We use this as a key
         /// in PDB hashtable. Guid is not enough due to collisions in several PDBs.
         /// </summary>
-        private string GetDebugId(string guid, string file)
-        {
-            return $"{guid}.{Path.GetFileNameWithoutExtension(file)}".ToLower();
-        }
+        private string GetDebugId(string guid, string file) =>
+            $"{guid}.{Path.GetFileNameWithoutExtension(file)}".ToLower();
     }
 }

--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/CreateSdkSymbolsLayout.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/CreateSdkSymbolsLayout.cs
@@ -57,7 +57,7 @@ namespace Microsoft.DotNet.Build.Tasks
 
         private void LogErrorOrWarning(bool isError, string message)
         {
-            if (FailOnMissingPDBs)
+            if (isError)
             {
                 Log.LogError(message);
             }
@@ -104,14 +104,14 @@ namespace Microsoft.DotNet.Build.Tasks
 
                     if (guid != string.Empty)
                     {
-                        if (!allPdbGuids.ContainsKey(guid))
+                        if (!allPdbGuids.ContainsKey(GetKey(guid, file)))
                         {
                             filesWithoutPDBs.Add(file.Substring(SdkLayoutPath.Length + 1));
                         }
                         else
                         {
                             // Copy matching pdb to symbols path, preserving sdk binary's hierarchy
-                            string sourcePath = (string)allPdbGuids[guid]!;
+                            string sourcePath = (string)allPdbGuids[GetKey(guid, file)]!;
                             string destinationPath =
                                 file.Replace(SdkLayoutPath, SdkSymbolsLayoutPath)
                                     .Replace(Path.GetFileName(file), Path.GetFileName(sourcePath));
@@ -142,13 +142,18 @@ namespace Microsoft.DotNet.Build.Tasks
 
                 var id = new BlobContentId(metadataReader.DebugMetadataHeader.Id);
                 string guid = $"{id.Guid:N}";
-                if (!string.IsNullOrEmpty(guid) && !allPdbGuids.ContainsKey(guid))
+                if (!string.IsNullOrEmpty(guid) && !allPdbGuids.ContainsKey(GetKey(guid, file)))
                 {
-                    allPdbGuids.Add(guid, file);
+                    allPdbGuids.Add(GetKey(guid, file), file);
                 }
             }
 
             return allPdbGuids;
+        }
+
+        private string GetKey(string guid, string file)
+        {
+            return $"{guid}.{Path.GetFileNameWithoutExtension(file)}".ToLower();
         }
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/3656

Compiler generated a PDB guid and adds to PE metadata. While GUID is not guaranteed to be unique, collisions should be extremely rare. Symbol indexing code did not expect collisions. This GUD is generated by compiler and it seems that there are a handful of files where we see collisions. This needs to be further investigated.

The fix for symbols-indexing code is to form the hashtable key from both guid and filename.