### PR TITLE
Set LatestCommit only for deployment-tools

### DIFF
--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -1,10 +1,5 @@
 <Project>
 
-  <ItemGroup>
-    <EnvironmentVariables Include="LatestCommit=$(GitCommitHash)" />
-    <EnvironmentVariables Include="OfficialBuildId=$(OfficialBuildId)" />
-  </ItemGroup>
-
   <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="AddSourceToNuGetConfig" />
   <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="ReadNuGetPackageInfos" />
   <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="RemoveInternetSourcesFromNuGetConfig" />

--- a/src/SourceBuild/content/repo-projects/deployment-tools.proj
+++ b/src/SourceBuild/content/repo-projects/deployment-tools.proj
@@ -9,5 +9,9 @@
     <RepositoryReference Include="runtime" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EnvironmentVariables Include="LatestCommit=$(GitCommitHash)" />
+  </ItemGroup>
+
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>


### PR DESCRIPTION
... and remove setting the `OfficialBuildId` env var as that's already done in the repo-projects/Directory.Build.props.