### PR TITLE
Don't build tests from the VMR by default

### DIFF
--- a/src/SourceBuild/content/Directory.Build.props
+++ b/src/SourceBuild/content/Directory.Build.props
@@ -120,7 +120,7 @@
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <!-- By default, the VMR builds with online sources when not building source-only. -->
     <DotNetBuildWithOnlineSources Condition="'$(DotNetBuildWithOnlineSources)' == '' and '$(DotNetBuildSourceOnly)' != 'true'">true</DotNetBuildWithOnlineSources>
-    <!-- By default, skip buliding tests when building the VMR. -->
+    <!-- By default, skip building tests when building the VMR. -->
     <DotNetBuildSkipTests Condition="'$(DotNetBuildSkipTests)' == ''">true</DotNetBuildSkipTests>
   </PropertyGroup>
 

--- a/src/SourceBuild/content/Directory.Build.props
+++ b/src/SourceBuild/content/Directory.Build.props
@@ -120,6 +120,8 @@
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <!-- By default, the VMR builds with online sources when not building source-only. -->
     <DotNetBuildWithOnlineSources Condition="'$(DotNetBuildWithOnlineSources)' == '' and '$(DotNetBuildSourceOnly)' != 'true'">true</DotNetBuildWithOnlineSources>
+    <!-- By default, skip buliding tests when building the VMR. -->
+    <DotNetBuildSkipTests Condition="'$(DotNetBuildSkipTests)' == ''">true</DotNetBuildSkipTests>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -58,7 +58,8 @@
     <BuildArgs>$(BuildArgs) /p:DotNetBuildRepo=true</BuildArgs>
     <!-- Indicate that the build is being run from the orchestrator -->
     <BuildArgs>$(BuildArgs) /p:DotNetBuildOrchestrator=true</BuildArgs>
-    <BuildArgs Condition="'$(CrossBuild)' == 'true'">$(BuildArgs) /p:CrossBuild=$(CrossBuild)</BuildArgs>
+    <BuildArgs Condition="'$(CrossBuild)' == 'true'">$(BuildArgs) /p:CrossBuild=true</BuildArgs>
+    <BuildArgs Condition="'$(DotNetBuildSkipTests)' == 'true'">$(BuildArgs) /p:DotNetBuildSkipTests=true</BuildArgs>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">


### PR DESCRIPTION
This is necessary until we have the "main-ub" branch that doesn't cloak files. In addition, I don't think we should build tests yet with the VMR. The highest priority right now is to get the product repo builds working, without tests.

Building tests got enabled via Arcade's dependency flow in https://github.com/dotnet/installer/commit/4a54e209f5098102c194a6fb75fe41bcfc9b5549

---

Related: We are discussing offline what the right default should be when building the VMR. IMO it should be not building tests because that's already the behavior in runtime and other repositories and we want that behavior when building the official product.