### PR TITLE
Add install state cleanup to finalizer

### DIFF
--- a/src/finalizer/CMakeLists.txt
+++ b/src/finalizer/CMakeLists.txt
@@ -55,6 +55,7 @@ target_link_libraries(Finalizer shell32.lib)
 target_link_libraries(Finalizer advapi32.lib)
 target_link_libraries(Finalizer version.lib)
 target_link_libraries(Finalizer msi.lib)
+target_link_libraries(Finalizer shlwapi.lib)
 
 # Add WiX libraries
 target_link_libraries(Finalizer wcautil.lib)

--- a/src/finalizer/precomp.h
+++ b/src/finalizer/precomp.h
@@ -12,6 +12,8 @@
 #include <winreg.h>
 #include <msi.h>
 #include <pathcch.h>
+#include <shlobj.h>
+#include <shlwapi.h>
 
 // Configure some logging parameters for WiX
 #define ExitTrace LogErrorString
@@ -26,3 +28,7 @@
 #include "pathutil.h"
 #include "strutil.h"
 #include "wiutil.h"
+#include "dirutil.h"
+#include "fileutil.h"
+#include "shelutil.h"
+


### PR DESCRIPTION
## Description

The CLI tracks additional information related to workload configurations through the install state file. The file is created under `ProgramData` by the CLI and needs to be manually removed when the CLI is uninstalled. 

## Impact

Minimal, we leave dangling files behind that are created as part of using the SDK and won't be removed because it's not part of the SDK install. We periodically get complaints from users when leaving files behind.

There is also the risk in the future that having install state files for workloads that are not applicable to installed SDK versions could cause undesired behavior.

## Testing

Manual testing using sandbox and running the finalizer to verify cleanup scenarios. 

## Risk

Low - the finalizer will only remove the file if it exists and it becomes a no-op for any SDKs that do not support generating the install state file.
