### PR TITLE
Add font files as allowed for runtime

### DIFF
--- a/src/VirtualMonoRepo/allowed-binaries.txt
+++ b/src/VirtualMonoRepo/allowed-binaries.txt
@@ -44,6 +44,8 @@ src/razor/**/SampleApp/**/fonts/*
 src/roslyn/**/CodeAnalysisTest/*
 src/roslyn/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/Resources/WindowsProxy.winmd # https://github.com/dotnet/roslyn/issues/66718
 
+src/runtime/src/*.woff
+src/runtime/src/*.woff2
 src/runtime/src/libraries/System.Diagnostics.EventLog/src/Messages/EventLogMessages.res # Icon
 src/runtime/src/libraries/System.Speech/src/*.upsmap # https://github.com/dotnet/runtime/issues/81692
 src/runtime/src/libraries/System.Text.Encoding.CodePages/src/Data/codepages.nlp # https://github.com/dotnet/runtime/issues/81693


### PR DESCRIPTION
The following files show up as detected binaries in the VMR:

src/runtime/src/mono/sample/wasm/blazor-frame/wwwroot/css/bootstrap-icons/fonts/bootstrap-icons.woff
src/runtime/src/mono/sample/wasm/blazor-frame/wwwroot/css/bootstrap-icons/fonts/bootstrap-icons.woff2

Updated the allowed binaries for runtime so that these fonts are allowed.