### PR TITLE
NGEN Microsoft.DotNet.MSBuildSdkResolver.dll and its dependencies

### DIFF
--- a/src/core-sdk-tasks/GenerateMSBuildExtensionsSWR.cs
+++ b/src/core-sdk-tasks/GenerateMSBuildExtensionsSWR.cs
@@ -29,20 +29,18 @@ namespace Microsoft.DotNet.Cli.Build
 
             AddFolder(sb,
                       @"msbuildExtensions",
-                      @"MSBuild",
-                      ngenAssemblies: false);
+                      @"MSBuild");
 
             AddFolder(sb,
                       @"msbuildExtensions-ver",
-                      @"MSBuild\Current",
-                      ngenAssemblies: false);
+                      @"MSBuild\Current");
 
             File.WriteAllText(OutputFile, sb.ToString());
 
             return true;
         }
 
-        private void AddFolder(StringBuilder sb, string relativeSourcePath, string swrInstallDir, bool ngenAssemblies)
+        private void AddFolder(StringBuilder sb, string relativeSourcePath, string swrInstallDir, bool ngenAssemblies = false)
         {
             string sourceFolder = Path.Combine(MSBuildExtensionsLayoutDirectory, relativeSourcePath);
             var files = Directory.GetFiles(sourceFolder)
@@ -80,7 +78,7 @@ namespace Microsoft.DotNet.Cli.Build
                 string newSwrInstallDir = Path.Combine(swrInstallDir, subfolderName);
 
                 // Don't propagate ngenAssemblies to subdirectories.
-                AddFolder(sb, newRelativeSourcePath, newSwrInstallDir, ngenAssemblies: false);
+                AddFolder(sb, newRelativeSourcePath, newSwrInstallDir);
             }
         }
 


### PR DESCRIPTION
MSBuild.exe currently spends a significant amount of time JITting `Microsoft.DotNet.MSBuildSdkResolver` and its dependencies, see https://github.com/dotnet/msbuild/issues/9303 for details.

This PR makes Visual Studio installer add these assemblies to the NGEN queue, which is a necessary condition for eliminating JITting. Just like `Microsoft.Build.*` assemblies, we need to NGEN these with two configurations: vsn.exe so it works in the devenv process, and MSBuild.exe so it works in MSBuild satellite processes.

cc @joeloff @marcpopMSFT