### PR TITLE
Always run vmr-scan

### DIFF
--- a/src/SourceBuild/content/eng/pipelines/ci.yml
+++ b/src/SourceBuild/content/eng/pipelines/ci.yml
@@ -18,8 +18,7 @@ trigger:
 pr: none
 
 stages:
-- ${{ if ne(variables['Build.Reason'], 'Schedule') }}:
-  - template: templates/stages/vmr-scan.yml
+- template: templates/stages/vmr-scan.yml
 
 - template: /src/installer/eng/pipelines/templates/stages/vmr-build.yml
   parameters:


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/3747

This PR allows the `vmr-scan` stage for the dotnet-dotnet pipeline to always run regardless of the build reason.