### PR TITLE
Use unique non-stable SDK version for comparison test

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SourceBuiltArtifactsTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SourceBuiltArtifactsTests.cs
@@ -56,10 +56,9 @@ public class SourceBuiltArtifactsTests : SdkTests
             DirectoryInfo sdkDir = new DirectoryInfo(Path.Combine(outputDir, "sdk"));
             string sdkVersionPath = sdkDir.GetFiles(".version", SearchOption.AllDirectories).Single().FullName;
             string[] sdkVersionLines = File.ReadAllLines(Path.Combine(outputDir, sdkVersionPath));
-            string expectedSdkVersion = sdkVersionLines[1];
+            string expectedSdkVersion = sdkVersionLines[3];  // Get the unique, non-stable, SDK version
 
-            // Disable due to https://github.com/dotnet/source-build/issues/3693
-            // Assert.Equal(expectedSdkVersion, sdkVersion);
+            Assert.Equal(expectedSdkVersion, sdkVersion);
         }
         finally
         {


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/3693

Also re-enables SDK version verification in `SourceBuildArtifactsTests.VerifyVersionFile`, which was disabled with https://github.com/dotnet/installer/commit/b49f63c76cb30a0cf9e7bcca5d17f5681b6763ac

The fix is simple - update the test to get the unique, non-stable SDK version from its `.version` file.

`.version` file in SDK has the following contents:
```
<sha>
<stable version>
<rid>
<real unique version>
```

i.e. in my local build this was:
```
fed94d5f58d11fe5c4eb6ba07904dd3775b21e6c
8.0.101
fedora.38-x64
8.0.101-servicing.23559.1
```
