### PR TITLE
Remove alpine RID for Alpine319_Online_MsftSdk leg

### DIFF
--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -137,7 +137,6 @@ stages:
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
         vmrBranch: ${{ variables.VmrBranch }}
         architecture: x64
-        artifactsRid: alpine.3.19-x64
         pool:
           name: ${{ variables.defaultPoolName }}
           demands: ${{ variables.defaultPoolDemands }}


### PR DESCRIPTION
When the prep script is run in the `Alpine319_Online_MsftSdk` leg, it specifies the `alpine.3.19-x64` RID which causes the corresponding `alpine.3.19-x64` artifacts tarball to be downloaded for prep. It should instead be targeting the centos artifacts because it will be bootstrapped for Alpine anyway. This allows us to [upgrade Alpine](https://github.com/dotnet/installer/pull/18209) without the issue of needing to have a predefined `alpine.3.19-x64` artifacts tarball in order for the prep to work.