### PR TITLE
Remove obsolete symreader dependency

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -195,11 +195,6 @@
       <Sha>63e4253ef37427fe51ee50b3225c1504889651df</Sha>
       <SourceBuild RepoName="source-build-externals" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.symreader" Version="2.1.0-beta.23608.1">
-      <Uri>https://github.com/dotnet/symreader</Uri>
-      <Sha>aa31e333b952f53910dc6bd08d80596eaaf89360</Sha>
-      <SourceBuild RepoName="symreader" ManagedOnly="true" />
-    </Dependency>
     <Dependency Name="System.CommandLine" Version="2.0.0-beta4.23407.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/command-line-api</Uri>
       <Sha>a045dd54a4c44723c215d992288160eb1401bb7f</Sha>


### PR DESCRIPTION
This dependency is not necessary for source-build.  It is still defined in the versions.details.xml dependency graph.
