### PR TITLE
Remove global CheckEolTargetFramework=false

### DIFF
--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -119,9 +119,6 @@
     <EnvironmentVariables Include="DeterministicSourcePaths=false" Condition="'$(DeterministicBuildOptOut)' == 'true'" />
 
     <EnvironmentVariables Include="SourceRoot=$(ProjectDirectory)" />
-
-    <!-- https://github.com/dotnet/source-build/issues/3081 -->
-    <EnvironmentVariables Include="CheckEolTargetFramework=false" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(EnableExtraDebugging)' == 'true'">


### PR DESCRIPTION
Closes https://github.com/dotnet/source-build/issues/3081

This PR removes the setting of CheckEolTargetFramework=false globally.

These changes should also be backported to 8.0