### PR TITLE
SB patch for net9.0 TFM in SBRP

### DIFF
--- a/src/SourceBuild/patches/source-build-reference-packages/0001-Explicitly-target-net9.0-for-NoOp-proj.patch
+++ b/src/SourceBuild/patches/source-build-reference-packages/0001-Explicitly-target-net9.0-for-NoOp-proj.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matt Thalman <mthalman@microsoft.com>
+Date: Tue, 7 Nov 2023 12:40:49 -0600
+Subject: [PATCH] Explicitly target net9.0 for NoOp proj
+
+https://github.com/dotnet/source-build/issues/3663
+---
+ eng/NoOp.csproj | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/eng/NoOp.csproj b/eng/NoOp.csproj
+index 659aa00a..3ecefd43 100644
+--- a/eng/NoOp.csproj
++++ b/eng/NoOp.csproj
+@@ -5,7 +5,7 @@
+   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+ 
+   <PropertyGroup>
+-    <TargetFramework>$(NetCurrent)</TargetFramework>
++    <TargetFramework>net9.0</TargetFramework>
+   </PropertyGroup>
+ 
+   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />


### PR DESCRIPTION
The stage 2 build for the VMR fails when attempting to build the SBRP repo because its NoOp.proj is referencing `NetCurrent`.

The failure is:

```
/vmr/src/source-build-reference-packages/artifacts/source-build/self/src/eng/NoOp.csproj : error NU1102: Unable to find package Microsoft.NETCore.App.Ref with version (= 8.0.0-rc.2.23479.6) [/vmr/.dotnet/sdk/9.0.100-alpha.1.23557.1/NuGet.targets] [/vmr/prereqs/packages/restored/ArcadeBootstrapPackage/microsoft.dotnet.arcade.sdk/9.0.0-beta.23553.1/tools/Build.proj]
```

The `NetCurrent` property comes from Arcade which is still configured to be `net8.0` and hasn't been updated to be `net9.0`.

To work around this, the `TargetFramework` property is updated to explicitly be `net9.0`.

Related to https://github.com/dotnet/source-build-reference-packages/pull/821