### PR TITLE
Revert "Merge branch 'release/8.0.2xx'"

### DIFF
--- a/eng/AfterSigning.targets
+++ b/eng/AfterSigning.targets
@@ -4,7 +4,6 @@
   </PropertyGroup>
 
   <Target Name="PopulateGenerateChecksumItems"
-          Condition="'$(PackInstaller)' == 'true'"
           AfterTargets="Build"
           BeforeTargets="GenerateChecksums" >
 

--- a/run-build.ps1
+++ b/run-build.ps1
@@ -8,7 +8,6 @@ param(
     [string]$Configuration="Debug",
     [string]$Architecture="x64",
     [switch]$Sign=$false,
-    [switch]$Pack=$false,
     [switch]$PgoInstrument,
     [bool]$WarnAsError=$true,
     [Parameter(ValueFromRemainingArguments=$true)][String[]]$ExtraParameters
@@ -24,11 +23,10 @@ if ($PgoInstrument) {
 }
 
 if ($Sign) {
-  $Parameters = "$Parameters -sign"
-}
+  $Parameters = "$Parameters -sign /p:SignCoreSdk=true"
 
-if ($Pack) {
-  $Parameters = "$Parameters /p:PackInstaller=true"
+  # Workaround https://github.com/dotnet/arcade/issues/1776
+  $WarnAsError = $false
 }
 
 $Parameters = "$Parameters -WarnAsError `$$WarnAsError"

--- a/run-build.sh
+++ b/run-build.sh
@@ -45,9 +45,6 @@ while [[ $# > 0 ]]; do
         --pgoInstrument)
             args+=("/p:PgoInstrument=true")
             ;;
-        --pack)
-            args+=("/p:PackInstaller=true")
-            ;;
         --help)
             echo "Usage: $0 [--configuration <CONFIGURATION>] [--architecture <ARCHITECTURE>] [--docker <IMAGENAME>] [--help]"
             echo ""

--- a/src/redist/targets/Crossgen.targets
+++ b/src/redist/targets/Crossgen.targets
@@ -2,7 +2,7 @@
   <!-- Crossgen is currently not supported on the s390x, ppc64le architecture as using mono instead of CoreCLR.
        Neither crossgen2 nor mono is supported on the loongarch64 architecture at present. -->
   <Target Name="CrossgenLayout"
-          Condition="'$(DISABLE_CROSSGEN)' == '' AND '$(Architecture)' != 's390x' AND '$(Architecture)' != 'ppc64le' AND '$(Architecture)' != 'loongarch64' AND '$(PackInstaller)' == 'true'"
+          Condition="'$(DISABLE_CROSSGEN)' == '' AND '$(Architecture)' != 's390x' AND '$(Architecture)' != 'ppc64le' AND '$(Architecture)' != 'loongarch64'"
           DependsOnTargets="SetSdkBrandingInfo">
     
     <PropertyGroup>

--- a/src/redist/targets/GenerateArchives.targets
+++ b/src/redist/targets/GenerateArchives.targets
@@ -1,7 +1,5 @@
 <Project>
-  <!-- Disable the GenerateArchives step in the local dev build, only do when -pack is specified to speed up dev builds -->
   <Target Name="GenerateArchives"
-          Condition="'$(PackInstaller)' == 'true'"
           DependsOnTargets="GenerateLayout;GetCurrentRuntimeInformation"
           BeforeTargets="AfterBuild">
 


### PR DESCRIPTION
This reverts commit e641a47a9f1abf6625a095bb3b81d5a1f89a3ed3, reversing changes made to dccd7139095df21a5df808cf1bc9dc8b944afb03.

This reverts the changes merged in https://github.com/dotnet/installer/pull/17775 which essentially try to make generating packages conditional to help with local dev builds. But it broke the official pipeline such that:

- only `Microsoft.SourceBuild.Intermediate.installer*nupkg` is generated
- compared to earlier builds which had multiple packages produced, including `Microsoft.Dotnet.Sdk.Internal*nupkg`.

This was discovered because of missing darc updates for `dotnet/runtime` for `Microsoft.Dotnet.Sdk.Internal*`.