### PR TITLE
Fix the minimum version logic to take into account that we're off-by-one for the 100 release

### DIFF
--- a/src/redist/targets/GenerateMSIs.targets
+++ b/src/redist/targets/GenerateMSIs.targets
@@ -321,6 +321,11 @@
           <ReadLinesFromFile File="$(MinimumMSBuildVersionFile)">
             <Output TaskParameter="Lines" PropertyName="MinimumVSVersion"/>
           </ReadLinesFromFile>
+
+          <PropertyGroup Condition=" '$(VersionSDKMinor)' == '1' and '$(StabilizePackageVersion)' == 'true' ">
+            <MinimumVSVersion>$(MinimumVSVersion.Substring(0,$(MinimumVSVersion.LastIndexOf('.'))))</MinimumVSVersion>
+            <MinimumVSVersion >$([MSBuild]::Add($(MinimumVSVersion), .1))</MinimumVSVersion>
+          </PropertyGroup>
   </Target>
 
   <Target Name="GenerateSdkBundle"


### PR DESCRIPTION
Fixes #17770

# Description
Previously, we were manually updating the VS version listed in the installation text every few previews. During .net 8 we changed that to be automatic based on the minimum version of MSBuild required for the SDK. Unfortunately, the minimum version of msbuild and the minimum for current TFM targeting are actually off by one minor version for the .1xx band.

This logic will have to get updated when we move to a new major VS version. This change trims the version to only show major.minor and it increases the minor by 1 in the 1xx band SDK.
**Before**
<img width="358" alt="image" src="https://github.com/dotnet/installer/assets/12663534/9bd474e4-0a14-4613-a10d-42fe791ca497">
**After**
<img width="370" alt="image" src="https://github.com/dotnet/installer/assets/12663534/8ffe809c-144b-4ebb-8f30-c540521a3f25">

# Customer Impact
Customers see 17.7.0 as the minimum version for targeting net8.0 which is incorrect.

# Regression

No

# Testing

Manual

# Risk

Minimal risk as it's an installer string change. No loc impact as this is piped through to the loc string.