### PR TITLE
Move VMR component list into `Components.md`

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "microsoft.dotnet.darc": {
-      "version": "1.1.0-beta.23620.3",
+      "version": "1.1.0-beta.23621.2",
       "commands": [
         "darc"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "microsoft.dotnet.darc": {
-      "version": "1.1.0-beta.23619.2",
+      "version": "1.1.0-beta.23620.3",
       "commands": [
         "darc"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "microsoft.dotnet.darc": {
-      "version": "1.1.0-beta.23621.2",
+      "version": "1.1.0-beta.23621.3",
       "commands": [
         "darc"
       ]

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -224,13 +224,13 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>7e95c635fb04fb81595c777ab6f3701474b9da43</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Darc" Version="1.1.0-beta.23619.2">
+    <Dependency Name="Microsoft.DotNet.Darc" Version="1.1.0-beta.23620.3">
       <Uri>https://github.com/dotnet/arcade-services</Uri>
-      <Sha>57c61af10606819426d205193aa0e9f2f1672050</Sha>
+      <Sha>a27032bc7b839bea8d48735f2e1d8b3e6b4290a5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.DarcLib" Version="1.1.0-beta.23619.2">
+    <Dependency Name="Microsoft.DotNet.DarcLib" Version="1.1.0-beta.23620.3">
       <Uri>https://github.com/dotnet/arcade-services</Uri>
-      <Sha>57c61af10606819426d205193aa0e9f2f1672050</Sha>
+      <Sha>a27032bc7b839bea8d48735f2e1d8b3e6b4290a5</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XliffTasks" Version="9.0.0-beta.23619.4">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -224,13 +224,13 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>7e95c635fb04fb81595c777ab6f3701474b9da43</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Darc" Version="1.1.0-beta.23620.3">
+    <Dependency Name="Microsoft.DotNet.Darc" Version="1.1.0-beta.23621.2">
       <Uri>https://github.com/dotnet/arcade-services</Uri>
-      <Sha>a27032bc7b839bea8d48735f2e1d8b3e6b4290a5</Sha>
+      <Sha>b36b90e324a45493202911635ac9f9b25066d90a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.DarcLib" Version="1.1.0-beta.23620.3">
+    <Dependency Name="Microsoft.DotNet.DarcLib" Version="1.1.0-beta.23621.2">
       <Uri>https://github.com/dotnet/arcade-services</Uri>
-      <Sha>a27032bc7b839bea8d48735f2e1d8b3e6b4290a5</Sha>
+      <Sha>b36b90e324a45493202911635ac9f9b25066d90a</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XliffTasks" Version="9.0.0-beta.23619.4">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -224,13 +224,13 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>7e95c635fb04fb81595c777ab6f3701474b9da43</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Darc" Version="1.1.0-beta.23621.2">
+    <Dependency Name="Microsoft.DotNet.Darc" Version="1.1.0-beta.23621.3">
       <Uri>https://github.com/dotnet/arcade-services</Uri>
-      <Sha>b36b90e324a45493202911635ac9f9b25066d90a</Sha>
+      <Sha>702f946f89ace6197fdca2ac309d32187c4bc1bd</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.DarcLib" Version="1.1.0-beta.23621.2">
+    <Dependency Name="Microsoft.DotNet.DarcLib" Version="1.1.0-beta.23621.3">
       <Uri>https://github.com/dotnet/arcade-services</Uri>
-      <Sha>b36b90e324a45493202911635ac9f9b25066d90a</Sha>
+      <Sha>702f946f89ace6197fdca2ac309d32187c4bc1bd</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XliffTasks" Version="9.0.0-beta.23619.4">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,7 +44,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/arcade-services -->
-    <MicrosoftDotNetDarcLibVersion>1.1.0-beta.23620.3</MicrosoftDotNetDarcLibVersion>
+    <MicrosoftDotNetDarcLibVersion>1.1.0-beta.23621.2</MicrosoftDotNetDarcLibVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/winforms -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,7 +44,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/arcade-services -->
-    <MicrosoftDotNetDarcLibVersion>1.1.0-beta.23619.2</MicrosoftDotNetDarcLibVersion>
+    <MicrosoftDotNetDarcLibVersion>1.1.0-beta.23620.3</MicrosoftDotNetDarcLibVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/winforms -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,7 +44,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/arcade-services -->
-    <MicrosoftDotNetDarcLibVersion>1.1.0-beta.23621.2</MicrosoftDotNetDarcLibVersion>
+    <MicrosoftDotNetDarcLibVersion>1.1.0-beta.23621.3</MicrosoftDotNetDarcLibVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependency from https://github.com/dotnet/winforms -->

--- a/eng/pipelines/templates/steps/vmr-pull-updates.yml
+++ b/eng/pipelines/templates/steps/vmr-pull-updates.yml
@@ -58,7 +58,7 @@ steps:
     --repository "installer:${{ parameters.targetRef }}"
     --recursive
     --remote "installer:$(pwd)"
-    --readme-template $(Agent.BuildDirectory)/installer/src/VirtualMonoRepo/README.template.md
+    --component-template $(Agent.BuildDirectory)/installer/src/VirtualMonoRepo/Component.template.md
     --tpn-template $(Agent.BuildDirectory)/installer/src/VirtualMonoRepo/THIRD-PARTY-NOTICES.template.txt
     --debug
     ||

--- a/eng/vmr-sync.sh
+++ b/eng/vmr-sync.sh
@@ -33,10 +33,10 @@
 ###   --debug
 ###       Optional. Turns on the most verbose logging for the VMR tooling
 ###
-###   --readme-template
-###       Optional. Template for VMRs README.md used for regenerating the file to list the newest versions of
+###   --component-template
+###       Optional. Template for VMRs Component.md used for regenerating the file to list the newest versions of
 ###       components.
-###       Defaults to src/VirtualMonoRepo/README.template.md
+###       Defaults to src/VirtualMonoRepo/Component.template.md
 ###
 ###   --recursive
 ###       Optional. Recursively synchronize all the source build dependencies (declared in Version.Details.xml)
@@ -104,7 +104,7 @@ repository=''
 additional_remotes=''
 recursive=false
 verbosity=verbose
-readme_template="$installer_dir/src/VirtualMonoRepo/README.template.md"
+readme_template="$installer_dir/src/VirtualMonoRepo/Component.template.md"
 tpn_template="$installer_dir/src/VirtualMonoRepo/THIRD-PARTY-NOTICES.template.txt"
 azdev_pat=''
 
@@ -139,8 +139,8 @@ while [[ $# -gt 0 ]]; do
       additional_remotes="$additional_remotes $2"
       shift
       ;;
-    --readme-template)
-      readme_template=$2
+    --component-template)
+      component_template=$2
       shift
       ;;
     --tpn-template)
@@ -268,7 +268,7 @@ fi
   --$verbosity                               \
   $recursive_arg                             \
   $additional_remotes                        \
-  --readme-template "$readme_template"       \
+  --component-template "$component_template" \
   --tpn-template "$tpn_template"             \
   --discard-patches                          \
   "$repository"

--- a/src/SourceBuild/content/README.md
+++ b/src/SourceBuild/content/README.md
@@ -160,11 +160,7 @@ To enable full offline source-building of the VMR, we have no other choice than 
 
 ### Detailed list
 
-<!-- component list beginning -->
-
-> Auto-generated list of components will go here
-
-<!-- component list end -->
+The full list of components synchronized into the VMR is [here (Components.md)](./Components.md).
 
 The repository also contains a [JSON manifest](https://github.com/dotnet/dotnet/blob/main/src/source-manifest.json) listing all components in a machine-readable format.
 

--- a/src/VirtualMonoRepo/Component.template.md
+++ b/src/VirtualMonoRepo/Component.template.md
@@ -1,0 +1,15 @@
+# List of components
+
+To enable full offline source-building of the VMR, we have no other choice than to synchronize all the necessary code into the VMR. This also includes any code referenced via git submodules. More details on why and how this is done can be found here:
+- [Strategy for managing external source dependencies](src/arcade/Documentation/UnifiedBuild/VMR-Strategy-For-External-Source.md)
+- [Source Synchronization Process](src/arcade/Documentation/UnifiedBuild/VMR-Design-And-Operation.md#source-synchronization-process)
+
+## Detailed list
+
+<!-- component list beginning -->
+
+> Auto-generated list of components will go here
+
+<!-- component list end -->
+
+The repository also contains a [JSON manifest](https://github.com/dotnet/dotnet/blob/main/src/source-manifest.json) listing all components in a machine-readable format.

--- a/src/VirtualMonoRepo/InitializeVMR.proj
+++ b/src/VirtualMonoRepo/InitializeVMR.proj
@@ -58,7 +58,7 @@
       VmrPath="$(VmrDir)"
       TmpPath="$(TmpDir)"
       InstallerPath="$(RepoRoot)"
-      ReadmeTemplatePath="$(MSBuildThisFileDirectory)/README.template.md"
+      ComponentTemplatePath="$(MSBuildThisFileDirectory)/Component.template.md"
       TpnTemplatePath="$(MSBuildThisFileDirectory)/THIRD-PARTY-NOTICES.template.txt"
       SourceMappingsPath="$(MSBuildThisFileDirectory)/source-mappings.json" />
 

--- a/src/VirtualMonoRepo/Tasks/VirtualMonoRepo_Initialize.cs
+++ b/src/VirtualMonoRepo/Tasks/VirtualMonoRepo_Initialize.cs
@@ -42,7 +42,7 @@ public class VirtualMonoRepo_Initialize : Build.Utilities.Task, ICancelableTask
 
     public string InstallerPath { get; set; }
 
-    public string ReadmeTemplatePath { get; set; }
+    public string ComponentTemplatePath { get; set; }
 
     public string TpnTemplatePath { get; set; }
 
@@ -72,7 +72,7 @@ public class VirtualMonoRepo_Initialize : Build.Utilities.Task, ICancelableTask
             Recursive,
             new NativePath(SourceMappingsPath),
             additionalRemotes,
-            ReadmeTemplatePath,
+            ComponentTemplatePath,
             TpnTemplatePath,
             generateCodeowners: false,
             discardPatches: true,


### PR DESCRIPTION
`README.md` becomes static and the live list of components goes in a file

https://github.com/dotnet/arcade-services/issues/2917