### PR TITLE
Rename to Alpine leg from `Offline` to `Online`

### DIFF
--- a/eng/pipelines/source-build-sdk-diff-tests.yml
+++ b/eng/pipelines/source-build-sdk-diff-tests.yml
@@ -38,7 +38,7 @@ jobs:
 
 - template: templates/jobs/sdk-diff-tests.yml
   parameters:
-    buildName: Alpine319_Offline_MsftSdk
+    buildName: Alpine319_Online_MsftSdk
     targetRid: alpine.3.19-x64
     architecture: x64
     dotnetDotnetRunId: ${{ parameters.dotnetDotnetRunId }}


### PR DESCRIPTION
Closes https://github.com/dotnet/source-build/issues/3929

The sdk-diff-test leg name now matches the [CI leg name](https://github.com/dotnet/installer/blob/92ebfab55958b7685483cefe8c2b667465d3b983/eng/pipelines/templates/stages/vmr-build.yml#L136).