### PR TITLE
Disable dotnet-watch test for mono

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetWatchTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetWatchTests.cs
@@ -16,6 +16,12 @@ public class DotNetWatchTests : SdkTests
     [Fact]
     public void WatchTests()
     {
+        if (DotNetHelper.IsMonoRuntime)
+        {
+            // TODO: Temporarily disabled due to https://github.com/dotnet/sdk/issues/37774
+            return;
+        }
+        
         string projectDirectory = DotNetHelper.ExecuteNew(DotNetTemplate.Console.GetName(), nameof(DotNetWatchTests));
         bool outputChanged = false;
 


### PR DESCRIPTION
Disables the dotnet-watch test for Mono runtime due to https://github.com/dotnet/sdk/issues/37774. Related to https://github.com/dotnet/installer/pull/18152.