### PR TITLE
Exclude repos that currently don't build for VB

### DIFF
--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -25,6 +25,26 @@
     <RepoManifestFile>$([MSBuild]::NormalizePath('$(ProjectDirectory)', 'artifacts', 'RepoManifest.xml'))</RepoManifestFile>
   </PropertyGroup>
 
+  <!-- Exclude repositories that currently don't build when not building source-only. -->
+  <ItemGroup Condition="'$(DotNetBuildVertical)' == 'true'">
+    <RepositoryReference Remove="roslyn" />
+    <RepositoryReference Remove="wpf" Condition="'$(TargetOS)' == 'windows'" />
+    <RepositoryReference Remove="msbuild" />
+    <RepositoryReference Remove="roslyn-analyzers" />
+    <RepositoryReference Remove="aspnetcore" />
+    <RepositoryReference Remove="razor" />
+    <RepositoryReference Remove="deployment-tools" />
+    <RepositoryReference Remove="format" />
+    <RepositoryReference Remove="nuget-client" />
+    <RepositoryReference Remove="templating" />
+    <RepositoryReference Remove="test-templates" />
+    <RepositoryReference Remove="fsharp" />
+    <RepositoryReference Remove="vstest" />
+    <RepositoryReference Remove="sdk" />
+    <RepositoryReference Remove="aspire" />
+    <RepositoryReference Remove="installer" />
+  </ItemGroup>
+
   <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="AddSourceToNuGetConfig" />
   <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="ReadNuGetPackageInfos" />
   <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="RemoveInternetSourcesFromNuGetConfig" />

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -28,7 +28,7 @@
   <!-- Exclude repositories that currently don't build when not building source-only. -->
   <ItemGroup Condition="'$(DotNetBuildVertical)' == 'true'">
     <RepositoryReference Remove="roslyn" />
-    <RepositoryReference Remove="wpf" Condition="'$(TargetOS)' == 'windows'" />
+    <RepositoryReference Remove="wpf" />
     <RepositoryReference Remove="msbuild" />
     <RepositoryReference Remove="roslyn-analyzers" />
     <RepositoryReference Remove="aspnetcore" />


### PR DESCRIPTION
This is needed in preparation of https://github.com/dotnet/source-build/issues/3823 to have green builds.

@mmitche and I will burn that list down over the next weeks.