### PR TITLE
Fix attribute type checking and use null-conditional operator

### DIFF
--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection/DummyAttributeTypeProvider.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection/DummyAttributeTypeProvider.cs
@@ -7,6 +7,8 @@ using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 
+#nullable enable
+
 namespace Microsoft.DotNet.SourceBuild.Tasks.LeakDetection
 {
 
@@ -32,3 +34,4 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.LeakDetection
         public bool IsSystemType(Type? type) => default(bool);
     }
 }
+

--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection/DummyAttributeTypeProvider.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection/DummyAttributeTypeProvider.cs
@@ -11,24 +11,24 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.LeakDetection
 {
 
     // An empty ICustomAttributeTypeProvider implementation is necessary to read metadata attribute values.
-    internal class DummyAttributeTypeProvider : ICustomAttributeTypeProvider<Type>
+    internal class DummyAttributeTypeProvider : ICustomAttributeTypeProvider<Type?>
     {
         public static readonly DummyAttributeTypeProvider Instance = new();
 
-        public Type GetPrimitiveType(PrimitiveTypeCode typeCode) => default(Type);
+        public Type? GetPrimitiveType(PrimitiveTypeCode typeCode) => default(Type);
 
-        public Type GetSystemType() => default(Type);
+        public Type? GetSystemType() => default(Type);
 
-        public Type GetSZArrayType(Type elementType) => default(Type);
+        public Type? GetSZArrayType(Type? elementType) => default(Type);
 
-        public Type GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind) => default(Type);
+        public Type? GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind) => default(Type);
 
-        public Type GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind) => default(Type);
+        public Type? GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind) => default(Type);
 
-        public Type GetTypeFromSerializedName(string name) => default(Type);
+        public Type? GetTypeFromSerializedName(string name) => default(Type);
 
-        public PrimitiveTypeCode GetUnderlyingEnumType(Type type) => default(PrimitiveTypeCode);
+        public PrimitiveTypeCode GetUnderlyingEnumType(Type? type) => default(PrimitiveTypeCode);
         
-        public bool IsSystemType(Type type) => default(bool);
+        public bool IsSystemType(Type? type) => default(bool);
     }
 }


### PR DESCRIPTION
This PR brings in changes from https://github.com/dotnet/source-build/issues/2804

These changes include:
- Using null-conditional operator in the `DummyAttributeTypeProvider`
- Adding support for checking `MemberReference TypeDefinition` and `MethodDefinition` assembly attribute types.

Addresses #https://github.com/dotnet/source-build/issues/3713