### PR TITLE
Update referenced SDK version for source build

### DIFF
--- a/src/SourceBuild/content/eng/Versions.props
+++ b/src/SourceBuild/content/eng/Versions.props
@@ -28,8 +28,8 @@
       of a .NET major or minor release, prebuilts may be needed. When the release is mature, prebuilts
       are not necessary, and this property is removed from the file.
     -->
-    <PrivateSourceBuiltSdkVersion>9.0.100-alpha.1.23567.1</PrivateSourceBuiltSdkVersion>
-    <PrivateSourceBuiltArtifactsVersion>9.0.100-alpha.1.23567.1</PrivateSourceBuiltArtifactsVersion>
+    <PrivateSourceBuiltSdkVersion>9.0.100-alpha.1.23603.1</PrivateSourceBuiltSdkVersion>
+    <PrivateSourceBuiltArtifactsVersion>9.0.100-alpha.1.23603.1</PrivateSourceBuiltArtifactsVersion>
     <PrivateSourceBuiltPrebuiltsVersion>0.1.0-9.0.100-6</PrivateSourceBuiltPrebuiltsVersion>
   </PropertyGroup>
 </Project>

--- a/src/SourceBuild/content/global.json
+++ b/src/SourceBuild/content/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "9.0.100-alpha.1.23524.3"
+    "dotnet": "9.0.100-alpha.1.23603.1"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.1",


### PR DESCRIPTION
The build of the SBRP repo in the VMR is failing for offline builds with this error:

```
/vmr/src/source-build-reference-packages/artifacts/source-build/self/src/src/referencePackages/src/system.io.hashing/8.0.0/System.IO.Hashing.8.0.0.csproj : error NU1102: Unable to find package Microsoft.NETCore.App.Ref with version (= 8.0.0-rc.2.23479.6) [/vmr/prereqs/packages/restored/ArcadeBootstrapPackage/microsoft.dotnet.arcade.sdk/9.0.0-beta.23565.1/tools/Build.proj]
```

This occurs when attempting to build a project that references `net8.0`. It attempts to load the RC2 version of Microsoft.NETCore.App.Ref because the currently referenced SDK version is referencing RC2 in its Microsoft.NETCoreSdk.BundledVersions.props file.

These changes bootstrap source build with a newer SDK version which has an updated Microsoft.NETCoreSdk.BundledVersions.props file that references 8.0.0 instead.

Use of the 8.0.0 version will succeed in the build because SBRP has already been updated to include a targeting pack for that version: https://github.com/dotnet/source-build-reference-packages/pull/829