### PR TITLE
These changes should allow complete cross-builds just via OverrideTargetRid

### DIFF
--- a/src/SourceBuild/content/Directory.Build.props
+++ b/src/SourceBuild/content/Directory.Build.props
@@ -25,6 +25,8 @@
     <Platform Condition="'$(Platform)' == '' AND '$(BuildArchitecture)' == 'loongarch64'">$(BuildArchitecture)</Platform>
     <Platform Condition="'$(Platform)' == ''">x64</Platform>
 
+    <TargetPlatform>$(Platform)</TargetPlatform>
+    <TargetPlatform Condition="'$(OverrideTargetRid)' != ''">$(OverrideTargetRid.Substring($(OverrideTargetRid.LastIndexOf('-'))).TrimStart('-'))</TargetPlatform>
     <UseStableVersions Condition="'$(UseStableVersions)' == ''">false</UseStableVersions>
   </PropertyGroup>
 
@@ -102,8 +104,8 @@
     <LeakDetectionTasksAssembly>$(LeakDetectionTasksBinDir)Microsoft.DotNet.SourceBuild.Tasks.LeakDetection.dll</LeakDetectionTasksAssembly>
 
     <BaseIntermediatePath>$(BaseOutputPath)obj/</BaseIntermediatePath>
-    <OutputPath>$(BaseOutputPath)$(Platform)/$(Configuration)/</OutputPath>
-    <IntermediatePath>$(BaseIntermediatePath)$(Platform)/$(Configuration)/</IntermediatePath>
+    <OutputPath>$(BaseOutputPath)$(TargetPlatform)/$(Configuration)/</OutputPath>
+    <IntermediatePath>$(BaseIntermediatePath)$(TargetPlatform)/$(Configuration)/</IntermediatePath>
     <LocalNuGetPackagesRoot>$(IntermediatePath)nuget-packages/</LocalNuGetPackagesRoot>
     <SourceBuiltBlobFeedDir>$(IntermediatePath)blob-feed/</SourceBuiltBlobFeedDir>
     <SourceBuiltPackagesPath>$(SourceBuiltBlobFeedDir)packages/</SourceBuiltPackagesPath>
@@ -166,11 +168,11 @@
     <TargetOS Condition="'$(TargetOS)' == '' AND $([MSBuild]::IsOSPlatform('LINUX'))">Linux</TargetOS>
     <TargetOS Condition="'$(TargetOS)' == '' AND $([MSBuild]::IsOSPlatform('FREEBSD'))">FreeBSD</TargetOS>
 
-    <PortableRid Condition="'$(__PortableTargetOS)' != ''">$(__PortableTargetOS)-$(Platform)</PortableRid>
-    <PortableRid Condition="'$(PortableRid)' == '' AND '$(TargetOS)' == 'FreeBSD'">freebsd-$(Platform)</PortableRid>
-    <PortableRid Condition="'$(PortableRid)' == '' AND '$(TargetOS)' == 'OSX'">osx-$(Platform)</PortableRid>
-    <PortableRid Condition="'$(PortableRid)' == '' AND '$(TargetOS)' == 'Linux'">linux-$(Platform)</PortableRid>
-    <PortableRid Condition="'$(PortableRid)' == '' AND '$(TargetOS)' == 'Windows_NT'">win-$(Platform)</PortableRid>
+    <PortableRid Condition="'$(__PortableTargetOS)' != ''">$(__PortableTargetOS)-$(TargetPlatform)</PortableRid>
+    <PortableRid Condition="'$(PortableRid)' == '' AND '$(TargetOS)' == 'FreeBSD'">freebsd-$(TargetPlatform)</PortableRid>
+    <PortableRid Condition="'$(PortableRid)' == '' AND '$(TargetOS)' == 'OSX'">osx-$(TargetPlatform)</PortableRid>
+    <PortableRid Condition="'$(PortableRid)' == '' AND '$(TargetOS)' == 'Linux'">linux-$(TargetPlatform)</PortableRid>
+    <PortableRid Condition="'$(PortableRid)' == '' AND '$(TargetOS)' == 'Windows_NT'">win-$(TargetPlatform)</PortableRid>
     <TargetRid Condition="'$(PortableBuild)' == 'true' AND '$(PortableRid)' != ''">$(PortableRid)</TargetRid>
   </PropertyGroup>
 

--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -58,6 +58,12 @@
     <ProjectBuildReason>'$(RepositoryName)'</ProjectBuildReason>
   </PropertyGroup>
 
+  <!-- Cross-build property setting from OverrideTargetRid -->
+  <PropertyGroup Condition="'$(OverrideTargetRid)' != ''">
+    <OverrideTargetOS>$(OverrideTargetRid.Substring(0, $(OverrideTargetRid.LastIndexOf('-'))))</OverrideTargetOS>
+    <OverrideTargetArch>$(OverrideTargetRid.Substring($(OverrideTargetRid.LastIndexOf('-'))).TrimStart('-'))</OverrideTargetArch>
+  </PropertyGroup>
+
   <ItemGroup>
     <EnvironmentVariables Include="DotNetBuildFromSource=true" />
     <EnvironmentVariables Include="DotNetBuildFromSourceFlavor=Product" />

--- a/src/SourceBuild/content/repo-projects/aspnetcore.proj
+++ b/src/SourceBuild/content/repo-projects/aspnetcore.proj
@@ -11,8 +11,8 @@
 
     <!-- StandardSourceBuildArgs include -publish which is not supported by the aspnetcore build script. -->
     <BuildCommandArgs>$(StandardSourceBuildArgs.Replace('--publish', ''))</BuildCommandArgs>
-    <!-- The arch flag (defaults to x64) overrides any value of TargetArchitecture that we might set -->
-    <BuildCommandArgs>$(BuildCommandArgs) --arch $(Platform)</BuildCommandArgs>
+    <BuildCommandArgs Condition="'$(OverrideTargetArch)' == ''">$(BuildCommandArgs) --arch $(Platform)</BuildCommandArgs>
+    <BuildCommandArgs Condition="'$(OverrideTargetArch)' != ''">$(BuildCommandArgs) --arch $(OverrideTargetArch)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) --no-build-repo-tasks</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) --no-build-nodejs</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:PortableBuild=$(_portableRidOverridden) /p:TargetRuntimeIdentifier=$(OverrideTargetRid)</BuildCommandArgs>

--- a/src/SourceBuild/content/repo-projects/runtime.proj
+++ b/src/SourceBuild/content/repo-projects/runtime.proj
@@ -23,6 +23,8 @@
     <BuildNonPortable Condition="'$(PortableBuild)' == 'true'">false</BuildNonPortable>
 
     <BuildCommandArgs>$(StandardSourceBuildArgs)</BuildCommandArgs>
+    <BuildCommandArgs Condition="'$(OverrideTargetArch)' != ''">$(BuildCommandArgs) --arch $(OverrideTargetArch)</BuildCommandArgs>
+    <BuildCommandArgs Condition="'$(OverrideTargetOS)' != ''">$(BuildCommandArgs) --os $(OverrideTargetOS)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:TargetRid=$(OverrideTargetRid)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:RuntimeOS=$(RuntimeOS)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:BaseOS=$(BaseOS)</BuildCommandArgs>

--- a/src/SourceBuild/content/repo-projects/sdk.proj
+++ b/src/SourceBuild/content/repo-projects/sdk.proj
@@ -9,7 +9,10 @@
     <!-- Propagate RID set in source-build to sdk repo -->
     <_platformIndex>$(NETCoreSdkPortableRuntimeIdentifier.LastIndexOf('-'))</_platformIndex>
     <_baseOS>$(NETCoreSdkPortableRuntimeIdentifier.Substring(0, $(_platformIndex)))</_baseOS>
-    <BuildCommandArgs>$(BuildCommandArgs) /p:PortableRid=$(_baseOS)-$(Platform)</BuildCommandArgs>
+    <_baseOS Condition="'$(OverrideTargetOS)' != ''">$(OverrideTargetOS)</_baseOS>
+    <_targetPortableArch>$(Platform)</_targetPortableArch>
+    <_targetPortableArch Condition="'$(OverrideTargetArch)' != ''">$(OverrideTargetArch)</_targetPortableArch>
+    <BuildCommandArgs>$(BuildCommandArgs) /p:PortableRid=$(_baseOS)-$(_targetPortableArch)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:TargetRid=$(TargetRid)</BuildCommandArgs>
 
     <!-- Just like mono, arm does not support NativeAot -->


### PR DESCRIPTION
My complete ARM64 build command:

```
docker run -e CROSSCOMPILE=1 -e ROOTFS_DIR=/crossrootfs/arm64 -w `pwd` --platform linux/amd64 -v `pwd`:`pwd` -it mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm64 ./build.sh --online --use-mono-runtime -- /p:OverrideTargetRid=linux-arm64 /p:PortableBuild=true /p:DotNetBuildVertical=true
```

I intend to test FreeBSD or Musl next.