### PR TITLE
Work around vstest issue with SB smoke tests

### DIFF
--- a/src/SourceBuild/content/eng/build.sourcebuild.targets
+++ b/src/SourceBuild/content/eng/build.sourcebuild.targets
@@ -182,7 +182,8 @@
     </PropertyGroup>
 
     <!-- Multiple loggers are specified so that results are captured in trx and pipelines can fail with AzDO pipeline warnings -->
-    <Exec Command="$(DotnetTool) test $(SmokeTestsDir) --logger:trx --logger:'console;verbosity=$(SmokeTestConsoleVerbosity)' -c $(Configuration)"
+    <!-- Workaround https://github.com/dotnet/source-build/issues/4003 by disabling VSTestUseMSBuildOutput -->
+    <Exec Command="$(DotnetTool) test $(SmokeTestsDir) --logger:trx --logger:'console;verbosity=$(SmokeTestConsoleVerbosity)' -c $(Configuration) -p:VSTestUseMSBuildOutput=false"
           IgnoreStandardErrorWarningFormat="true"
           EnvironmentVariables="
             SMOKE_TESTS_SDK_TARBALL_PATH=$(SdkTarballPath);


### PR DESCRIPTION
Workaround for https://github.com/dotnet/source-build/issues/4003