### PR TITLE
Delete target for SourceLink packages

### DIFF
--- a/src/SourceBuild/content/Directory.Build.targets
+++ b/src/SourceBuild/content/Directory.Build.targets
@@ -1,15 +1,5 @@
 <Project>
 
-  <Target Name="RemoveUninteresingToolingPackageReferences"
-          BeforeTargets="CollectPackageReferences">
-    <!-- The source-build infra doesn't need sourcelink. Avoid this prebuilt. -->
-    <ItemGroup>
-      <PackageReference Remove="Microsoft.SourceLink.GitHub" />
-      <PackageReference Remove="Microsoft.SourceLink.Vsts.Git" />
-      <PackageReference Remove="Microsoft.SourceLink.AzureRepos.Git" />
-    </ItemGroup>
-  </Target>
-
   <Target Name="DetermineMicrosoftSourceBuildIntermediateInstallerVersion">
     <!-- Manually load the installer version from the PVP.     -->
     <XmlPeek XmlInputPath="$(IntermediatePath)PackageVersions.package-source-build.Current.props"


### PR DESCRIPTION
SourceLink packages aren't brought in via Arcade anymore.

- Please add description for changes you are making.
- If there is an issue related to this PR, please add the reference.
