### PR TITLE
Enable coherency dependency flow for emsdk

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -13,22 +13,10 @@
     <!--  Begin: Package sources from DotNet-msbuild-Trusted -->
     <!--  End: Package sources from DotNet-msbuild-Trusted -->
     <!--  Begin: Package sources from dotnet-runtime -->
-    <add key="darc-int-dotnet-runtime-e0f0de8" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-runtime-e0f0de87/nuget/v3/index.json" />
-    <add key="darc-int-dotnet-runtime-e0f0de8-3" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-runtime-e0f0de87-3/nuget/v3/index.json" />
-    <add key="darc-int-dotnet-runtime-e0f0de8-2" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-runtime-e0f0de87-2/nuget/v3/index.json" />
-    <add key="darc-int-dotnet-runtime-e0f0de8-1" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-runtime-e0f0de87-1/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-runtime -->
     <!--  Begin: Package sources from dotnet-templating -->
-    <add key="darc-int-dotnet-templating-c2eaaa1" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-templating-c2eaaa1f/nuget/v3/index.json" />
-    <add key="darc-int-dotnet-templating-c2eaaa1-3" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-templating-c2eaaa1f-3/nuget/v3/index.json" />
-    <add key="darc-int-dotnet-templating-c2eaaa1-2" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-templating-c2eaaa1f-2/nuget/v3/index.json" />
-    <add key="darc-int-dotnet-templating-c2eaaa1-1" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-templating-c2eaaa1f-1/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-templating -->
     <!--  Begin: Package sources from dotnet-windowsdesktop -->
-    <add key="darc-int-dotnet-windowsdesktop-5bb01c1" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-windowsdesktop-5bb01c1a/nuget/v3/index.json" />
-    <add key="darc-int-dotnet-windowsdesktop-5bb01c1-3" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-windowsdesktop-5bb01c1a-3/nuget/v3/index.json" />
-    <add key="darc-int-dotnet-windowsdesktop-5bb01c1-2" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-windowsdesktop-5bb01c1a-2/nuget/v3/index.json" />
-    <add key="darc-int-dotnet-windowsdesktop-5bb01c1-1" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-windowsdesktop-5bb01c1a-1/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-windowsdesktop -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
@@ -51,22 +39,10 @@
     <!--  Begin: Package sources from dotnet-aspnetcore -->
     <!--  End: Package sources from dotnet-aspnetcore -->
     <!--  Begin: Package sources from dotnet-runtime -->
-    <add key="darc-int-dotnet-runtime-e0f0de8-1" value="true" />
-    <add key="darc-int-dotnet-runtime-e0f0de8-2" value="true" />
-    <add key="darc-int-dotnet-runtime-e0f0de8-3" value="true" />
-    <add key="darc-int-dotnet-runtime-e0f0de8" value="true" />
     <!--  End: Package sources from dotnet-runtime -->
     <!--  Begin: Package sources from dotnet-templating -->
-    <add key="darc-int-dotnet-templating-c2eaaa1-1" value="true" />
-    <add key="darc-int-dotnet-templating-c2eaaa1-2" value="true" />
-    <add key="darc-int-dotnet-templating-c2eaaa1-3" value="true" />
-    <add key="darc-int-dotnet-templating-c2eaaa1" value="true" />
     <!--  End: Package sources from dotnet-templating -->
     <!--  Begin: Package sources from dotnet-windowsdesktop -->
-    <add key="darc-int-dotnet-windowsdesktop-5bb01c1-1" value="true" />
-    <add key="darc-int-dotnet-windowsdesktop-5bb01c1-2" value="true" />
-    <add key="darc-int-dotnet-windowsdesktop-5bb01c1-3" value="true" />
-    <add key="darc-int-dotnet-windowsdesktop-5bb01c1" value="true" />
     <!--  End: Package sources from dotnet-windowsdesktop -->
     <!--  Begin: Package sources from dotnet-windowsdesktop -->
     <!--  End: Package sources from dotnet-windowsdesktop -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -166,9 +166,9 @@
       <Sha>698fdad58fa64a55f16cd9562c90224cc498ed02</Sha>
       <SourceBuildTarball RepoName="xdt" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-6.0.300" Version="6.0.4">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-6.0.400" Version="6.0.22" CoherentParentDependency="VS.Redist.Common.NetCore.SharedFramework.x64.6.0">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>52e9452f82e26f9fcae791e84c082ae22f1ef66f</Sha>
+      <Sha>3c754f28788fae642dc307a948479204e9f7dd5a</Sha>
     </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build" Version="0.1.0-alpha.1.21519.2" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/source-build</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -185,8 +185,8 @@
     <XamarinMacOSWorkloadManifestVersion>12.3.303</XamarinMacOSWorkloadManifestVersion>
     <XamarinTvOSWorkloadManifestVersion>15.4.303</XamarinTvOSWorkloadManifestVersion>
     <MonoWorkloadManifestVersion>6.0.5</MonoWorkloadManifestVersion>
-    <MicrosoftNETWorkloadEmscriptenManifest60200Version>6.0.4</MicrosoftNETWorkloadEmscriptenManifest60200Version>
-    <EmscriptenWorkloadManifestVersion>$(MicrosoftNETWorkloadEmscriptenManifest60200Version)</EmscriptenWorkloadManifestVersion>
+    <MicrosoftNETWorkloadEmscriptenManifest60400Version>6.0.22</MicrosoftNETWorkloadEmscriptenManifest60400Version>
+    <EmscriptenWorkloadManifestVersion>$(MicrosoftNETWorkloadEmscriptenManifest60400Version)</EmscriptenWorkloadManifestVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- pinned dependency. This package is not being produced outside of the 2.0 branch of corefx and should not change. -->


### PR DESCRIPTION
# Description
Previously we left the baseline manifest for runtime/emsdk pinned and only updated as needed. Recently, Larry found that some IT tools would remove the components if the old versions were present.

# Customer Impact
Our testers are trained to skip manifest updates which is what lead to the old versions being installed and then removed. I think very few customers skip manifest updates but it's safer to update the baseline manifest along with the runtime. This is what we do in 6.0.1xx, 7.0.1xx, 7.0.3xx, and 7.0.4xx already and this PR just gets us inline with that.
https://github.com/dotnet/sdk/issues/35645

# Regression

No

# Testing

Manual

# Risk

Minimal risk as this is already done in other branches