### PR TITLE
Stop making tools.sh changes during source-build

### DIFF
--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -58,29 +58,6 @@
       NewText="$(NewText)" />
   </Target>
 
-  <Target Name="UpdateBuildToolFramework"
-          BeforeTargets="Build"
-          Condition="'$(EngCommonToolsShFile)' != ''"
-          Inputs="$(MSBuildProjectFullPath)"
-          Outputs="$(RepoCompletedSemaphorePath)UpdateBuildToolFramework.complete" >
-
-    <!-- Update the BuildToolFramework for repos that have not adopted the current version of Arcade-->
-    <ReplaceTextInFile InputFile="$(EngCommonToolsShFile)"
-                       OldText="_InitializeBuildToolFramework=&quot;netcoreapp3.1&quot;"
-                       NewText="_InitializeBuildToolFramework=&quot;$(NetCurrent)&quot;" />
-    <ReplaceTextInFile InputFile="$(EngCommonToolsShFile)"
-                       OldText="_InitializeBuildToolFramework=&quot;net7.0&quot;"
-                       NewText="_InitializeBuildToolFramework=&quot;$(NetCurrent)&quot;" />
-
-    <!-- Temporary workaround for when the ci option is specified, non-zero exit are swallowed which prevents builds from failing within 
-         the build process.  https://github.com/dotnet/source-build/issues/2307 -->
-    <ReplaceTextInFile InputFile="$(EngCommonToolsShFile)"
-                       OldText="ExitWithExitCode 0"
-                       NewText="ExitWithExitCode $exit_code" />
-
-    <WriteLinesToFile File="$(RepoCompletedSemaphorePath)UpdateBuildToolFramework.complete" Overwrite="true" />
-  </Target>
-
   <Target Name="UpdateNuGetConfig"
           BeforeTargets="Build"
           Condition="'$(NuGetConfigFile)' != '' OR '@(NuGetConfigFiles)' != ''"

--- a/src/SourceBuild/patches/command-line-api/0001-Allow-override-of-build-tool-framework-version.patch
+++ b/src/SourceBuild/patches/command-line-api/0001-Allow-override-of-build-tool-framework-version.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nikola Milosavljevic <nikolam@microsoft.com>
+Date: Mon, 30 Oct 2023 22:45:58 +0000
+Subject: [PATCH] Allow override of build tool framework version
+
+Backport: https://github.com/dotnet/command-line-api/pull/2283
+---
+ eng/common/tools.sh | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/eng/common/tools.sh b/eng/common/tools.sh
+index 2f27d745..422e711d 100644
+--- a/eng/common/tools.sh
++++ b/eng/common/tools.sh
+@@ -312,7 +312,12 @@ function InitializeBuildTool {
+   # return values
+   _InitializeBuildTool="$_InitializeDotNetCli/dotnet"
+   _InitializeBuildToolCommand="msbuild"
+-  _InitializeBuildToolFramework="net7.0"
++  # use override if it exists - commonly set by source-build
++  if [[ -z "${_OverrideArcadeInitializeBuildToolFramework}" ]]; then
++    _InitializeBuildToolFramework="net7.0"
++  else
++    _InitializeBuildToolFramework="${_OverrideArcadeInitializeBuildToolFramework}"
++  fi
+ }
+ 
+ # Set RestoreNoCache as a workaround for https://github.com/NuGet/Home/issues/3116

--- a/src/SourceBuild/patches/xdt/0001-Allow-override-of-build-tool-framework-version.patch
+++ b/src/SourceBuild/patches/xdt/0001-Allow-override-of-build-tool-framework-version.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nikola Milosavljevic <nikolam@microsoft.com>
+Date: Mon, 30 Oct 2023 22:52:31 +0000
+Subject: [PATCH] Allow override of build tool framework version
+
+Backport: https://github.com/dotnet/source-build/issues/3171
+---
+ eng/common/tools.sh | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/eng/common/tools.sh b/eng/common/tools.sh
+index 17f0a36..343490c 100755
+--- a/eng/common/tools.sh
++++ b/eng/common/tools.sh
+@@ -312,7 +312,12 @@ function InitializeBuildTool {
+   # return values
+   _InitializeBuildTool="$_InitializeDotNetCli/dotnet"
+   _InitializeBuildToolCommand="msbuild"
+-  _InitializeBuildToolFramework="netcoreapp3.1"
++  # use override if it exists - commonly set by source-build
++  if [[ -z "${_OverrideArcadeInitializeBuildToolFramework}" ]]; then
++    _InitializeBuildToolFramework="netcoreapp3.1"
++  else
++    _InitializeBuildToolFramework="${_OverrideArcadeInitializeBuildToolFramework}"
++  fi
+ }
+ 
+ # Set RestoreNoCache as a workaround for https://github.com/NuGet/Home/issues/3116

--- a/src/SourceBuild/patches/xdt/0001-Allow-override-of-build-tool-framework-version.patch
+++ b/src/SourceBuild/patches/xdt/0001-Allow-override-of-build-tool-framework-version.patch
@@ -3,7 +3,7 @@ From: Nikola Milosavljevic <nikolam@microsoft.com>
 Date: Mon, 30 Oct 2023 22:52:31 +0000
 Subject: [PATCH] Allow override of build tool framework version
 
-Backport: https://github.com/dotnet/source-build/issues/3171
+Backport: https://github.com/dotnet/aspnetcore/issues/51753
 ---
  eng/common/tools.sh | 7 ++++++-
  1 file changed, 6 insertions(+), 1 deletion(-)


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/3171

We do not need to modify the return value anymore, as it does not impact source-build.

There are two patches for build tool framework changes - only two repos were affected. `command-line-api` patch references a backport PR: https://github.com/dotnet/command-line-api/pull/2283. `xdt` patch references the original issue, as backport is not deemed necessary.

All changes were verified in private build and using internal VMR pipeline.