### PR TITLE
.NET Source-Build 6.0.124 October 2023 Updates

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -174,7 +174,7 @@
       or minor release, prebuilts may be needed. When the release is mature, prebuilts are not
       necessary, and this property is removed from the file.
     -->
-    <PrivateSourceBuiltArtifactsPackageVersion>6.0.123</PrivateSourceBuiltArtifactsPackageVersion>
+    <PrivateSourceBuiltArtifactsPackageVersion>6.0.124</PrivateSourceBuiltArtifactsPackageVersion>
   </PropertyGroup>
   <!-- Workload manifest package versions -->
   <PropertyGroup>

--- a/src/SourceBuild/tarball/content/global.json
+++ b/src/SourceBuild/tarball/content/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "6.0.123"
+    "dotnet": "6.0.124"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.1",


### PR DESCRIPTION
Source-build updates for the .NET 6.0.24 / 6.0.124 October 2023 release.