### PR TITLE
Add nuget-client patch for shortening sb inner clone path

### DIFF
--- a/src/SourceBuild/patches/nuget-client/0001-Shorten-source-build-inner-clone-paths-5543.patch
+++ b/src/SourceBuild/patches/nuget-client/0001-Shorten-source-build-inner-clone-paths-5543.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ella Hathaway <67609881+ellahathaway@users.noreply.github.com>
+Date: Fri, 15 Dec 2023 10:01:14 -0800
+Subject: [PATCH] Shorten source-build inner clone paths (#5543)
+
+Backport: https://github.com/NuGet/NuGet.Client/pull/5543
+---
+ eng/pipelines/templates/Source_Build.yml | 2 +-
+ eng/source-build/build.sh                | 4 ++--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/eng/pipelines/templates/Source_Build.yml b/eng/pipelines/templates/Source_Build.yml
+index 7163c617e..842904c4f 100644
+--- a/eng/pipelines/templates/Source_Build.yml
++++ b/eng/pipelines/templates/Source_Build.yml
+@@ -12,7 +12,7 @@ steps:
+   condition: "or(failed(), eq(variables['System.debug'], 'true'))"
+   continueOnError: true
+   inputs:
+-    PathToPublish: "artifacts/source-build/self/log/source-build.binlog"
++    PathToPublish: "artifacts/sb/log/source-build.binlog"
+     ArtifactName: "Source-build log"
+     ArtifactType: Container
+ 
+diff --git a/eng/source-build/build.sh b/eng/source-build/build.sh
+index 292b0fff8..cdf226b06 100755
+--- a/eng/source-build/build.sh
++++ b/eng/source-build/build.sh
+@@ -85,7 +85,7 @@ ReadGlobalVersion Microsoft.DotNet.Arcade.Sdk
+ export ARCADE_VERSION=$_ReadGlobalVersion
+ 
+ if [ -z "$DotNetBuildFromSourceFlavor" ] || [ "$DotNetBuildFromSourceFlavor" != "Product" ]; then
+-  export NUGET_PACKAGES=$scriptroot/../../artifacts/source-build/self/package-cache/
++  export NUGET_PACKAGES=$scriptroot/../../artifacts/sb/package-cache/
+ fi
+ 
+-"$DOTNET" msbuild "$scriptroot/source-build.proj" /p:Configuration=$configuration /p:DotNetBuildFromSource=true /p:ArcadeBuildFromSource=true "/p:RepoRoot=$scriptroot/../../" "/bl:$scriptroot/../../artifacts/source-build/self/log/source-build.binlog" $args
++"$DOTNET" msbuild "$scriptroot/source-build.proj" /p:Configuration=$configuration /p:DotNetBuildFromSource=true /p:ArcadeBuildFromSource=true "/p:RepoRoot=$scriptroot/../../" "/bl:$scriptroot/../../artifacts/sb/log/source-build.binlog" $args


### PR DESCRIPTION
This is a patch for changes in https://github.com/NuGet/NuGet.Client/pull/5543 related to shortening the source-build inner clone path from `source-build/self` to `sb`