### PR TITLE
Update fedora image from 36 to 38

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -160,9 +160,9 @@ stages:
               _RuntimeIdentifier: ''
               _BuildArchitecture: 'x64'
               _TestArg: $(_NonWindowsTestArg)
-            Build_Fedora_36_Debug_x64:
+            Build_Fedora_38_Debug_x64:
               _BuildConfig: Debug
-              _DockerParameter: '--docker fedora.36'
+              _DockerParameter: '--docker fedora.38'
               _LinuxPortable: '--linux-portable'
               _RuntimeIdentifier: ''
               _BuildArchitecture: 'x64'

--- a/eng/docker/fedora.38/Dockerfile
+++ b/eng/docker/fedora.38/Dockerfile
@@ -4,14 +4,14 @@
 #
 
 # Dockerfile that creates a container suitable to build dotnet-cli
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-36-20220716171953-531d246
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-38-20231107041221-75bbd6b
 
 RUN dnf install -y nss
 
 RUN dnf clean all
 
 # Override RID set by the dotnet-buildtools-prereqs docker image
-ENV __PUBLISH_RID=fedora.36-x64
+ENV __PUBLISH_RID=fedora.38-x64
 
 # Setup User to match Host User, and give superuser permissions 
 ARG USER_ID=0 


### PR DESCRIPTION
Fedora 36 is EOL, and is causing pipeline failures https://dev.azure.com/dnceng/internal/_build/results?buildId=2322703&view=logs&j=1cb4780c-230d-5c7d-bbbd-b04a2410a90f&t=8dfd2649-98bc-575a-3b85-aeb750a185dc