### PR TITLE
Remove unused SetNuGetPackagesEnvironment target

### DIFF
--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -1,4 +1,4 @@
-<Project InitialTargets="SetNuGetPackagesEnvironment">
+<Project>
 
   <ItemGroup>
     <EnvironmentVariables Include="LatestCommit=$(GitCommitHash)" />

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -512,18 +512,6 @@
           IgnoreStandardErrorWarningFormat="true" />
   </Target>
 
-  <Target Name="SetNuGetPackagesEnvironment" Condition="'$(ArchiveDownloadedPackages)' == 'true'">
-    <PropertyGroup>
-      <LocalNuGetPackagesRootForRepository>$(LocalNuGetPackagesRoot)$(RepositoryName)/</LocalNuGetPackagesRootForRepository>
-    </PropertyGroup>
-
-    <MakeDir Directories="$(LocalNuGetPackagesRootForRepository)" />
-
-    <ItemGroup>
-      <EnvironmentVariables Include="NUGET_PACKAGES=$(LocalNuGetPackagesRootForRepository)" />
-    </ItemGroup>
-  </Target>
-
   <Target Name="SetSourceBuiltSdkOverrides"
           BeforeTargets="Build"
           Condition="'@(UseSourceBuiltSdkOverride)' != ''">


### PR DESCRIPTION
As far as I can see, this target was necessary before the prebuilt report feature was added but is now unused.

Removing to simplify the infrastructure.
