### PR TITLE
Add DotNetBuildOrchestrator flag

### DIFF
--- a/src/SourceBuild/content/Directory.Build.props
+++ b/src/SourceBuild/content/Directory.Build.props
@@ -99,6 +99,11 @@
 
     <!-- TargetFrameworkDefaults.props -->
     <NetCurrent>net9.0</NetCurrent>
+
+    <!-- Set up the build phase since the orchestrator switch is passed.
+         From RepoDefaults.props. -->
+    <DotNetBuild>true</DotNetBuild>
+    <DotNetBuildPhase>Orchestrator</DotNetBuildPhase>
   </PropertyGroup>
 
   <!-- Manually import the Versions.props file when the Arcade SDK isn't used. -->

--- a/src/SourceBuild/content/Directory.Build.props
+++ b/src/SourceBuild/content/Directory.Build.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <_SuppressSdkImports Condition="'$(DotNetBuildFromSource)' == 'true'">true</_SuppressSdkImports>
     <Configuration Condition="$(Configuration) == ''">Release</Configuration>
+    <DotNetBuildOrchestrator>true</DotNetBuildOrchestrator>
   </PropertyGroup>
 
   <PropertyGroup Label="CalculateTargetOS">

--- a/src/SourceBuild/content/build.proj
+++ b/src/SourceBuild/content/build.proj
@@ -16,7 +16,8 @@
                        $(RepoProjectsDir)$(RootRepo).proj"
              Targets="Build"
              BuildInParallel="false"
-             StopOnFirstFailure="true" />
+             StopOnFirstFailure="true"
+             Properties="DotNetBuildOrchestrator=true" />
   </Target>
 
   <Import Project="$(RepositoryEngineeringDir)build.sourcebuild.targets" Condition="'$(DotNetBuildFromSource)' == 'true'" />

--- a/src/SourceBuild/content/build.proj
+++ b/src/SourceBuild/content/build.proj
@@ -16,8 +16,7 @@
                        $(RepoProjectsDir)$(RootRepo).proj"
              Targets="Build"
              BuildInParallel="false"
-             StopOnFirstFailure="true"
-             Properties="DotNetBuildOrchestrator=true" />
+             StopOnFirstFailure="true" />
   </Target>
 
   <Import Project="$(RepositoryEngineeringDir)build.sourcebuild.targets" Condition="'$(DotNetBuildFromSource)' == 'true'" />

--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -57,6 +57,8 @@
     <BuildArgs>$(BuildArgs) -bl</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:CopySrcInsteadOfClone=true</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:DotNetBuildRepo=true</BuildArgs>
+    <!-- Indicate that the build is being run from the orchestrator -->
+    <BuildArgs>$(BuildArgs) /p:DotNetBuildOrchestrator=true</BuildArgs>
     <BuildArgs Condition="'$(CrossBuild)' == 'true'">$(BuildArgs) /p:CrossBuild=$(CrossBuild)</BuildArgs>
   </PropertyGroup>
 


### PR DESCRIPTION
Adds the DotNetBuildOrchestrator flag when building from the VMR. This is passed via build.proj (since it should always be active when building from the VMR) and to the individual repo builds. It's probably not really necessary within the ochestrator's code, since this code isn't run in a non-orchestrator context, but it is good to be consistent. In cases where the Arcade SDK is not used (skip arcade imports), the values that would be derived from DotNetBuildOrchestrator=true (DotNetBuildPhase=Orchestrator and DotNetBuild=true) are set explicitly.

This will not be active in SB or VMR modes until the latest arcades are in use as the bootstrap arcade, or within the global.json of the VMR. I tested what will happen when these are updated and all derived switches in the repos appear to be working as expected.
