### PR TITLE
Remove DotNetCoreSdkDir

### DIFF
--- a/src/SourceBuild/content/repo-projects/msbuild.proj
+++ b/src/SourceBuild/content/repo-projects/msbuild.proj
@@ -10,7 +10,6 @@
     <BuildCommandArgs>$(BuildCommandArgs) $(FlagParameterPrefix)nodereuse $(ArcadeFalseBoolBuildArg)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) $(FlagParameterPrefix)warnAsError $(ArcadeFalseBoolBuildArg)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) $(OutputVersionArgs)</BuildCommandArgs>
-    <BuildCommandArgs>$(BuildCommandArgs) /p:DotNetCoreSdkDir=$(DotNetCliToolDir)</BuildCommandArgs>
     <BuildCommand>$(StandardSourceBuildCommand) $(BuildCommandArgs)</BuildCommand>
   </PropertyGroup>
 


### PR DESCRIPTION
Remove explicit CoreSdk directory set. This is passed in via DOTNET_INSTALL_DIR
