### PR TITLE
Cloak files from Windows repos

### DIFF
--- a/src/VirtualMonoRepo/allowed-binaries.txt
+++ b/src/VirtualMonoRepo/allowed-binaries.txt
@@ -1,4 +1,5 @@
 *.bmp
+*.doc
 *.docx
 *.gif
 *.ico

--- a/src/VirtualMonoRepo/source-mappings.json
+++ b/src/VirtualMonoRepo/source-mappings.json
@@ -210,11 +210,21 @@
         },
         {
             "name": "winforms",
-            "defaultRemote": "https://github.com/dotnet/winforms"
+            "defaultRemote": "https://github.com/dotnet/winforms",
+            "exclude": [
+                "src/System.Windows.Forms.Design/src/Resources/colordlg.data",
+                "winforms/src/System.Windows.Forms/src/Resources/System/Windows/Forms/Design/Thumbs.db"
+            ]
         },
         {
             "name": "wpf",
-            "defaultRemote": "https://github.com/dotnet/wpf"
+            "defaultRemote": "https://github.com/dotnet/wpf",
+            "exclude": [
+                "src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/Hyphenation/Hyphen_en.hdict",
+                "src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/Hyphenation/Hyphen_en.lex",
+                "src/Microsoft.DotNet.Wpf/src/ReachFramework/Resources/generated/*.resources",
+                "src/Microsoft.DotNet.Wpf/src/Shared/Tracing/resources/*.bin"
+            ]
         },
         {
             "name": "windowsdesktop",

--- a/src/VirtualMonoRepo/source-mappings.json
+++ b/src/VirtualMonoRepo/source-mappings.json
@@ -212,14 +212,19 @@
             "name": "winforms",
             "defaultRemote": "https://github.com/dotnet/winforms",
             "exclude": [
+                // https://github.com/dotnet/source-build/issues/3745
                 "src/System.Windows.Forms.Design/src/Resources/colordlg.data",
-                "winforms/src/System.Windows.Forms/src/Resources/System/Windows/Forms/Design/Thumbs.db"
+                "src/System.Windows.Forms/src/Resources/System/Windows/Forms/Design/Thumbs.db",
+
+                // https://github.com/dotnet/source-build/issues/3772
+                "src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/**"
             ]
         },
         {
             "name": "wpf",
             "defaultRemote": "https://github.com/dotnet/wpf",
             "exclude": [
+                // https://github.com/dotnet/source-build/issues/3746
                 "src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/Hyphenation/Hyphen_en.hdict",
                 "src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/Hyphenation/Hyphen_en.lex",
                 "src/Microsoft.DotNet.Wpf/src/ReachFramework/Resources/generated/*.resources",


### PR DESCRIPTION
Cloaks binaries that are being brought in to the VMR by the `winforms` and `wpf` repos.

These consist of the following types:
* binaries: Related to https://github.com/dotnet/source-build/issues/3745 and https://github.com/dotnet/source-build/issues/3746. 
* source with license not compatible with free and open source: related to https://github.com/dotnet/source-build/issues/3772

I'm going to keep these issues open since these files still need to be addressed in the future as part of the Unified Build work.

Also adds `.doc` as an allowed binary.

