### PR TITLE
Cloak spectre-console/Nuget.Config and xunit/NuGet.Config

### DIFF
--- a/src/VirtualMonoRepo/source-mappings.json
+++ b/src/VirtualMonoRepo/source-mappings.json
@@ -161,7 +161,9 @@
                 "src/humanizer/samples/**/*.js",
                 "src/newtonsoft-json/**/NuGet.Config",
                 "src/spectre-console/docs/**",
-                "src/spectre-console/examples/Console/Canvas/Mandelbrot.cs"
+                "src/spectre-console/NuGet.Config",
+                "src/spectre-console/examples/Console/Canvas/Mandelbrot.cs",
+                "src/xunit/NuGet.Config"
             ]
         },
         {


### PR DESCRIPTION
VMR pipelines are currently failing `Secure Supply Chain Analysis` with the following error:

```
Azure Artifacts Configuration Analysis found 1 package configuration file in the repository which do not comply with Microsoft package feed security policies.
```

In an attempt to mitigate this error, this PR cloaks two Nuget.Config files that produce warnings in `Secure Supply Chain Analysis`.

[Example build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2354554&view=logs&j=fa5c2909-0e29-5671-d5eb-16d6c40e0c4a&t=edf6ea5d-8fa9-5661-2fd8-1370b24b9911&l=49) (internal link)
