### PR TITLE
Remove unused Microsoft.Build.CentralPackageVersions

### DIFF
--- a/src/SourceBuild/content/global.json
+++ b/src/SourceBuild/content/global.json
@@ -3,7 +3,6 @@
     "dotnet": "9.0.100-alpha.1.23603.1"
   },
   "msbuild-sdks": {
-    "Microsoft.Build.CentralPackageVersions": "2.0.1",
     "Microsoft.Build.Traversal": "2.0.2",
     "Microsoft.NET.Sdk.IL": "3.0.0-preview-27107-01",
     "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21304.1",

--- a/src/SourceBuild/content/repo-projects/msbuild.proj
+++ b/src/SourceBuild/content/repo-projects/msbuild.proj
@@ -2,8 +2,6 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <OutputVersionArgs>$(OutputVersionArgs) /p:DisableNerdbankVersioning=true</OutputVersionArgs>
-
     <LogVerbosityOptOut>true</LogVerbosityOptOut>
     <BuildCommandArgs>$(StandardSourceBuildArgs)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) $(FlagParameterPrefix)v $(LogVerbosity)</BuildCommandArgs>

--- a/src/SourceBuild/content/repo-projects/msbuild.proj
+++ b/src/SourceBuild/content/repo-projects/msbuild.proj
@@ -15,7 +15,6 @@
 
   <ItemGroup>
     <UseSourceBuiltSdkOverride Include="@(ArcadeSdkOverride)" />
-    <UseSourceBuiltSdkOverride Include="@(CentralVersionsSdkOverride)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -23,44 +22,6 @@
     <RepositoryReference Include="runtime" />
     <RepositoryReference Include="roslyn" />
   </ItemGroup>
-
-  <!--
-    Begin workaround: https://github.com/dotnet/source-build/issues/933
-
-    The CentralPackageVersions SDK isn't actually source-built. We get it as a text-only prebuilt,
-    but the NuGet resolver seems flaky so we're using our resolver instead. We only have access to
-    the nupkg ahead of time when building, so only enable this workaround then.
-  -->
-  <ItemGroup>
-    <CentralPackageVersionsSdkOverride Include="Microsoft.Build.CentralPackageVersions" Group="CENTRAL_PACKAGE_VERSIONS" />
-  </ItemGroup>
-
-  <Target Name="ExtractCentralPackageVersionsSdkPackage"
-          BeforeTargets="SetSourceBuiltSdkOverrides"
-          Inputs="$(MSBuildProjectFullPath)"
-          Outputs="$(RepoCompletedSemaphorePath)ExtractCentralPackageVersionsSdkPackage.complete">
-    <ItemGroup>
-      <_CentralVersionsToolPackage
-        Include="$(ReferencePackagesDir)%(CentralPackageVersionsSdkOverride.Identity)*.nupkg"
-        Id="%(CentralPackageVersionsSdkOverride.Identity)" />
-    </ItemGroup>
-
-    <PropertyGroup>
-      <CentralVersionsSdkDir>$(SourceBuiltSdksDir)%(_CentralVersionsToolPackage.Id)/</CentralVersionsSdkDir>
-    </PropertyGroup>
-
-    <Message Importance="High" Text="Setting up SDK package for UseSourceBuiltSdkOverride: %(_CentralVersionsToolPackage.Filename)" />
-
-    <ZipFileExtractToDirectory
-      SourceArchive="@(_CentralVersionsToolPackage)"
-      DestinationDirectory="$(CentralVersionsSdkDir)"
-      OverwriteDestination="true" />
- 
-    <WriteLinesToFile File="$(RepoCompletedSemaphorePath)ExtractCentralPackageVersionsSdkPackage.complete" Overwrite="true" />
-  </Target>
-  <!--
-    End workaround: https://github.com/dotnet/source-build/issues/933
-  -->
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>


### PR DESCRIPTION
MSBuild used that msbuild sdk but it's now unused and should be deleted from the VMR and SBRP.
