### PR TITLE
Only generate RootFs during crossbuild when ROOTFS_DIR is not set

### DIFF
--- a/src/SourceBuild/content/eng/tools/init-build.proj
+++ b/src/SourceBuild/content/eng/tools/init-build.proj
@@ -113,15 +113,15 @@
   </Target>
 
   <Target Name="GenerateRootFs"
-          Condition="'$(BuildOS)' != 'windows'">
+          Condition=" '$(BuildOS)' != 'windows' AND '$(CrossBuild)' == 'true' AND $(ROOTFS_DIR) == '' ">
     <PropertyGroup>
       <ArmEnvironmentVariables Condition="'$(ArmEnvironmentVariables)' == ''">ROOTFS_DIR=$(ArtifactsObjDir)crossrootfs/arm</ArmEnvironmentVariables>
       <ArmEnvironmentVariables Condition="'$(Platform)' == 'armel'">ROOTFS_DIR=$(ArtifactsObjDir)crossrootfs/armel</ArmEnvironmentVariables>
     </PropertyGroup>
 
-    <Exec Command="$(ArmEnvironmentVariables) $(RepoRoot)cross/build-rootfs.sh"
+    <Exec Command="$(ArmEnvironmentVariables) $(RepositoryEngineeringDir)cross/build-rootfs.sh"
           Condition="$(TargetArchitecture.Contains('arm')) and '$(TargetArchitecture)' != 'armel' and '$(BuildArchitecture)' != 'arm64' and '$(BuildArchitecture)' != 'arm'" />
-    <Exec Command="$(ArmEnvironmentVariables) $(RepoRoot)cross/armel/tizen-build-rootfs.sh"
+    <Exec Command="$(ArmEnvironmentVariables) $(RepositoryEngineeringDir)cross/armel/tizen-build-rootfs.sh"
           Condition="'$(TargetArchitecture)' == 'armel'" />
   </Target>
 

--- a/src/SourceBuild/content/eng/tools/init-build.proj
+++ b/src/SourceBuild/content/eng/tools/init-build.proj
@@ -113,7 +113,7 @@
   </Target>
 
   <Target Name="GenerateRootFs"
-          Condition=" '$(BuildOS)' != 'windows' AND '$(CrossBuild)' == 'true' AND $(ROOTFS_DIR) == '' ">
+          Condition="'$(BuildOS)' != 'windows' and '$(CrossBuild)' == 'true' and '$(ROOTFS_DIR)' == ''">
     <PropertyGroup>
       <ArmEnvironmentVariables Condition="'$(ArmEnvironmentVariables)' == ''">ROOTFS_DIR=$(ArtifactsObjDir)crossrootfs/arm</ArmEnvironmentVariables>
       <ArmEnvironmentVariables Condition="'$(Platform)' == 'armel'">ROOTFS_DIR=$(ArtifactsObjDir)crossrootfs/armel</ArmEnvironmentVariables>


### PR DESCRIPTION
https://github.com/dotnet/installer/pull/18214 added a GenerateRootFs target that causes issues in the linux-arm64 crossbuild vertical. It should be conditioned to only run on Unix CrossBuilds when ROOTFS_DIR is not already set, and it should find the script in the `eng` directory rather than the repo root directory.
