### PR TITLE
Rebootstrap with new SB artifacts and SDK

### DIFF
--- a/src/SourceBuild/content/eng/Versions.props
+++ b/src/SourceBuild/content/eng/Versions.props
@@ -22,8 +22,8 @@
       of a .NET major or minor release, prebuilts may be needed. When the release is mature, prebuilts
       are not necessary, and this property is removed from the file.
     -->
-    <PrivateSourceBuiltSdkVersion>9.0.100-alpha.1.24055.1</PrivateSourceBuiltSdkVersion>
-    <PrivateSourceBuiltArtifactsVersion>9.0.100-alpha.1.24055.1</PrivateSourceBuiltArtifactsVersion>
+    <PrivateSourceBuiltSdkVersion>9.0.100-alpha.1.24067.1</PrivateSourceBuiltSdkVersion>
+    <PrivateSourceBuiltArtifactsVersion>9.0.100-alpha.1.24067.1</PrivateSourceBuiltArtifactsVersion>
     <PrivateSourceBuiltPrebuiltsVersion>0.1.0-9.0.100-6</PrivateSourceBuiltPrebuiltsVersion>
     <!-- msbuild -->
     <MicrosoftBuildVersion>15.7.179</MicrosoftBuildVersion>

--- a/src/SourceBuild/content/global.json
+++ b/src/SourceBuild/content/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "9.0.100-alpha.1.24055.2"
+    "dotnet": "9.0.100-alpha.1.24067.4"
   },
   "msbuild-sdks": {
     "Microsoft.Build.NoTargets": "3.7.0",

--- a/src/SourceBuild/patches/arcade/0001-Add-S.C.I.-and-S.R.M.-dependencies-14377.patch
+++ b/src/SourceBuild/patches/arcade/0001-Add-S.C.I.-and-S.R.M.-dependencies-14377.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ella Hathaway <67609881+ellahathaway@users.noreply.github.com>
+Date: Wed, 17 Jan 2024 10:07:45 -0800
+Subject: [PATCH] Add S.C.I. and S.R.M. dependencies (#14377)
+
+---
+ eng/Version.Details.xml | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/eng/Version.Details.xml b/eng/Version.Details.xml
+index c968ec3d..7d3af34d 100644
+--- a/eng/Version.Details.xml
++++ b/eng/Version.Details.xml
+@@ -123,9 +123,19 @@
+       <Sha>39aef81ec6cffa06da9964b46d4b9e3bf2fc9979</Sha>
+       <SourceBuild RepoName="sdk" ManagedOnly="true" />
+     </Dependency>
++    <!-- Transitive dependency needed for source build. -->
++    <Dependency Name="System.Collections.Immutable" Version="7.0.0">
++      <Uri>https://github.com/dotnet/runtime</Uri>
++      <Sha>d099f075e45d2aa6007a22b71b45a08758559f80</Sha>
++    </Dependency>
+     <Dependency Name="System.CommandLine" Version="2.0.0-beta4.23307.1">
+       <Uri>https://github.com/dotnet/command-line-api</Uri>
+       <Sha>02fe27cd6a9b001c8feb7938e6ef4b3799745759</Sha>
+     </Dependency>
++    <!-- Transitive dependency needed for source build. -->
++    <Dependency Name="System.Reflection.Metadata" Version="7.0.0">
++      <Uri>https://github.com/dotnet/runtime</Uri>
++      <Sha>d099f075e45d2aa6007a22b71b45a08758559f80</Sha>
++    </Dependency>
+   </ToolsetDependencies>
+ </Dependencies>


### PR DESCRIPTION
Re-bootstrapping the VMR with new source-build artifacts and SDK.

Fixes https://github.com/dotnet/source-build/issues/3974
Unblocks https://github.com/dotnet/installer/pull/18213
