### PR TITLE
Downgrade implicit version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -26,8 +26,8 @@
     <VersionFeature21>30</VersionFeature21>
     <VersionFeature31>32</VersionFeature31>
     <VersionFeature50>17</VersionFeature50>
-    <VersionFeature60>$([MSBuild]::Add($(VersionFeature), 25))</VersionFeature60>
-    <VersionFeature70>$([MSBuild]::Add($(VersionFeature), 14))</VersionFeature70>
+    <VersionFeature60>$([MSBuild]::Add($(VersionFeature), 24))</VersionFeature60>
+    <VersionFeature70>$([MSBuild]::Add($(VersionFeature), 13))</VersionFeature70>
     <!-- Should be kept in sync with VersionFeature70. It should match the version of Microsoft.NET.ILLink.Tasks
          referenced by the same 7.0 SDK that references the 7.0.VersionFeature70 runtime pack. -->
     <_NET70ILLinkPackVersion>7.0.100-1.23211.1</_NET70ILLinkPackVersion>


### PR DESCRIPTION
Currently, we are not tracking changes to be released for 6 or 7 in December. Preparing the downgrade of the implicit version in case that ends up being the case.
