### PR TITLE
Updating Aspire manifest to 9.0 version

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -174,9 +174,9 @@
       <Sha>c14a1d2af9d67eec272ff7d7f3c5bb6b114798fe</Sha>
       <SourceBuild RepoName="emsdk" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.Aspire.Manifest-8.0.100" Version="8.0.0-preview.3.24060.4">
+    <Dependency Name="Microsoft.NET.Sdk.Aspire.Manifest-9.0.100-alpha.1" Version="9.0.0-alpha.1.24072.6">
       <Uri>https://github.com/dotnet/aspire</Uri>
-      <Sha>66a1dd77e4077592a587c1429c8814d1057dc474</Sha>
+      <Sha>8a902ec654d701cbcb47c5730bd006e50bd561ef</Sha>
       <SourceBuild RepoName="aspire" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.Deployment.DotNet.Releases" Version="2.0.0-preview.1.24057.2" CoherentParentDependency="Microsoft.NET.Sdk">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -251,8 +251,8 @@
   </PropertyGroup>
   <!-- Workload manifest package versions -->
   <PropertyGroup>
-    <AspireFeatureBand>8.0.100</AspireFeatureBand>
-    <AspireWorkloadManifestVersion>8.0.0-preview.3.24060.4</AspireWorkloadManifestVersion>
+    <AspireFeatureBand>9.0.100-alpha.1</AspireFeatureBand>
+    <MicrosoftNETSdkAspireManifest90100alpha1PackageVersion>9.0.0-alpha.1.24072.6</MicrosoftNETSdkAspireManifest90100alpha1PackageVersion>
     <MauiFeatureBand>9.0.100-alpha.1</MauiFeatureBand>
     <MauiWorkloadManifestVersion>9.0.0-ci.net9.9818</MauiWorkloadManifestVersion>
     <XamarinAndroidWorkloadManifestVersion>34.99.0-preview.1.109</XamarinAndroidWorkloadManifestVersion>

--- a/src/redist/targets/BundledManifests.targets
+++ b/src/redist/targets/BundledManifests.targets
@@ -18,7 +18,7 @@
     <BundledManifests Include="Microsoft.NET.Workload.Mono.ToolChain.net6" FeatureBand="$(MonoWorkloadFeatureBand)" Version="$(MonoWorkloadManifestVersion)" />
     <BundledManifests Include="Microsoft.NET.Workload.Mono.ToolChain.net7" FeatureBand="$(MonoWorkloadFeatureBand)" Version="$(MonoWorkloadManifestVersion)" />
     <BundledManifests Include="Microsoft.NET.Workload.Mono.ToolChain.net8" FeatureBand="$(MonoWorkloadFeatureBand)" Version="$(MonoWorkloadManifestVersion)" />
-    <BundledManifests Include="Microsoft.NET.Sdk.Aspire" FeatureBand="$(AspireFeatureBand)" Version="$(AspireWorkloadManifestVersion)" />
+    <BundledManifests Include="Microsoft.NET.Sdk.Aspire" FeatureBand="$(AspireFeatureBand)" Version="$(MicrosoftNETSdkAspireManifest90100alpha1PackageVersion)" />
   </ItemGroup>
 
   <!-- Calculate NuGet package IDs for bundled manifests -->


### PR DESCRIPTION
cc @marcpopMSFT 

dotnet/aspire vNext branch is now producing 9.0 workloads, so this is updating installer to use those for preview 1.