### PR TITLE
[VMR] Fix path to build.proj in build.ps1

### DIFF
--- a/src/SourceBuild/content/eng/build.ps1
+++ b/src/SourceBuild/content/eng/build.ps1
@@ -38,8 +38,9 @@ function Build {
   InitializeToolset
 
   $bl = if ($binaryLog) { '/bl:' + (Join-Path $LogDir 'Build.binlog') } else { '' }
+  $buildProj = Join-Path $RepoRoot 'build.proj'
 
-  MSBuild "$PSScriptRoot\build.proj" `
+  MSBuild $buildProj `
     $bl `
     --tl:off `
     /p:Configuration=$configuration `


### PR DESCRIPTION
The location here got changed very late and I missed this bug. This just proves that we really need Windows CI protection.

Validated offline.