### PR TITLE
Remove DotNetBuildVertical passed to repos from orchestrator

### DIFF
--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -142,7 +142,6 @@
 
   <ItemGroup>
     <EnvironmentVariables Include="DotNetBuildFromSource=true" Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
-    <EnvironmentVariables Include="DotNetBuildVertical=true" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(EnableExtraDebugging)' == 'true'">


### PR DESCRIPTION
This variable should no longer be necessary now that the new switches are in place.

Removing DotNetBuildFromSource requires a new arcade in source-build.
