### PR TITLE
Exclusion for unknown license ref in aspnetcore

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseExclusions.txt
@@ -28,8 +28,9 @@ src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/eula.rtf
 # aspnetcore
 #
 
-# Line 1 is a generic statement about license applicability that is being detected as "unknown"
+# A generic statement about license applicability that is being detected as "unknown"
 src/aspnetcore/src/Components/THIRD-PARTY-NOTICES.txt|unknown
+src/aspnetcore/THIRD-PARTY-NOTICES.txt|unknown
 
 # Windows installer files that have a reference to a URL for license
 src/aspnetcore/src/Installers/Windows/**/*.wxl|unknown-license-reference


### PR DESCRIPTION
An `unknown` license reference is being detected in the aspnetcore repo due to the changes in https://github.com/dotnet/aspnetcore/pull/51443. The detection is on this line: https://github.com/dotnet/aspnetcore/blob/8f29039763ed05514fda1c21e575489b15f699dd/THIRD-PARTY-NOTICES.txt#L386. This text is about license applicability and not the license itself so I've added an exclusion for it.