### PR TITLE
Do not reuse existing installation of .NET CLI in SB prep script

### DIFF
--- a/src/SourceBuild/content/prep.sh
+++ b/src/SourceBuild/content/prep.sh
@@ -156,6 +156,7 @@ function BootstrapArtifacts {
 # Check for the version of dotnet to install
 if [ "$installDotnet" == true ]; then
   echo "  Installing dotnet..."
+  use_installed_dotnet_cli=false
   (source ./eng/common/tools.sh && InitializeDotNetCli true)
 fi
 


### PR DESCRIPTION
The [license scanning pipeline](https://github.com/dotnet/installer/blob/main/eng/pipelines/source-build-license-scan.yml) started failing a few days after the .NET 8 release in the `release/8.0.1xx` branch with the following error when attempting to run the tests:

```
/mnt/vss/_work/_temp/b1e87c0a-be03-4c81-9479-04ec3419f26c.sh: line 1: /mnt/vss/_work/1/s/.dotnet/dotnet: No such file or directory
```

The [step which installs the .NET CLI](https://github.com/dotnet/installer/blob/051677ef33279f1f0531f14d363c72ab0182abd2/eng/pipelines/source-build-license-scan.yml#L71-L72) was essentially a no-op, not installing it at all. This behavior began as a result of the agent version being updated to include .NET 8 preinstalled. The behavior of the eng/common/tools.sh script that is used to install the .NET CLI was [detecting this already installed version because it matched the version specified in global.json](https://github.com/dotnet/installer/blob/55d888791b88b97d86ff12b4e931dc3f0470a2df/eng/common/tools.sh#L146C108-L146C126). Because this installation was skipped, nothing existed at the expected installation location where the test execution was targeting.

The solution to this is to set a flag which causes the installation to skip the check for a matching installation.