### PR TITLE
Pass a few switches to the orchestrator

### DIFF
--- a/src/SourceBuild/content/Directory.Build.props
+++ b/src/SourceBuild/content/Directory.Build.props
@@ -121,7 +121,7 @@
     <!-- Builds from the VMR are by definition vertical builds. -->
     <DotNetBuildVertical Condition="'$(DotNetBuildVertical)' == '' and '$(DotNetBuildFromSource)' != 'true'">true</DotNetBuildVertical>
     <!-- By default, the VMR builds with online sources. -->
-    <BuildWithOnlineSources Condition="'$(BuildWithOnlineSources)' == '' and '$(DotNetBuildVertical)' == 'true'">true</BuildWithOnlineSources>
+    <DotNetBuildWithOnlineSources Condition="'$(DotNetBuildWithOnlineSources)' == '' and '$(DotNetBuildVertical)' == 'true'">true</DotNetBuildWithOnlineSources>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/SourceBuild/content/build.sh
+++ b/src/SourceBuild/content/build.sh
@@ -119,10 +119,10 @@ while [[ $# > 0 ]]; do
     # Source-only settings
     -source-only|-so)
       sourceOnly=true
-      properties="$properties /p:DotNetBuildFromSource=true"
+      properties="$properties /p:DotNetBuildFromSource=true /p:DotNetBuildSourceOnly=true"
       ;;
     -online)
-      properties="$properties /p:BuildWithOnlineSources=true"
+      properties="$properties /p:DotNetBuildWithOnlineSources=true"
       ;;
     -poison)
       properties="$properties /p:EnablePoison=true"

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -82,7 +82,7 @@
 
     <RemoveInternetSourcesFromNuGetConfig
       NuGetConfigFile="%(NuGetConfigFiles.Identity)"
-      BuildWithOnlineSources="$(BuildWithOnlineSources)"
+      BuildWithOnlineSources="$(DotNetBuildWithOnlineSources)"
       KeepFeedPrefixes="@(KeepFeedPrefixes)"
       Condition="'$(DotNetBuildFromSource)' == 'true'" />
 
@@ -112,7 +112,7 @@
 
     <UpdateNuGetConfigPackageSourcesMappings
       NuGetConfigFile="%(NuGetConfigFiles.Identity)"
-      BuildWithOnlineSources="$(BuildWithOnlineSources)"
+      BuildWithOnlineSources="$(DotNetBuildWithOnlineSources)"
       SourceBuildSources="$(SourceBuildSources)" />
 
     <MakeDir Directories="$(BaseIntermediateOutputPath)" />


### PR DESCRIPTION
- Pass DotNetBuildSourceOnly in source-only mode
- Update BuildWithOnlySources to DotNetBuildWithOnlineSources.

DotNetBuildWithOnlySources will be used in place of DotNetBuildOffline (gone)
