### PR TITLE
Cloak spectre.console's package.json file

### DIFF
--- a/src/VirtualMonoRepo/source-mappings.json
+++ b/src/VirtualMonoRepo/source-mappings.json
@@ -160,6 +160,7 @@
                 "src/application-insights/**/NuGet.config",
                 "src/humanizer/samples/**/*.js",
                 "src/newtonsoft-json/**/NuGet.Config",
+                "src/spectre-console/docs/package.json",
                 "src/spectre-console/examples/Console/Canvas/Mandelbrot.cs"
             ]
         },


### PR DESCRIPTION
The Secure Supply Chain Analysis task in the VMR build is complaining about the https://github.com/spectreconsole/spectre.console/blob/main/docs/package.json file that gets included by source-build-externals:

```
##[warning]src/source-build-externals/src/spectre-console/docs/package.json - CFS0001: Missing sibling .npmrc file. (https://aka.ms/cfs/npm)
```

This file is used by NodeJS for building the spectre.console docs and isn't required in the VMR. I've resolved the violation by cloaking this file.