### PR TITLE
Cloak spectre.console example file

### DIFF
--- a/src/VirtualMonoRepo/source-mappings.json
+++ b/src/VirtualMonoRepo/source-mappings.json
@@ -154,12 +154,13 @@
             "name": "source-build-externals",
             "defaultRemote": "https://github.com/dotnet/source-build-externals",
             "exclude": [
-                "src/humanizer/samples/**/*.js",
                 "src/application-insights/**/*.exe",
                 "src/application-insights/**/*.dll",
                 "src/application-insights/**/*.zip",
                 "src/application-insights/**/NuGet.config",
-                "src/newtonsoft-json/**/NuGet.Config"
+                "src/humanizer/samples/**/*.js",
+                "src/newtonsoft-json/**/NuGet.Config",
+                "src/spectre-console/examples/Console/Canvas/Mandelbrot.cs"
             ]
         },
         {


### PR DESCRIPTION
The Mandelbrot example from the spectre.console repo referenced in source-build-externals [contains a reference to a license](https://github.com/dotnet/source-build-externals/pull/244#issuecomment-1874425187) that is [disallowed for .NET](https://github.com/dotnet/source-build-externals/pull/244#issuecomment-1875794325). Since it's just an example file, it's not necessary to include it in the VMR. These changes exclude it. This has been [fixed in the original repo](https://github.com/spectreconsole/spectre.console/pull/1426). Once SBE references a new release of spectre.console, there won't be a need for the cloaking.