### PR TITLE
Update 8.0 item templates version to official RC2 build

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -163,7 +163,7 @@
     <MicrosoftDotNetCommonItemTemplates50PackageVersion>5.0.403</MicrosoftDotNetCommonItemTemplates50PackageVersion>
     <MicrosoftDotNetCommonItemTemplates60PackageVersion>6.0.302</MicrosoftDotNetCommonItemTemplates60PackageVersion>
     <MicrosoftDotNetCommonItemTemplates70PackageVersion>7.0.100</MicrosoftDotNetCommonItemTemplates70PackageVersion>
-    <MicrosoftDotNetCommonItemTemplates80PackageVersion>8.0.100-rc.2.23463.24</MicrosoftDotNetCommonItemTemplates80PackageVersion>
+    <MicrosoftDotNetCommonItemTemplates80PackageVersion>8.0.100-rc.2.23480.5</MicrosoftDotNetCommonItemTemplates80PackageVersion>
     <MicrosoftWinFormsProjectTemplates50PackageVersion>5.0.17-servicing.22215.4</MicrosoftWinFormsProjectTemplates50PackageVersion>
     <MicrosoftWinFormsProjectTemplates60PackageVersion>6.0.7-servicing.22322.3</MicrosoftWinFormsProjectTemplates60PackageVersion>
     <MicrosoftWinFormsProjectTemplates70PackageVersion>7.0.0-rtm.22518.7</MicrosoftWinFormsProjectTemplates70PackageVersion>


### PR DESCRIPTION
The VMR build fails with this error in installer:

```
/vmr/src/installer/artifacts/source-build/self/src/artifacts/obj/redist/Release/net9.0/TemplatePackageDownloader/TemplatePackageDownloader.csproj : error NU1102: Unable to find package Microsoft.DotNet.Common.ProjectTemplates.8.0 with version (= 8.0.100-rc.2.23463.24)
/vmr/src/installer/artifacts/source-build/self/src/artifacts/obj/redist/Release/net9.0/TemplatePackageDownloader/TemplatePackageDownloader.csproj : error NU1102:   - Found 1 version(s) in source-built [ Nearest version: 9.0.100-alpha.1.23528.1 ]
/vmr/src/installer/artifacts/source-build/self/src/artifacts/obj/redist/Release/net9.0/TemplatePackageDownloader/TemplatePackageDownloader.csproj : error NU1102:   - Found 1 version(s) in prebuilt [ Nearest version: 8.0.100-rc.2.23480.5 ]
/vmr/src/installer/artifacts/source-build/self/src/artifacts/obj/redist/Release/net9.0/TemplatePackageDownloader/TemplatePackageDownloader.csproj : error NU1102:   - Found 1 version(s) in previously-source-built [ Nearest version: 8.0.100-rc.2.23480.5 ]
/vmr/src/installer/artifacts/source-build/self/src/artifacts/obj/redist/Release/net9.0/TemplatePackageDownloader/TemplatePackageDownloader.csproj : error NU1102:   - Found 0 version(s) in reference-packages
```

This is because the version of `Microsoft.DotNet.Common.ProjectTemplates.8.0` that is referenced is not the version that was released with N-1 (i.e. not the officially released version). This is resolved by updating it to the official version.