### PR TITLE
Download and compare linux-musl-x64 MSFT sdk

### DIFF
--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-build-tarball.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-build-tarball.yml
@@ -85,7 +85,7 @@ jobs:
   - ${{ if ne(parameters.excludeSdkContentTests, 'true') }}:
     - download: ${{ parameters.installerBuildResourceId }}
       artifact: BlobArtifacts
-      patterns: '**/dotnet-sdk-+([0-9]).+([0-9]).+([0-9])?(-@(preview|rc|rtm)*)-linux-${{ parameters.architecture }}.tar.gz'
+      patterns: '**/dotnet-sdk-+([0-9]).+([0-9]).+([0-9])?(-@(preview|rc|rtm)*)-linux*-${{ parameters.architecture }}.tar.gz'
       displayName: Download MSFT sdk Tarball
 
   - ${{ if eq(parameters.usePreviousArtifacts, 'true') }}:

--- a/src/SourceBuild/tarball/content/Directory.Build.props
+++ b/src/SourceBuild/tarball/content/Directory.Build.props
@@ -174,6 +174,7 @@
     <PortableRid Condition="'$(TargetOS)' == 'FreeBSD'">freebsd-$(Platform)</PortableRid>
     <PortableRid Condition="'$(TargetOS)' == 'OSX'">osx-$(Platform)</PortableRid>
     <PortableRid Condition="'$(TargetOS)' == 'Linux'">linux-$(Platform)</PortableRid>
+    <PortableRid Condition="$(TargetRid.StartsWith('linux-musl')) or $(TargetRid.StartsWith('alpine'))">linux-musl-$(Platform)</PortableRid>
     <PortableRid Condition="'$(TargetOS)' == 'Windows_NT'">win-$(Platform)</PortableRid>
     <TargetRid Condition="'$(PortableBuild)' == 'true' AND '$(PortableRid)' != ''">$(PortableRid)</TargetRid>
   </PropertyGroup>


### PR DESCRIPTION
Addresses https://github.com/dotnet/source-build/issues/3714

This PR:
- Fixes the regex used for downloading the MSFT sdk so that it now matches [`linux-musl-x64` as done in 6.0](https://github.com/dotnet/installer/blob/release/6.0.1xx/src/SourceBuild/Arcade/eng/common/templates/job/source-build-build-tarball.yml#L88)
- Adds in a portable rid for `linux-musl`. This now matches the [portableRid for `linux-musl` in 6.0](https://github.com/dotnet/installer/blob/1b5e0e204956294804c290739a41e440d184d0af/src/SourceBuild/tarball/content/Directory.Build.props#L184)

Azdo pipeline run with these changes: https://dev.azure.com/dnceng/internal/_build/results?buildId=2317704&view=results