### PR TITLE
Disable format test for mono

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetFormatTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetFormatTests.cs
@@ -22,6 +22,12 @@ public class DotNetFormatTests : SdkTests
     [Fact]
     public void FormatProject()
     {
+        if (DotNetHelper.IsMonoRuntime)
+        {
+            // TODO: Temporarily disabled due to https://github.com/dotnet/sdk/issues/37774
+            return;
+        }
+
         string unformattedCsFilePath = Path.Combine(BaselineHelper.GetAssetsDirectory(), UnformattedFileName);
 
         string projectDirectory = DotNetHelper.ExecuteNew("console", nameof(FormatProject), "C#");


### PR DESCRIPTION
Disable dotnet-format test when using the mono runtime due to https://github.com/dotnet/sdk/issues/37774