### PR TITLE
Disable inner-clone in product source-build

### DIFF
--- a/src/SourceBuild/content/Directory.Build.targets
+++ b/src/SourceBuild/content/Directory.Build.targets
@@ -19,7 +19,7 @@
     -->
     <PropertyGroup>
       <SdkFilename>%(SdkTarballItem.Filename)%(SdkTarballItem.Extension)</SdkFilename>
-      <SourceBuiltSdkVersion>$(SdkFilename.Replace("$(SdkFilenamePrefix)",).Replace("-$(TargetRid)$(ArchiveExtension)",))</SourceBuiltSdkVersion>
+      <SourceBuiltSdkVersion>$(SdkFilename.Replace('$(SdkFilenamePrefix)','').Replace('-$(TargetRid)$(ArchiveExtension)',''))</SourceBuiltSdkVersion>
     </PropertyGroup>
   </Target>
 

--- a/src/SourceBuild/content/Directory.Build.targets
+++ b/src/SourceBuild/content/Directory.Build.targets
@@ -7,7 +7,7 @@
       <SdkFilenamePrefix>dotnet-sdk-</SdkFilenamePrefix>
     </PropertyGroup>
     <ItemGroup>
-      <SdkTarballItem Include="$(SourceBuiltAssetsDir)$(SdkFilenamePrefix)*$(TarBallExtension)" />
+      <SdkTarballItem Include="$(SourceBuiltAssetsDir)$(SdkFilenamePrefix)*$(ArchiveExtension)" />
     </ItemGroup>
 
     <!--
@@ -15,11 +15,11 @@
 
       Example:
       dotnet-sdk-9.0.100-alpha.1.24057.1-fedora.38-x64.tar.gz
-      dotnet-sdk-<SdkVersion>-<TargetRid><TarBallExtension>
+      dotnet-sdk-<SdkVersion>-<TargetRid><ArchiveExtension>
     -->
     <PropertyGroup>
       <SdkFilename>%(SdkTarballItem.Filename)%(SdkTarballItem.Extension)</SdkFilename>
-      <SourceBuiltSdkVersion>$(SdkFilename.Replace("$(SdkFilenamePrefix)",).Replace("-$(TargetRid)$(TarBallExtension)",))</SourceBuiltSdkVersion>
+      <SourceBuiltSdkVersion>$(SdkFilename.Replace("$(SdkFilenamePrefix)",).Replace("-$(TargetRid)$(ArchiveExtension)",))</SourceBuiltSdkVersion>
     </PropertyGroup>
   </Target>
 

--- a/src/SourceBuild/content/Directory.Build.targets
+++ b/src/SourceBuild/content/Directory.Build.targets
@@ -3,32 +3,24 @@
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" Condition="'$(SkipArcadeSdkImport)' != 'true'" />
 
   <Target Name="DetermineSourceBuiltSdkVersion">
-    <ItemGroup>
-      <SdkTarballItem Include="$(SourceBuiltAssetsDir)dotnet-sdk-*$(TarBallExtension)" />
-    </ItemGroup>
     <PropertyGroup>
-      <SdkTarball>%(SdkTarballItem.Identity)</SdkTarball>
-      <SdkLayout>$(ArtifactsTmpDir)Sdk</SdkLayout>
-      <BundledVersionsPropsRelativePath>sdk/*/Microsoft.NETCoreSdk.BundledVersions.props</BundledVersionsPropsRelativePath>
+      <SdkFilenamePrefix>dotnet-sdk-</SdkFilenamePrefix>
     </PropertyGroup>
-
-    <MakeDir Directories="$(SdkLayout)" />
-    <Exec Command="tar -xzf $(SdkTarball) -C $(SdkLayout)"
-          WorkingDirectory="$(SdkLayout)" />
-
     <ItemGroup>
-      <BundledVersionsPropsFile Include="$(SdkLayout)/$(BundledVersionsPropsRelativePath)" />
+      <SdkTarballItem Include="$(SourceBuiltAssetsDir)$(SdkFilenamePrefix)*$(TarBallExtension)" />
     </ItemGroup>
 
-    <XmlPeek XmlInputPath="@(BundledVersionsPropsFile)"
-             Query="Project/PropertyGroup/NETCoreSdkVersion/text()">
-        <Output TaskParameter="Result" ItemName="SourceBuiltSdkVersionItem" />
-    </XmlPeek>
-    <PropertyGroup>
-      <SourceBuiltSdkVersion>@(SourceBuiltSdkVersionItem)</SourceBuiltSdkVersion>
-    </PropertyGroup>
+    <!--
+      Extract SDK version from SDK tarball filename.
 
-    <RemoveDir Directories="$(SdkLayout)" />
+      Example:
+      dotnet-sdk-9.0.100-alpha.1.24057.1-fedora.38-x64.tar.gz
+      dotnet-sdk-<SdkVersion>-<TargetRid><TarBallExtension>
+    -->
+    <PropertyGroup>
+      <SdkFilename>%(SdkTarballItem.Filename)%(SdkTarballItem.Extension)</SdkFilename>
+      <SourceBuiltSdkVersion>$(SdkFilename.Replace("$(SdkFilenamePrefix)",).Replace("-$(TargetRid)$(TarBallExtension)",))</SourceBuiltSdkVersion>
+    </PropertyGroup>
   </Target>
 
 </Project>

--- a/src/SourceBuild/content/Directory.Build.targets
+++ b/src/SourceBuild/content/Directory.Build.targets
@@ -2,18 +2,33 @@
 
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" Condition="'$(SkipArcadeSdkImport)' != 'true'" />
 
-  <Target Name="DetermineMicrosoftSourceBuildIntermediateInstallerVersion"
-          Condition="'$(DotNetBuildFromSource)' == 'true'">
-    <!-- Manually load the installer version from the PVP. -->
-    <XmlPeek XmlInputPath="$(SharedIntermediateOutputPath)PackageVersions.package-source-build.Current.props"
-             Query="msb:Project/msb:PropertyGroup/msb:MicrosoftSourceBuildIntermediateInstallerVersion/text()"
-             Namespaces="&lt;Namespace Prefix='msb' Uri='http://schemas.microsoft.com/developer/msbuild/2003'/&gt;">
-        <Output TaskParameter="Result" ItemName="MicrosoftSourceBuildIntermediateInstallerVersionItem" />
+  <Target Name="DetermineSourceBuiltSdkVersion">
+    <ItemGroup>
+      <SdkTarballItem Include="$(SourceBuiltAssetsDir)dotnet-sdk-*$(TarBallExtension)" />
+    </ItemGroup>
+    <PropertyGroup>
+      <SdkTarball>%(SdkTarballItem.Identity)</SdkTarball>
+      <SdkLayout>$(ArtifactsTmpDir)Sdk</SdkLayout>
+      <BundledVersionsPropsRelativePath>sdk/*/Microsoft.NETCoreSdk.BundledVersions.props</BundledVersionsPropsRelativePath>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(SdkLayout)" />
+    <Exec Command="tar -xzf $(SdkTarball) -C $(SdkLayout)"
+          WorkingDirectory="$(SdkLayout)" />
+
+    <ItemGroup>
+      <BundledVersionsPropsFile Include="$(SdkLayout)/$(BundledVersionsPropsRelativePath)" />
+    </ItemGroup>
+
+    <XmlPeek XmlInputPath="@(BundledVersionsPropsFile)"
+             Query="Project/PropertyGroup/NETCoreSdkVersion/text()">
+        <Output TaskParameter="Result" ItemName="SourceBuiltSdkVersionItem" />
     </XmlPeek>
     <PropertyGroup>
-      <MicrosoftSourceBuildIntermediateInstallerVersion>@(MicrosoftSourceBuildIntermediateInstallerVersionItem)</MicrosoftSourceBuildIntermediateInstallerVersion>
-      <MicrosoftSourceBuildIntermediateInstallerVersion Condition="'$(MicrosoftSourceBuildIntermediateInstallerVersion)' == ''">$(installerOutputPackageVersion)</MicrosoftSourceBuildIntermediateInstallerVersion>
+      <SourceBuiltSdkVersion>@(SourceBuiltSdkVersionItem)</SourceBuiltSdkVersion>
     </PropertyGroup>
+
+    <RemoveDir Directories="$(SdkLayout)" />
   </Target>
 
 </Project>

--- a/src/SourceBuild/content/eng/build.sourcebuild.targets
+++ b/src/SourceBuild/content/eng/build.sourcebuild.targets
@@ -60,11 +60,11 @@
   <Target Name="RepackageSymbols"
           AfterTargets="Build"
           DependsOnTargets="
-            DetermineMicrosoftSourceBuildIntermediateInstallerVersion;
+            DetermineSourceBuiltSdkVersion;
             DiscoverSymbolsTarballs;
             ExtractSymbolsTarballs">
     <PropertyGroup>
-      <UnifiedSymbolsTarball>$(SharedOutputPath)dotnet-symbols-all-$(MicrosoftSourceBuildIntermediateInstallerVersion)-$(TargetRid)$(ArchiveExtension)</UnifiedSymbolsTarball>
+      <UnifiedSymbolsTarball>$(SharedOutputPath)dotnet-symbols-all-$(SourceBuiltSdkVersion)-$(TargetRid)$(ArchiveExtension)</UnifiedSymbolsTarball>
     </PropertyGroup>
 
     <Exec Command="tar --numeric-owner -czf $(UnifiedSymbolsTarball) *"
@@ -84,7 +84,7 @@
 
     <PropertyGroup>
       <SdkSymbolsLayout>$(ArtifactsTmpDir)SdkSymbols</SdkSymbolsLayout>
-      <SdkSymbolsTarball>$(SharedOutputPath)dotnet-symbols-sdk-$(MicrosoftSourceBuildIntermediateInstallerVersion)-$(TargetRid)$(ArchiveExtension)</SdkSymbolsTarball>
+      <SdkSymbolsTarball>$(SharedOutputPath)dotnet-symbols-sdk-$(SourceBuiltSdkVersion)-$(TargetRid)$(ArchiveExtension)</SdkSymbolsTarball>
       <SdkLayout>$(ArtifactsTmpDir)Sdk</SdkLayout>
       <SdkTarball>%(SdkTarballItem.Identity)</SdkTarball>
     </PropertyGroup>
@@ -214,10 +214,10 @@
   </Target>
 
   <Target Name="CreateSmokeTestPrereqsTarballIfPrereqsExist"
-          DependsOnTargets="DetermineMicrosoftSourceBuildIntermediateInstallerVersion"
+          DependsOnTargets="DetermineSourceBuiltSdkVersion"
           Condition="'@(SmokeTestsPrereqs->Count())' != '0'">
     <PropertyGroup>
-      <SmokeTestPrereqsTarballName>$(SharedOutputPath)dotnet-smoke-test-prereqs.$(MicrosoftSourceBuildIntermediateInstallerVersion).$(TargetRid)$(ArchiveExtension)</SmokeTestPrereqsTarballName>
+      <SmokeTestPrereqsTarballName>$(SharedOutputPath)dotnet-smoke-test-prereqs.$(SourceBuiltSdkVersion).$(TargetRid)$(ArchiveExtension)</SmokeTestPrereqsTarballName>
       <SmokeTestsPrereqPackagesDir>$(SmokeTestsArtifactsDir)prereq-packages/</SmokeTestsPrereqPackagesDir>
     </PropertyGroup>
 
@@ -247,10 +247,10 @@
   </Target>
 
   <Target Name="CreatePrebuiltsTarballIfPrebuiltsExist"
-          DependsOnTargets="DetermineMicrosoftSourceBuildIntermediateInstallerVersion"
+          DependsOnTargets="DetermineSourceBuiltSdkVersion"
           Condition="'@(PrebuiltFile->Count())' != '0'">
     <PropertyGroup>
-      <TarballFilePath>$(SharedOutputPath)$(SourceBuiltPrebuiltsTarballName).$(MicrosoftSourceBuildIntermediateInstallerVersion).$(TargetRid)$(ArchiveExtension)</TarballFilePath>
+      <TarballFilePath>$(SharedOutputPath)$(SourceBuiltPrebuiltsTarballName).$(SourceBuiltSdkVersion).$(TargetRid)$(ArchiveExtension)</TarballFilePath>
       <TarballWorkingDir>$(ResultingPrebuiltPackagesDir)</TarballWorkingDir>
     </PropertyGroup>
 

--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -16,6 +16,7 @@
 
     <ProjectDirectory>$([MSBuild]::NormalizeDirectory('$(SrcDir)', '$(RepositoryName)'))</ProjectDirectory>
     <PackagesOutput>$([MSBuild]::NormalizeDirectory('$(ProjectDirectory)', 'artifacts', 'packages', '$(Configuration)', 'NonShipping'))</PackagesOutput>
+    <RepoManifestFile>$(ProjectDirectory)artifacts/RepoManifest.xml</RepoManifestFile>
 
     <!-- Paths to the version props files -->
     <PackageVersionPropsPath>$(SharedIntermediateOutputPath)PackageVersions.$(RepositoryName).props</PackageVersionPropsPath>

--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -16,7 +16,6 @@
 
     <ProjectDirectory>$([MSBuild]::NormalizeDirectory('$(SrcDir)', '$(RepositoryName)'))</ProjectDirectory>
     <PackagesOutput>$([MSBuild]::NormalizeDirectory('$(ProjectDirectory)', 'artifacts', 'packages', '$(Configuration)', 'NonShipping'))</PackagesOutput>
-    <RepoManifestFile>$(ProjectDirectory)artifacts/RepoManifest.xml</RepoManifestFile>
 
     <!-- Paths to the version props files -->
     <PackageVersionPropsPath>$(SharedIntermediateOutputPath)PackageVersions.$(RepositoryName).props</PackageVersionPropsPath>

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -16,6 +16,7 @@
     <PackageReportDataFile>$(PackageReportDir)prebuilt-usage.xml</PackageReportDataFile>
     <ProjectAssetsJsonArchiveFile>$(PackageReportDir)all-project-assets-json-files.zip</ProjectAssetsJsonArchiveFile>
     <ProdConManifestFile>$(PackageReportDir)prodcon-build.xml</ProdConManifestFile>
+    <RepoManifestFile>$([MSBuild]::NormalizePath('$(ProjectDirectory)', 'artifacts', 'RepoManifest.xml'))</RepoManifestFile>
   </PropertyGroup>
 
   <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="AddSourceToNuGetConfig" />
@@ -286,19 +287,27 @@
     </ItemGroup>
   </Target>
 
+  <!--
+    Condition should be removed after source-build picks up version of Arcade that has
+    source-build infra changes for removal od inner-clone in VMR build. Until then some
+    repos will produce intermediate packages instead of repo manifest file.
+
+    https://github.com/dotnet/source-build/issues/3930
+  -->
   <Target Name="CopyRepoArtifacts"
           AfterTargets="Package"
-          Condition="Exists($(RepoManifestFile))">
-
+          Condition="Exists($(RepoManifestFile))"
+          Inputs="$(RepoManifestFile)"
+          Outputs="$(BaseIntermediateOutputPath)ArtifactsCopy.complete">
     <XmlPeek XmlInputPath="$(RepoManifestFile)"
              Query="Build/Artifact/@Path">
-        <Output TaskParameter="Result" ItemName="ArtifactPath" />
+        <Output TaskParameter="Result" ItemName="RepoManifestArtifact" />
     </XmlPeek>
 
     <ItemGroup>
-      <_Asset Include="@(ArtifactPath)" Condition="'%(Extension)' != '.nupkg'"/>
-      <_Package Include="@(ArtifactPath)" Condition="'%(Extension)' == '.nupkg'"/>
-      <_NonShippingPackage Include="@(_Package)" Condition="$([System.Text.RegularExpressions.Regex]::Match(%(Identity),'[\\\\/]NonShipping[\\\\/]').Success)"/>
+      <_Asset Include="@(RepoManifestArtifact)" Condition="'%(Extension)' != '.nupkg'"/>
+      <_Package Include="@(RepoManifestArtifact)" Condition="'%(Extension)' == '.nupkg'"/>
+      <_NonShippingPackage Include="@(_Package)" Condition="$([System.String]::Copy('%(Identity)').Contains('$([System.IO.Path]::DirectorySeparatorChar)NonShipping$([System.IO.Path]::DirectorySeparatorChar)'))"/>
     </ItemGroup>
 
     <PropertyGroup>
@@ -335,6 +344,10 @@
       Lines="@(_NonShippingPackage->'%(Filename)%(Extension)')"
       Overwrite="true" />
 
+    <MakeDir Directories="$(BaseIntermediateOutputPath)" />
+    <Touch Files="$(BaseIntermediateOutputPath)ArtifactsCopy.complete" AlwaysCreate="true">
+      <Output TaskParameter="TouchedFiles" ItemName="FileWrites" />
+    </Touch>
   </Target>
 
   <!--

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -286,6 +286,11 @@
     </ItemGroup>
   </Target>
 
+  <!--
+    This target can be removed after source-build picks up version of Arcade that has
+    source-build infra changes for removal od inner-clone in VMR build. Until then the target
+    is needed for building source-build-reference-packages and arcade repos.
+  -->
   <Target Name="ExtractIntermediatePackages"
           AfterTargets="Package"
           Inputs="$(MSBuildProjectFullPath)"

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -286,6 +286,57 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="CopyRepoArtifacts"
+          AfterTargets="Package"
+          Condition="Exists($(RepoManifestFile))">
+
+    <XmlPeek XmlInputPath="$(RepoManifestFile)"
+             Query="Build/Artifact/@Path">
+        <Output TaskParameter="Result" ItemName="ArtifactPath" />
+    </XmlPeek>
+
+    <ItemGroup>
+      <_Asset Include="@(ArtifactPath)" Condition="'%(Extension)' != '.nupkg'"/>
+      <_Package Include="@(ArtifactPath)" Condition="'%(Extension)' == '.nupkg'"/>
+      <_NonShippingPackage Include="@(_Package)" Condition="$([System.Text.RegularExpressions.Regex]::Match(%(Identity),'[\\\\/]NonShipping[\\\\/]').Success)"/>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_NupkgsDestination>$(SourceBuiltPackagesPath)</_NupkgsDestination>
+      <_NupkgsDestination Condition="'$(RepositoryName)' == 'source-build-reference-packages'">$(ReferencePackagesDir)</_NupkgsDestination>
+    </PropertyGroup>
+
+    <!-- Building SBRP: At this point the References directory contains the previously-source-built SBRPs,
+         clear it before copying the current SBRPs.  This ensures n-1 SBRPs aren't required to build the product repos. -->
+    <RemoveDir
+      Condition="'$(RepositoryName)' == 'source-build-reference-packages'"
+      Directories="$(ReferencePackagesDir)" />
+
+    <!-- Copy nupkgs -->
+    <Copy
+      Condition="'@(_Package)' != ''"
+      SourceFiles="@(_Package)"
+      DestinationFolder="$(_NupkgsDestination)" />
+
+    <!-- Copy assets -->
+    <Copy
+      Condition="'@(_Asset)' != ''"
+      SourceFiles="@(_Asset)"
+      DestinationFolder="$(SourceBuiltAssetsDir)" />
+
+    <!-- Generate non-shipping package list -->
+    <PropertyGroup>
+      <NonShippingPackagesList Condition="'@(_NonShippingPackage)' != ''">$(PackageListsDir)$(NonShippingPackagesListPrefix)$(RepositoryName).lst</NonShippingPackagesList>
+    </PropertyGroup>
+
+    <WriteLinesToFile
+      Condition="'$(NonShippingPackagesList)' != ''"
+      File="$(NonShippingPackagesList)"
+      Lines="@(_NonShippingPackage->'%(Filename)%(Extension)')"
+      Overwrite="true" />
+
+  </Target>
+
   <!--
     This target can be removed after source-build picks up version of Arcade that has
     source-build infra changes for removal od inner-clone in VMR build. Until then the target

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -305,9 +305,9 @@
     </XmlPeek>
 
     <ItemGroup>
-      <_Asset Include="@(RepoManifestArtifact)" Condition="'%(Extension)' != '.nupkg'"/>
-      <_Package Include="@(RepoManifestArtifact)" Condition="'%(Extension)' == '.nupkg'"/>
-      <_NonShippingPackage Include="@(_Package)" Condition="$([System.String]::Copy('%(Identity)').Contains('$([System.IO.Path]::DirectorySeparatorChar)NonShipping$([System.IO.Path]::DirectorySeparatorChar)'))"/>
+      <RepoManifestAsset Include="@(RepoManifestArtifact)" Condition="'%(Extension)' != '.nupkg'"/>
+      <RepoManifestPackage Include="@(RepoManifestArtifact)" Condition="'%(Extension)' == '.nupkg'"/>
+      <RepoManifestNonShippingPackage Include="@(RepoManifestPackage)" Condition="$([System.String]::Copy('%(Identity)').Contains('$([System.IO.Path]::DirectorySeparatorChar)NonShipping$([System.IO.Path]::DirectorySeparatorChar)'))"/>
     </ItemGroup>
 
     <PropertyGroup>
@@ -323,25 +323,25 @@
 
     <!-- Copy nupkgs -->
     <Copy
-      Condition="'@(_Package)' != ''"
-      SourceFiles="@(_Package)"
+      Condition="'@(RepoManifestPackage)' != ''"
+      SourceFiles="@(RepoManifestPackage)"
       DestinationFolder="$(_NupkgsDestination)" />
 
     <!-- Copy assets -->
     <Copy
-      Condition="'@(_Asset)' != ''"
-      SourceFiles="@(_Asset)"
+      Condition="'@(RepoManifestAsset)' != ''"
+      SourceFiles="@(RepoManifestAsset)"
       DestinationFolder="$(SourceBuiltAssetsDir)" />
 
     <!-- Generate non-shipping package list -->
     <PropertyGroup>
-      <NonShippingPackagesList Condition="'@(_NonShippingPackage)' != ''">$(PackageListsDir)$(NonShippingPackagesListPrefix)$(RepositoryName).lst</NonShippingPackagesList>
+      <NonShippingPackagesList Condition="'@(RepoManifestNonShippingPackage)' != ''">$(PackageListsDir)$(NonShippingPackagesListPrefix)$(RepositoryName).lst</NonShippingPackagesList>
     </PropertyGroup>
 
     <WriteLinesToFile
       Condition="'$(NonShippingPackagesList)' != ''"
       File="$(NonShippingPackagesList)"
-      Lines="@(_NonShippingPackage->'%(Filename)%(Extension)')"
+      Lines="@(RepoManifestNonShippingPackage->'%(Filename)%(Extension)')"
       Overwrite="true" />
 
     <MakeDir Directories="$(BaseIntermediateOutputPath)" />

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -290,6 +290,8 @@
     This target can be removed after source-build picks up version of Arcade that has
     source-build infra changes for removal od inner-clone in VMR build. Until then the target
     is needed for building source-build-reference-packages and arcade repos.
+
+    https://github.com/dotnet/source-build/issues/3930
   -->
   <Target Name="ExtractIntermediatePackages"
           AfterTargets="Package"

--- a/src/SourceBuild/content/repo-projects/package-source-build.proj
+++ b/src/SourceBuild/content/repo-projects/package-source-build.proj
@@ -13,45 +13,32 @@
 
   <Target Name="CustomRepoBuild"
           AfterTargets="RepoBuild"
-          DependsOnTargets="DetermineMicrosoftSourceBuildIntermediateInstallerVersion">
+          DependsOnTargets="DetermineSourceBuiltSdkVersion">
     <!-- Copy PVP to packages dir in order to package them together -->
     <Copy SourceFiles="$(CurrentSourceBuiltPackageVersionPropsPath)" DestinationFiles="$(SourceBuiltPackagesPath)PackageVersions.props" />
 
-    <!-- Expand SBRP intermediate package into separate folder and remove intermediate package -->
     <PropertyGroup>
       <SourceBuildReferencePackagesDestination>$(SourceBuiltPackagesPath)SourceBuildReferencePackages/</SourceBuildReferencePackagesDestination>
-      <SBRPIntermediateWildcard>Microsoft.SourceBuild.Intermediate.source-build-reference-packages*.nupkg</SBRPIntermediateWildcard>
     </PropertyGroup>
-    <ItemGroup>
-      <SourceBuildReferencePackagesIntermediatePackage Include="$(SourceBuiltPackagesPath)$(SBRPIntermediateWildcard)"/>
-    </ItemGroup>
-
-    <Unzip SourceFiles="@(SourceBuildReferencePackagesIntermediatePackage)"
-           DestinationFolder="$(SourceBuildReferencePackagesDestination)extractArtifacts"
-           SkipUnchangedFiles="true"
-           Condition="'@(SourceBuildReferencePackagesIntermediatePackage)' != ''" />
 
     <ItemGroup>
-      <SourceBuildReferencePackagesNupkgFiles Include="$(SourceBuildReferencePackagesDestination)extractArtifacts/**/*.nupkg" />
+      <SourceBuildReferencePackagesNupkgFiles Include="$(ReferencePackagesDir)**/*.nupkg" />
     </ItemGroup>
 
+    <!-- Copy reference packages from ReferencePackagesDir to blob-feed reference packages path. -->
     <Copy
       Condition="'@(SourceBuildReferencePackagesNupkgFiles)' != ''"
       SourceFiles="@(SourceBuildReferencePackagesNupkgFiles)"
       DestinationFiles="@(SourceBuildReferencePackagesNupkgFiles -> '$(SourceBuildReferencePackagesDestination)%(Filename)%(Extension)')" />
 
-    <RemoveDir
-      Condition="Exists('$(SourceBuildReferencePackagesDestination)extractArtifacts/')"
-      Directories="$(SourceBuildReferencePackagesDestination)extractArtifacts/" />
-
     <PropertyGroup>
-      <SourceBuiltTarballName>$(SharedOutputPath)$(SourceBuiltArtifactsTarballName).$(MicrosoftSourceBuildIntermediateInstallerVersion).$(TargetRid)$(ArchiveExtension)</SourceBuiltTarballName>
+      <SourceBuiltTarballName>$(SharedOutputPath)$(SourceBuiltArtifactsTarballName).$(SourceBuiltSdkVersion).$(TargetRid)$(ArchiveExtension)</SourceBuiltTarballName>
       <SourceBuiltVersionFileName>.version</SourceBuiltVersionFileName>
     </PropertyGroup>
 
     <!-- Content of the .version file to include in the tarball -->
     <ItemGroup>
-      <VersionFileContent Include="$(RepositoryCommit);$(MicrosoftSourceBuildIntermediateInstallerVersion)" />
+      <VersionFileContent Include="$(RepositoryCommit);$(SourceBuiltSdkVersion)" />
     </ItemGroup>
 
     <WriteLinesToFile

--- a/src/SourceBuild/content/repo-projects/source-build-externals.proj
+++ b/src/SourceBuild/content/repo-projects/source-build-externals.proj
@@ -1,6 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!--
+      We need to continue to use inner-clone for this repo, as there are hundreds of modified files
+      after a build, due to numerous patches and modifications we need to do.
+
+      Modified files make developer experience worse, as they would need to be manually reverted.
+    -->
     <BuildArgs>$(BuildArgs) /p:UseInnerClone=true</BuildArgs>
   </PropertyGroup>
 

--- a/src/SourceBuild/content/repo-projects/source-build-externals.proj
+++ b/src/SourceBuild/content/repo-projects/source-build-externals.proj
@@ -1,2 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <BuildArgs>$(BuildArgs) /p:UseInnerClone=true</BuildArgs>
+  </PropertyGroup>
+
 </Project>

--- a/src/SourceBuild/content/repo-projects/source-build-reference-packages.proj
+++ b/src/SourceBuild/content/repo-projects/source-build-reference-packages.proj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <!--
       All packages built in SBRP repo are copied to prereqs/package/reference.
-      Nothing gets copied to blob-feed packages cache, as we are not building intermediate packages anymore.
+      Nothing gets copied to blob-feed packages cache.
 
-      This would cause issue with validation in EnsurePackagesCreated target.
+      This would cause an issue with validation in EnsurePackagesCreated target.
       We need to skip it for SBRP repo.
     -->
     <SkipEnsurePackagesCreated>true</SkipEnsurePackagesCreated>

--- a/src/SourceBuild/content/repo-projects/source-build-reference-packages.proj
+++ b/src/SourceBuild/content/repo-projects/source-build-reference-packages.proj
@@ -1,6 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!--
+      All packages built in SBRP repo are copied to prereqs/package/reference.
+      Nothing gets copied to blob-feed packages cache, as we are not building intermediate packages anymore.
+
+      This would cause issue with validation in EnsurePackagesCreated target.
+      We need to skip it for SBRP repo.
+    -->
+    <SkipEnsurePackagesCreated>true</SkipEnsurePackagesCreated>
+
     <!-- SBRP builds before Arcade so it also needs the bootstrap Arcade version -->
     <UseBootstrapArcade>true</UseBootstrapArcade>
 

--- a/src/SourceBuild/patches/arcade/0001-Disable-inner-clone-in-product-source-build.patch
+++ b/src/SourceBuild/patches/arcade/0001-Disable-inner-clone-in-product-source-build.patch
@@ -1,0 +1,301 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nikola Milosavljevic <nikolam@microsoft.com>
+Date: Tue, 9 Jan 2024 02:15:49 +0000
+Subject: [PATCH] Disable inner-clone in product source-build
+
+---
+ .../tools/SourceBuild/AfterSourceBuild.proj   | 48 +++++++++++-
+ .../SourceBuild/SourceBuildArcade.targets     | 75 ++++++++++++++++++-
+ .../SourceBuildArcadeBuild.targets            |  5 +-
+ .../SourceBuild/SourceBuildIntermediate.proj  | 51 +------------
+ 4 files changed, 127 insertions(+), 52 deletions(-)
+
+diff --git a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
+index 31f544e6..3fed45fc 100644
+--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
++++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
+@@ -15,7 +15,8 @@
+           Condition="'$(ArcadeInnerBuildFromSource)' != 'true'"
+           DependsOnTargets="
+             ReportPrebuiltUsage;
+-            PackSourceBuildIntermediateNupkgs" />
++            PackSourceBuildIntermediateNupkgs;
++            CopyRepoArtifacts" />
+ 
+   <Target Name="WritePrebuiltUsageData">
+     <ItemGroup>
+@@ -117,11 +118,56 @@
+       DestinationFiles="$(SourceBuildIntermediateNupkgLicenseFile)" />
+   </Target>
+ 
++  <!-- In VMR build we copy repo artifacts directly, without using the intermediate nupkgs. -->
++  <Target Name="CopyRepoArtifacts"
++          Condition="'$(DotNetBuildFromSourceFlavor)' == 'Product'"
++          DependsOnTargets="
++            GetCategorizedIntermediateNupkgContents;
++            CreateRepoSymbolsArchive">
++
++    <PropertyGroup>
++      <_NupkgsDestination>$(CurrentSourceBuiltPackagesDir)</_NupkgsDestination>
++      <_NupkgsDestination Condition="'$(GitHubRepositoryName)' == 'source-build-reference-packages'">$(ReferencePackagesDir)</_NupkgsDestination>
++    </PropertyGroup>
++
++    <ItemGroup>
++      <_AssetsToCopy Include="@(IntermediateNupkgFile)" Condition="'%(Extension)' != '.nupkg'" />
++      <_NugetPackagesToCopy Include="@(IntermediateNupkgFile)" Condition="'%(Extension)' == '.nupkg'"/>
++    </ItemGroup>
++
++    <!-- Copy non-shipping package list -->
++    <Copy
++      Condition="'$(NonShippingPackagesList)' != ''"
++      SourceFiles="$(NonShippingPackagesList)"
++      DestinationFolder="$(PackageListsDir)" />
++
++    <!-- Building SBRP: At this point the References directory contains the previously-source-built SBRPs,
++         clear it before copying the current SBRPs.  This ensures n-1 SBRPs aren't required to build the product repos. -->
++    <RemoveDir
++      Condition="'$(GitHubRepositoryName)' == 'source-build-reference-packages'"
++      Directories="$(ReferencePackagesDir)" />
++
++    <!-- Copy nupkgs -->
++    <Copy
++      Condition="'@(_NugetPackagesToCopy)' != ''"
++      SourceFiles="@(_NugetPackagesToCopy)"
++      DestinationFolder="$(_NupkgsDestination)" />
++
++    <!-- Copy assets -->
++    <Copy
++      Condition="'@(_AssetsToCopy)' != ''"
++      SourceFiles="@(_AssetsToCopy)"
++      DestinationFolder="$(SourceBuiltAssetsDir)" />
++  </Target>
++
+   <!--
+     Create source-build intermediate NuGet package and supplemental intermediate NuGet packages (if
+     necessary) for dependency transport to downstream repos.
++
++    In VMR build we do not use the intermediate nupkgs, so we skip this step.
+   -->
+   <Target Name="PackSourceBuildIntermediateNupkgs"
++          Condition="'$(DotNetBuildFromSourceFlavor)' != 'Product'"
+           DependsOnTargets="
+             CopyIntermediateNupkgProjToProjectDirectory;
+             GetLicenseFileForIntermediateNupkgPack;
+diff --git a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+index 2d1a20d5..df7bfde8 100644
+--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
++++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+@@ -24,12 +24,26 @@
+     <CurrentRepoSourceBuildPackageCache>$([MSBuild]::NormalizeDirectory('$(SourceBuildOutputDir)', 'package-cache'))</CurrentRepoSourceBuildPackageCache>
+     <SourceBuildSelfPrebuiltReportDir>$([MSBuild]::NormalizeDirectory('$(SourceBuildOutputDir)', 'prebuilt-report'))</SourceBuildSelfPrebuiltReportDir>
+ 
++    <!--
++      Do not use inner-clone in full product source-build, unless explicitly requested,
++      i.e. for specific repos, like source-build-externals.
++    -->
++    <UseInnerClone Condition="'$(UseInnerClone)' == '' and '$(DotNetBuildFromSourceFlavor)' != 'Product'">true</UseInnerClone>
++    <UseInnerClone Condition="'$(UseInnerClone)' == '' and '$(DotNetBuildFromSourceFlavor)' == 'Product'">false</UseInnerClone>
++
++    <!-- Do not create intermediate package in full product source-build. -->
++    <CreateIntermediatePackage Condition="'$(DotNetBuildFromSourceFlavor)' != 'Product'">true</CreateIntermediatePackage>
++    <CreateIntermediatePackage Condition="'$(DotNetBuildFromSourceFlavor)' == 'Product'">false</CreateIntermediatePackage>
++
+     <!--
+       Keep artifacts/ inside source dir so that ancestor-based file lookups find the inner repo, not
+       the outer repo. The inner repo global.json and NuGet.config files may have been modified by
+       source-build, and we want projects inside the artifacts/ dir to respect that.
++
++      Inner-clone removal - in VMR use regular artifacts dir.
+     -->
+     <CurrentRepoSourceBuildArtifactsDir>$([MSBuild]::NormalizeDirectory('$(CurrentRepoSourceBuildSourceDir)', 'artifacts'))</CurrentRepoSourceBuildArtifactsDir>
++    <CurrentRepoSourceBuildArtifactsDir Condition="'$(UseInnerClone)' == 'false'">$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)'))</CurrentRepoSourceBuildArtifactsDir>
+     <CurrentRepoSourceBuildArtifactsPackagesDir>$([MSBuild]::NormalizeDirectory('$(CurrentRepoSourceBuildArtifactsDir)', 'packages', '$(Configuration)'))</CurrentRepoSourceBuildArtifactsPackagesDir>
+ 
+     <CurrentRepoSourceBuildNuGetSourceName>source-build-int-nupkg-cache</CurrentRepoSourceBuildNuGetSourceName>
+@@ -106,8 +120,8 @@
+     <ItemGroup>
+       <IntermediateNupkgFile Include="@(IntermediateNupkgArtifactFile)" PackagePath="artifacts" />
+ 
+-      <!-- Report goes into the 'main' intermediate nupkg. -->
+-      <IntermediateNupkgFile Include="$(SourceBuildSelfPrebuiltReportDir)**\*" PackagePath="prebuilt-report" />
++      <!-- Report goes into the 'main' intermediate nupkg, if we're creating it. -->
++      <IntermediateNupkgFile Condition="'$(CreateIntermediatePackage)' == 'true'" Include="$(SourceBuildSelfPrebuiltReportDir)**\*" PackagePath="prebuilt-report" />
+     </ItemGroup>
+ 
+     <RemoveDuplicates Inputs="@(IntermediateNupkgFile)">
+@@ -118,6 +132,63 @@
+       <IntermediateNonShippingNupkgFile Include="@(IntermediatePackageFile)" Condition="$([System.Text.RegularExpressions.Regex]::Match(%(Identity),'[\\\\/]NonShipping[\\\\/]').Success)"/>
+       <SupplementalIntermediateNupkgCategory Include="%(IntermediatePackageFile.Category)" />
+     </ItemGroup>
++
++    <PropertyGroup>
++      <!-- The prefix needs to match what's defined in tarball source-build infra. Consider using a single property, in the future. -->
++      <NonShippingPackagesListPrefix>NonShipping.Packages.</NonShippingPackagesListPrefix>
++      <NonShippingPackagesList Condition="'@(IntermediateNonShippingNupkgFile)' != ''">$(CurrentRepoSourceBuildArtifactsPackagesDir)$(NonShippingPackagesListPrefix)$(GitHubRepositoryName).lst</NonShippingPackagesList>
++    </PropertyGroup>
++
++    <WriteLinesToFile
++      Condition="'$(NonShippingPackagesList)' != ''"
++      File="$(NonShippingPackagesList)"
++      Lines="@(IntermediateNonShippingNupkgFile->'%(Filename)%(Extension)')"
++      Overwrite="true" />
++
++  </Target>
++
++  <!--
++    Create symbols archive.
++
++    Conditioning out for Windows as the tar execution below doesn't work cross-plat.
++  -->
++  <Target Name="CreateRepoSymbolsArchive" Condition="'$(OS)' != 'Windows_NT'">
++    <PropertyGroup>
++      <SymbolsRoot>$(CurrentRepoSourceBuildArtifactsDir)</SymbolsRoot>
++      <!-- Fall back to repo root for source-build-externals or repos that don't have the regular SymbolsRoot as defined above -->
++      <SymbolsRoot Condition="!Exists('$(SymbolsRoot)') or '$(GitHubRepositoryName)' == 'source-build-externals'">$(RepoRoot)</SymbolsRoot>
++      <SymbolsArchiveLocation>$(CurrentRepoSourceBuildArtifactsPackagesDir)</SymbolsArchiveLocation>
++      <SymbolsArchiveLocation Condition="'$(GitHubRepositoryName)' == 'nuget-client'">$(PackageOutputPath)</SymbolsArchiveLocation>
++      <!--
++        If we're doing full product source-build, we do not have intermediate package to carry this archive.
++        Instead, we create it in blob-feed assets folder, directly.
++      -->
++      <SymbolsArchiveLocation Condition="'$(DotNetBuildFromSourceFlavor)' == 'Product'">$(SourceBuiltAssetsDir)</SymbolsArchiveLocation>
++      <SymbolsList>$(SymbolsArchiveLocation)\symbols.lst</SymbolsList>
++      <SymbolsArchivePrefix>Symbols.</SymbolsArchivePrefix>
++      <!-- $(Version) and $(TargetRid) are only available when target is executed as part of intermediate package creation. -->
++      <SymbolsArchiveSuffix Condition="'$(CreateIntermediatePackage)' == 'true'">.$(Version).$(TargetRid)</SymbolsArchiveSuffix>
++      <SymbolsArchiveName>$(SymbolsArchiveLocation)$(SymbolsArchivePrefix)$(GitHubRepositoryName)$(SymbolsArchiveSuffix)$(ArchiveExtension)</SymbolsArchiveName>
++    </PropertyGroup>
++
++    <ItemGroup>
++      <AbsoluteSymbolPath Include="$(SymbolsRoot)\**\obj\**\*.pdb" />
++      <AbsoluteSymbolPath Update="@(AbsoluteSymbolPath)" Condition="'@(AbsoluteSymbolPath)' != ''">
++        <RelativePath>$([MSBuild]::MakeRelative($(SymbolsRoot), %(FullPath)))</RelativePath>
++      </AbsoluteSymbolPath>
++    </ItemGroup>
++
++    <WriteLinesToFile
++      File="$(SymbolsList)"
++      Lines="@(AbsoluteSymbolPath->'%(RelativePath)')"
++      Overwrite="true"
++      Condition="'@(AbsoluteSymbolPath)' != ''" />
++
++    <Exec Command="tar --numeric-owner -czf $(SymbolsArchiveName) --files-from=$(SymbolsList)"
++          WorkingDirectory="$(SymbolsRoot)" Condition="Exists($(SymbolsList))" />
++    <Message Importance="High" Text="Packaged symbols to $(SymbolsArchiveName)" Condition="Exists($(SymbolsArchiveName))" />
++
++    <Delete Files="$(SymbolsList)" Condition="Exists($(SymbolsList))" />
+   </Target>
+ 
+ </Project>
+diff --git a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
+index 177a5267..18ab693c 100644
+--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
++++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
+@@ -11,6 +11,7 @@
+     <CurrentRepoSourceBuildBinlogFile>$([MSBuild]::NormalizePath('$(CurrentRepoSourceBuildArtifactsDir)', 'sourcebuild.binlog'))</CurrentRepoSourceBuildBinlogFile>
+ 
+     <InnerSourceBuildRepoRoot Condition="'$(InnerSourceBuildRepoRoot)' == ''">$(CurrentRepoSourceBuildSourceDir)</InnerSourceBuildRepoRoot>
++    <InnerSourceBuildRepoRoot Condition="'$(UseInnerClone)' != 'true'">$(RepoRoot)</InnerSourceBuildRepoRoot>
+ 
+     <CleanInnerSourceBuildRepoRoot Condition="'$(CleanInnerSourceBuildRepoRoot)' == ''">true</CleanInnerSourceBuildRepoRoot>
+ 
+@@ -112,7 +113,7 @@
+           DependsOnTargets="CopyInnerSourceBuildRepoRoot;CloneInnerSourceBuildRepoRoot">
+   </Target>
+ 
+-  <Target Name="CopyInnerSourceBuildRepoRoot" Condition=" '$(CopySrcInsteadOfClone)' == 'true' ">
++  <Target Name="CopyInnerSourceBuildRepoRoot" Condition=" '$(CopySrcInsteadOfClone)' == 'true' and '$(UseInnerClone)' == 'true' ">
+     <ItemGroup>
+       <SourceBuildFilesToCopy Include="$(RepoRoot)/**/*" />
+       <SourceBuildFilesToCopy Include="$(RepoRoot)/**/.*" />
+@@ -132,7 +133,7 @@
+     access to the git data, this also makes it easy to see what changes the source-build infra has
+     made, for diagnosis or exploratory purposes.
+   -->
+-  <Target Name="CloneInnerSourceBuildRepoRoot" Condition=" '$(CopySrcInsteadOfClone)' != 'true'">
++  <Target Name="CloneInnerSourceBuildRepoRoot" Condition=" '$(CopySrcInsteadOfClone)' != 'true' and '$(UseInnerClone)' == 'true' ">
+     <PropertyGroup>
+       <!--
+         By default, copy WIP. WIP copy helps with local machine dev work. Don't copy WIP if this is
+diff --git a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
+index 5b20e23c..1abb1dd2 100644
+--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
++++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
+@@ -53,6 +53,7 @@
+   <Target Name="GetIntermediateNupkgArtifactFiles"
+           DependsOnTargets="
+             GetCategorizedIntermediateNupkgContents;
++            CreateRepoSymbolsArchive;
+             GetSupplementalIntermediateNupkgManifest;
+             GetSymbolsArchive;
+             GetNonShippingNupkgList"
+@@ -81,66 +82,22 @@
+   </Target>
+ 
+   <!--
+-    Create symbols archive and include it in the main intermediate nupkg, by default.
++    Include symbols archive in the main intermediate nupkg, by default.
+ 
+     Repos can select a different intermediate nupkg by defining 'SymbolsIntermediateNupkgCategory'
+     property in eng/SourceBuild.props.
+-
+-    Conditioning out for Windows as the tar execution below doesn't work cross-plat.
+   -->
+   <Target Name="GetSymbolsArchive"
+-    Condition="'$(SupplementalIntermediateNupkgCategory)' == '$(SymbolsIntermediateNupkgCategory)' and
+-               '$(OS)' != 'Windows_NT'">
+-    <PropertyGroup>
+-      <SymbolsRoot>$(CurrentRepoSourceBuildArtifactsDir)</SymbolsRoot>
+-      <!-- Fall back to repo root for source-build-externals or repos that don't have the regular SymbolsRoot as defined above -->
+-      <SymbolsRoot Condition="!Exists('$(SymbolsRoot)') or '$(GitHubRepositoryName)' == 'source-build-externals'">$(RepoRoot)</SymbolsRoot>
+-      <SymbolsArchiveLocation>$(CurrentRepoSourceBuildArtifactsPackagesDir)</SymbolsArchiveLocation>
+-      <SymbolsArchiveLocation Condition="'$(GitHubRepositoryName)' == 'nuget-client'">$(PackageOutputPath)</SymbolsArchiveLocation>
+-      <SymbolsList>$(SymbolsArchiveLocation)\symbols.lst</SymbolsList>
+-      <SymbolsArchivePrefix>Symbols.</SymbolsArchivePrefix>
+-      <SymbolsArchiveSuffix>.$(Version).$(TargetRid)</SymbolsArchiveSuffix>
+-      <SymbolsArchiveName>$(SymbolsArchiveLocation)$(SymbolsArchivePrefix)$(GitHubRepositoryName)$(SymbolsArchiveSuffix)$(ArchiveExtension)</SymbolsArchiveName>
+-    </PropertyGroup>
+-
+-    <ItemGroup>
+-      <AbsoluteSymbolPath Include="$(SymbolsRoot)\**\obj\**\*.pdb" />
+-      <AbsoluteSymbolPath Update="@(AbsoluteSymbolPath)" Condition="'@(AbsoluteSymbolPath)' != ''">
+-        <RelativePath>$([MSBuild]::MakeRelative($(SymbolsRoot), %(FullPath)))</RelativePath>
+-      </AbsoluteSymbolPath>
+-    </ItemGroup>
+-
+-    <WriteLinesToFile
+-      File="$(SymbolsList)"
+-      Lines="@(AbsoluteSymbolPath->'%(RelativePath)')"
+-      Overwrite="true"
+-      Condition="'@(AbsoluteSymbolPath)' != ''" />
+-
+-    <Exec Command="tar --numeric-owner -czf $(SymbolsArchiveName) --files-from=$(SymbolsList)"
+-          WorkingDirectory="$(SymbolsRoot)" Condition="Exists($(SymbolsList))" />
+-    <Message Importance="High" Text="Packaged symbols to $(SymbolsArchiveName)" Condition="Exists($(SymbolsArchiveName))" />
++    Condition="'$(SupplementalIntermediateNupkgCategory)' == '$(SymbolsIntermediateNupkgCategory)' and '$(SymbolsArchiveName)' != ''">
+ 
+     <ItemGroup Condition="Exists($(SymbolsArchiveName))">
+       <Content Include="$(SymbolsArchiveName)" PackagePath="artifacts" />
+     </ItemGroup>
+-
+-    <Delete Files="$(SymbolsList)" Condition="Exists($(SymbolsList))" />
+   </Target>
+ 
+   <!-- Create a list of non-shipping packages and include it in the intermediate package. -->
+   <Target Name="GetNonShippingNupkgList"
+-          Condition="'@(IntermediateNonShippingNupkgFile)' != ''">
+-    <PropertyGroup>
+-      <!-- The prefix needs to match what's defined in tarball source-build infra. Consider using a single property, in the future. -->
+-      <NonShippingPackagesListPrefix>NonShipping.Packages.</NonShippingPackagesListPrefix>
+-      <NonShippingPackagesList>$(CurrentRepoSourceBuildArtifactsPackagesDir)$(NonShippingPackagesListPrefix)$(GitHubRepositoryName).lst</NonShippingPackagesList>
+-    </PropertyGroup>
+-
+-    <WriteLinesToFile
+-      File="$(NonShippingPackagesList)"
+-      Lines="@(IntermediateNonShippingNupkgFile->'%(Filename)%(Extension)')"
+-      Overwrite="true" />
+-
++          Condition="'$(NonShippingPackagesList)' != ''">
+     <ItemGroup>
+       <!-- The list of non-shipping packages goes into the "main" intermediate nupkg. -->
+       <Content Include="$(NonShippingPackagesList)" PackagePath="." />

--- a/src/SourceBuild/patches/arcade/0001-Disable-inner-clone-in-product-source-build.patch
+++ b/src/SourceBuild/patches/arcade/0001-Disable-inner-clone-in-product-source-build.patch
@@ -1,14 +1,14 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nikola Milosavljevic <nikolam@microsoft.com>
-Date: Tue, 16 Jan 2024 20:38:54 +0000
+Date: Tue, 16 Jan 2024 21:26:06 +0000
 Subject: [PATCH] Disable inner-clone in product source-build
 
 ---
  .../tools/SourceBuild/AfterSourceBuild.proj   | 34 ++++++++-
- .../SourceBuild/SourceBuildArcade.targets     | 72 ++++++++++++++++++-
+ .../SourceBuild/SourceBuildArcade.targets     | 71 ++++++++++++++++++-
  .../SourceBuildArcadeBuild.targets            |  5 +-
  .../SourceBuild/SourceBuildIntermediate.proj  | 56 ++-------------
- 4 files changed, 112 insertions(+), 55 deletions(-)
+ 4 files changed, 111 insertions(+), 55 deletions(-)
 
 diff --git a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
 index 31f544e6..0b56b22f 100644
@@ -75,7 +75,7 @@ index 31f544e6..0b56b22f 100644
              CopyIntermediateNupkgProjToProjectDirectory;
              GetLicenseFileForIntermediateNupkgPack;
 diff --git a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
-index 2d1a20d5..c80243d9 100644
+index 2d1a20d5..5d91b110 100644
 --- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
 +++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
 @@ -18,9 +18,19 @@
@@ -98,7 +98,7 @@ index 2d1a20d5..c80243d9 100644
      <CurrentRepoSourceBuildPackageCache>$([MSBuild]::NormalizeDirectory('$(SourceBuildOutputDir)', 'package-cache'))</CurrentRepoSourceBuildPackageCache>
      <SourceBuildSelfPrebuiltReportDir>$([MSBuild]::NormalizeDirectory('$(SourceBuildOutputDir)', 'prebuilt-report'))</SourceBuildSelfPrebuiltReportDir>
  
-@@ -28,8 +38,11 @@
+@@ -28,6 +38,8 @@
        Keep artifacts/ inside source dir so that ancestor-based file lookups find the inner repo, not
        the outer repo. The inner repo global.json and NuGet.config files may have been modified by
        source-build, and we want projects inside the artifacts/ dir to respect that.
@@ -106,11 +106,8 @@ index 2d1a20d5..c80243d9 100644
 +      Inner-clone removal - in VMR use regular artifacts dir.
      -->
      <CurrentRepoSourceBuildArtifactsDir>$([MSBuild]::NormalizeDirectory('$(CurrentRepoSourceBuildSourceDir)', 'artifacts'))</CurrentRepoSourceBuildArtifactsDir>
-+    <CurrentRepoSourceBuildArtifactsDir Condition="'$(UseInnerClone)' != 'true'">$(ArtifactsDir)</CurrentRepoSourceBuildArtifactsDir>
      <CurrentRepoSourceBuildArtifactsPackagesDir>$([MSBuild]::NormalizeDirectory('$(CurrentRepoSourceBuildArtifactsDir)', 'packages', '$(Configuration)'))</CurrentRepoSourceBuildArtifactsPackagesDir>
- 
-     <CurrentRepoSourceBuildNuGetSourceName>source-build-int-nupkg-cache</CurrentRepoSourceBuildNuGetSourceName>
-@@ -106,8 +119,8 @@
+@@ -106,8 +118,8 @@
      <ItemGroup>
        <IntermediateNupkgFile Include="@(IntermediateNupkgArtifactFile)" PackagePath="artifacts" />
  
@@ -121,7 +118,7 @@ index 2d1a20d5..c80243d9 100644
      </ItemGroup>
  
      <RemoveDuplicates Inputs="@(IntermediateNupkgFile)">
-@@ -118,6 +131,61 @@
+@@ -118,6 +130,61 @@
        <IntermediateNonShippingNupkgFile Include="@(IntermediatePackageFile)" Condition="$([System.Text.RegularExpressions.Regex]::Match(%(Identity),'[\\\\/]NonShipping[\\\\/]').Success)"/>
        <SupplementalIntermediateNupkgCategory Include="%(IntermediatePackageFile.Category)" />
      </ItemGroup>

--- a/src/SourceBuild/patches/arcade/0001-Disable-inner-clone-in-product-source-build.patch
+++ b/src/SourceBuild/patches/arcade/0001-Disable-inner-clone-in-product-source-build.patch
@@ -1,17 +1,17 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nikola Milosavljevic <nikolam@microsoft.com>
-Date: Thu, 11 Jan 2024 21:12:12 +0000
+Date: Sat, 13 Jan 2024 20:01:24 +0000
 Subject: [PATCH] Disable inner-clone in product source-build
 
 ---
- .../tools/SourceBuild/AfterSourceBuild.proj   | 46 +++++++++++-
- .../SourceBuild/SourceBuildArcade.targets     | 73 ++++++++++++++++++-
+ .../tools/SourceBuild/AfterSourceBuild.proj   | 32 ++++++++-
+ .../SourceBuild/SourceBuildArcade.targets     | 72 ++++++++++++++++++-
  .../SourceBuildArcadeBuild.targets            |  5 +-
- .../SourceBuild/SourceBuildIntermediate.proj  | 51 +------------
- 4 files changed, 123 insertions(+), 52 deletions(-)
+ .../SourceBuild/SourceBuildIntermediate.proj  | 51 ++-----------
+ 4 files changed, 108 insertions(+), 52 deletions(-)
 
 diff --git a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
-index 31f544e6..2de4e955 100644
+index 31f544e6..1b33e23f 100644
 --- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
 +++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
 @@ -15,7 +15,8 @@
@@ -20,54 +20,40 @@ index 31f544e6..2de4e955 100644
              ReportPrebuiltUsage;
 -            PackSourceBuildIntermediateNupkgs" />
 +            PackSourceBuildIntermediateNupkgs;
-+            CopyRepoArtifacts" />
++            CreateRepoManifest" />
  
    <Target Name="WritePrebuiltUsageData">
      <ItemGroup>
-@@ -117,11 +118,54 @@
+@@ -117,11 +118,40 @@
        DestinationFiles="$(SourceBuildIntermediateNupkgLicenseFile)" />
    </Target>
  
-+  <!-- In VMR build we copy repo artifacts directly, without using the intermediate nupkgs. -->
-+  <Target Name="CopyRepoArtifacts"
++  <!--
++    In VMR build we create repo manifest.
++    SB orchestrator will parse the manifest and copy the artifacts to the right locations.
++  -->
++  <Target Name="CreateRepoManifest"
 +          Condition="'$(DotNetBuildFromSourceFlavor)' == 'Product'"
 +          DependsOnTargets="
 +            GetCategorizedIntermediateNupkgContents;
 +            CreateRepoSymbolsArchive">
 +
 +    <PropertyGroup>
-+      <_NupkgsDestination>$(CurrentSourceBuiltPackagesDir)</_NupkgsDestination>
-+      <_NupkgsDestination Condition="'$(GitHubRepositoryName)' == 'source-build-reference-packages'">$(ReferencePackagesDir)</_NupkgsDestination>
++      <RepoManifestFile>$(ArtifactsDir)RepoManifest.xml</RepoManifestFile>
 +    </PropertyGroup>
 +
 +    <ItemGroup>
-+      <_AssetsToCopy Include="@(IntermediateNupkgFile)" Condition="'%(Extension)' != '.nupkg'" />
-+      <_NugetPackagesToCopy Include="@(IntermediateNupkgFile)" Condition="'%(Extension)' == '.nupkg'"/>
++      <Line Include='&lt;Build&gt;' />
++      <Line Include='&lt;Artifact Path="%(IntermediateNupkgFile.Identity)" /&gt;' />
++      <Line Include='&lt;/Build&gt;' />
 +    </ItemGroup>
 +
-+    <!-- Copy non-shipping package list -->
-+    <Copy
-+      Condition="'$(NonShippingPackagesList)' != ''"
-+      SourceFiles="$(NonShippingPackagesList)"
-+      DestinationFolder="$(PackageListsDir)" />
++    <WriteLinesToFile
++      File="$(RepoManifestFile)"
++      Lines="@(Line)"
++      Overwrite="true"
++      />
 +
-+    <!-- Building SBRP: At this point the References directory contains the previously-source-built SBRPs,
-+         clear it before copying the current SBRPs.  This ensures n-1 SBRPs aren't required to build the product repos. -->
-+    <RemoveDir
-+      Condition="'$(GitHubRepositoryName)' == 'source-build-reference-packages'"
-+      Directories="$(ReferencePackagesDir)" />
-+
-+    <!-- Copy nupkgs -->
-+    <Copy
-+      Condition="'@(_NugetPackagesToCopy)' != ''"
-+      SourceFiles="@(_NugetPackagesToCopy)"
-+      DestinationFolder="$(_NupkgsDestination)" />
-+
-+    <!-- Copy assets -->
-+    <Copy
-+      Condition="'@(_AssetsToCopy)' != ''"
-+      SourceFiles="@(_AssetsToCopy)"
-+      DestinationFolder="$(SourceBuiltAssetsDir)" />
 +  </Target>
 +
    <!--
@@ -80,7 +66,7 @@ index 31f544e6..2de4e955 100644
              CopyIntermediateNupkgProjToProjectDirectory;
              GetLicenseFileForIntermediateNupkgPack;
 diff --git a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
-index 2d1a20d5..4ccb159a 100644
+index 2d1a20d5..afbef0d6 100644
 --- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
 +++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
 @@ -24,12 +24,24 @@
@@ -119,7 +105,7 @@ index 2d1a20d5..4ccb159a 100644
      </ItemGroup>
  
      <RemoveDuplicates Inputs="@(IntermediateNupkgFile)">
-@@ -118,6 +130,63 @@
+@@ -118,6 +130,62 @@
        <IntermediateNonShippingNupkgFile Include="@(IntermediatePackageFile)" Condition="$([System.Text.RegularExpressions.Regex]::Match(%(Identity),'[\\\\/]NonShipping[\\\\/]').Success)"/>
        <SupplementalIntermediateNupkgCategory Include="%(IntermediatePackageFile.Category)" />
      </ItemGroup>
@@ -149,12 +135,7 @@ index 2d1a20d5..4ccb159a 100644
 +      <!-- Fall back to repo root for source-build-externals or repos that don't have the regular SymbolsRoot as defined above -->
 +      <SymbolsRoot Condition="!Exists('$(SymbolsRoot)') or '$(GitHubRepositoryName)' == 'source-build-externals'">$(RepoRoot)</SymbolsRoot>
 +      <SymbolsArchiveLocation>$(CurrentRepoSourceBuildArtifactsPackagesDir)</SymbolsArchiveLocation>
-+      <SymbolsArchiveLocation Condition="'$(GitHubRepositoryName)' == 'nuget-client'">$(PackageOutputPath)</SymbolsArchiveLocation>
-+      <!--
-+        If we're doing full product source-build, we do not have intermediate package to carry this archive.
-+        Instead, we create it in blob-feed assets folder, directly.
-+      -->
-+      <SymbolsArchiveLocation Condition="'$(DotNetBuildFromSourceFlavor)' == 'Product'">$(SourceBuiltAssetsDir)</SymbolsArchiveLocation>
++      <SymbolsArchiveLocation Condition="'$(GitHubRepositoryName)' == 'nuget-client' and '$(PackageOutputPath)' != ''">$(PackageOutputPath)</SymbolsArchiveLocation>
 +      <SymbolsList>$(SymbolsArchiveLocation)\symbols.lst</SymbolsList>
 +      <SymbolsArchivePrefix>Symbols.</SymbolsArchivePrefix>
 +      <!-- $(Version) and $(TargetRid) are only available when target is executed as part of intermediate package creation. -->
@@ -178,6 +159,10 @@ index 2d1a20d5..4ccb159a 100644
 +    <Exec Command="tar --numeric-owner -czf $(SymbolsArchiveName) --files-from=$(SymbolsList)"
 +          WorkingDirectory="$(SymbolsRoot)" Condition="Exists($(SymbolsList))" />
 +    <Message Importance="High" Text="Packaged symbols to $(SymbolsArchiveName)" Condition="Exists($(SymbolsArchiveName))" />
++
++    <ItemGroup>
++      <IntermediateNupkgFile Include="$(SymbolsArchiveName)" PackagePath="artifacts" Condition="Exists($(SymbolsArchiveName)) and '$(CreateIntermediatePackage)' != 'true'" />
++    </ItemGroup>
 +
 +    <Delete Files="$(SymbolsList)" Condition="Exists($(SymbolsList))" />
    </Target>

--- a/src/SourceBuild/patches/arcade/0001-Disable-inner-clone-in-product-source-build.patch
+++ b/src/SourceBuild/patches/arcade/0001-Disable-inner-clone-in-product-source-build.patch
@@ -1,17 +1,17 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nikola Milosavljevic <nikolam@microsoft.com>
-Date: Sat, 13 Jan 2024 20:01:24 +0000
+Date: Tue, 16 Jan 2024 04:45:09 +0000
 Subject: [PATCH] Disable inner-clone in product source-build
 
 ---
  .../tools/SourceBuild/AfterSourceBuild.proj   | 32 ++++++++-
- .../SourceBuild/SourceBuildArcade.targets     | 72 ++++++++++++++++++-
+ .../SourceBuild/SourceBuildArcade.targets     | 71 ++++++++++++++++++-
  .../SourceBuildArcadeBuild.targets            |  5 +-
- .../SourceBuild/SourceBuildIntermediate.proj  | 51 ++-----------
- 4 files changed, 108 insertions(+), 52 deletions(-)
+ .../SourceBuild/SourceBuildIntermediate.proj  | 56 ++-------------
+ 4 files changed, 110 insertions(+), 54 deletions(-)
 
 diff --git a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
-index 31f544e6..1b33e23f 100644
+index 31f544e6..67595736 100644
 --- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
 +++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
 @@ -15,7 +15,8 @@
@@ -31,29 +31,29 @@ index 31f544e6..1b33e23f 100644
 +  <!--
 +    In VMR build we create repo manifest.
 +    SB orchestrator will parse the manifest and copy the artifacts to the right locations.
++
++    This can be removed once we enable standard repo assets manifests and SB orchestrator
++    starts using it - https://github.com/dotnet/source-build/issues/3970
 +  -->
 +  <Target Name="CreateRepoManifest"
 +          Condition="'$(DotNetBuildFromSourceFlavor)' == 'Product'"
 +          DependsOnTargets="
 +            GetCategorizedIntermediateNupkgContents;
 +            CreateRepoSymbolsArchive">
-+
 +    <PropertyGroup>
 +      <RepoManifestFile>$(ArtifactsDir)RepoManifest.xml</RepoManifestFile>
 +    </PropertyGroup>
 +
 +    <ItemGroup>
-+      <Line Include='&lt;Build&gt;' />
-+      <Line Include='&lt;Artifact Path="%(IntermediateNupkgFile.Identity)" /&gt;' />
-+      <Line Include='&lt;/Build&gt;' />
++      <RepoManifestLine Include='&lt;Build&gt;' />
++      <RepoManifestLine Include='&lt;Artifact Path="%(IntermediateNupkgFile.Identity)" /&gt;' />
++      <RepoManifestLine Include='&lt;/Build&gt;' />
 +    </ItemGroup>
 +
 +    <WriteLinesToFile
 +      File="$(RepoManifestFile)"
-+      Lines="@(Line)"
-+      Overwrite="true"
-+      />
-+
++      Lines="@(RepoManifestLine)"
++      Overwrite="true" />
 +  </Target>
 +
    <!--
@@ -66,7 +66,7 @@ index 31f544e6..1b33e23f 100644
              CopyIntermediateNupkgProjToProjectDirectory;
              GetLicenseFileForIntermediateNupkgPack;
 diff --git a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
-index 2d1a20d5..afbef0d6 100644
+index 2d1a20d5..0390ec54 100644
 --- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
 +++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
 @@ -24,12 +24,24 @@
@@ -90,7 +90,7 @@ index 2d1a20d5..afbef0d6 100644
 +      Inner-clone removal - in VMR use regular artifacts dir.
      -->
      <CurrentRepoSourceBuildArtifactsDir>$([MSBuild]::NormalizeDirectory('$(CurrentRepoSourceBuildSourceDir)', 'artifacts'))</CurrentRepoSourceBuildArtifactsDir>
-+    <CurrentRepoSourceBuildArtifactsDir Condition="'$(UseInnerClone)' != 'true'">$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)'))</CurrentRepoSourceBuildArtifactsDir>
++    <CurrentRepoSourceBuildArtifactsDir Condition="'$(UseInnerClone)' != 'true'">$(ArtifactsDir)</CurrentRepoSourceBuildArtifactsDir>
      <CurrentRepoSourceBuildArtifactsPackagesDir>$([MSBuild]::NormalizeDirectory('$(CurrentRepoSourceBuildArtifactsDir)', 'packages', '$(Configuration)'))</CurrentRepoSourceBuildArtifactsPackagesDir>
  
      <CurrentRepoSourceBuildNuGetSourceName>source-build-int-nupkg-cache</CurrentRepoSourceBuildNuGetSourceName>
@@ -105,7 +105,7 @@ index 2d1a20d5..afbef0d6 100644
      </ItemGroup>
  
      <RemoveDuplicates Inputs="@(IntermediateNupkgFile)">
-@@ -118,6 +130,62 @@
+@@ -118,6 +130,61 @@
        <IntermediateNonShippingNupkgFile Include="@(IntermediatePackageFile)" Condition="$([System.Text.RegularExpressions.Regex]::Match(%(Identity),'[\\\\/]NonShipping[\\\\/]').Success)"/>
        <SupplementalIntermediateNupkgCategory Include="%(IntermediatePackageFile.Category)" />
      </ItemGroup>
@@ -121,7 +121,6 @@ index 2d1a20d5..afbef0d6 100644
 +      File="$(NonShippingPackagesList)"
 +      Lines="@(IntermediateNonShippingNupkgFile->'%(Filename)%(Extension)')"
 +      Overwrite="true" />
-+
 +  </Target>
 +
 +  <!--
@@ -135,17 +134,17 @@ index 2d1a20d5..afbef0d6 100644
 +      <!-- Fall back to repo root for source-build-externals or repos that don't have the regular SymbolsRoot as defined above -->
 +      <SymbolsRoot Condition="!Exists('$(SymbolsRoot)') or '$(GitHubRepositoryName)' == 'source-build-externals'">$(RepoRoot)</SymbolsRoot>
 +      <SymbolsArchiveLocation>$(CurrentRepoSourceBuildArtifactsPackagesDir)</SymbolsArchiveLocation>
-+      <SymbolsArchiveLocation Condition="'$(GitHubRepositoryName)' == 'nuget-client' and '$(PackageOutputPath)' != ''">$(PackageOutputPath)</SymbolsArchiveLocation>
-+      <SymbolsList>$(SymbolsArchiveLocation)\symbols.lst</SymbolsList>
++      <SymbolsArchiveLocation Condition="'$(GitHubRepositoryName)' == 'nuget-client' and '$(PackageOutputPath)' != ''">$([MSBuild]::EnsureTrailingSlash('$(PackageOutputPath)'))</SymbolsArchiveLocation>
++      <SymbolsList>$([MSBuild]::NormalizePath('$(SymbolsArchiveLocation)', 'symbols.lst'))</SymbolsList>
 +      <SymbolsArchivePrefix>Symbols.</SymbolsArchivePrefix>
 +      <!-- $(Version) and $(TargetRid) are only available when target is executed as part of intermediate package creation. -->
 +      <SymbolsArchiveSuffix Condition="'$(CreateIntermediatePackage)' == 'true'">.$(Version).$(TargetRid)</SymbolsArchiveSuffix>
-+      <SymbolsArchiveName>$(SymbolsArchiveLocation)$(SymbolsArchivePrefix)$(GitHubRepositoryName)$(SymbolsArchiveSuffix)$(ArchiveExtension)</SymbolsArchiveName>
++      <SymbolsArchiveFile>$(SymbolsArchiveLocation)$(SymbolsArchivePrefix)$(GitHubRepositoryName)$(SymbolsArchiveSuffix)$(ArchiveExtension)</SymbolsArchiveFile>
 +    </PropertyGroup>
 +
 +    <ItemGroup>
-+      <AbsoluteSymbolPath Include="$(SymbolsRoot)\**\obj\**\*.pdb" />
-+      <AbsoluteSymbolPath Update="@(AbsoluteSymbolPath)" Condition="'@(AbsoluteSymbolPath)' != ''">
++      <AbsoluteSymbolPath Include="$(SymbolsRoot)**\obj\**\*.pdb" />
++      <AbsoluteSymbolPath Condition="'@(AbsoluteSymbolPath)' != ''">
 +        <RelativePath>$([MSBuild]::MakeRelative($(SymbolsRoot), %(FullPath)))</RelativePath>
 +      </AbsoluteSymbolPath>
 +    </ItemGroup>
@@ -156,12 +155,12 @@ index 2d1a20d5..afbef0d6 100644
 +      Overwrite="true"
 +      Condition="'@(AbsoluteSymbolPath)' != ''" />
 +
-+    <Exec Command="tar --numeric-owner -czf $(SymbolsArchiveName) --files-from=$(SymbolsList)"
++    <Exec Command="tar --numeric-owner -czf $(SymbolsArchiveFile) --files-from=$(SymbolsList)"
 +          WorkingDirectory="$(SymbolsRoot)" Condition="Exists($(SymbolsList))" />
-+    <Message Importance="High" Text="Packaged symbols to $(SymbolsArchiveName)" Condition="Exists($(SymbolsArchiveName))" />
++    <Message Importance="High" Text="Packaged symbols to $(SymbolsArchiveFile)" Condition="Exists($(SymbolsList))" />
 +
 +    <ItemGroup>
-+      <IntermediateNupkgFile Include="$(SymbolsArchiveName)" PackagePath="artifacts" Condition="Exists($(SymbolsArchiveName)) and '$(CreateIntermediatePackage)' != 'true'" />
++      <IntermediateNupkgFile Include="$(SymbolsArchiveFile)" PackagePath="artifacts" Condition="Exists($(SymbolsArchiveFile)) and '$(CreateIntermediatePackage)' != 'true'" />
 +    </ItemGroup>
 +
 +    <Delete Files="$(SymbolsList)" Condition="Exists($(SymbolsList))" />
@@ -199,7 +198,7 @@ index 177a5267..18ab693c 100644
        <!--
          By default, copy WIP. WIP copy helps with local machine dev work. Don't copy WIP if this is
 diff --git a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
-index 5b20e23c..1abb1dd2 100644
+index 5b20e23c..e120e38d 100644
 --- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
 +++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildIntermediate.proj
 @@ -53,6 +53,7 @@
@@ -210,7 +209,7 @@ index 5b20e23c..1abb1dd2 100644
              GetSupplementalIntermediateNupkgManifest;
              GetSymbolsArchive;
              GetNonShippingNupkgList"
-@@ -81,66 +82,22 @@
+@@ -81,66 +82,23 @@
    </Target>
  
    <!--
@@ -249,14 +248,16 @@ index 5b20e23c..1abb1dd2 100644
 -      Lines="@(AbsoluteSymbolPath->'%(RelativePath)')"
 -      Overwrite="true"
 -      Condition="'@(AbsoluteSymbolPath)' != ''" />
--
++    Condition="'$(SupplementalIntermediateNupkgCategory)' == '$(SymbolsIntermediateNupkgCategory)' and '$(SymbolsArchiveFile)' != ''">
+ 
 -    <Exec Command="tar --numeric-owner -czf $(SymbolsArchiveName) --files-from=$(SymbolsList)"
 -          WorkingDirectory="$(SymbolsRoot)" Condition="Exists($(SymbolsList))" />
 -    <Message Importance="High" Text="Packaged symbols to $(SymbolsArchiveName)" Condition="Exists($(SymbolsArchiveName))" />
-+    Condition="'$(SupplementalIntermediateNupkgCategory)' == '$(SymbolsIntermediateNupkgCategory)' and '$(SymbolsArchiveName)' != ''">
- 
-     <ItemGroup Condition="Exists($(SymbolsArchiveName))">
-       <Content Include="$(SymbolsArchiveName)" PackagePath="artifacts" />
+-
+-    <ItemGroup Condition="Exists($(SymbolsArchiveName))">
+-      <Content Include="$(SymbolsArchiveName)" PackagePath="artifacts" />
++    <ItemGroup Condition="Exists($(SymbolsArchiveFile))">
++      <Content Include="$(SymbolsArchiveFile)" PackagePath="artifacts" />
      </ItemGroup>
 -
 -    <Delete Files="$(SymbolsList)" Condition="Exists($(SymbolsList))" />
@@ -276,7 +277,8 @@ index 5b20e23c..1abb1dd2 100644
 -      Lines="@(IntermediateNonShippingNupkgFile->'%(Filename)%(Extension)')"
 -      Overwrite="true" />
 -
-+          Condition="'$(NonShippingPackagesList)' != ''">
++          Condition="'$(NonShippingPackagesList)' != ''"
++          DependsOnTargets="GetCategorizedIntermediateNupkgContents">
      <ItemGroup>
        <!-- The list of non-shipping packages goes into the "main" intermediate nupkg. -->
        <Content Include="$(NonShippingPackagesList)" PackagePath="." />

--- a/src/SourceBuild/patches/arcade/0001-Disable-inner-clone-in-product-source-build.patch
+++ b/src/SourceBuild/patches/arcade/0001-Disable-inner-clone-in-product-source-build.patch
@@ -1,17 +1,17 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nikola Milosavljevic <nikolam@microsoft.com>
-Date: Tue, 16 Jan 2024 04:45:09 +0000
+Date: Tue, 16 Jan 2024 20:38:54 +0000
 Subject: [PATCH] Disable inner-clone in product source-build
 
 ---
- .../tools/SourceBuild/AfterSourceBuild.proj   | 32 ++++++++-
- .../SourceBuild/SourceBuildArcade.targets     | 71 ++++++++++++++++++-
+ .../tools/SourceBuild/AfterSourceBuild.proj   | 34 ++++++++-
+ .../SourceBuild/SourceBuildArcade.targets     | 72 ++++++++++++++++++-
  .../SourceBuildArcadeBuild.targets            |  5 +-
  .../SourceBuild/SourceBuildIntermediate.proj  | 56 ++-------------
- 4 files changed, 110 insertions(+), 54 deletions(-)
+ 4 files changed, 112 insertions(+), 55 deletions(-)
 
 diff --git a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
-index 31f544e6..67595736 100644
+index 31f544e6..0b56b22f 100644
 --- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
 +++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
 @@ -15,7 +15,8 @@
@@ -24,6 +24,15 @@ index 31f544e6..67595736 100644
  
    <Target Name="WritePrebuiltUsageData">
      <ItemGroup>
+@@ -26,7 +27,7 @@
+       <SourceBuiltPackageFiles Include="$(PreviouslySourceBuiltNupkgCacheDir)**/*.nupkg" Condition=" '$(PreviouslySourceBuiltNupkgCacheDir)' != '' " />
+ 
+       <!-- Add some other potential top-level project directories for a more specific report. -->
+-      <ProjectDirectories Include="$(CurrentRepoSourceBuildSourceDir)" />
++      <ProjectDirectories Include="$(CurrentRepoSourceBuildSourceDir)"  Condition="'$(UseInnerClone)' == 'true'" />
+       <!-- Finally, scan entire source-build, in case project.assets.json ends up in an unexpected place. -->
+       <ProjectDirectories Include="$(SourceBuildOutputDir)" />
+     </ItemGroup>
 @@ -117,11 +118,40 @@
        DestinationFiles="$(SourceBuildIntermediateNupkgLicenseFile)" />
    </Target>
@@ -66,13 +75,13 @@ index 31f544e6..67595736 100644
              CopyIntermediateNupkgProjToProjectDirectory;
              GetLicenseFileForIntermediateNupkgPack;
 diff --git a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
-index 2d1a20d5..0390ec54 100644
+index 2d1a20d5..c80243d9 100644
 --- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
 +++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
-@@ -24,12 +24,24 @@
-     <CurrentRepoSourceBuildPackageCache>$([MSBuild]::NormalizeDirectory('$(SourceBuildOutputDir)', 'package-cache'))</CurrentRepoSourceBuildPackageCache>
-     <SourceBuildSelfPrebuiltReportDir>$([MSBuild]::NormalizeDirectory('$(SourceBuildOutputDir)', 'prebuilt-report'))</SourceBuildSelfPrebuiltReportDir>
+@@ -18,9 +18,19 @@
+   <Import Project="$(RepositoryEngineeringDir)SourceBuild.props" Condition="Exists('$(RepositoryEngineeringDir)SourceBuild.props')" />
  
+   <PropertyGroup>
 +    <!--
 +      Do not use inner-clone in full product source-build, unless explicitly requested,
 +      i.e. for specific repos, like source-build-externals.
@@ -82,7 +91,14 @@ index 2d1a20d5..0390ec54 100644
 +    <!-- Do not create intermediate package in full product source-build. -->
 +    <CreateIntermediatePackage Condition="'$(DotNetBuildFromSourceFlavor)' != 'Product'">true</CreateIntermediatePackage>
 +
-     <!--
+     <!-- Prefer abbreviations to avoid long paths (breaks on Windows) -->
+     <SourceBuildOutputDir Condition="'$(SourceBuildOutputDir)' == ''">$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'sb'))</SourceBuildOutputDir>
+     <CurrentRepoSourceBuildSourceDir>$([MSBuild]::NormalizeDirectory('$(SourceBuildOutputDir)', 'src'))</CurrentRepoSourceBuildSourceDir>
++    <CurrentRepoSourceBuildSourceDir Condition="'$(UseInnerClone)' != 'true'">$(RepoRoot)</CurrentRepoSourceBuildSourceDir>
+     <CurrentRepoSourceBuildPackageCache>$([MSBuild]::NormalizeDirectory('$(SourceBuildOutputDir)', 'package-cache'))</CurrentRepoSourceBuildPackageCache>
+     <SourceBuildSelfPrebuiltReportDir>$([MSBuild]::NormalizeDirectory('$(SourceBuildOutputDir)', 'prebuilt-report'))</SourceBuildSelfPrebuiltReportDir>
+ 
+@@ -28,8 +38,11 @@
        Keep artifacts/ inside source dir so that ancestor-based file lookups find the inner repo, not
        the outer repo. The inner repo global.json and NuGet.config files may have been modified by
        source-build, and we want projects inside the artifacts/ dir to respect that.
@@ -94,7 +110,7 @@ index 2d1a20d5..0390ec54 100644
      <CurrentRepoSourceBuildArtifactsPackagesDir>$([MSBuild]::NormalizeDirectory('$(CurrentRepoSourceBuildArtifactsDir)', 'packages', '$(Configuration)'))</CurrentRepoSourceBuildArtifactsPackagesDir>
  
      <CurrentRepoSourceBuildNuGetSourceName>source-build-int-nupkg-cache</CurrentRepoSourceBuildNuGetSourceName>
-@@ -106,8 +118,8 @@
+@@ -106,8 +119,8 @@
      <ItemGroup>
        <IntermediateNupkgFile Include="@(IntermediateNupkgArtifactFile)" PackagePath="artifacts" />
  
@@ -105,7 +121,7 @@ index 2d1a20d5..0390ec54 100644
      </ItemGroup>
  
      <RemoveDuplicates Inputs="@(IntermediateNupkgFile)">
-@@ -118,6 +130,61 @@
+@@ -118,6 +131,61 @@
        <IntermediateNonShippingNupkgFile Include="@(IntermediatePackageFile)" Condition="$([System.Text.RegularExpressions.Regex]::Match(%(Identity),'[\\\\/]NonShipping[\\\\/]').Success)"/>
        <SupplementalIntermediateNupkgCategory Include="%(IntermediatePackageFile.Category)" />
      </ItemGroup>

--- a/src/SourceBuild/patches/arcade/0001-Disable-inner-clone-in-product-source-build.patch
+++ b/src/SourceBuild/patches/arcade/0001-Disable-inner-clone-in-product-source-build.patch
@@ -1,14 +1,14 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nikola Milosavljevic <nikolam@microsoft.com>
-Date: Tue, 9 Jan 2024 02:15:49 +0000
+Date: Wed, 10 Jan 2024 18:12:05 +0000
 Subject: [PATCH] Disable inner-clone in product source-build
 
 ---
  .../tools/SourceBuild/AfterSourceBuild.proj   | 48 +++++++++++-
- .../SourceBuild/SourceBuildArcade.targets     | 75 ++++++++++++++++++-
+ .../SourceBuild/SourceBuildArcade.targets     | 73 ++++++++++++++++++-
  .../SourceBuildArcadeBuild.targets            |  5 +-
  .../SourceBuild/SourceBuildIntermediate.proj  | 51 +------------
- 4 files changed, 127 insertions(+), 52 deletions(-)
+ 4 files changed, 125 insertions(+), 52 deletions(-)
 
 diff --git a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
 index 31f544e6..3fed45fc 100644
@@ -82,10 +82,10 @@ index 31f544e6..3fed45fc 100644
              CopyIntermediateNupkgProjToProjectDirectory;
              GetLicenseFileForIntermediateNupkgPack;
 diff --git a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
-index 2d1a20d5..df7bfde8 100644
+index 2d1a20d5..4ccb159a 100644
 --- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
 +++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
-@@ -24,12 +24,26 @@
+@@ -24,12 +24,24 @@
      <CurrentRepoSourceBuildPackageCache>$([MSBuild]::NormalizeDirectory('$(SourceBuildOutputDir)', 'package-cache'))</CurrentRepoSourceBuildPackageCache>
      <SourceBuildSelfPrebuiltReportDir>$([MSBuild]::NormalizeDirectory('$(SourceBuildOutputDir)', 'prebuilt-report'))</SourceBuildSelfPrebuiltReportDir>
  
@@ -94,11 +94,9 @@ index 2d1a20d5..df7bfde8 100644
 +      i.e. for specific repos, like source-build-externals.
 +    -->
 +    <UseInnerClone Condition="'$(UseInnerClone)' == '' and '$(DotNetBuildFromSourceFlavor)' != 'Product'">true</UseInnerClone>
-+    <UseInnerClone Condition="'$(UseInnerClone)' == '' and '$(DotNetBuildFromSourceFlavor)' == 'Product'">false</UseInnerClone>
 +
 +    <!-- Do not create intermediate package in full product source-build. -->
 +    <CreateIntermediatePackage Condition="'$(DotNetBuildFromSourceFlavor)' != 'Product'">true</CreateIntermediatePackage>
-+    <CreateIntermediatePackage Condition="'$(DotNetBuildFromSourceFlavor)' == 'Product'">false</CreateIntermediatePackage>
 +
      <!--
        Keep artifacts/ inside source dir so that ancestor-based file lookups find the inner repo, not
@@ -108,11 +106,11 @@ index 2d1a20d5..df7bfde8 100644
 +      Inner-clone removal - in VMR use regular artifacts dir.
      -->
      <CurrentRepoSourceBuildArtifactsDir>$([MSBuild]::NormalizeDirectory('$(CurrentRepoSourceBuildSourceDir)', 'artifacts'))</CurrentRepoSourceBuildArtifactsDir>
-+    <CurrentRepoSourceBuildArtifactsDir Condition="'$(UseInnerClone)' == 'false'">$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)'))</CurrentRepoSourceBuildArtifactsDir>
++    <CurrentRepoSourceBuildArtifactsDir Condition="'$(UseInnerClone)' != 'true'">$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)'))</CurrentRepoSourceBuildArtifactsDir>
      <CurrentRepoSourceBuildArtifactsPackagesDir>$([MSBuild]::NormalizeDirectory('$(CurrentRepoSourceBuildArtifactsDir)', 'packages', '$(Configuration)'))</CurrentRepoSourceBuildArtifactsPackagesDir>
  
      <CurrentRepoSourceBuildNuGetSourceName>source-build-int-nupkg-cache</CurrentRepoSourceBuildNuGetSourceName>
-@@ -106,8 +120,8 @@
+@@ -106,8 +118,8 @@
      <ItemGroup>
        <IntermediateNupkgFile Include="@(IntermediateNupkgArtifactFile)" PackagePath="artifacts" />
  
@@ -123,7 +121,7 @@ index 2d1a20d5..df7bfde8 100644
      </ItemGroup>
  
      <RemoveDuplicates Inputs="@(IntermediateNupkgFile)">
-@@ -118,6 +132,63 @@
+@@ -118,6 +130,63 @@
        <IntermediateNonShippingNupkgFile Include="@(IntermediatePackageFile)" Condition="$([System.Text.RegularExpressions.Regex]::Match(%(Identity),'[\\\\/]NonShipping[\\\\/]').Success)"/>
        <SupplementalIntermediateNupkgCategory Include="%(IntermediatePackageFile.Category)" />
      </ItemGroup>

--- a/src/SourceBuild/patches/arcade/0001-Disable-inner-clone-in-product-source-build.patch
+++ b/src/SourceBuild/patches/arcade/0001-Disable-inner-clone-in-product-source-build.patch
@@ -1,17 +1,17 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nikola Milosavljevic <nikolam@microsoft.com>
-Date: Wed, 10 Jan 2024 18:12:05 +0000
+Date: Thu, 11 Jan 2024 21:12:12 +0000
 Subject: [PATCH] Disable inner-clone in product source-build
 
 ---
- .../tools/SourceBuild/AfterSourceBuild.proj   | 48 +++++++++++-
+ .../tools/SourceBuild/AfterSourceBuild.proj   | 46 +++++++++++-
  .../SourceBuild/SourceBuildArcade.targets     | 73 ++++++++++++++++++-
  .../SourceBuildArcadeBuild.targets            |  5 +-
  .../SourceBuild/SourceBuildIntermediate.proj  | 51 +------------
- 4 files changed, 125 insertions(+), 52 deletions(-)
+ 4 files changed, 123 insertions(+), 52 deletions(-)
 
 diff --git a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
-index 31f544e6..3fed45fc 100644
+index 31f544e6..2de4e955 100644
 --- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
 +++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
 @@ -15,7 +15,8 @@
@@ -24,7 +24,7 @@ index 31f544e6..3fed45fc 100644
  
    <Target Name="WritePrebuiltUsageData">
      <ItemGroup>
-@@ -117,11 +118,56 @@
+@@ -117,11 +118,54 @@
        DestinationFiles="$(SourceBuildIntermediateNupkgLicenseFile)" />
    </Target>
  
@@ -73,11 +73,9 @@ index 31f544e6..3fed45fc 100644
    <!--
      Create source-build intermediate NuGet package and supplemental intermediate NuGet packages (if
      necessary) for dependency transport to downstream repos.
-+
-+    In VMR build we do not use the intermediate nupkgs, so we skip this step.
    -->
    <Target Name="PackSourceBuildIntermediateNupkgs"
-+          Condition="'$(DotNetBuildFromSourceFlavor)' != 'Product'"
++          Condition="'$(CreateIntermediatePackage)' == 'true'"
            DependsOnTargets="
              CopyIntermediateNupkgProjToProjectDirectory;
              GetLicenseFileForIntermediateNupkgPack;


### PR DESCRIPTION
Contributes to: https://github.com/dotnet/source-build/issues/3072

There is a PR in `arcade` repo for the patch carried in this PR: https://github.com/dotnet/arcade/pull/14348

### Summary of changes

Several new properties, for artifacts destination paths, are passed to repo build.

A new way to determine sdk version was required due to removal of `installer`'s intermediate package.

SBRP repo requires setting `SkipEnsurePackagesCreated` to `true` to skip the verification target. The only package that was created in the past was the Intermediate package, carrying reference package. What would have been the content of that package continues to be copied to `prereqs/packages/reference`.

`ExtractIntermediatePackages` target is still needed for `arcade` and `sbrp` repo builds. This can be removed once source-build picks up new arcade tooling that contains inner-clone removal work.

I was considering an improvement in `DetermineSourceBuiltSdkVersion` target, and use of `Zip` task, however it does not support `tar.gz` today, so this will stay as Linux-only, like the target it replaces - `DetermineMicrosoftSourceBuildIntermediateInstallerVersion`. Once Windows is enabled, SDK package would be a `.zip` and `Zip` task would be used for Windows build.

### Benefits

Besides simpler developer workflow and removal of inner-build complexities, there are several performance benefits:
- Faster product build - saving about 6 minutes
- Smaller disk footprint, If not using `--clean-while-building` option - saving 9GB
- Smaller symbols files, as compiler is now able to add sourcelinks instead of embedding all source files