### PR TITLE
[release/9.0.1xx-preview1] Update dependencies from https://github.com/dotnet/aspire

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -247,9 +247,9 @@
          aren't shipping, or those extensions packages depend on aspnetcore packages that won't ship. However, given the cost
          of maintaining this coherency path is high. This being toolset means that aspire is responsible for its own coherency.
     -->
-    <Dependency Name="Microsoft.NET.Sdk.Aspire.Manifest-9.0.100-preview.1" Version="9.0.0-alpha.1.24075.7">
+    <Dependency Name="Microsoft.NET.Sdk.Aspire.Manifest-9.0.100-preview.1" Version="9.0.0-preview.1.24079.4">
       <Uri>https://github.com/dotnet/aspire</Uri>
-      <Sha>f99439fc44b8460fc475f8ffa319593df71d7891</Sha>
+      <Sha>1226bf2df28644de5f808dc1674f4a195fb333e8</Sha>
       <SourceBuild RepoName="aspire" ManagedOnly="true" />
     </Dependency>
   </ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -252,7 +252,7 @@
   <!-- Workload manifest package versions -->
   <PropertyGroup>
     <AspireFeatureBand>9.0.100-preview.1</AspireFeatureBand>
-    <MicrosoftNETSdkAspireManifest90100preview1PackageVersion>9.0.0-alpha.1.24075.7</MicrosoftNETSdkAspireManifest90100preview1PackageVersion>
+    <MicrosoftNETSdkAspireManifest90100preview1PackageVersion>9.0.0-preview.1.24079.4</MicrosoftNETSdkAspireManifest90100preview1PackageVersion>
     <MauiFeatureBand>9.0.100-alpha.1</MauiFeatureBand>
     <MauiWorkloadManifestVersion>9.0.0-ci.net9.9818</MauiWorkloadManifestVersion>
     <XamarinAndroidWorkloadManifestVersion>34.99.0-preview.1.109</XamarinAndroidWorkloadManifestVersion>


### PR DESCRIPTION
cc @mmitche 

While this is not required, this is updating the baseline manifest of aspire with a version that has a coherent runtime, extensions and aspnetcore. Not sure if we are still taking changes, but if we are, this is a nice to have.
