### PR TITLE
Add Mariner cross-compile VMR builds

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -255,19 +255,21 @@ jobs:
       docker run --rm -v "$(sourcesPath):/vmr" -w /vmr $customRunArgs ${{ parameters.container }} ./build.sh --clean-while-building $(additionalBuildArgs) $customBuildArgs $extraBuildProperties
     displayName: Build
 
-  - script: |
-      set -x
+  # Don't run tests if overriding RID, we don't support that for now
+  - ${{ if eq(parameters.overrideRid, '') }}:
+    - script: |
+        set -x
 
-      dockerVolumeArgs="-v $(sourcesPath):/vmr"
-      dockerEnvArgs="-e SMOKE_TESTS_EXCLUDE_OMNISHARP=${{ parameters.excludeOmniSharpTests }} -e SMOKE_TESTS_WARN_SDK_CONTENT_DIFFS=true -e SMOKE_TESTS_RUNNING_IN_CI=true"
-      poisonArg=''
+        dockerVolumeArgs="-v $(sourcesPath):/vmr"
+        dockerEnvArgs="-e SMOKE_TESTS_EXCLUDE_OMNISHARP=${{ parameters.excludeOmniSharpTests }} -e SMOKE_TESTS_WARN_SDK_CONTENT_DIFFS=true -e SMOKE_TESTS_RUNNING_IN_CI=true"
+        poisonArg=''
 
-      if [[ '${{ parameters.enablePoison }}' == 'True' ]]; then
-        poisonArg='--poison'
-      fi
+        if [[ '${{ parameters.enablePoison }}' == 'True' ]]; then
+          poisonArg='--poison'
+        fi
 
-      docker run --rm $dockerVolumeArgs -w /vmr $dockerEnvArgs ${{ parameters.container }} ./build.sh $poisonArg --run-smoke-test $(additionalBuildArgs) -- -p:SmokeTestConsoleVerbosity=detailed
-    displayName: Run Tests
+        docker run --rm $dockerVolumeArgs -w /vmr $dockerEnvArgs ${{ parameters.container }} ./build.sh $poisonArg --run-smoke-test $(additionalBuildArgs) -- -p:SmokeTestConsoleVerbosity=detailed
+      displayName: Run Tests
 
   # Don't use CopyFiles@2 as it encounters permissions issues because it indexes all files in the source directory graph.
   - script: |

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -239,7 +239,7 @@ jobs:
         customBuildArgs="$customBuildArgs --use-mono-runtime"
       fi
 
-      if [[ ! -z '${{ parameters.crossRootFs }}' || -! -z '${{ parameters.overrideRid }}' ]]; then
+      if [[ ! -z '${{ parameters.crossRootFs }}' || ! -z '${{ parameters.overrideRid }}' ]]; then
         extraBuildProperties="--"
       fi
 

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -61,6 +61,14 @@ parameters:
   type: boolean
   default: false
 
+- name: crossRootFS
+  type: string
+  default: ''
+
+- name: overrideRid
+  type: string
+  default: ''
+
 jobs:
 - job: ${{ parameters.buildName }}_${{ parameters.architecture }}
   timeoutInMinutes: 150
@@ -231,7 +239,20 @@ jobs:
         customBuildArgs="$customBuildArgs --use-mono-runtime"
       fi
 
-      docker run --rm -v "$(sourcesPath):/vmr" -w /vmr $customRunArgs ${{ parameters.container }} ./build.sh --clean-while-building $(additionalBuildArgs) $customBuildArgs
+      if [[ ! -z '${{ parameters.crossRootFs }}' || -! -z '${{ parameters.overrideRid }}' ]]; then
+        extraBuildProperties="--"
+      fi
+
+      if [[ ! -z '${{ parameters.crossRootFs }}' ]]; then
+        customRunArgs="$customRunArgs -e CROSSCOMPILE=1 -e ROOTFS_DIR=${{ parameters.crossRootFs}}"
+        extraBuildProperties="$extraBuildProperties /p:PortableBuild=true /p:DotNetBuildVertical=true"
+      fi
+
+      if [[ ! -z '${{ parameters.overrideRid }}' ]]; then
+        extraBuildProperties="$extraBuildProperties /p:OverrideTargetRid=${{ parameters.overrideRid }}"
+      fi
+
+      docker run --rm -v "$(sourcesPath):/vmr" -w /vmr $customRunArgs ${{ parameters.container }} ./build.sh --clean-while-building $(additionalBuildArgs) $customBuildArgs $extraBuildProperties
     displayName: Build
 
   - script: |

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -65,7 +65,7 @@ parameters:
   type: string
   default: ''
 
-- name: overrideRid
+- name: targetRid
   type: string
   default: ''
 
@@ -239,7 +239,7 @@ jobs:
         customBuildArgs="$customBuildArgs --use-mono-runtime"
       fi
 
-      if [[ ! -z '${{ parameters.crossRootFs }}' || ! -z '${{ parameters.overrideRid }}' ]]; then
+      if [[ ! -z '${{ parameters.crossRootFs }}' || ! -z '${{ parameters.targetRid }}' ]]; then
         extraBuildProperties="--"
       fi
 
@@ -248,15 +248,15 @@ jobs:
         extraBuildProperties="$extraBuildProperties /p:PortableBuild=true /p:DotNetBuildVertical=true"
       fi
 
-      if [[ ! -z '${{ parameters.overrideRid }}' ]]; then
-        extraBuildProperties="$extraBuildProperties /p:OverrideTargetRid=${{ parameters.overrideRid }}"
+      if [[ ! -z '${{ parameters.targetRid }}' ]]; then
+        extraBuildProperties="$extraBuildProperties /p:OverrideTargetRid=${{ parameters.targetRid }}"
       fi
 
       docker run --rm -v "$(sourcesPath):/vmr" -w /vmr $customRunArgs ${{ parameters.container }} ./build.sh --clean-while-building $(additionalBuildArgs) $customBuildArgs $extraBuildProperties
     displayName: Build
 
   # Don't run tests if overriding RID, we don't support that for now
-  - ${{ if eq(parameters.overrideRid, '') }}:
+  - ${{ if eq(parameters.targetRid, '') }}:
     - script: |
         set -x
 

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -22,8 +22,6 @@ parameters:
   fedora38Container: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-38
   ubuntu2204Container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04
   ubuntu2204ArmContainer: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-arm64
-  marinerX64CrossContainer: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64
-  marinerArm64CrossContainer: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm64
 
   # Internal builds
   poolInternalAmd64:
@@ -89,46 +87,6 @@ stages:
       runOnline: true                    # ✅
       useMonoRuntime: false              # 🚫
       withPreviousSDK: false             # 🚫
-
-  - template: ../jobs/vmr-build.yml
-    parameters:
-      # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-      buildName: MarinerCrossX64_Online_MsftSdk
-      isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-      vmrBranch: ${{ variables.VmrBranch }}
-      architecture: x64
-      pool:
-        name: ${{ variables.defaultPoolName }}
-        demands: ${{ variables.defaultPoolDemands }}
-      container: ${{ parameters.marinerx64CrossContainer }}
-      buildFromArchive: false            # 🚫
-      enablePoison: false                # 🚫
-      excludeOmniSharpTests: true        # ✅
-      runOnline: true                    # ✅
-      useMonoRuntime: true               # ✅
-      withPreviousSDK: false             # 🚫
-      crossRootFs: '/crossrootfs/x64'    # 📝
-      targetRid: 'linux-x64'             # 📝
-
-  - template: ../jobs/vmr-build.yml
-    parameters:
-      # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-      buildName: MarinerCrossArm64_Online_MsftSdk
-      isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-      vmrBranch: ${{ variables.VmrBranch }}
-      architecture: x64
-      pool:
-        name: ${{ variables.defaultPoolName }}
-        demands: ${{ variables.defaultPoolDemands }}
-      container: ${{ parameters.marinerArm64CrossContainer }}
-      buildFromArchive: false            # 🚫
-      enablePoison: false                # 🚫
-      excludeOmniSharpTests: true        # ✅
-      runOnline: true                    # ✅
-      useMonoRuntime: true               # ✅
-      withPreviousSDK: false             # 🚫
-      crossRootFs: '/crossrootfs/arm64'  # 📝
-      targetRid: 'linux-arm64'           # 📝
 
   - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
 

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -108,7 +108,7 @@ stages:
       useMonoRuntime: true               # ✅
       withPreviousSDK: false             # 🚫
       crossRootFs: '/crossrootfs/x64'    # 📝
-      overrideRid: 'linux-x64'           # 📝
+      targetRid: 'linux-x64'             # 📝
 
   - template: ../jobs/vmr-build.yml
     parameters:
@@ -128,7 +128,7 @@ stages:
       useMonoRuntime: true               # ✅
       withPreviousSDK: false             # 🚫
       crossRootFs: '/crossrootfs/arm64'  # 📝
-      overrideRid: 'linux-arm64'         # 📝
+      targetRid: 'linux-arm64'           # 📝
 
   - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
 

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -22,6 +22,8 @@ parameters:
   fedora38Container: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-38
   ubuntu2204Container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04
   ubuntu2204ArmContainer: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-arm64
+  marinerX64CrossContainer: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64
+  marinerArm64CrossContainer: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm64
 
   # Internal builds
   poolInternalAmd64:
@@ -87,6 +89,46 @@ stages:
       runOnline: true                    # ✅
       useMonoRuntime: false              # 🚫
       withPreviousSDK: false             # 🚫
+
+  - template: ../jobs/vmr-build.yml
+    parameters:
+      # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
+      buildName: MarinerCrossX64_Online_MsftSdk
+      isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+      vmrBranch: ${{ variables.VmrBranch }}
+      architecture: x64
+      pool:
+        name: ${{ variables.defaultPoolName }}
+        demands: ${{ variables.defaultPoolDemands }}
+      container: ${{ parameters.marinerx64CrossContainer }}
+      buildFromArchive: false            # 🚫
+      enablePoison: false                # 🚫
+      excludeOmniSharpTests: true        # ✅
+      runOnline: true                    # ✅
+      useMonoRuntime: true               # ✅
+      withPreviousSDK: false             # 🚫
+      crossRootFs: '/crossrootfs/x64'    # 📝
+      overrideRid: 'linux-x64'           # 📝
+
+  - template: ../jobs/vmr-build.yml
+    parameters:
+      # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
+      buildName: MarinerCrossArm64_Online_MsftSdk
+      isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+      vmrBranch: ${{ variables.VmrBranch }}
+      architecture: x64
+      pool:
+        name: ${{ variables.defaultPoolName }}
+        demands: ${{ variables.defaultPoolDemands }}
+      container: ${{ parameters.marinerArm64CrossContainer }}
+      buildFromArchive: false            # 🚫
+      enablePoison: false                # 🚫
+      excludeOmniSharpTests: true        # ✅
+      runOnline: true                    # ✅
+      useMonoRuntime: true               # ✅
+      withPreviousSDK: false             # 🚫
+      crossRootFs: '/crossrootfs/arm64'  # 📝
+      overrideRid: 'linux-arm64'         # 📝
 
   - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
 

--- a/eng/pipelines/templates/stages/vmr-cross-build.yml
+++ b/eng/pipelines/templates/stages/vmr-cross-build.yml
@@ -1,0 +1,107 @@
+### This stage source-builds https://github.com/dotnet/dotnet with varying parameters
+### If run in a PR, new changes are applied to a local copy of the VMR, then it is source-built and tested
+
+parameters:
+  dependsOn: []
+  condition: always()
+
+  # Branch of the VMR to use (to push to for internal builds)
+  vmrBranch: $(Build.SourceBranch)
+
+  # True when the build is a lite build
+  isLiteBuild:
+
+  # True when build is running from dotnet/dotnet directly
+  isBuiltFromVmr:
+
+  # The following parameters aren't expected to be passed in rather they are used for encapsulation
+  # -----------------------------------------------------------------------------------------------
+  marinerX64CrossContainer: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64
+  marinerArm64CrossContainer: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm64
+
+  # Internal builds
+  poolInternalAmd64:
+    name: NetCore1ESPool-Svc-Internal
+    demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+  poolInternalAmd64PR:
+    name: NetCore1ESPool-Internal-XL
+    demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+  poolInternalArm64:
+    name: Docker-Linux-Arm-Internal
+
+  # Public builds / PRs
+  poolPublicAmd64:
+    name: NetCore-Public-XL
+    demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
+
+stages:
+- stage: VMR_Source_Build
+  displayName: VMR Source-Build
+  dependsOn: ${{ parameters.dependsOn }}
+  condition: ${{ parameters.condition }}
+  variables:
+  - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+    - name: defaultPoolName
+      value: ${{ parameters.poolPublicAmd64.name }}
+    - name: defaultPoolDemands
+      value: ${{ parameters.poolPublicAmd64.demands }}
+  - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+    - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
+      - name: defaultPoolName
+        value: ${{ parameters.poolInternalAmd64PR.name }}
+      - name: defaultPoolDemands
+        value: ${{ parameters.poolInternalAmd64PR.demands }}
+    - ${{ else }}:
+      - name: defaultPoolName
+        value: ${{ parameters.poolInternalAmd64.name }}
+      - name: defaultPoolDemands
+        value: ${{ parameters.poolInternalAmd64.demands }}
+
+  - ${{ if ne(parameters.vmrBranch, '') }}:
+    - name: VmrBranch
+      value: ${{ parameters.vmrBranch }}
+  - ${{ else }}:
+    - name: VmrBranch
+      value: ${{ replace(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), 'refs/pull/', '') }}
+
+  jobs:
+
+  - template: ../jobs/vmr-build.yml
+    parameters:
+      # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
+      buildName: MarinerCrossX64_Online_MsftSdk
+      isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+      vmrBranch: ${{ variables.VmrBranch }}
+      architecture: x64
+      pool:
+        name: ${{ variables.defaultPoolName }}
+        demands: ${{ variables.defaultPoolDemands }}
+      container: ${{ parameters.marinerx64CrossContainer }}
+      buildFromArchive: false            # 🚫
+      enablePoison: false                # 🚫
+      excludeOmniSharpTests: true        # ✅
+      runOnline: true                    # ✅
+      useMonoRuntime: true               # ✅
+      withPreviousSDK: false             # 🚫
+      crossRootFs: '/crossrootfs/x64'    # 📝
+      targetRid: 'linux-x64'             # 📝
+
+  - template: ../jobs/vmr-build.yml
+    parameters:
+      # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
+      buildName: MarinerCrossArm64_Online_MsftSdk
+      isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+      vmrBranch: ${{ variables.VmrBranch }}
+      architecture: x64
+      pool:
+        name: ${{ variables.defaultPoolName }}
+        demands: ${{ variables.defaultPoolDemands }}
+      container: ${{ parameters.marinerArm64CrossContainer }}
+      buildFromArchive: false            # 🚫
+      enablePoison: false                # 🚫
+      excludeOmniSharpTests: true        # ✅
+      runOnline: true                    # ✅
+      useMonoRuntime: true               # ✅
+      withPreviousSDK: false             # 🚫
+      crossRootFs: '/crossrootfs/arm64'  # 📝
+      targetRid: 'linux-arm64'           # 📝

--- a/eng/pipelines/templates/stages/vmr-cross-build.yml
+++ b/eng/pipelines/templates/stages/vmr-cross-build.yml
@@ -35,7 +35,7 @@ parameters:
     demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
 
 stages:
-- stage: VMR_Source_Build
+- stage: VMR_PoC_Build
   displayName: VMR Source-Build
   dependsOn: ${{ parameters.dependsOn }}
   condition: ${{ parameters.condition }}

--- a/eng/pipelines/templates/stages/vmr-cross-build.yml
+++ b/eng/pipelines/templates/stages/vmr-cross-build.yml
@@ -36,7 +36,7 @@ parameters:
 
 stages:
 - stage: VMR_PoC_Build
-  displayName: VMR Source-Build
+  displayName: VMR PoC-Build
   dependsOn: ${{ parameters.dependsOn }}
   condition: ${{ parameters.condition }}
   variables:

--- a/src/SourceBuild/content/eng/pipelines/ci-crossbuild.yml
+++ b/src/SourceBuild/content/eng/pipelines/ci-crossbuild.yml
@@ -1,0 +1,27 @@
+# This is the dotnet/dotnet pipeline that is triggered every weekday at midnight PST (08:00 UTC) for "main" and when changes are pushed to release/* and internal/release/* branches.
+
+schedules:
+- cron: '0 8 * * Mon-Fri'
+  displayName: Weekday midnight build
+  branches:
+    include:
+    - main
+  batch: true
+
+trigger:
+  batch: true
+  branches:
+   include:
+   - release/*
+   - internal/release/*
+
+pr: none
+
+stages:
+- ${{ if ne(variables['Build.Reason'], 'Schedule') }}:
+  - template: templates/stages/vmr-scan.yml
+
+- template: /src/installer/eng/pipelines/templates/stages/vmr-cross-build.yml
+  parameters:
+    isBuiltFromVmr: true
+    isLiteBuild: false


### PR DESCRIPTION
Ref https://github.com/dotnet/source-build/issues/3671
Ref https://github.com/dotnet/source-build/issues/3699
Ref https://github.com/dotnet/source-build/issues/3654

Mono builds for now, until someone on CoreCLR can sign off on it working with CoreCLR instead (which it didn't last time I tried, but it might be better now)