### PR TITLE
Update SB SDK diff exclusions and baseline

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkFileDiffExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkFileDiffExclusions.txt
@@ -73,6 +73,21 @@ msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Security
 msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Security.Permissions.dll
 msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Windows.Extensions.dll
 
+# netfx runtimes for dotnet-watch - https://github.com/dotnet/source-build/issues/3999
+msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/BuildHost-net472/*
+msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/BuildHost-netcore/runtimes/*
+msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/BuildHost-netcore/System.Collections.Immutable.dll
+msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/BuildHost-netcore/System.Reflection.Metadata.dll
+msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/BuildHost-netcore/System.Text.Encodings.Web.dll
+msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/BuildHost-netcore/System.Text.Json.dll
+msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/BuildHost-netcore/System.Threading.Channels.dll
+msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Microsoft.VisualStudio.Setup.Configuration.Interop.dll
+sb,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/runtimes/*
+sb,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Configuration.ConfigurationManager.dll
+sb,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Diagnostics.EventLog.dll
+sb,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.IO.Pipelines.dll
+sb,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Security.Cryptography.ProtectedData.dll
+
 # netfx runtimes for dotnet-format - https://github.com/dotnet/source-build/issues/3509
 msft,./sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.CodeAnalysis.Elfie.dll
 msft,./sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.Win32.SystemEvents.dll
@@ -82,6 +97,24 @@ msft,./sdk/x.y.z/DotnetTools/dotnet-format/System.Drawing.Common.dll
 msft,./sdk/x.y.z/DotnetTools/dotnet-format/System.Security.Cryptography.ProtectedData.dll
 msft,./sdk/x.y.z/DotnetTools/dotnet-format/System.Security.Permissions.dll
 msft,./sdk/x.y.z/DotnetTools/dotnet-format/System.Windows.Extensions.dll
+
+# netfx runtimes for dotnet-format - https://github.com/dotnet/source-build/issues/3998
+msft,./sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-net472/*
+msft,./sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/runtimes/*
+msft,./sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/System.Collections.Immutable.dll
+msft,./sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/System.Reflection.Metadata.dll
+msft,./sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/System.Text.Encodings.Web.dll
+msft,./sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/System.Text.Json.dll
+msft,./sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/System.Threading.Channels.dll
+msft,./sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.Build.Tasks.Core.dll
+msft,./sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.Build.Utilities.Core.dll
+msft,./sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.NET.StringTools.dll
+sb,./sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.Win32.SystemEvents.dll
+sb,./sdk/x.y.z/DotnetTools/dotnet-format/System.Configuration.ConfigurationManager.dll
+sb,./sdk/x.y.z/DotnetTools/dotnet-format/System.Drawing.Common.dll
+sb,./sdk/x.y.z/DotnetTools/dotnet-format/System.Security.Cryptography.ProtectedData.dll
+sb,./sdk/x.y.z/DotnetTools/dotnet-format/System.Security.Permissions.dll
+sb,./sdk/x.y.z/DotnetTools/dotnet-format/System.Windows.Extensions.dll
 
 # netfx runtimes for fsharp - https://github.com/dotnet/source-build/issues/3290
 msft,./sdk/x.y.z/FSharp/Microsoft.VisualStudio.Setup.Configuration.Interop.dll

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdkFiles.diff
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdkFiles.diff
@@ -45,13 +45,6 @@ index ------------
  ./packs/Microsoft.NETCore.App.Ref/x.y.z/
  ./packs/Microsoft.NETCore.App.Ref/x.y.z/analyzers/
 @@ ------------ @@
- ./sdk/x.y.z/.version
- ./sdk/x.y.z/AppHostTemplate/
- ./sdk/x.y.z/AppHostTemplate/apphost
--./sdk/x.y.z/containerize.deps.json
--./sdk/x.y.z/containerize.exe
--./sdk/x.y.z/containerize.runtimeconfig.json
- ./sdk/x.y.z/Containers/
  ./sdk/x.y.z/Containers/build/
  ./sdk/x.y.z/Containers/build/Microsoft.NET.Build.Containers.props
  ./sdk/x.y.z/Containers/build/Microsoft.NET.Build.Containers.targets
@@ -239,7 +232,6 @@ index ------------
 -./sdk/x.y.z/Containers/tasks/net472/System.Reflection.Metadata.dll
 -./sdk/x.y.z/Containers/tasks/net472/System.Reflection.MetadataLoadContext.dll
 -./sdk/x.y.z/Containers/tasks/net472/System.Runtime.CompilerServices.Unsafe.dll
--./sdk/x.y.z/Containers/tasks/net472/System.Security.AccessControl.dll
 -./sdk/x.y.z/Containers/tasks/net472/System.Security.Principal.Windows.dll
 -./sdk/x.y.z/Containers/tasks/net472/System.Text.Encodings.Web.dll
 -./sdk/x.y.z/Containers/tasks/net472/System.Text.Json.dll
@@ -278,14 +270,6 @@ index ------------
  ./sdk/x.y.z/Microsoft.Common.CrossTargeting.targets
  ./sdk/x.y.z/Microsoft.Common.CurrentVersion.targets
  ./sdk/x.y.z/Microsoft.Common.overridetasks
-@@ ------------ @@
- ./sdk/x.y.z/Microsoft.VisualBasic.CrossTargeting.targets
- ./sdk/x.y.z/Microsoft.VisualBasic.CurrentVersion.targets
- ./sdk/x.y.z/Microsoft.VisualBasic.targets
--./sdk/x.y.z/Microsoft.VisualStudio.Setup.Configuration.Interop.dll
- ./sdk/x.y.z/Microsoft.VisualStudio.TestPlatform.Client.dll
- ./sdk/x.y.z/Microsoft.VisualStudio.TestPlatform.Common.dll
- ./sdk/x.y.z/Microsoft.VisualStudio.TestPlatform.ObjectModel.dll
 @@ ------------ @@
  ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WebAssembly/tools/
  ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WebAssembly/tools/netx.y/


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/3922

Closes https://github.com/dotnet/source-build/issues/3998 and https://github.com/dotnet/source-build/issues/3999.

This PR adds dotnet-format and dotnet-watch exclusions for both the SB and MSFT SDKs to the exclusions files and removes relevant lines from the baseline diff.