### PR TITLE
Enable open ssl sha 1 signatures for CentOS Stream 9

### DIFF
--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-build-tarball.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-build-tarball.yml
@@ -123,19 +123,24 @@ jobs:
       set -x
       df -h
 
-      networkArgs=
+      customRunArgs=
       customBuildArgs=
       if [[ '$(_RunOnline)' == 'true' ]]; then
         customBuildArgs='--online'
       else
-        networkArgs='--network none'
+        customRunArgs='--network none'
+      fi
+
+      # See https://github.com/dotnet/source-build/issues/3712
+      if [[ '$(_OverrideDistroDisablingSha1)' == 'true' ]]; then
+        customRunArgs="$customRunArgs -e OPENSSL_ENABLE_SHA1_SIGNATURES=1"
       fi
 
       if [[ '$(_EnablePoison)' == 'true' ]]; then
         customBuildArgs="$customBuildArgs --poison"
       fi
 
-      docker run --rm -v $(tarballDir):/tarball -w /tarball ${networkArgs} $(_Container) ./build.sh --clean-while-building ${customBuildArgs} $(additionalBuildArgs)
+      docker run --rm -v $(tarballDir):/tarball -w /tarball ${customRunArgs} $(_Container) ./build.sh --clean-while-building ${customBuildArgs} $(additionalBuildArgs)
     displayName: Build Tarball
 
   - ${{ if ne(variables['System.TeamProject'], 'public') }}:

--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build.yml
@@ -11,7 +11,7 @@ parameters:
   # -----------------------------------------------------------------------------------------------
   alpine317Container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.17
   centOS7Container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-source-build
-  centOSStream9Container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9-20220107135047-4cd394c
+  centOSStream9Container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9
   debian11Arm64Container: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-arm64v8
   fedora38Container: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-38
   ubuntu1804Container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04
@@ -40,18 +40,21 @@ jobs:
         _BootstrapPrep: true
         _Container: ${{ parameters.alpine317Container }}
         _ExcludeOmniSharpTests: true
+        _OverrideDistroDisablingSha1: false
         _RunOnline: false
       CentOS7-Online:
         _BootstrapPrep: false
         _Container: ${{ parameters.centOS7Container }}
         _EnablePoison: false
         _ExcludeOmniSharpTests: true
+        _OverrideDistroDisablingSha1: false
         _RunOnline: true
       CentOS7-Offline:
         _BootstrapPrep: false
         _Container: ${{ parameters.centOS7Container }}
         _EnablePoison: false
         _ExcludeOmniSharpTests: true
+        _OverrideDistroDisablingSha1: false
         _RunOnline: false
       ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
         CentOSStream9-Offline:
@@ -59,18 +62,21 @@ jobs:
           _Container: ${{ parameters.centOSStream9Container }}
           _EnablePoison: false
           _ExcludeOmniSharpTests: false
+          _OverrideDistroDisablingSha1: true
           _RunOnline: false
         Fedora38-Offline:
           _BootstrapPrep: false
           _Container: ${{ parameters.fedora38Container }}
           _EnablePoison: true
           _ExcludeOmniSharpTests: false
+          _OverrideDistroDisablingSha1: false
           _RunOnline: false
         Ubuntu1804-Offline:
           _BootstrapPrep: false
           _Container: ${{ parameters.ubuntu1804Container }}
           _EnablePoison: false
           _ExcludeOmniSharpTests: false
+          _OverrideDistroDisablingSha1: false
           _RunOnline: false
     name: Build_Tarball_x64
     pool:
@@ -94,6 +100,7 @@ jobs:
           _Container: ${{ parameters.debian11Arm64Container }}
           _EnablePoison: false
           _ExcludeOmniSharpTests: false
+          _OverrideDistroDisablingSha1: false
           _RunOnline: false
       name: Build_Tarball_arm64
       pool: ${{ parameters.poolInternalArm64 }}
@@ -114,6 +121,7 @@ jobs:
           _Container: ${{ parameters.fedora38Container }}
           _EnablePoison: false
           _ExcludeOmniSharpTests: false
+          _OverrideDistroDisablingSha1: false
           _RunOnline: false
       name: Build_Tarball_x64_Using_Previous
       pool:


### PR DESCRIPTION
Closes https://github.com/dotnet/source-build/issues/3712

CentOS stream 9 job was experiencing cryptographic errors when building the source-build-reference-packages repo. This PR enables `OPENSSL_ENABLE_SHA1_SIGNATURES` for CentOS stream 9, as set by `_OverrideDistroDisablingSha1`

Pipeline run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2325804&view=logs&j=cd18f07a-0eff-5b1f-ddc2-be2e681458a1&t=7030a823-c29b-57ab-10e4-fa6ba4280626
