### PR TITLE
Re-enable dotnet-format tests on Alpine

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetFormatTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetFormatTests.cs
@@ -22,12 +22,6 @@ public class DotNetFormatTests : SdkTests
     [Fact]
     public void FormatProject()
     {
-        if (Config.TargetRid.Contains("alpine"))
-        {
-            // Skipping this test on Alpine due to https://github.com/dotnet/format/issues/1945
-            return;
-        }
-
         string unformattedCsFilePath = Path.Combine(BaselineHelper.GetAssetsDirectory(), UnformattedFileName);
 
         string projectDirectory = DotNetHelper.ExecuteNew("console", nameof(FormatProject), "C#");


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/3598

We've had to disable tests on Alpine due to issues with MSBuildLocator dependency. That has been fixed and test can be re-enabled.

I've tested in local Alpine build, but also doing a [full VMR verification](https://dev.azure.com/dnceng/internal/_build/results?buildId=2295925&view=results).
