### PR TITLE
Update list of assembly exclusions

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkAssemblyVersionDiffExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkAssemblyVersionDiffExclusions.txt
@@ -37,6 +37,15 @@
 ./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/BuildHost-netcore/System.Composition.*
 ./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/BuildHost-netcore/System.IO.Pipelines.dll
 
+# These assemblies are lifted to 9.0 (https://github.com/dotnet/source-build/issues/4013)
+./sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/runtimes/browser/lib/netx.y/System.Text.Encodings.Web.dll
+./sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/System.Collections.Immutable.dll
+./sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/System.Reflection.Metadata.dll
+./sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/System.Text.Encodings.Web.dll
+./sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/System.Text.Json.dll
+./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/BuildHost-netcore/System.Collections.Immutable.dll
+./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/BuildHost-netcore/System.Reflection.Metadata.dll
+
 # These assemblies are lifted to a higher version naturally via SB
 ./sdk/x.y.z/DotnetTools/dotnet-format/*/Microsoft.CodeAnalysis.*
 ./sdk/x.y.z/DotnetTools/dotnet-format/Humanizer.dll


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4013

The following diffs are addressed by adding the exclusions in this PR:

```
-sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/runtimes/browser/lib/netx.y/System.Text.Encodings.Web.dll - 7.0.0
-sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/System.Collections.Immutable.dll - 8.0.0
+sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/runtimes/browser/lib/netx.y/System.Text.Encodings.Web.dll - 9.0.0
+sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/System.Collections.Immutable.dll - 9.0.0
-sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/System.Reflection.Metadata.dll - 8.0.0
-sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/System.Text.Encodings.Web.dll - 7.0.0
-sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/System.Text.Json.dll - 7.0.0
+sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/System.Reflection.Metadata.dll - 9.0.0
+sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/System.Text.Encodings.Web.dll - 9.0.0
+sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/System.Text.Json.dll - 9.0.0
-sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/BuildHost-netcore/System.Collections.Immutable.dll - 8.0.0
+sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/BuildHost-netcore/System.Collections.Immutable.dll - 9.0.0
-sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/BuildHost-netcore/System.Reflection.Metadata.dll - 8.0.0
+sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/BuildHost-netcore/System.Reflection.Metadata.dll - 9.0.0
```
