### PR TITLE
Fix casing of cloaked file path

### DIFF
--- a/src/VirtualMonoRepo/source-mappings.json
+++ b/src/VirtualMonoRepo/source-mappings.json
@@ -228,7 +228,7 @@
                 "src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/Hyphenation/Hyphen_en.hdict",
                 "src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/Hyphenation/Hyphen_en.lex",
                 "src/Microsoft.DotNet.Wpf/src/ReachFramework/Resources/generated/*.resources",
-                "src/Microsoft.DotNet.Wpf/src/Shared/Tracing/resources/*.bin"
+                "src/Microsoft.DotNet.Wpf/src/Shared/Tracing/resources/*.BIN"
             ]
         },
         {


### PR DESCRIPTION
There's still a warning showing up for a binary file in the wpf repo:

```
src/wpf/src/Microsoft.DotNet.Wpf/src/Shared/Tracing/resources/wpf-etwTEMP.BIN
```

This fixes the casing of the file extension to match.