### PR TITLE
Allow .doc files as binaries in the VMR

### DIFF
--- a/src/VirtualMonoRepo/allowed-binaries.txt
+++ b/src/VirtualMonoRepo/allowed-binaries.txt
@@ -1,4 +1,5 @@
 *.bmp
+*.doc
 *.docx
 *.gif
 *.ico


### PR DESCRIPTION
We already allow .docx files, and .doc files are essentially the same thing.

Contributes to https://github.com/dotnet/source-build/issues/3746