### PR TITLE
Run sdk pipeline 3 hours after dotnet-dotnet pipeline

### DIFF
--- a/eng/pipelines/source-build-sdk-diff-tests.yml
+++ b/eng/pipelines/source-build-sdk-diff-tests.yml
@@ -1,6 +1,6 @@
 schedules:
-- cron: "0 7 * * 1-5"
-  displayName: Run on weekdays at 7am UTC
+- cron: "0 11 * * 1-5"
+  displayName: Run on weekdays at 11am UTC
   branches:
     include:
     - main


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/3919

This PR modifies the schedule of the SDK diff pipeline. Previously, the pipeline was set to run one hour prior to the midnight build of the main branch in the dotnet-dotnet pipeline. The updated configuration now schedules the SDK diff pipeline to run three hours after the midnight build of the dotnet-dotnet pipeline. This change ensures that the SDK diff tests are performed on the most recent build.