### PR TITLE
Add feed to acquire Microsoft.NET.ILLink.Tasks.8.0.0

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/online.NuGet.Config
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/online.NuGet.Config
@@ -5,5 +5,6 @@
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
     <add key="dotnet8-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8-transport/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-runtime-488a8a3" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-488a8a35/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
The changes from https://github.com/dotnet/installer/pull/17597 introduced stable versioning that broke the source build smoke tests. It gets the following error for any test which needs to restore Microsoft.NET.ILLink.Tasks:

```
Unable to find a stable package Microsoft.NET.ILLink.Tasks with version (>= 8.0.0) [/vmr/build.proj]
 - Found 1015 version(s) in dotnet8 [ Nearest version: 8.0.100-1.22608.1 ] [/vmr/build.proj]
 - Found 13 version(s) in dotnet-public [ Nearest version: 8.0.100-1.23067.1 ] [/vmr/build.proj]
 - Found 0 version(s) in dotnet8-transport [/vmr/build.proj]
```

This is fixed by adding the NuGet feed which provides Microsoft.NET.ILLink.Tasks.8.0.0 to the smoke test NuGet.config file.