### PR TITLE
Don't set PortableBuild=... on non source-build

### DIFF
--- a/src/SourceBuild/content/repo-projects/aspnetcore.proj
+++ b/src/SourceBuild/content/repo-projects/aspnetcore.proj
@@ -1,13 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OverrideTargetRid>$(TargetRid)</OverrideTargetRid>
-    <OverrideTargetRid Condition="'$(TargetOS)' == 'osx'">osx-$(TargetArchitecture)</OverrideTargetRid>
-    <OverrideTargetRid Condition="'$(TargetOS)' == 'freebsd'">freebsd-$(TargetArchitecture)</OverrideTargetRid>
-    <OverrideTargetRid Condition="'$(TargetOS)' == 'windows'">win-$(TargetArchitecture)</OverrideTargetRid>
-    <_portableRidOverridden Condition="'$(TargetRid)' != '$(OverrideTargetRid)'">true</_portableRidOverridden>
-    <_portableRidOverridden Condition="'$(TargetRid)' == '$(OverrideTargetRid)'">false</_portableRidOverridden>
-
     <!-- AspNetCore doesn't have a root build script but one under the eng folder. -->
     <BuildScript>$(ProjectDirectory)eng\build$(ShellExtension)</BuildScript>
 
@@ -20,9 +13,20 @@
     <BuildArgs Condition="'$(OverrideTargetArch)' != ''">$(BuildArgs) $(FlagParameterPrefix)arch $(OverrideTargetArch)</BuildArgs>
     <BuildArgs Condition="'$(DotNetBuildVertical)' != 'true' or '$(BuildOS)' != 'windows'">$(BuildArgs) $(FlagParameterPrefix)no-build-repo-tasks</BuildArgs>
     <BuildArgs Condition="'$(DotNetBuildVertical)' != 'true' or '$(BuildOS)' != 'windows'">$(BuildArgs) $(FlagParameterPrefix)no-build-nodejs</BuildArgs>
-    <BuildArgs>$(BuildArgs) /p:PortableBuild=$(_portableRidOverridden) /p:TargetRuntimeIdentifier=$(OverrideTargetRid)</BuildArgs>
 
     <LogVerbosityOptOut>true</LogVerbosityOptOut>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
+    <OverrideTargetRid>$(TargetRid)</OverrideTargetRid>
+    <OverrideTargetRid Condition="'$(TargetOS)' == 'osx'">osx-$(TargetArchitecture)</OverrideTargetRid>
+    <OverrideTargetRid Condition="'$(TargetOS)' == 'freebsd'">freebsd-$(TargetArchitecture)</OverrideTargetRid>
+    <OverrideTargetRid Condition="'$(TargetOS)' == 'windows'">win-$(TargetArchitecture)</OverrideTargetRid>
+    <_portableRidOverridden Condition="'$(TargetRid)' != '$(OverrideTargetRid)'">true</_portableRidOverridden>
+    <_portableRidOverridden Condition="'$(TargetRid)' == '$(OverrideTargetRid)'">false</_portableRidOverridden>
+
+    <BuildArgs>$(BuildArgs) /p:PortableBuild=$(_portableRidOverridden)</BuildArgs>
+    <BuildArgs>$(BuildArgs) /p:TargetRuntimeIdentifier=$(OverrideTargetRid)</BuildArgs>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SourceBuild/content/repo-projects/installer.proj
+++ b/src/SourceBuild/content/repo-projects/installer.proj
@@ -30,8 +30,8 @@
     <BuildArgs>$(BuildArgs) /p:DOTNET_INSTALL_DIR=$(DotNetRoot)</BuildArgs>
 
     <BuildArgs Condition="'$(TargetOS)' != 'windows'">$(BuildArgs) /p:AspNetCoreInstallerRid=$(OverrideTargetRid)</BuildArgs>
-    <!-- core-sdk always wants to build portable on OSX and FreeBSD -->
-    <BuildArgs Condition="'$(TargetOS)' == 'freebsd'">$(BuildArgs) /p:PortableBuild=true</BuildArgs>
+    <!-- installer always wants to build portable on FreeBSD -->
+    <BuildArgs Condition="'$(TargetOS)' == 'freebsd' and '$(DotNetBuildFromSource)' == 'true'">$(BuildArgs) /p:PortableBuild=true</BuildArgs>
     <BuildArgs Condition="'$(TargetOS)' != 'windows'">$(BuildArgs) /p:CoreSetupRid=$(OverrideTargetRid)</BuildArgs>
 
     <!-- Consume the source-built Core-Setup and toolset. This line must be removed to source-build CLI without source-building Core-Setup first. -->

--- a/src/SourceBuild/content/repo-projects/runtime.proj
+++ b/src/SourceBuild/content/repo-projects/runtime.proj
@@ -14,10 +14,6 @@
     <_platformIndex>$(NETCoreSdkPortableRuntimeIdentifier.LastIndexOf('-'))</_platformIndex>
     <BaseOS>$(NETCoreSdkPortableRuntimeIdentifier.Substring(0, $(_platformIndex)))-$(TargetArchitecture)</BaseOS>
 
-    <PortableBuild Condition="'$(PortableBuild)' == ''">false</PortableBuild>
-    <BuildNonPortable>true</BuildNonPortable>
-    <BuildNonPortable Condition="'$(PortableBuild)' == 'true'">false</BuildNonPortable>
-
     <!-- Use the repo root build script -->
     <BuildScript>$(ProjectDirectory)build$(ShellExtension)</BuildScript>
 
@@ -26,6 +22,13 @@
     <BuildArgs>$(BuildArgs) /p:TargetRid=$(OverrideTargetRid)</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:RuntimeOS=$(RuntimeOS)</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:BaseOS=$(BaseOS)</BuildArgs>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
+    <PortableBuild Condition="'$(PortableBuild)' == ''">false</PortableBuild>
+    <BuildNonPortable>true</BuildNonPortable>
+    <BuildNonPortable Condition="'$(PortableBuild)' == 'true'">false</BuildNonPortable>
+
     <BuildArgs>$(BuildArgs) /p:PortableBuild=$(PortableBuild)</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:SourceBuildNonPortable=$(BuildNonPortable)</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:UsingToolMicrosoftNetCompilers=false</BuildArgs>


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4042

This might break cross-builds but I'm fine with that as those aren't yet productized.