### PR TITLE
Define NetCurrent at VMR root

### DIFF
--- a/src/SourceBuild/content/Directory.Build.props
+++ b/src/SourceBuild/content/Directory.Build.props
@@ -4,6 +4,7 @@
     <ImportNetSdkFromRepoToolset>false</ImportNetSdkFromRepoToolset>
     <_SuppressSdkImports>true</_SuppressSdkImports>
     <Configuration Condition="$(Configuration) == ''">Release</Configuration>
+    <NetCurrent Condition="'$(SkipArcadeSdkImport)' == 'true'">net9.0</NetCurrent>
   </PropertyGroup>
 
   <Import Condition="'$(SkipArcadeSdkImport)' != 'true'" Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/3812

The removal of the hardcoding of `NetCurrent` in https://github.com/dotnet/installer/pull/17987 was causing the leak detection build to fail. This PR reintroduces the hardcoding of NetCurrent, but only if importing the Arcade sdk is skipped.