### PR TITLE
Use multiple processes for license scan

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
@@ -150,7 +150,7 @@ public class LicenseScanTests : TestBase
         string ignoreOptions = string.Join(" ", s_ignoredFilePatterns.Select(pattern => $"--ignore {pattern}"));
         ExecuteHelper.ExecuteProcessValidateExitCode(
             "scancode",
-            $"--license --strip-root --only-findings {ignoreOptions} --json-pp {scancodeResultsPath} {Config.LicenseScanPath}",
+            $"--license --processes 4 --strip-root --only-findings {ignoreOptions} --json-pp {scancodeResultsPath} {Config.LicenseScanPath}",
             OutputHelper);
 
         JsonDocument doc = JsonDocument.Parse(File.ReadAllText(scancodeResultsPath));


### PR DESCRIPTION
The license scan job for the runtime repo within the VMR is timing out after 7 hrs. This is only happening in the release/9.0.1xx-preview1 branch. The main branch is running in the usual 5.5 hrs. Not sure why exactly it's having issues in the release branch.

However, I found that by configuring the call to scancode to set the number of processes to a higher value, the scan executes in less time. So I can get a successful scan in about 2.5 hrs.

Fixes https://github.com/dotnet/source-build/issues/3765