### PR TITLE
Use Directory.Build.props only

### DIFF
--- a/src/SourceBuild/content/src/Directory.Build.props
+++ b/src/SourceBuild/content/src/Directory.Build.props
@@ -1,7 +1,10 @@
 <Project>
 
-  <!--
-    Prevent repo src automatic Directory.Build imports from finding source-build infra.
-  -->
+  <!-- This is an empty Directory.Build.props file to prevent projects which reside
+       under this directory to use any of the repository local settings. -->
+  <PropertyGroup>
+    <ImportDirectoryPackagesProps>false</ImportDirectoryPackagesProps>
+    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+  </PropertyGroup>
 
 </Project>

--- a/src/SourceBuild/content/src/Directory.Build.targets
+++ b/src/SourceBuild/content/src/Directory.Build.targets
@@ -1,7 +1,0 @@
-<Project>
-
-  <!--
-    Prevent repo src automatic Directory.Build imports from finding source-build infra.
-  -->
-
-</Project>

--- a/src/SourceBuild/content/test/Directory.Build.props
+++ b/src/SourceBuild/content/test/Directory.Build.props
@@ -1,7 +1,10 @@
 <Project>
 
-  <!--
-    Prevent repo src automatic Directory.Build imports from finding source-build infra.
-  -->
+  <!-- This is an empty Directory.Build.props file to prevent projects which reside
+       under this directory to use any of the repository local settings. -->
+  <PropertyGroup>
+    <ImportDirectoryPackagesProps>false</ImportDirectoryPackagesProps>
+    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+  </PropertyGroup>
 
 </Project>

--- a/src/SourceBuild/content/test/Directory.Build.targets
+++ b/src/SourceBuild/content/test/Directory.Build.targets
@@ -1,7 +1,0 @@
-<Project>
-
-  <!--
-    Prevent repo src automatic Directory.Build imports from finding source-build infra.
-  -->
-
-</Project>


### PR DESCRIPTION
This is the pattern that we follow in the Arcade.Sdk which also prevents accidental Central Package Management uses (Directory.Packages.props is automatically picked-up if it exists).