### PR TITLE
Enabling MSI builds targeting net9

### DIFF
--- a/src/redist/targets/GenerateMSIs.targets
+++ b/src/redist/targets/GenerateMSIs.targets
@@ -335,11 +335,8 @@
 
     <!-- Choose "latest" template MSI to go in bundle. -->
     <ItemGroup>
-      <!-- While we don't have 9.0 templates available (need SDK update, choose the 8.0 templates -->
-      <!-- <LatestTemplateInstallerComponent Include="@(TemplatesMsiComponent)"
-                                        Condition="'%(TemplatesMajorMinorVersion)' == '$(MajorMinorVersion)'"/> -->
       <LatestTemplateInstallerComponent Include="@(TemplatesMsiComponent)"
-                                         Condition="'%(TemplatesMajorMinorVersion)' == '8.0'"/>
+                                        Condition="'%(TemplatesMajorMinorVersion)' == '$(MajorMinorVersion)'"/>
     </ItemGroup>
     <PropertyGroup>
       <LatestTemplateMsiInstallerFile>@(LatestTemplateInstallerComponent->'%(MSIInstallerFile)')</LatestTemplateMsiInstallerFile>


### PR DESCRIPTION
Looks like we previously enabled this for the zip installs which is what our tests actually test. This was missed in the clean.

Fixes #17744

#17453 