### PR TITLE
Update vmr-build.yml

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -225,9 +225,9 @@ jobs:
 
       # Allows Arcade to have access to the commit for the build
       customEnvVars="BUILD_SOURCEVERSION=$BUILD_SOURCEVERSION"
-      customBuildArgs=
+      customBuildArgs="--ci"
       if [[ '${{ parameters.runOnline }}' == 'True' ]]; then
-        customBuildArgs='--online'
+        customBuildArgs="$customBuildArgs --online"
       else
         customRunArgs="$customRunArgs --network none"
       fi

--- a/src/redist/targets/Crossgen.targets
+++ b/src/redist/targets/Crossgen.targets
@@ -2,7 +2,7 @@
   <!-- Crossgen is currently not supported on the s390x, ppc64le architecture as using mono instead of CoreCLR.
        Neither crossgen2 nor mono is supported on the loongarch64 architecture at present. -->
   <Target Name="CrossgenLayout"
-          Condition="'$(DISABLE_CROSSGEN)' == '' AND '$(Architecture)' != 's390x' AND '$(Architecture)' != 'ppc64le' AND '$(Architecture)' != 'loongarch64' AND !('$(CROSSBUILD)' == 'true' AND '$(DotnetBuildVertical)' == 'true')"
+          Condition="'$(DISABLE_CROSSGEN)' == '' AND '$(Architecture)' != 's390x' AND '$(Architecture)' != 'ppc64le' AND '$(Architecture)' != 'loongarch64' AND !('$(CROSSBUILD)' == 'true' AND '$(DotNetBuildVertical)' == 'true')"
           DependsOnTargets="SetSdkBrandingInfo">
 
     <PropertyGroup>


### PR DESCRIPTION
This comes from https://github.com/dotnet/dotnet/pull/46/files#diff-14e27eaea40a4b9b2c7f4e2156294996ebf63aa6ce9fe65cefb55c44aa2ed89c which I forgot to port over in https://github.com/dotnet/installer/commit/44ac53279f5ccb250902916bd79cda3e82263117.

The build scripts now accept the `-ci` switch which should be used in pipelines. Based on that switch we enable/disable the minimal console log in the VMR.

nit: also fixing one wrong casing of `DotNetBuildVertical`