### PR TITLE
Remove MicrosoftSourceLinkVersion usage

### DIFF
--- a/src/SourceBuild/content/build.sh
+++ b/src/SourceBuild/content/build.sh
@@ -236,13 +236,7 @@ if [[ $arcadeSdkLine =~ $versionPattern ]]; then
   export SOURCE_BUILT_SDK_DIR_ARCADE=$packagesRestoredDir/ArcadeBootstrapPackage/microsoft.dotnet.arcade.sdk/$ARCADE_BOOTSTRAP_VERSION
 fi
 
-sourceLinkLine=$(grep -m 1 'MicrosoftSourceLinkCommonVersion' "$packageVersionsPath")
-versionPattern="<MicrosoftSourceLinkCommonVersion>(.*)</MicrosoftSourceLinkCommonVersion>"
-if [[ $sourceLinkLine =~ $versionPattern ]]; then
-  export SOURCE_LINK_BOOTSTRAP_VERSION=${BASH_REMATCH[1]}
-fi
-
-echo "Found bootstrap SDK $SDK_VERSION, bootstrap Arcade $ARCADE_BOOTSTRAP_VERSION, bootstrap SourceLink $SOURCE_LINK_BOOTSTRAP_VERSION"
+echo "Found bootstrap SDK $SDK_VERSION, bootstrap Arcade $ARCADE_BOOTSTRAP_VERSION"
 
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
 export NUGET_PACKAGES=$packagesRestoredDir/

--- a/src/SourceBuild/content/repo-projects/sourcelink.proj
+++ b/src/SourceBuild/content/repo-projects/sourcelink.proj
@@ -11,10 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ExtraPackageVersionPropsPackageInfo Include="MicrosoftSourceLinkVersion" Version="$(SOURCE_LINK_BOOTSTRAP_VERSION)" />
-  </ItemGroup>
-
-  <ItemGroup>
     <RepositoryReference Include="command-line-api" />
   </ItemGroup>
 


### PR DESCRIPTION
Sourcelink got added directly into the .NET SDK with .NET 8. The MicrosoftSourceLinkVersion property isn't respected anymore as Arcade doesn't bring sourcelink packages in anymore.

Instead, sourcelink is now brought in as a native feature of the .NET SDK.