### PR TITLE
Fix VMR build tagging

### DIFF
--- a/eng/pipelines/templates/jobs/sdk-diff-tests.yml
+++ b/eng/pipelines/templates/jobs/sdk-diff-tests.yml
@@ -38,7 +38,7 @@ jobs:
       
       echo "Dotnet-dotnet build: https://dev.azure.com/dnceng/internal/_build/results?buildId=$dotnet_dotnet_build&view=results"
 
-      installer_sha=$(az pipelines build tag list --organization '$(AZDO_ORG)' --project '$(AZDO_PROJECT)' --build-id $dotnet_dotnet_build --output tsv | sed "s,installer-,,g")
+      installer_sha=$(az pipelines build tag list --organization '$(AZDO_ORG)' --project '$(AZDO_PROJECT)' --build-id $dotnet_dotnet_build --output tsv | sed "s,installer ,,g")
       installer_build=$(az pipelines runs list --organization '$(AZDO_ORG)' --project '$(AZDO_PROJECT)' --pipeline-ids '$(INSTALLER_OFFICIAL_CI_PIPELINE_ID)' --query "[?sourceVersion == '$installer_sha'].id" --output tsv)
       if [[ -z "$installer_build" ]]; then
         echo "Could not find a build of installer for commit '$installer_sha'"

--- a/src/SourceBuild/content/eng/pipelines/templates/stages/vmr-scan.yml
+++ b/src/SourceBuild/content/eng/pipelines/templates/stages/vmr-scan.yml
@@ -28,7 +28,7 @@ stages:
     - script: |
         set -e
         sha=`./.dotnet/dotnet darc vmr get-version --vmr "$(Build.SourcesDirectory)" installer`
-        echo "##vso[build.addbuildtag]installer-$sha"
+        echo "##vso[build.addbuildtag]$sha"
       displayName: Tag the build
       workingDirectory: $(Build.SourcesDirectory)/src/installer
 


### PR DESCRIPTION
The source-build-sdk-diff-tests pipeline is failing in the main branch when attempting to find an associated installer build. Here's an example of the output:

```
Could not find a build of installer for commit 'installer 29db8a1157d69ade22d933d666ea5ec21a42c8c8'
```

You can see that the commit value is incorrect because it has `installer ` in the value. That's why it's not able to find an associated build on that commit because it's an invalid commit value. The incorrect value stems from the VMR build not being tagged correctly. As an example, it has the following tag:

```
installer-installer 29db8a1157d69ade22d933d666ea5ec21a42c8c8
```

This gets [parsed using sed](https://github.com/dotnet/installer/blob/7a73043e8a740e0ed0389684d4864ba12fb526a0/eng/pipelines/templates/jobs/sdk-diff-tests.yml#L41) to the value we were seeing before: `installer 29db8a1157d69ade22d933d666ea5ec21a42c8c8`. The reason for `installer` showing up twice is that a new [change from darc](https://github.com/dotnet/arcade-services/pull/3107) is adding it automatically.

To fix this, the logic which prepends `installer-` has been removed and the parsing logic has been updated to expect the syntax `installer <sha>` instead of `installer-<sha>`.