### PR TITLE
Set git author information in vmr-synchronization.yml

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-synchronization.yml
+++ b/eng/pipelines/templates/jobs/vmr-synchronization.yml
@@ -56,6 +56,11 @@ jobs:
       vmrBranch: ${{ parameters.vmrBranch }}
       targetRef: ${{ parameters.targetRef }}
 
+  - script: >
+      git config --global user.name "dotnet-maestro[bot]"
+      git config --global user.email "dotnet-maestro[bot]@users.noreply.github.com"
+    displayName: Set git author to dotnet-maestro[bot]
+
   
   - ${{ if and(not(parameters.noPush), not(in(variables['Build.Reason'], 'PullRequest')), eq(variables['System.TeamProject'], 'internal')) }}:
     # Push main and release branches to the public VMR


### PR DESCRIPTION
This should fix the "Ubuntu" author shown on the sync commits:

<img width="410" alt="image" src="https://github.com/dotnet/installer/assets/1376924/31d235c8-33aa-4f8a-a923-a39d5e1685eb">
