### PR TITLE
Update SB SDK diff baseline

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdkFiles.diff
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdkFiles.diff
@@ -49,6 +49,7 @@ index ------------
  ./sdk-manifests/
  ./sdk-manifests/x.y.z/
 -./sdk-manifests/x.y.z/
+-./sdk-manifests/x.y.z/
  ./sdk-manifests/x.y.z/microsoft.net.workload.emscripten.current/
  ./sdk-manifests/x.y.z/microsoft.net.workload.emscripten.current/x.y.z/
  ./sdk-manifests/x.y.z/microsoft.net.workload.emscripten.current/x.y.z/WorkloadManifest.json


### PR DESCRIPTION
The `sdk-manifests` directory now lists 3 sub-directories for the Microsoft SDK (see https://github.com/dotnet/sdk/issues/36385):

* 8.0.100-rc.1
  * microsoft.net.sdk.aspire
* 8.0.100-rc.2
  * microsoft.net.sdk.android
  * microsoft.net.sdk.ios
  * microsoft.net.sdk.maccatalyst
  * microsoft.net.sdk.macos
  * microsoft.net.sdk.maui
  * microsoft.net.sdk.tvos
* 8.0.100-rtm
  * microsoft.net.workload.emscripten.current
  * microsoft.net.workload.emscripten.net6
  * microsoft.net.workload.emscripten.net7
  * microsoft.net.workload.mono.toolchain.current
  * microsoft.net.workload.mono.toolchain.net6
  * microsoft.net.workload.mono.toolchain.net7

The source built SDK has just the 8.0.100-rtm directory:

* 8.0.100-rtm
  * microsoft.net.workload.emscripten.current
  * microsoft.net.workload.emscripten.net6
  * microsoft.net.workload.emscripten.net7
  * microsoft.net.workload.mono.toolchain.current
  * microsoft.net.workload.mono.toolchain.net6
  * microsoft.net.workload.mono.toolchain.net7

This is expected. Updating the diff baseline to reflect this. Since the versions get normalized to `x.y.z` they appear as duplicate directory names in the baseline.