### PR TITLE
Update SDK diff baseline

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdkFiles.diff
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdkFiles.diff
@@ -49,7 +49,6 @@ index ------------
  ./sdk-manifests/
  ./sdk-manifests/x.y.z/
 -./sdk-manifests/x.y.z/
--./sdk-manifests/x.y.z/
  ./sdk-manifests/x.y.z/microsoft.net.workload.emscripten.current/
  ./sdk-manifests/x.y.z/microsoft.net.workload.emscripten.current/x.y.z/
  ./sdk-manifests/x.y.z/microsoft.net.workload.emscripten.current/x.y.z/WorkloadManifest.json


### PR DESCRIPTION
Related to https://github.com/dotnet/installer/pull/17613

These changes are due to stable versioning. Rather than sdk-manifests/8.0.100-rtm there is now just sdk-manifests/8.0.100. This also consolidates the sub-directories that were previously contained in sdk-manifests/8.0.100-rc.1 so that they exist in sdk-manifests/8.0.100. This means there are now only 2 sub-directories under sdk-manifests: 8.0.100-rc.2 and 8.0.100.