### PR TITLE
Revert "Bump `darc` to fix package version updates"

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "microsoft.dotnet.darc": {
-      "version": "1.1.0-beta.23527.3",
+      "version": "1.1.0-beta.23416.3",
       "commands": [
         "darc"
       ]

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -222,13 +222,13 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>39042b4048580366d35a7c1c4f4ce8fc0dbea4b4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Darc" Version="1.1.0-beta.23527.3">
+    <Dependency Name="Microsoft.DotNet.Darc" Version="1.1.0-beta.23416.3">
       <Uri>https://github.com/dotnet/arcade-services</Uri>
-      <Sha>6e08a501d23d7ca53cfe10d74d0a002f75040a4d</Sha>
+      <Sha>5d63a226d022fda90cae2c239e882ad253baa758</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.DarcLib" Version="1.1.0-beta.23527.3">
+    <Dependency Name="Microsoft.DotNet.DarcLib" Version="1.1.0-beta.23416.3">
       <Uri>https://github.com/dotnet/arcade-services</Uri>
-      <Sha>6e08a501d23d7ca53cfe10d74d0a002f75040a4d</Sha>
+      <Sha>5d63a226d022fda90cae2c239e882ad253baa758</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging.Console" Version="8.0.0-alpha.1.22557.12">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,7 +44,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/arcade-services -->
-    <MicrosoftDotNetDarcLibVersion>1.1.0-beta.23527.3</MicrosoftDotNetDarcLibVersion>
+    <MicrosoftDotNetDarcLibVersion>1.1.0-beta.23416.3</MicrosoftDotNetDarcLibVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/winforms -->

--- a/eng/vmr-sync.sh
+++ b/eng/vmr-sync.sh
@@ -135,7 +135,7 @@ while [[ $# -gt 0 ]]; do
       recursive=true
       ;;
     --remote)
-      additional_remotes="$additional_remotes $2"
+      additional_remotes="$additional_remotes,$2"
       shift
       ;;
     --readme-template)
@@ -265,9 +265,9 @@ fi
   $azdev_pat                                 \
   --$verbosity                               \
   $recursive_arg                             \
-  $additional_remotes                        \
   --readme-template "$readme_template"       \
   --tpn-template "$tpn_template"             \
+  $additional_remotes                        \
   "$repository"
 
 if [[ $? == 0 ]]; then

--- a/src/VirtualMonoRepo/Tasks/GitFileManagerFactory.cs
+++ b/src/VirtualMonoRepo/Tasks/GitFileManagerFactory.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.DotNet.VirtualMonoRepo.Tasks;
+
+public class GitFileManagerFactory : IGitFileManagerFactory
+{
+    private readonly IVmrInfo _vmrInfo;
+    private readonly VmrRemoteConfiguration _remoteConfiguration;
+    private readonly IProcessManager _processManager;
+    private readonly IVersionDetailsParser _versionDetailsParser;
+    private readonly ILoggerFactory _loggerFactory;
+
+    public GitFileManagerFactory(
+        IVmrInfo vmrInfo,
+        VmrRemoteConfiguration remoteConfiguration,
+        IProcessManager processManager,
+        IVersionDetailsParser versionDetailsParser,
+        ILoggerFactory loggerFactory)
+    {
+        _vmrInfo = vmrInfo;
+        _remoteConfiguration = remoteConfiguration;
+        _processManager = processManager;
+        _versionDetailsParser = versionDetailsParser;
+        _loggerFactory = loggerFactory;
+    }
+
+    public IGitFileManager Create(string repoUri)
+        => new GitFileManager(CreateGitRepo(repoUri), _versionDetailsParser, _loggerFactory.CreateLogger<GitFileManager>());
+
+    private IGitRepo CreateGitRepo(string repoUri) => GitRepoTypeParser.ParseFromUri(repoUri) switch
+    {
+        GitRepoType.AzureDevOps => throw new Exception("VMR initialization should not require Azure DevOps repositories"),
+
+        GitRepoType.GitHub => new GitHubClient(
+            _processManager.GitExecutable,
+            _remoteConfiguration.GitHubToken,
+            _loggerFactory.CreateLogger<GitHubClient>(),
+            _vmrInfo.TmpPath,
+            // Caching not in use for Darc local client.
+            null),
+
+        GitRepoType.Local => new LocalGitClient(_processManager.GitExecutable, _loggerFactory.CreateLogger<LocalGitClient>()),
+        _ => throw new ArgumentException("Unknown git repository type", nameof(repoUri)),
+    };
+}

--- a/src/VirtualMonoRepo/Tasks/VirtualMonoRepo_Initialize.cs
+++ b/src/VirtualMonoRepo/Tasks/VirtualMonoRepo_Initialize.cs
@@ -74,8 +74,6 @@ public class VirtualMonoRepo_Initialize : Build.Utilities.Task, ICancelableTask
             additionalRemotes,
             ReadmeTemplatePath,
             TpnTemplatePath,
-            generateCodeowners: false,
-            discardPatches: true,
             _cancellationToken.Token);
         return true;
     }
@@ -84,6 +82,7 @@ public class VirtualMonoRepo_Initialize : Build.Utilities.Task, ICancelableTask
 
     private IServiceProvider CreateServiceProvider() => new ServiceCollection()
         .AddLogging(b => b.AddConsole().AddFilter(l => l >= LogLevel.Information))
-        .AddVmrManagers("git", VmrPath, TmpPath, null, null)
+        .AddTransient<GitFileManagerFactory>()
+        .AddVmrManagers(sp => sp.GetRequiredService<GitFileManagerFactory>(), "git", VmrPath, TmpPath, null, null)
         .BuildServiceProvider();
 }


### PR DESCRIPTION
Reverts #17639

This was causing a failure in the VMR for PRs to the installer repo. It seems that the sourcelink repo wasn't synchronizing properly to the VMR, resulting in strange build errors.

Here's a link to the [failing build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2302962&view=results) (internal link). After reverting this change, the build got past this issue.

Specifically, I see this in the sync log for sourcelink repo:

```
warn: The following mappings do not appear in current update's dependency tree:
        - cecil
        - format
        - razor
        - roslyn-analyzers
        - templating
        - xdt
```