### PR TITLE
Cloak spectre.console binary files

### DIFF
--- a/src/VirtualMonoRepo/source-mappings.json
+++ b/src/VirtualMonoRepo/source-mappings.json
@@ -160,7 +160,11 @@
                 "src/application-insights/**/NuGet.config",
                 "src/humanizer/samples/**/*.js",
                 "src/newtonsoft-json/**/NuGet.Config",
+                "src/spectre-console/docs/input/assets/CascadiaMonoPL.woff2",
+                "src/spectre-console/docs/input/assets/images/table.mp4",
+                "src/spectre-console/docs/input/assets/images/table.webm",
                 "src/spectre-console/docs/package.json",
+                "src/spectre-console/docs/src/SocialCards/CascadiaCodePL.woff2",
                 "src/spectre-console/examples/Console/Canvas/Mandelbrot.cs"
             ]
         },

--- a/src/VirtualMonoRepo/source-mappings.json
+++ b/src/VirtualMonoRepo/source-mappings.json
@@ -160,11 +160,7 @@
                 "src/application-insights/**/NuGet.config",
                 "src/humanizer/samples/**/*.js",
                 "src/newtonsoft-json/**/NuGet.Config",
-                "src/spectre-console/docs/input/assets/CascadiaMonoPL.woff2",
-                "src/spectre-console/docs/input/assets/images/table.mp4",
-                "src/spectre-console/docs/input/assets/images/table.webm",
-                "src/spectre-console/docs/package.json",
-                "src/spectre-console/docs/src/SocialCards/CascadiaCodePL.woff2",
+                "src/spectre-console/docs/**",
                 "src/spectre-console/examples/Console/Canvas/Mandelbrot.cs"
             ]
         },


### PR DESCRIPTION
Closes https://github.com/dotnet/source-build/issues/3911

This PR cloaks the following sprectre-console binaries in order to resolve the relevant Secure Supply Chain Analysis issues in the VMR build.

```
src/source-build-externals/src/spectre-console/docs/input/assets/CascadiaMonoPL.woff2
src/source-build-externals/src/spectre-console/docs/input/assets/images/table.mp4
src/source-build-externals/src/spectre-console/docs/input/assets/images/table.webm
src/source-build-externals/src/spectre-console/docs/src/SocialCards/CascadiaCodePL.woff2
```