### PR TITLE
Bootstrap to newer .NET 9 SDK for source build

### DIFF
--- a/src/SourceBuild/content/eng/Versions.props
+++ b/src/SourceBuild/content/eng/Versions.props
@@ -28,8 +28,8 @@
       of a .NET major or minor release, prebuilts may be needed. When the release is mature, prebuilts
       are not necessary, and this property is removed from the file.
     -->
-    <PrivateSourceBuiltSdkVersion>9.0.100-alpha.1.23557.1</PrivateSourceBuiltSdkVersion>
-    <PrivateSourceBuiltArtifactsVersion>9.0.100-alpha.1.23557.1</PrivateSourceBuiltArtifactsVersion>
+    <PrivateSourceBuiltSdkVersion>9.0.100-alpha.1.23567.1</PrivateSourceBuiltSdkVersion>
+    <PrivateSourceBuiltArtifactsVersion>9.0.100-alpha.1.23567.1</PrivateSourceBuiltArtifactsVersion>
     <PrivateSourceBuiltPrebuiltsVersion>0.1.0-9.0.100-6</PrivateSourceBuiltPrebuiltsVersion>
   </PropertyGroup>
 </Project>

--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -77,10 +77,7 @@
     <EnvironmentVariables Include="_InitializeDotNetCli=$(DotNetCliToolDir)" />
     <EnvironmentVariables Include="_DotNetInstallDir=$(DotNetCliToolDir)" />
     <EnvironmentVariables Include="_InitializeToolset=$(SourceBuiltSdksDir)Microsoft.DotNet.Arcade.Sdk/tools/Build.proj" Condition="'$(UseBootstrapArcade)' != 'true'" />
-
-    <!-- TODO: Revert net8.0 bootstrapping hack: https://github.com/dotnet/source-build/issues/3743-->
-    <EnvironmentVariables Include="_OverrideArcadeInitializeBuildToolFramework=$(NetCurrent)" Condition="'$(UseBootstrapArcade)' != 'true'"  />
-    <EnvironmentVariables Include="_OverrideArcadeInitializeBuildToolFramework=net8.0" Condition="'$(UseBootstrapArcade)' == 'true'"  />
+    <EnvironmentVariables Include="_OverrideArcadeInitializeBuildToolFramework=$(NetCurrent)" />
 
     <EnvironmentVariables Include="DotNetUseShippingVersions=true" />
 


### PR DESCRIPTION
This is a progression of the changes from https://github.com/dotnet/installer/pull/17822. Those changes were based on an older build of the .NET 9 SDK. But now that those changes have gone in, we've got a new build that we can bootstrap on. This gives us the latest updates which include some Arcade updates needed to unblock some Unified Build work. It also provides an Arcade that targets .NET 9 which allows us to remove a workaround needed for setting the TFM for the bootstrapped Arcade.

Unfortunately, main is still using RC2 build for the 8.0 targeting pack version. So this won't allow offline builds to pass due to a prebuilt for Microsoft.NETCore.App.Ref.8.0.0-rc.2.23479.6 in SBRP. The changes in https://github.com/dotnet/source-build-reference-packages/pull/829 will help with that but will only be effective when main is updated to use 8.0.0 for the 8.0 targeting pack version.