### PR TITLE
Delete DotNetRestorePackagesPath prop

### DIFF
--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -64,7 +64,6 @@
     <EnvironmentVariables Include="DotNetBuildFromSource=true" />
     <EnvironmentVariables Include="DotNetBuildFromSourceFlavor=Product" />
     <EnvironmentVariables Include="DotNetPackageVersionPropsPath=$(PackageVersionPropsPath)" />
-    <EnvironmentVariables Include="DotNetRestorePackagesPath=$(PackagesDir)" />
 
     <!-- Arcade tools.sh picks up DotNetCoreSdkDir, but we can pass DOTNET_INSTALL_DIR directly. -->
     <EnvironmentVariables Include="DOTNET_INSTALL_DIR=$(DotNetCliToolDir)" />


### PR DESCRIPTION
`DotNetRestorePackagesPath` is an unused property and got replaced by `CurrentRepoSourceBuildPackageCache` years ago: https://github.com/dotnet/arcade/blob/05493e05d4bbf262f1be1bd517ac95f5bff3a2ef/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets#L100C48-L100C82
