### PR TITLE
Update Arcade SDK bootstrap version for non source-build

### DIFF
--- a/src/SourceBuild/content/eng/Version.Details.xml
+++ b/src/SourceBuild/content/eng/Version.Details.xml
@@ -3,9 +3,9 @@
   <ProductDependencies>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="9.0.0-beta.24058.6">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="9.0.0-beta.24066.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>05493e05d4bbf262f1be1bd517ac95f5bff3a2ef</Sha>
+      <Sha>d5ee27a55ec6383c29790f3ec666e7c87f7da022</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/src/SourceBuild/content/global.json
+++ b/src/SourceBuild/content/global.json
@@ -4,6 +4,6 @@
   },
   "msbuild-sdks": {
     "Microsoft.Build.NoTargets": "3.7.0",
-    "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.24058.6"
+    "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.24066.3"
   }
 }


### PR DESCRIPTION
This seems to be the bootstrap version used in source-build.