### PR TITLE
Add Blue Oak license to allow list

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
@@ -49,6 +49,7 @@ public class LicenseScanTests : TestBase
         "apache-2.0 WITH apple-runtime-library-exception", // https://github.com/nexB/scancode-toolkit/blob/develop/src/licensedcode/data/licenses/apple-runtime-library-exception.LICENSE
         "apache-2.0 WITH llvm-exception", // https://foundation.llvm.org/relicensing/LICENSE.txt
         "apsl-2.0", // https://opensource.org/license/apsl-2-0-php/
+        "blueoak-1.0.0", // https://blueoakcouncil.org/license/1.0.0
         "boost-1.0", // https://opensource.org/license/bsl-1-0/
         "bsd-new", // https://opensource.org/license/BSD-3-clause/
         "bsd-original", // https://github.com/nexB/scancode-toolkit/blob/develop/src/licensedcode/data/licenses/bsd-original.LICENSE


### PR DESCRIPTION
This license is also [allowed by Fedora](https://github.com/dotnet/source-build/issues/4014#issuecomment-1908876997).

Fixes https://github.com/dotnet/source-build/issues/4014