### PR TITLE
Stop injecting NoWarns into repo's Directory.Build.props

### DIFF
--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -26,38 +26,6 @@
     <MSBuild Projects="@(_DependentProject)" Targets="Build" BuildInParallel="$(BuildInParallel)" StopOnFirstFailure="true" />
   </Target>
 
-  <Target Name="AddNoWarns"
-          BeforeTargets="Build"
-          Condition=" EXISTS('$(ProjectDirectory)Directory.Build.props') OR EXISTS('$(ProjectDirectory)src/Directory.Build.props') "
-          Inputs="$(MSBuildProjectFullPath)"
-          Outputs="$(RepoCompletedSemaphorePath)AddNoWarns.complete" >
-
-    <!-- Don't warn on warnings that can be generated in source-build
-         but not necessarily in repo builds. 
-
-         NU1603 - See https://github.com/dotnet/source-build/issues/2766.
-
-         NU5104 - During preview builds, some packages have pre-release versions.
-                  Some repos with stable versions may need to uptake these packages 
-                  with pre-release versions because of PVP when building with 
-                  source-build.  -->
-    <PropertyGroup>
-      <OldText><![CDATA[</Project>]]></OldText>
-      <NewText>
-        <![CDATA[  <PropertyGroup>
-    <NoWarn>%24(NoWarn);NU5104;NU1603;$(RepoNoWarns)</NoWarn>
-  </PropertyGroup>
-</Project>]]>
-      </NewText>
-
-      <DirectoryBuildPropsFile Condition=" EXISTS('$(ProjectDirectory)Directory.Build.props') ">$(ProjectDirectory)Directory.Build.props</DirectoryBuildPropsFile>
-      <DirectoryBuildPropsFile Condition=" '$(DirectoryBuildPropsFile)' == '' AND EXISTS('$(ProjectDirectory)src/Directory.Build.props') ">$(ProjectDirectory)src/Directory.Build.props</DirectoryBuildPropsFile>
-    </PropertyGroup>
-    <ReplaceTextInFile InputFile="$(DirectoryBuildPropsFile)"
-      OldText="$(OldText)"
-      NewText="$(NewText)" />
-  </Target>
-
   <Target Name="UpdateNuGetConfig"
           BeforeTargets="Build"
           Condition="'$(NuGetConfigFile)' != '' OR '@(NuGetConfigFiles)' != ''"

--- a/src/SourceBuild/content/repo-projects/nuget-client.proj
+++ b/src/SourceBuild/content/repo-projects/nuget-client.proj
@@ -4,8 +4,6 @@
   <PropertyGroup>
     <NuGetKeyFilePath>$(KeysDir)NuGet.Client.snk</NuGetKeyFilePath>
     <DeterministicBuildOptOut>true</DeterministicBuildOptOut>
-    <!-- SYSLIB0051 - Type or member is obsolete: https://github.com/NuGet/Home/issues/12626 -->
-    <RepoNoWarns>SYSLIB0051</RepoNoWarns>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SourceBuild/content/repo-projects/runtime.proj
+++ b/src/SourceBuild/content/repo-projects/runtime.proj
@@ -5,9 +5,6 @@
   <PropertyGroup>
     <LogVerbosityOptOut>true</LogVerbosityOptOut>
 
-    <!-- NU5129: https://github.com/dotnet/runtime/issues/89208 -->
-    <RepoNoWarns>NU5129</RepoNoWarns>
-
     <CleanCommand>$(ProjectDirectory)/clean$(ShellExtension)</CleanCommand>
 
     <OverrideTargetRid>$(TargetRid)</OverrideTargetRid>

--- a/src/SourceBuild/content/repo-projects/vstest.proj
+++ b/src/SourceBuild/content/repo-projects/vstest.proj
@@ -6,8 +6,6 @@
     <BuildCommandArgs>$(BuildCommandArgs) /p:SemanticVersioningV1=true</BuildCommandArgs>
     <BuildCommand>$(ProjectDirectory)\eng\common\build$(ShellExtension) $(BuildCommandArgs)</BuildCommand>
     <DeterministicBuildOptOut>true</DeterministicBuildOptOut>
-    <!-- IDE0090: https://github.com/microsoft/vstest/pull/4674 -->
-    <RepoNoWarns>IDE0090</RepoNoWarns>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SourceBuild/patches/nuget-client/0001-Add-obsolete-attributes-to-legacy-serialization-type.patch
+++ b/src/SourceBuild/patches/nuget-client/0001-Add-obsolete-attributes-to-legacy-serialization-type.patch
@@ -1,0 +1,219 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nikola Milosavljevic <nikolam@microsoft.com>
+Date: Tue, 7 Nov 2023 18:44:00 +0000
+Subject: [PATCH] Add obsolete attributes to legacy serialization types
+
+Backport: https://github.com/NuGet/NuGet.Client/pull/5496
+---
+ .../Exceptions/PackageSourceException.cs                       | 3 +++
+ src/NuGet.Core/NuGet.Commands/Common/CommandException.cs       | 3 +++
+ .../Exceptions/NuGetConfigurationException.cs                  | 3 +++
+ src/NuGet.Core/NuGet.Frameworks/FrameworkException.cs          | 3 +++
+ .../Licenses/NuGetLicenseExpressionParsingException.cs         | 3 +++
+ .../NuGet.Protocol/Exceptions/FatalProtocolException.cs        | 3 +++
+ .../NuGet.Protocol/Exceptions/InvalidCacheProtocolException.cs | 3 +++
+ .../NuGet.Protocol/Exceptions/NuGetProtocolException.cs        | 3 +++
+ .../NuGet.Protocol/Exceptions/RetriableProtocolException.cs    | 3 +++
+ src/NuGet.Core/NuGet.Protocol/Plugins/PluginException.cs       | 3 +++
+ src/NuGet.Core/NuGet.Protocol/Plugins/ProtocolException.cs     | 3 +++
+ .../Exceptions/NuGetResolverConstraintException.cs             | 3 +++
+ .../NuGet.Resolver/Exceptions/NuGetResolverException.cs        | 3 +++
+ .../NuGet.Resolver/Exceptions/NuGetResolverInputException.cs   | 3 +++
+ 14 files changed, 42 insertions(+)
+
+diff --git a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Exceptions/PackageSourceException.cs b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Exceptions/PackageSourceException.cs
+index ef589f85a..623d92259 100644
+--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Exceptions/PackageSourceException.cs
++++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/Exceptions/PackageSourceException.cs
+@@ -14,6 +14,9 @@ public PackageSourceException(string message)
+         {
+         }
+ 
++#if NET8_0_OR_GREATER
++        [Obsolete(DiagnosticId = "SYSLIB0051")] // https://github.com/dotnet/docs/issues/34893
++#endif
+         protected PackageSourceException(SerializationInfo info, StreamingContext context) : base(info, context)
+         {
+         }
+diff --git a/src/NuGet.Core/NuGet.Commands/Common/CommandException.cs b/src/NuGet.Core/NuGet.Commands/Common/CommandException.cs
+index 0b2ded3fc..8ffa132ac 100644
+--- a/src/NuGet.Core/NuGet.Commands/Common/CommandException.cs
++++ b/src/NuGet.Core/NuGet.Commands/Common/CommandException.cs
+@@ -29,6 +29,9 @@ public CommandException(string message, Exception exception)
+         {
+         }
+ 
++#if NET8_0_OR_GREATER
++        [Obsolete(DiagnosticId = "SYSLIB0051")] // https://github.com/dotnet/docs/issues/34893
++#endif
+         protected CommandException(SerializationInfo info, StreamingContext context)
+             : base(info, context)
+         {
+diff --git a/src/NuGet.Core/NuGet.Configuration/Exceptions/NuGetConfigurationException.cs b/src/NuGet.Core/NuGet.Configuration/Exceptions/NuGetConfigurationException.cs
+index 7e62c4562..7eef58607 100644
+--- a/src/NuGet.Core/NuGet.Configuration/Exceptions/NuGetConfigurationException.cs
++++ b/src/NuGet.Core/NuGet.Configuration/Exceptions/NuGetConfigurationException.cs
+@@ -22,6 +22,9 @@ public NuGetConfigurationException(string message, Exception innerException)
+         {
+         }
+ 
++#if NET8_0_OR_GREATER
++        [Obsolete(DiagnosticId = "SYSLIB0051")] // https://github.com/dotnet/docs/issues/34893
++#endif
+         protected NuGetConfigurationException(SerializationInfo info, StreamingContext context) : base(info, context)
+         {
+         }
+diff --git a/src/NuGet.Core/NuGet.Frameworks/FrameworkException.cs b/src/NuGet.Core/NuGet.Frameworks/FrameworkException.cs
+index 9e538d481..99d6ebb5e 100644
+--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkException.cs
++++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkException.cs
+@@ -14,6 +14,9 @@ public FrameworkException(string message)
+         {
+         }
+ 
++#if NET8_0_OR_GREATER
++        [Obsolete(DiagnosticId = "SYSLIB0051")] // https://github.com/dotnet/docs/issues/34893
++#endif
+         protected FrameworkException(SerializationInfo info, StreamingContext context) : base(info, context)
+         {
+         }
+diff --git a/src/NuGet.Core/NuGet.Packaging/Licenses/NuGetLicenseExpressionParsingException.cs b/src/NuGet.Core/NuGet.Packaging/Licenses/NuGetLicenseExpressionParsingException.cs
+index b48fe5bdd..1af5356e0 100644
+--- a/src/NuGet.Core/NuGet.Packaging/Licenses/NuGetLicenseExpressionParsingException.cs
++++ b/src/NuGet.Core/NuGet.Packaging/Licenses/NuGetLicenseExpressionParsingException.cs
+@@ -18,6 +18,9 @@ public NuGetLicenseExpressionParsingException(string message, Exception innerExc
+         {
+         }
+ 
++#if NET8_0_OR_GREATER
++        [Obsolete(DiagnosticId = "SYSLIB0051")] // https://github.com/dotnet/docs/issues/34893
++#endif
+         protected NuGetLicenseExpressionParsingException(SerializationInfo info, StreamingContext context) : base(info, context)
+         {
+         }
+diff --git a/src/NuGet.Core/NuGet.Protocol/Exceptions/FatalProtocolException.cs b/src/NuGet.Core/NuGet.Protocol/Exceptions/FatalProtocolException.cs
+index 68913b98d..fcb1e9dac 100644
+--- a/src/NuGet.Core/NuGet.Protocol/Exceptions/FatalProtocolException.cs
++++ b/src/NuGet.Core/NuGet.Protocol/Exceptions/FatalProtocolException.cs
+@@ -18,6 +18,9 @@ public FatalProtocolException(string message, Exception innerException) : base(m
+         {
+         }
+ 
++#if NET8_0_OR_GREATER
++        [Obsolete(DiagnosticId = "SYSLIB0051")] // https://github.com/dotnet/docs/issues/34893
++#endif
+         protected FatalProtocolException(SerializationInfo info, StreamingContext context) : base(info, context)
+         {
+         }
+diff --git a/src/NuGet.Core/NuGet.Protocol/Exceptions/InvalidCacheProtocolException.cs b/src/NuGet.Core/NuGet.Protocol/Exceptions/InvalidCacheProtocolException.cs
+index de810344a..ca9b08c77 100644
+--- a/src/NuGet.Core/NuGet.Protocol/Exceptions/InvalidCacheProtocolException.cs
++++ b/src/NuGet.Core/NuGet.Protocol/Exceptions/InvalidCacheProtocolException.cs
+@@ -23,6 +23,9 @@ public InvalidCacheProtocolException(string message, Exception innerException)
+         {
+         }
+ 
++#if NET8_0_OR_GREATER
++        [Obsolete(DiagnosticId = "SYSLIB0051")] // https://github.com/dotnet/docs/issues/34893
++#endif
+         protected InvalidCacheProtocolException(SerializationInfo info, StreamingContext context) : base(info, context)
+         {
+         }
+diff --git a/src/NuGet.Core/NuGet.Protocol/Exceptions/NuGetProtocolException.cs b/src/NuGet.Core/NuGet.Protocol/Exceptions/NuGetProtocolException.cs
+index 8a1a81c9d..dc5566170 100644
+--- a/src/NuGet.Core/NuGet.Protocol/Exceptions/NuGetProtocolException.cs
++++ b/src/NuGet.Core/NuGet.Protocol/Exceptions/NuGetProtocolException.cs
+@@ -22,6 +22,9 @@ public NuGetProtocolException(string message, Exception innerException)
+         {
+         }
+ 
++#if NET8_0_OR_GREATER
++        [Obsolete(DiagnosticId = "SYSLIB0051")] // https://github.com/dotnet/docs/issues/34893
++#endif
+         protected NuGetProtocolException(SerializationInfo info, StreamingContext context) : base(info, context)
+         {
+         }
+diff --git a/src/NuGet.Core/NuGet.Protocol/Exceptions/RetriableProtocolException.cs b/src/NuGet.Core/NuGet.Protocol/Exceptions/RetriableProtocolException.cs
+index 4a63a8f4c..46e0001b4 100644
+--- a/src/NuGet.Core/NuGet.Protocol/Exceptions/RetriableProtocolException.cs
++++ b/src/NuGet.Core/NuGet.Protocol/Exceptions/RetriableProtocolException.cs
+@@ -17,6 +17,9 @@ public RetriableProtocolException(string message, Exception innerException) : ba
+         {
+         }
+ 
++#if NET8_0_OR_GREATER
++        [Obsolete(DiagnosticId = "SYSLIB0051")] // https://github.com/dotnet/docs/issues/34893
++#endif
+         protected RetriableProtocolException(SerializationInfo info, StreamingContext context) : base(info, context)
+         {
+         }
+diff --git a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginException.cs b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginException.cs
+index da7df46fd..9976aa6c4 100644
+--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginException.cs
++++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginException.cs
+@@ -31,6 +31,9 @@ public PluginException(string message, Exception innerException)
+         {
+         }
+ 
++#if NET8_0_OR_GREATER
++        [Obsolete(DiagnosticId = "SYSLIB0051")] // https://github.com/dotnet/docs/issues/34893
++#endif
+         private PluginException(SerializationInfo info, StreamingContext context) : base(info, context)
+         {
+         }
+diff --git a/src/NuGet.Core/NuGet.Protocol/Plugins/ProtocolException.cs b/src/NuGet.Core/NuGet.Protocol/Plugins/ProtocolException.cs
+index df18f9f81..9f1ee5b11 100644
+--- a/src/NuGet.Core/NuGet.Protocol/Plugins/ProtocolException.cs
++++ b/src/NuGet.Core/NuGet.Protocol/Plugins/ProtocolException.cs
+@@ -31,6 +31,9 @@ public ProtocolException(string message, Exception innerException)
+         {
+         }
+ 
++#if NET8_0_OR_GREATER
++        [Obsolete(DiagnosticId = "SYSLIB0051")] // https://github.com/dotnet/docs/issues/34893
++#endif
+         private ProtocolException(SerializationInfo info, StreamingContext context) : base(info, context)
+         {
+         }
+diff --git a/src/NuGet.Core/NuGet.Resolver/Exceptions/NuGetResolverConstraintException.cs b/src/NuGet.Core/NuGet.Resolver/Exceptions/NuGetResolverConstraintException.cs
+index 6998e28c1..1f3c51adb 100644
+--- a/src/NuGet.Core/NuGet.Resolver/Exceptions/NuGetResolverConstraintException.cs
++++ b/src/NuGet.Core/NuGet.Resolver/Exceptions/NuGetResolverConstraintException.cs
+@@ -17,6 +17,9 @@ public NuGetResolverConstraintException(string message)
+         {
+         }
+ 
++#if NET8_0_OR_GREATER
++        [Obsolete(DiagnosticId = "SYSLIB0051")] // https://github.com/dotnet/docs/issues/34893
++#endif
+         protected NuGetResolverConstraintException(SerializationInfo info, StreamingContext context) : base(info, context)
+         {
+         }
+diff --git a/src/NuGet.Core/NuGet.Resolver/Exceptions/NuGetResolverException.cs b/src/NuGet.Core/NuGet.Resolver/Exceptions/NuGetResolverException.cs
+index e2b426eb4..7edeaf690 100644
+--- a/src/NuGet.Core/NuGet.Resolver/Exceptions/NuGetResolverException.cs
++++ b/src/NuGet.Core/NuGet.Resolver/Exceptions/NuGetResolverException.cs
+@@ -14,6 +14,9 @@ public NuGetResolverException(string message)
+         {
+         }
+ 
++#if NET8_0_OR_GREATER
++        [Obsolete(DiagnosticId = "SYSLIB0051")] // https://github.com/dotnet/docs/issues/34893
++#endif
+         protected NuGetResolverException(SerializationInfo info, StreamingContext context) : base(info, context)
+         {
+         }
+diff --git a/src/NuGet.Core/NuGet.Resolver/Exceptions/NuGetResolverInputException.cs b/src/NuGet.Core/NuGet.Resolver/Exceptions/NuGetResolverInputException.cs
+index e1542ec4f..f10f6a9f4 100644
+--- a/src/NuGet.Core/NuGet.Resolver/Exceptions/NuGetResolverInputException.cs
++++ b/src/NuGet.Core/NuGet.Resolver/Exceptions/NuGetResolverInputException.cs
+@@ -17,6 +17,9 @@ public NuGetResolverInputException(string message)
+         {
+         }
+ 
++#if NET8_0_OR_GREATER
++        [Obsolete(DiagnosticId = "SYSLIB0051")] // https://github.com/dotnet/docs/issues/34893
++#endif
+         protected NuGetResolverInputException(SerializationInfo info, StreamingContext context) : base(info, context)
+         {
+         }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/3117

This PR stops modifications of `Directory.Build.props` to inject NoWarns during VMR build.

I have [validated](https://dev.azure.com/dnceng/internal/_build/results?buildId=2308713&view=results) that most of the NoWarns are not needed anymore. The only remaining one is in `nuget.client` for which I'm adding a patch. Backport PR is also out: https://github.com/NuGet/NuGet.Client/pull/5496

Full validation build with updated `nuget.client` patch is in progress: https://dev.azure.com/dnceng/internal/_build/results?buildId=2309593&view=results