### PR TITLE
Add coherent dependency for emsdk on runtime and run an coherency update

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -7,20 +7,16 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-aspnetcore -->
-    <add key="darc-int-dotnet-aspnetcore-bc25dd5" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-aspnetcore-bc25dd5d/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-aspnetcore -->
     <!--  Begin: Package sources from dotnet-emsdk -->
     <!--  End: Package sources from dotnet-emsdk -->
     <!--  Begin: Package sources from DotNet-msbuild-Trusted -->
     <!--  End: Package sources from DotNet-msbuild-Trusted -->
     <!--  Begin: Package sources from dotnet-runtime -->
-    <add key="darc-int-dotnet-runtime-e0f0de8" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-runtime-e0f0de87/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-runtime -->
     <!--  Begin: Package sources from dotnet-templating -->
-    <add key="darc-int-dotnet-templating-81b4aff" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-templating-81b4aff8/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-templating -->
     <!--  Begin: Package sources from dotnet-windowsdesktop -->
-    <add key="darc-int-dotnet-windowsdesktop-5bb01c1" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-windowsdesktop-5bb01c1a/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-windowsdesktop -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
@@ -41,15 +37,11 @@
     <!--  Begin: Package sources from DotNet-msbuild-Trusted -->
     <!--  End: Package sources from DotNet-msbuild-Trusted -->
     <!--  Begin: Package sources from dotnet-aspnetcore -->
-    <add key="darc-int-dotnet-aspnetcore-bc25dd5" value="true" />
     <!--  End: Package sources from dotnet-aspnetcore -->
     <!--  Begin: Package sources from dotnet-runtime -->
-    <add key="darc-int-dotnet-runtime-e0f0de8" value="true" />
     <!--  Begin: Package sources from dotnet-templating -->
-    <add key="darc-int-dotnet-templating-81b4aff" value="true" />
     <!--  End: Package sources from dotnet-templating -->
     <!--  Begin: Package sources from dotnet-windowsdesktop -->
-    <add key="darc-int-dotnet-windowsdesktop-5bb01c1" value="true" />
     <!--  End: Package sources from dotnet-windowsdesktop -->
     <!--  End: Package sources from dotnet-runtime -->
     <!--  Begin: Package sources from dotnet-windowsdesktop -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -166,9 +166,9 @@
       <Sha>698fdad58fa64a55f16cd9562c90224cc498ed02</Sha>
       <SourceBuildTarball RepoName="xdt" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-6.0.300" Version="6.0.4">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-6.0.300" Version="6.0.22" CoherentParentDependency="VS.Redist.Common.NetCore.SharedFramework.x64.6.0">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>52e9452f82e26f9fcae791e84c082ae22f1ef66f</Sha>
+      <Sha>3c754f28788fae642dc307a948479204e9f7dd5a</Sha>
     </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build" Version="0.1.0-alpha.1.21519.2" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/source-build</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -185,8 +185,8 @@
     <XamarinMacOSWorkloadManifestVersion>12.3.100-rc.1.125</XamarinMacOSWorkloadManifestVersion>
     <XamarinTvOSWorkloadManifestVersion>15.4.100-rc.1.125</XamarinTvOSWorkloadManifestVersion>
     <MonoWorkloadManifestVersion>6.0.4</MonoWorkloadManifestVersion>
-    <MicrosoftNETWorkloadEmscriptenManifest60200Version>6.0.4</MicrosoftNETWorkloadEmscriptenManifest60200Version>
-    <EmscriptenWorkloadManifestVersion>$(MicrosoftNETWorkloadEmscriptenManifest60200Version)</EmscriptenWorkloadManifestVersion>
+    <MicrosoftNETWorkloadEmscriptenManifest60300Version>6.0.22</MicrosoftNETWorkloadEmscriptenManifest60300Version>
+    <EmscriptenWorkloadManifestVersion>$(MicrosoftNETWorkloadEmscriptenManifest60300Version)</EmscriptenWorkloadManifestVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- pinned dependency. This package is not being produced outside of the 2.0 branch of corefx and should not change. -->


### PR DESCRIPTION
# Description
Previously we left the baseline manifest for runtime/emsdk pinned and only updated as needed. Recently, Larry found that some IT tools would remove the components if the old versions were present.

# Customer Impact
Our testers are trained to skip manifest updates which is what lead to the old versions being installed and then removed. I think very few customers skip manifest updates but it's safer to update the baseline manifest along with the runtime. This is what we do in 6.0.1xx, 7.0.1xx, 7.0.3xx, and 7.0.4xx already and this PR just gets us inline with that.
https://github.com/dotnet/sdk/issues/35645

# Regression

No

# Testing

Manual

# Risk

Minimal risk as this is already done in other branches