### PR TITLE
Stop using OverrideTargetRid, use TargetOS/TargetArchitecture instead

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -69,6 +69,14 @@ parameters:
   type: string
   default: ''
 
+- name: targetOS
+  type: string
+  default: ''
+
+- name: targetArch
+  type: string
+  default: ''
+
 jobs:
 - job: ${{ parameters.buildName }}_${{ parameters.architecture }}
   timeoutInMinutes: 150
@@ -247,20 +255,20 @@ jobs:
         useDocker=true
       fi
 
-      if [[ ! -z '${{ parameters.targetRid }}' ]]; then
-        extraBuildProperties="--"
-        if [[ '${{ parameters.useMonoRuntime }}' == 'True' ]]; then
-            customEnvVars="$customEnvVars CROSSCOMPILE=1"
-        fi
-        extraBuildProperties="$extraBuildProperties /p:PortableBuild=true /p:DotNetBuildVertical=true /p:CrossBuild=true"
+      if [[ '${{ parameters.useMonoRuntime }}' == 'True' ]]; then
+        customEnvVars="$customEnvVars CROSSCOMPILE=1"
       fi
 
       if [[ ! -z '${{ parameters.crossRootFs }}' ]]; then
         customEnvVars="$customEnvVars ROOTFS_DIR=${{ parameters.crossRootFs}}"
       fi
 
-      if [[ ! -z '${{ parameters.targetRid }}' ]]; then
-        extraBuildProperties="$extraBuildProperties /p:OverrideTargetRid=${{ parameters.targetRid }}"
+      if [[ ! -z '${{ parameters.targetOS }}' ]]; then
+        extraBuildProperties="$extraBuildProperties /p:TargetOS=${{ parameters.targetOS }}"
+      fi
+
+      if [[ ! -z '${{ parameters.targetArch }}' ]]; then
+        extraBuildProperties="$extraBuildProperties /p:TargetArchitecture=${{ parameters.targetArch }}"
       fi
 
       # Only use Docker stuff on Linux

--- a/eng/pipelines/templates/stages/vmr-cross-build.yml
+++ b/eng/pipelines/templates/stages/vmr-cross-build.yml
@@ -89,6 +89,8 @@ stages:
       withPreviousSDK: false             # 🚫
       crossRootFs: '/crossrootfs/x64'    # 📝
       targetRid: 'linux-x64'             # 📝
+      targetOS: 'linux'                  # 📝
+      targetArch: 'x64'                  # 📝
 
   - template: ../jobs/vmr-build.yml
     parameters:
@@ -109,6 +111,8 @@ stages:
       withPreviousSDK: false             # 🚫
       crossRootFs: '/crossrootfs/arm64'  # 📝
       targetRid: 'linux-arm64'           # 📝
+      targetOS: 'linux'                  # 📝
+      targetArch: 'arm64'                # 📝
 
   - template: ../jobs/vmr-build.yml
     parameters:
@@ -127,6 +131,8 @@ stages:
       useMonoRuntime: true               # ✅
       withPreviousSDK: false             # 🚫
       targetRid: 'osx-x64'               # 📝
+      targetOS: 'osx'                    # 📝
+      targetArch: 'x64'                  # 📝
 
   - template: ../jobs/vmr-build.yml
     parameters:
@@ -145,6 +151,8 @@ stages:
       useMonoRuntime: true               # ✅
       withPreviousSDK: false             # 🚫
       targetRid: 'osx-arm64'             # 📝
+      targetOS: 'osx'                    # 📝
+      targetArch: 'arm64'                # 📝
 
   - template: ../jobs/vmr-build.yml
     parameters:
@@ -165,3 +173,5 @@ stages:
       withPreviousSDK: false             # 🚫
       crossRootFs: '/crossrootfs/arm64'  # 📝
       targetRid: 'linux-arm64'           # 📝
+      targetOS: 'linux'                  # 📝
+      targetArch: 'arm64'                # 📝

--- a/src/SourceBuild/content/Directory.Build.props
+++ b/src/SourceBuild/content/Directory.Build.props
@@ -24,17 +24,7 @@
     <HostArchitecture Condition="'$(HostArchitecture)' == ''">$(BuildArchitecture)</HostArchitecture>
 
     <!-- When building on non-x64 architectures, there may be no cross-compilation available, select a target architecture that is the same as the build. -->
-    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' and '$(BuildArchitecture)' == 'arm'">arm</TargetArchitecture>
-    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' and '$(BuildArchitecture)' == 'armv6'">armv6</TargetArchitecture>
-    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' and '$(BuildArchitecture)' == 'armel'">armel</TargetArchitecture>
-    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' and '$(BuildArchitecture)' == 'arm64'">arm64</TargetArchitecture>
-    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' and '$(BuildArchitecture)' == 'riscv64'">riscv64</TargetArchitecture>
-    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' and '$(BuildArchitecture)' == 'loongarch64'">loongarch64</TargetArchitecture>
-    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' and '$(BuildArchitecture)' == 's390x'">s390x</TargetArchitecture>
-    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' and '$(BuildArchitecture)' == 'ppc64le'">ppc64le</TargetArchitecture>
-
-    <TargetArchitecture Condition="'$(OverrideTargetRid)' != ''">$(OverrideTargetRid.Substring($(OverrideTargetRid.LastIndexOf('-'))).TrimStart('-'))</TargetArchitecture>
-    <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">x64</TargetArchitecture>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">$(BuildArchitecture)</TargetArchitecture>
 
     <Platform Condition="'$(Platform)' == '' and '$(InferPlatformFromTargetArchitecture)' == 'true'">$(TargetArchitecture)</Platform>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
@@ -47,6 +37,9 @@
 
     <HostRid Condition="'$(HostRid)' == ''">$(BuildRid)</HostRid>
     <TargetRid Condition="'$(TargetRid)' == ''">$(BuildRid)</TargetRid>
+
+    <!-- Source-only builds are non portable. -->
+    <PortableBuild Condition="'$(PortableBuild)' == '' and '$(DotNetBuildSourceOnly)' != 'true'">true</PortableBuild>
 
     <PortableRid Condition="'$(__PortableTargetOS)' != ''">$(__PortableTargetOS)-$(TargetArchitecture)</PortableRid>
     <PortableRid Condition="'$(PortableRid)' == '' and '$(TargetOS)' == 'freebsd'">freebsd-$(TargetArchitecture)</PortableRid>

--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -81,12 +81,6 @@
     <AspNetRazorBuildServerLogFile>$(AspNetRazorBuildServerLogDir)razor-build-server.log</AspNetRazorBuildServerLogFile>
   </PropertyGroup>
 
-  <!-- Cross-build property setting from OverrideTargetRid -->
-  <PropertyGroup Condition="'$(OverrideTargetRid)' != ''">
-    <OverrideTargetOS>$(OverrideTargetRid.Substring(0, $(OverrideTargetRid.LastIndexOf('-'))))</OverrideTargetOS>
-    <OverrideTargetArch>$(OverrideTargetRid.Substring($(OverrideTargetRid.LastIndexOf('-'))).TrimStart('-'))</OverrideTargetArch>
-  </PropertyGroup>
-
   <ItemGroup>
     <!-- Arcade tools.sh picks up DotNetCoreSdkDir, but we can pass DOTNET_INSTALL_DIR directly. -->
     <EnvironmentVariables Include="DOTNET_INSTALL_DIR=$(DotNetRoot)" />

--- a/src/SourceBuild/content/repo-projects/aspnetcore.proj
+++ b/src/SourceBuild/content/repo-projects/aspnetcore.proj
@@ -9,8 +9,7 @@
     <!-- On Windows, build all for the VB PoC -->
     <BuildActions Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(BuildOS)' == 'windows'">$(FlagParameterPrefix)restore $(FlagParameterPrefix)all $(FlagParameterPrefix)pack</BuildActions>
 
-    <BuildArgs Condition="'$(OverrideTargetArch)' == ''">$(BuildArgs) $(FlagParameterPrefix)arch $(TargetArchitecture)</BuildArgs>
-    <BuildArgs Condition="'$(OverrideTargetArch)' != ''">$(BuildArgs) $(FlagParameterPrefix)arch $(OverrideTargetArch)</BuildArgs>
+    <BuildArgs>$(BuildArgs) $(FlagParameterPrefix)arch $(TargetArchitecture)</BuildArgs>
     <BuildArgs Condition="'$(DotNetBuildSourceOnly)' == 'true' or '$(BuildOS)' != 'windows'">$(BuildArgs) $(FlagParameterPrefix)no-build-repo-tasks</BuildArgs>
     <BuildArgs Condition="'$(DotNetBuildSourceOnly)' == 'true' or '$(BuildOS)' != 'windows'">$(BuildArgs) $(FlagParameterPrefix)no-build-nodejs</BuildArgs>
 

--- a/src/SourceBuild/content/repo-projects/runtime.proj
+++ b/src/SourceBuild/content/repo-projects/runtime.proj
@@ -17,8 +17,8 @@
     <!-- Use the repo root build script -->
     <BuildScript>$(ProjectDirectory)build$(ShellExtension)</BuildScript>
 
-    <BuildArgs Condition="'$(OverrideTargetArch)' != ''">$(BuildArgs) $(FlagParameterPrefix)arch $(OverrideTargetArch)</BuildArgs>
-    <BuildArgs Condition="'$(OverrideTargetOS)' != ''">$(BuildArgs) $(FlagParameterPrefix)os $(OverrideTargetOS)</BuildArgs>
+    <BuildArgs>$(BuildArgs) $(FlagParameterPrefix)arch $(TargetArchitecture)</BuildArgs>
+    <BuildArgs>$(BuildArgs) $(FlagParameterPrefix)os $(TargetOS)</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:TargetRid=$(OverrideTargetRid)</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:RuntimeOS=$(RuntimeOS)</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:BaseOS=$(BaseOS)</BuildArgs>

--- a/src/SourceBuild/content/repo-projects/sdk.proj
+++ b/src/SourceBuild/content/repo-projects/sdk.proj
@@ -11,9 +11,8 @@
     <!-- Propagate RID set in source-build to sdk repo -->
     <_platformIndex>$(NETCoreSdkPortableRuntimeIdentifier.LastIndexOf('-'))</_platformIndex>
     <_baseOS>$(NETCoreSdkPortableRuntimeIdentifier.Substring(0, $(_platformIndex)))</_baseOS>
-    <_baseOS Condition="'$(OverrideTargetOS)' != ''">$(OverrideTargetOS)</_baseOS>
+    <_baseOS Condition="'$(PortableBuild)' == 'true'">$(TargetOS)</_baseOS>
     <_targetPortableArch>$(TargetArchitecture)</_targetPortableArch>
-    <_targetPortableArch Condition="'$(OverrideTargetArch)' != ''">$(OverrideTargetArch)</_targetPortableArch>
 
     <BuildArgs>$(BuildArgs) /p:PackageProjectUrl=https://github.com/dotnet/sdk</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:PortableRid=$(_baseOS)-$(_targetPortableArch)</BuildArgs>


### PR DESCRIPTION
We should probably be using HostOS/HostArchitecture instead, but "TargetRid" is baked into a lot of places so I'd want more discussion before making sweeping changes.