### PR TITLE
Reference real SDK version in source-build artifacts package

### DIFF
--- a/src/SourceBuild/content/repo-projects/package-source-build.proj
+++ b/src/SourceBuild/content/repo-projects/package-source-build.proj
@@ -20,8 +20,39 @@
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
+  <Target Name="DetermineSdkVersion">
+    <ItemGroup>
+      <SdkTarballItem Include="$(SourceBuiltAssetsDir)dotnet-sdk-*$(TarBallExtension)" />
+    </ItemGroup>
+    <PropertyGroup>
+      <SdkTarball>%(SdkTarballItem.Identity)</SdkTarball>
+      <SdkLayout>$(ArtifactsTmpDir)Sdk</SdkLayout>
+      <BundledVersionsPropsRelativePath>sdk/*/Microsoft.NETCoreSdk.BundledVersions.props</BundledVersionsPropsRelativePath>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(SdkLayout)" />
+    <Exec Command="tar -xzf $(SdkTarball) -C $(SdkLayout)"
+          WorkingDirectory="$(SdkLayout)" />
+
+    <ItemGroup>
+      <BundledVersionsPropsFile Include="$(SdkLayout)/$(BundledVersionsPropsRelativePath)" />
+    </ItemGroup>
+
+    <XmlPeek XmlInputPath="@(BundledVersionsPropsFile)"
+             Query="Project/PropertyGroup/NETCoreSdkVersion/text()">
+        <Output TaskParameter="Result" ItemName="SdkVersionItem" />
+    </XmlPeek>
+    <PropertyGroup>
+      <SdkVersion>@(SdkVersionItem)</SdkVersion>
+    </PropertyGroup>
+
+    <RemoveDir Directories="$(SdkLayout)" />
+  </Target>
+
   <Target Name="RepoBuild"
-          DependsOnTargets="DetermineMicrosoftSourceBuildIntermediateInstallerVersion">
+          DependsOnTargets="
+            DetermineMicrosoftSourceBuildIntermediateInstallerVersion;
+            DetermineSdkVersion">
     <!-- Copy PVP to packages dir in order to package them together -->
     <Copy SourceFiles="$(IncludedPackageVersionPropsFile)" DestinationFiles="$(SourceBuiltPackagesPath)PackageVersions.props" />
 
@@ -60,7 +91,7 @@
 
     <!-- Content of the .version file to include in the tarball -->
     <ItemGroup>
-      <VersionFileContent Include="$(RepositoryCommit);$(MicrosoftSourceBuildIntermediateInstallerVersion)" />
+      <VersionFileContent Include="$(RepositoryCommit);$(SdkVersion)" />
     </ItemGroup>
 
     <WriteLinesToFile

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SourceBuiltArtifactsTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SourceBuiltArtifactsTests.cs
@@ -58,8 +58,7 @@ public class SourceBuiltArtifactsTests : SdkTests
             string[] sdkVersionLines = File.ReadAllLines(Path.Combine(outputDir, sdkVersionPath));
             string expectedSdkVersion = sdkVersionLines[1];
 
-            // Disable due to https://github.com/dotnet/source-build/issues/3693
-            // Assert.Equal(expectedSdkVersion, sdkVersion);
+            Assert.Equal(expectedSdkVersion, sdkVersion);
         }
         finally
         {


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/3693

Also re-enables SDK version verification in `SourceBuildArtifactsTests.VerifyVersionFile`, which was disabled with https://github.com/dotnet/installer/commit/b49f63c76cb30a0cf9e7bcca5d17f5681b6763ac

We are now obtaining real SDK version from the SDK produced in source-build.

We are extracting the whole SDK, as both Alpine and Ubuntu have issues and require special `tar` syntax to extract single files. This doesn't affect performance much anyway.