### PR TITLE
Update source build pipeline triggers

### DIFF
--- a/eng/pipelines/source-build-license-scan.yml
+++ b/eng/pipelines/source-build-license-scan.yml
@@ -8,10 +8,6 @@ schedules:
     - main
     - release/*
     - internal/release/*
-    exclude:
-    # These 8.0.1xx-* branches can be removed from the exclusions once they get deleted from the repo
-    - release/8.0.1xx-*
-    - internal/release/8.0.1xx-*
 
 pr: none
 trigger: none

--- a/eng/pipelines/source-build-license-scan.yml
+++ b/eng/pipelines/source-build-license-scan.yml
@@ -6,8 +6,8 @@ schedules:
   branches:
     include:
     - main
-    - release/*
-    - internal/release/*
+    - release/*.0.1xx*
+    - internal/release/*.0.1xx*
 
 pr: none
 trigger: none

--- a/eng/pipelines/source-build-license-scan.yml
+++ b/eng/pipelines/source-build-license-scan.yml
@@ -1,12 +1,17 @@
 # Pipeline documentation at https://github.com/dotnet/dotnet/blob/main/docs/license-scanning.md
 
 schedules:
-- cron: "0 7 * * 1-5"
-  displayName: Run on weekdays at 7am UTC
+- cron: "0 7 * * 1"
+  displayName: Run on Mondays at 7am UTC
   branches:
     include:
     - main
     - release/*
+    - internal/release/*
+    exclude:
+    # These 8.0.1xx-* branches can be removed from the exclusions once they get deleted from the repo
+    - release/8.0.1xx-*
+    - internal/release/8.0.1xx-*
 
 pr: none
 trigger: none

--- a/eng/pipelines/source-build-sdk-diff-tests.yml
+++ b/eng/pipelines/source-build-sdk-diff-tests.yml
@@ -6,10 +6,6 @@ schedules:
     - main
     - release/*.0.1xx*
     - internal/release/*.0.1xx*
-    exclude:
-    # These 8.0.1xx-* branches can be removed from the exclusions once they get deleted from the repo
-    - release/8.0.1xx-*
-    - internal/release/8.0.1xx-*
 
 pr: none
 trigger: none

--- a/eng/pipelines/source-build-sdk-diff-tests.yml
+++ b/eng/pipelines/source-build-sdk-diff-tests.yml
@@ -4,7 +4,20 @@ schedules:
   branches:
     include:
     - main
-    - release/*
+    - release/*.0.1xx*
+    - internal/release/*.0.1xx*
+    exclude:
+    - release/3*
+    - internal/release/3*
+    - release/5*
+    - internal/release/5*
+    - release/6*
+    - internal/release/6*
+    - release/7*
+    - internal/release/7*
+    # These 8.0.1xx-* branches can be removed from the exclusions once they get deleted from the repo
+    - release/8.0.1xx-*
+    - internal/release/8.0.1xx-*
 
 pr: none
 trigger: none

--- a/eng/pipelines/source-build-sdk-diff-tests.yml
+++ b/eng/pipelines/source-build-sdk-diff-tests.yml
@@ -7,14 +7,6 @@ schedules:
     - release/*.0.1xx*
     - internal/release/*.0.1xx*
     exclude:
-    - release/3*
-    - internal/release/3*
-    - release/5*
-    - internal/release/5*
-    - release/6*
-    - internal/release/6*
-    - release/7*
-    - internal/release/7*
     # These 8.0.1xx-* branches can be removed from the exclusions once they get deleted from the repo
     - release/8.0.1xx-*
     - internal/release/8.0.1xx-*


### PR DESCRIPTION
Updates the sdk diff and license scan pipelines to run for specific branches.

The current schedules as they're defined in the YAML files aren't being honored because they're overridden in the AzDO pipeline configuration. The reason for this is described in https://github.com/dotnet/source-build/issues/3407.

In order to provide better maintainability, we're getting rid of that override configuration and relying instead on the YAML. To avoid the pipeline from continuing to be run for obsolete branches that it will fail on, those branches are being excluded via the YAML configuration. For 8.0, we're excluding all past preview and RC branches using the `8.0.1xx-*` syntax.

Note that the sdk diff pipeline is based on the installer repo and the license scan pipeline is based on the VMR. So they have different trigger configurations because of the differences there (e.g. installer has legacy .NET versions that need to be excluded).
 
Fixes https://github.com/dotnet/source-build/issues/3407