### PR TITLE
Update dependencies from dotnet/source-build-externals

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -190,9 +190,9 @@
       <Sha>b4f8847a36543b3274dc252534d0175de35bd16c</Sha>
       <SourceBuild RepoName="deployment-tools" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="9.0.0-alpha.1.24066.1">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="9.0.0-alpha.1.24076.1">
       <Uri>https://github.com/dotnet/source-build-externals</Uri>
-      <Sha>6fc8c1ac45220a4d9b4c59bf2ff187dafcb1da3f</Sha>
+      <Sha>414a85bf970355c0e91d6a2de1ee183fafbfcecd</Sha>
       <SourceBuild RepoName="source-build-externals" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="System.CommandLine" Version="2.0.0-beta4.24068.1" CoherentParentDependency="Microsoft.NET.Sdk">


### PR DESCRIPTION
Backport of https://github.com/dotnet/installer/pull/18412 to get the changes from https://github.com/dotnet/source-build-externals/pull/258.

Fixes https://github.com/dotnet/source-build/issues/4037