### PR TITLE
Respect ci switch for source-only builds

### DIFF
--- a/src/SourceBuild/content/build.sh
+++ b/src/SourceBuild/content/build.sh
@@ -206,6 +206,10 @@ function Build {
 
   else
 
+    if [ "$ci" == "true" ]; then
+      properties="$properties /p:ContinuousIntegrationBuild=true"
+    fi
+
     "$CLI_ROOT/dotnet" build-server shutdown
 
     if [ "$test" == "true" ]; then


### PR DESCRIPTION
I noticed that `/p:ContinuousIntegrationBuild=true` isn't set when passing the `--ci` switch in and building from source. This is related to source-only using a different build path. This fixes that. Long-term, we should consolidate both paths to do the same thing and use the Arcade script infrastructure consistently.