### PR TITLE
[release/8.0.1xx] Use PAT to enable pulling code from non-dnceng AzDO orgs

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-synchronization.yml
+++ b/eng/pipelines/templates/jobs/vmr-synchronization.yml
@@ -32,6 +32,7 @@ jobs:
       - name: vmrPublicUrl
         value: https://github.com/dotnet/dotnet
     - ${{ if and( eq(variables['System.TeamProject'], 'internal'), startswith(variables['Build.SourceBranch'], 'refs/heads/internal/release/')) }}:
+      # https://dev.azure.com/dnceng/internal/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=172&path=DotNetBot-AzDO-PAT
       - group: DotNetBot-AzDO-PAT
       - name: vmrInternalUrl
         value: https://dnceng@dev.azure.com/dnceng/internal/_git/dotnet-dotnet

--- a/eng/pipelines/templates/steps/vmr-pull-updates.yml
+++ b/eng/pipelines/templates/steps/vmr-pull-updates.yml
@@ -39,7 +39,7 @@ steps:
     ./eng/vmr-sync.sh
     --vmr ${{ parameters.vmrPath }}
     --tmp $(Agent.TempDirectory)
-    --azdev-pat '$(System.AccessToken)'
+    --azdev-pat '$(dn-bot-all-orgs-code-r)'
     --branch ${{ parameters.vmrBranch }}
     --repository "installer:${{ parameters.targetRef }}"
     --recursive


### PR DESCRIPTION
This PAT allows also the devdiv org

https://dev.azure.com/dnceng/internal/_build/results?buildId=2358052&view=results