### PR TITLE
Attempt to remove env-var passing of DotNetBuildFromSource in the orchestrator

### DIFF
--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -141,7 +141,6 @@
   <!-- VBPOC - I'm not sure about this. Some of this may be needed for VB, but I'm not sure why some pieces like
        DotNetBuildFromSource are in there for source-build at all. -->
   <ItemGroup>
-    <EnvironmentVariables Include="DotNetBuildFromSource=true" Condition="'$(DotNetBuildFromSource)' == 'true'" />
     <EnvironmentVariables Include="DotNetBuildVertical=true" Condition="'$(DotNetBuildVertical)' == 'true'" />
   </ItemGroup>
 


### PR DESCRIPTION
It's not really clear why this was there, or why it was passed via env-var. Remove and see what happens.