### PR TITLE
Update source build prebuilts tarball version

### DIFF
--- a/src/SourceBuild/content/eng/Versions.props
+++ b/src/SourceBuild/content/eng/Versions.props
@@ -24,7 +24,7 @@
     -->
     <PrivateSourceBuiltSdkVersion>9.0.100-alpha.1.24067.1</PrivateSourceBuiltSdkVersion>
     <PrivateSourceBuiltArtifactsVersion>9.0.100-alpha.1.24067.1</PrivateSourceBuiltArtifactsVersion>
-    <PrivateSourceBuiltPrebuiltsVersion>0.1.0-9.0.100-8</PrivateSourceBuiltPrebuiltsVersion>
+    <PrivateSourceBuiltPrebuiltsVersion>0.1.0-9.0.100-9</PrivateSourceBuiltPrebuiltsVersion>
     <!-- msbuild -->
     <MicrosoftBuildVersion>15.7.179</MicrosoftBuildVersion>
   </PropertyGroup>


### PR DESCRIPTION
Updates the prebuilt tarball to include `System.CommandLine.2.0.0-beta4.23307.1`.

Related to https://github.com/dotnet/source-build/issues/4001