### PR TITLE
[release/8.0.1xx] Do not fetch again in VMR synchronization

### DIFF
--- a/eng/pipelines/templates/steps/vmr-prepare.yml
+++ b/eng/pipelines/templates/steps/vmr-prepare.yml
@@ -29,8 +29,6 @@ steps:
     clean: true
 
 - script: |
-    set -euxo pipefail
-    git fetch --all
     git checkout --track origin/${{ parameters.vmrBranch }}
     echo "##vso[task.setvariable variable=vmrBranch]${{ parameters.vmrBranch }}"
   displayName: Check out ${{ parameters.vmrBranch }}


### PR DESCRIPTION
Fetching failed here: https://dev.azure.com/dnceng/internal/_build/results?buildId=2304315&view=logs&j=95ab0fd7-626d-5a23-52da-75a7bffd05ce&t=4791c24c-5da3-536b-8d95-a97e8adb43ce&l=13

We will just rely on AzDO UI settings to clone the whole repo.