### PR TITLE
Update alpine-3.17 to alpine-3.19-WithNode

### DIFF
--- a/eng/pipelines/source-build-sdk-diff-tests.yml
+++ b/eng/pipelines/source-build-sdk-diff-tests.yml
@@ -38,8 +38,8 @@ jobs:
 
 - template: templates/jobs/sdk-diff-tests.yml
   parameters:
-    buildName: Alpine317_Offline_MsftSdk
-    targetRid: alpine.3.17-x64
+    buildName: Alpine319_Offline_MsftSdk
+    targetRid: alpine.3.19-x64
     architecture: x64
     dotnetDotnetRunId: ${{ parameters.dotnetDotnetRunId }}
 

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -192,7 +192,7 @@ jobs:
       fi
       
       if [[ '${{ parameters.withPreviousSDK }}' == 'True' ]]; then
-        # Source-built artifacts are from CentOS 8 Stream or Alpine 3.17. We want to download them without
+        # Source-built artifacts are from CentOS 8 Stream or Alpine 3.19. We want to download them without
         # downloading portable versions from the internet.
         customPrepArgs="${customPrepArgs} --no-sdk --no-bootstrap"
         prepSdk=false

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -16,7 +16,7 @@ parameters:
 
   # The following parameters aren't expected to be passed in rather they are used for encapsulation
   # -----------------------------------------------------------------------------------------------
-  alpine317Container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.17
+  alpine319Container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
   centOSStream8Container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8
   centOSStream9Container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9
   fedora39Container: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-39
@@ -112,15 +112,15 @@ stages:
     - template: ../jobs/vmr-build.yml
       parameters:
         # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-        buildName: Alpine317_Offline_PreviousSourceBuiltSdk
+        buildName: Alpine319_Offline_PreviousSourceBuiltSdk
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
         vmrBranch: ${{ variables.VmrBranch }}
         architecture: x64
-        artifactsRid: alpine.3.17-x64
+        artifactsRid: alpine.3.19-x64
         pool:
           name: ${{ variables.defaultPoolName }}
           demands: ${{ variables.defaultPoolDemands }}
-        container: ${{ parameters.alpine317Container }}
+        container: ${{ parameters.alpine319Container }}
         buildFromArchive: false            # 🚫
         enablePoison: true                 # ✅
         excludeOmniSharpTests: true        # ✅
@@ -133,15 +133,15 @@ stages:
     - template: ../jobs/vmr-build.yml
       parameters:
         # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-        buildName: Alpine317_Online_MsftSdk
+        buildName: Alpine319_Online_MsftSdk
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
         vmrBranch: ${{ variables.VmrBranch }}
         architecture: x64
-        artifactsRid: alpine.3.17-x64
+        artifactsRid: alpine.3.19-x64
         pool:
           name: ${{ variables.defaultPoolName }}
           demands: ${{ variables.defaultPoolDemands }}
-        container: ${{ parameters.alpine317Container }}
+        container: ${{ parameters.alpine319Container }}
         buildFromArchive: false            # 🚫
         enablePoison: false                # 🚫
         excludeOmniSharpTests: true        # ✅


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/3920

Note that the alpine-3.19 artifacts will need to be uploaded due to changing the artifacts rid from `alpine.3.17-x64` to `alpine-3.19-x64`.