### PR TITLE
Condition inner-clone properties

### DIFF
--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -55,7 +55,6 @@
     <BuildArgs>$(FlagParameterPrefix)ci</BuildArgs>
     <BuildArgs>$(BuildArgs) $(FlagParameterPrefix)configuration $(Configuration)</BuildArgs>
     <BuildArgs>$(BuildArgs) -bl</BuildArgs>
-    <BuildArgs>$(BuildArgs) /p:CopySrcInsteadOfClone=true</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:DotNetBuildRepo=true</BuildArgs>
     <BuildArgs Condition="'$(CrossBuild)' == 'true'">$(BuildArgs) /p:CrossBuild=$(CrossBuild)</BuildArgs>
   </PropertyGroup>

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -220,6 +220,16 @@
              StopOnFirstFailure="true" />
   </Target>
 
+  <!-- Update build command with repo-conditioned arguments. -->
+  <Target Name="UpdateBuildCommandWithRepoConditionedArguments"
+          BeforeTargets="Build">
+    <PropertyGroup Condition="'$(UseInnerClone)' == 'true'">
+      <BuildCommand>$(BuildCommand) /p:UseInnerClone=true</BuildCommand>
+      <BuildCommand>$(BuildCommand) /p:CopySrcInsteadOfClone=true</BuildCommand>
+      <BuildCommand>$(BuildCommand) /p:CopyWipIntoInnerSourceBuildRepo=true</BuildCommand>
+    </PropertyGroup>
+  </Target>
+
   <Target Name="Build"
           DependsOnTargets="BuildRepoReferences"
           Inputs="$(MSBuildProjectFullPath)"

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -2,6 +2,12 @@
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets, $(MSBuildThisFileDirectory)..))" />
 
+  <PropertyGroup Condition="'$(UseInnerClone)' == 'true'">
+    <BuildArgs>$(BuildArgs) /p:UseInnerClone=true</BuildArgs>
+    <BuildArgs>$(BuildArgs) /p:CopySrcInsteadOfClone=true</BuildArgs>
+    <BuildArgs>$(BuildArgs) /p:CopyWipIntoInnerSourceBuildRepo=true</BuildArgs>
+  </PropertyGroup>
+
   <PropertyGroup>
     <BuildCommand Condition="'$(BuildCommand)' == '' and '$(IsUtilityProject)' != 'true'">$(BuildScript) $(BuildActions) $(BuildArgs)</BuildCommand>
 
@@ -218,16 +224,6 @@
              Targets="Build"
              BuildInParallel="$(BuildInParallel)"
              StopOnFirstFailure="true" />
-  </Target>
-
-  <!-- Update build command with repo-conditioned arguments. -->
-  <Target Name="UpdateBuildCommandWithRepoConditionedArguments"
-          BeforeTargets="Build">
-    <PropertyGroup Condition="'$(UseInnerClone)' == 'true'">
-      <BuildCommand>$(BuildCommand) /p:UseInnerClone=true</BuildCommand>
-      <BuildCommand>$(BuildCommand) /p:CopySrcInsteadOfClone=true</BuildCommand>
-      <BuildCommand>$(BuildCommand) /p:CopyWipIntoInnerSourceBuildRepo=true</BuildCommand>
-    </PropertyGroup>
   </Target>
 
   <Target Name="Build"

--- a/src/SourceBuild/content/repo-projects/source-build-externals.proj
+++ b/src/SourceBuild/content/repo-projects/source-build-externals.proj
@@ -7,7 +7,7 @@
 
       Modified files make developer experience worse, as they would need to be manually reverted.
     -->
-    <BuildArgs>$(BuildArgs) /p:UseInnerClone=true</BuildArgs>
+    <UseInnerClone>true</UseInnerClone>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/3935

We need a new target, as `BuildArgs` is evaluated early, before any properties in repo projects. I'm allowing other repos to eventually use inner-clone, as needed.

Alternative approach was to set all 3 properties in `source-build-externals.proj`, but that would make them specific to that project.

This is targeting Preview 2.
