### PR TITLE
Add back security-partners-dotnet pipeline

### DIFF
--- a/src/SourceBuild/tarball/content/eng/pipelines/security-partners-dotnet.yml
+++ b/src/SourceBuild/tarball/content/eng/pipelines/security-partners-dotnet.yml
@@ -1,0 +1,33 @@
+# DO NOT DELETE: This is used to validate PRs in the internal security-partners-dotnet repo
+
+trigger: none
+
+variables:
+- name: cfsNPMWarnLevel
+  value: none
+
+- name: cfsNugetWarnLevel
+  value: none
+
+- name: myGetWarnLevel
+  value: none
+
+- name: NuGetSecurityAnalysisWarningLevel
+  value: none
+
+jobs:
+- template: ../../src/installer/src/SourceBuild/Arcade/eng/common/templates/job/source-build-build-tarball.yml
+  parameters:
+    architecture: x64
+    excludeSdkContentTests: true
+    matrix:
+      Ubuntu1804-Offline:
+        _BootstrapPrep: false
+        _Container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04
+        _EnablePoison: false
+        _ExcludeOmniSharpTests: false
+        _RunOnline: false
+    name: Build_Tarball_x64
+    pool:
+      name: NetCore1ESPool-Svc-Internal
+      demands: ImageOverride -equals Build.Ubuntu.1804.Amd64


### PR DESCRIPTION
This was erroneously deleted in https://github.com/dotnet/installer/pull/17696. This pipeline is needed to run PR validation for the internal security-partners-dotnet repo.