### PR TITLE
Add templating patch to target net9.0

### DIFF
--- a/src/SourceBuild/patches/templating/0001-Set-NETCoreTargetFramework-to-net9.0.patch
+++ b/src/SourceBuild/patches/templating/0001-Set-NETCoreTargetFramework-to-net9.0.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matt Thalman <mthalman@microsoft.com>
+Date: Tue, 12 Dec 2023 10:49:01 -0600
+Subject: [PATCH] Set NETCoreTargetFramework to net9.0
+
+Backport: https://github.com/dotnet/source-build/issues/3663
+---
+ Directory.Build.props | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Directory.Build.props b/Directory.Build.props
+index 6370d08a9..7292506cd 100644
+--- a/Directory.Build.props
++++ b/Directory.Build.props
+@@ -5,7 +5,7 @@
+ 
+     <PropertyGroup>
+         <LangVersion>preview</LangVersion>
+-        <NETCoreTargetFramework>net8.0</NETCoreTargetFramework>
++        <NETCoreTargetFramework>net9.0</NETCoreTargetFramework>
+         <NETStandardTargetFramework>netstandard2.0</NETStandardTargetFramework>
+         <NETFullTargetFramework>net48</NETFullTargetFramework>
+         <Product>Microsoft .NET Core</Product>

--- a/src/SourceBuild/patches/templating/0001-Set-NETCoreTargetFramework-to-net9.0.patch
+++ b/src/SourceBuild/patches/templating/0001-Set-NETCoreTargetFramework-to-net9.0.patch
@@ -9,7 +9,7 @@ Backport: https://github.com/dotnet/source-build/issues/3663
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Directory.Build.props b/Directory.Build.props
-index 3d5fc9726..dfc909211 100644
+index 6370d08a9..7292506cd 100644
 --- a/Directory.Build.props
 +++ b/Directory.Build.props
 @@ -5,7 +5,7 @@
@@ -19,5 +19,5 @@ index 3d5fc9726..dfc909211 100644
 -        <NETCoreTargetFramework>net8.0</NETCoreTargetFramework>
 +        <NETCoreTargetFramework>net9.0</NETCoreTargetFramework>
          <NETStandardTargetFramework>netstandard2.0</NETStandardTargetFramework>
-         <NETFullTargetFramework>net472</NETFullTargetFramework>
+         <NETFullTargetFramework>net48</NETFullTargetFramework>
          <Product>Microsoft .NET Core</Product>

--- a/src/SourceBuild/patches/templating/0001-Set-NETCoreTargetFramework-to-net9.0.patch
+++ b/src/SourceBuild/patches/templating/0001-Set-NETCoreTargetFramework-to-net9.0.patch
@@ -9,7 +9,7 @@ Backport: https://github.com/dotnet/source-build/issues/3663
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Directory.Build.props b/Directory.Build.props
-index 6370d08a9..7292506cd 100644
+index 3d5fc9726..dfc909211 100644
 --- a/Directory.Build.props
 +++ b/Directory.Build.props
 @@ -5,7 +5,7 @@
@@ -19,5 +19,5 @@ index 6370d08a9..7292506cd 100644
 -        <NETCoreTargetFramework>net8.0</NETCoreTargetFramework>
 +        <NETCoreTargetFramework>net9.0</NETCoreTargetFramework>
          <NETStandardTargetFramework>netstandard2.0</NETStandardTargetFramework>
-         <NETFullTargetFramework>net48</NETFullTargetFramework>
+         <NETFullTargetFramework>net472</NETFullTargetFramework>
          <Product>Microsoft .NET Core</Product>


### PR DESCRIPTION
An offline build of the VMR fails during the templating repo due to prebuilts of 8.0 ref packs. This is because the projects are targeting `net8.0`. This resolves it by adding a patch to target `net9.0` instead.