### PR TITLE
Add back security-partners-dotnet pipeline

### DIFF
--- a/src/SourceBuild/tarball/content/eng/pipelines/security-partners-dotnet.yml
+++ b/src/SourceBuild/tarball/content/eng/pipelines/security-partners-dotnet.yml
@@ -1,0 +1,32 @@
+trigger: none
+
+variables:
+- name: cfsNPMWarnLevel
+  value: none
+
+- name: cfsNugetWarnLevel
+  value: none
+
+- name: myGetWarnLevel
+  value: none
+
+- name: NuGetSecurityAnalysisWarningLevel
+  value: none
+
+jobs:
+- template: ../../src/installer/src/SourceBuild/Arcade/eng/common/templates/job/source-build-build-tarball.yml
+  parameters:
+    architecture: x64
+    excludeSdkContentTests: true
+    matrix:
+      Ubuntu2004-Offline:
+        _BootstrapPrep: true
+        _Container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04
+        _EnablePoison: false
+        _ExcludeOmniSharpTests: false
+        _RunOnline: false
+        _WithPreviousSDK: false
+    name: Build_Tarball_x64
+    pool:
+      name: NetCore1ESPool-Svc-Internal
+      demands: ImageOverride -equals Build.Ubuntu.1804.Amd64


### PR DESCRIPTION
Related to the changes in https://github.com/dotnet/installer/pull/17955, but uses configuration specific to 7.0.