### PR TITLE
Update SdkResolver layout to work for Desktop and Core MSBuild

### DIFF
--- a/src/SourceBuild/content/Directory.Build.props
+++ b/src/SourceBuild/content/Directory.Build.props
@@ -153,7 +153,7 @@
     <ArcadeBootstrapPackageDir Condition="'$(DotNetBuildSourceOnly)' == 'true'">$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'ArcadeBootstrapPackage'))</ArcadeBootstrapPackageDir>
     <ArcadeBootstrapPackageDir Condition="'$(DotNetBuildSourceOnly)' != 'true'">$(NuGetPackageRoot)</ArcadeBootstrapPackageDir>
 
-    <VSMSBuildSdkResolversDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts', 'toolset', 'VSSdkResolvers'))</VSMSBuildSdkResolversDir>
+    <VSMSBuildSdkResolversDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'toolset', 'VSSdkResolvers'))</VSMSBuildSdkResolversDir>
 
     <!-- Shared output and intermediate output path folders that are architecture and configuration specific. -->
     <SharedOutputPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', '$(TargetArchitecture)', '$(Configuration)'))</SharedOutputPath>

--- a/src/SourceBuild/content/Directory.Build.props
+++ b/src/SourceBuild/content/Directory.Build.props
@@ -153,6 +153,8 @@
     <ArcadeBootstrapPackageDir Condition="'$(DotNetBuildSourceOnly)' == 'true'">$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'ArcadeBootstrapPackage'))</ArcadeBootstrapPackageDir>
     <ArcadeBootstrapPackageDir Condition="'$(DotNetBuildSourceOnly)' != 'true'">$(NuGetPackageRoot)</ArcadeBootstrapPackageDir>
 
+    <VSMSBuildSdkResolversDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts', 'toolset', 'VSSdkResolvers'))</VSMSBuildSdkResolversDir>
+
     <!-- Shared output and intermediate output path folders that are architecture and configuration specific. -->
     <SharedOutputPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', '$(TargetArchitecture)', '$(Configuration)'))</SharedOutputPath>
     <SharedIntermediateOutputPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsObjDir)', '$(TargetArchitecture)', '$(Configuration)'))</SharedIntermediateOutputPath>

--- a/src/SourceBuild/content/build.sh
+++ b/src/SourceBuild/content/build.sh
@@ -215,7 +215,7 @@ function Build {
     if [ "$test" == "true" ]; then
       "$CLI_ROOT/dotnet" msbuild "$scriptroot/build.proj" -bl:"$scriptroot/artifacts/log/$configuration/BuildTests.binlog" -flp:"LogFile=$scriptroot/artifacts/log/$configuration/BuildTests.log" -clp:v=m $properties
     else
-      "$CLI_ROOT/dotnet" msbuild "$scriptroot/eng/tools/init-build.proj" -bl:"$scriptroot/artifacts/log/$configuration/BuildMSBuildSdkResolver.binlog" -flp:LogFile="$scriptroot/artifacts/log/$configuration/BuildMSBuildSdkResolver.log" /t:ExtractToolPackage,LayoutMSBuildSdkResolver $properties
+      "$CLI_ROOT/dotnet" msbuild "$scriptroot/eng/tools/init-build.proj" -bl:"$scriptroot/artifacts/log/$configuration/BuildMSBuildSdkResolver.binlog" -flp:LogFile="$scriptroot/artifacts/log/$configuration/BuildMSBuildSdkResolver.log" /t:ExtractToolPackage,BuildMSBuildSdkResolver $properties
 
       # kill off the MSBuild server so that on future invocations we pick up our custom SDK Resolver
       "$CLI_ROOT/dotnet" build-server shutdown

--- a/src/SourceBuild/content/build.sh
+++ b/src/SourceBuild/content/build.sh
@@ -215,7 +215,7 @@ function Build {
     if [ "$test" == "true" ]; then
       "$CLI_ROOT/dotnet" msbuild "$scriptroot/build.proj" -bl:"$scriptroot/artifacts/log/$configuration/BuildTests.binlog" -flp:"LogFile=$scriptroot/artifacts/log/$configuration/BuildTests.log" -clp:v=m $properties
     else
-      "$CLI_ROOT/dotnet" msbuild "$scriptroot/eng/tools/init-build.proj" -bl:"$scriptroot/artifacts/log/$configuration/BuildMSBuildSdkResolver.binlog" -flp:LogFile="$scriptroot/artifacts/log/$configuration/BuildMSBuildSdkResolver.log" /t:ExtractToolPackage,BuildMSBuildSdkResolver $properties
+      "$CLI_ROOT/dotnet" msbuild "$scriptroot/eng/tools/init-build.proj" -bl:"$scriptroot/artifacts/log/$configuration/BuildMSBuildSdkResolver.binlog" -flp:LogFile="$scriptroot/artifacts/log/$configuration/BuildMSBuildSdkResolver.log" /t:ExtractToolPackage,LayoutMSBuildSdkResolver $properties
 
       # kill off the MSBuild server so that on future invocations we pick up our custom SDK Resolver
       "$CLI_ROOT/dotnet" build-server shutdown

--- a/src/SourceBuild/content/eng/tools/init-build.proj
+++ b/src/SourceBuild/content/eng/tools/init-build.proj
@@ -14,7 +14,7 @@
           DependsOnTargets="
       UnpackTarballs;
       BuildXPlatTasks;
-      LayoutMSBuildSdkResolver;
+      BuildMSBuildSdkResolver;
       BuildLeakDetection;
       ExtractToolPackage;
       GenerateRootFs;
@@ -81,20 +81,9 @@
     <SourceBuildMSBuildSdkResolverManifestPath>$([MSBuild]::NormalizePath('$(VSMSBuildSdkResolversDir)', 'SourceBuild.MSBuildSdkResolver', 'SourceBuild.MSBuildSdkResolver.xml'))</SourceBuildMSBuildSdkResolverManifestPath>
   </PropertyGroup>
 
-  <Target Name="LayoutMSBuildSdkResolver"
-          DependsOnTargets="BuildMSBuildSdkResolver"
-          Inputs="$(MSBuildProjectFullPath)"
-          Outputs="$(SourceBuildMSBuildSdkResolverManifestPath)">
-
-    <WriteLinesToFile
-      File="$(SourceBuildMSBuildSdkResolverManifestPath)"
-      Lines="&lt;SdkResolver&gt;&lt;Path&gt;%(SourceBuildSdkResolver.FullPath)&lt;/Path&gt;&lt;/SdkResolver&gt;"
-      Overwrite="true" />
-  </Target>
-
   <!-- Build msbuild tasks. -->
   <Target Name="BuildXPlatTasks"
-          DependsOnTargets="UnpackTarballs;LayoutMSBuildSdkResolver"
+          DependsOnTargets="UnpackTarballs;BuildMSBuildSdkResolver"
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(BaseIntermediateOutputPath)BuildXPlatTasks.complete">
     <MSBuild Projects="tasks\Microsoft.DotNet.SourceBuild.Tasks.XPlat\Microsoft.DotNet.SourceBuild.Tasks.XPlat.csproj"
@@ -112,7 +101,7 @@
 
   <!-- Build msbuild tasks for the poisoning feature. -->
   <Target Name="BuildLeakDetection"
-          DependsOnTargets="ExtractToolPackage;LayoutMSBuildSdkResolver"
+          DependsOnTargets="ExtractToolPackage;BuildMSBuildSdkResolver"
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(BaseIntermediateOutputPath)BuildLeakDetection.complete"
           Condition="'$(EnablePoison)' == 'true'">

--- a/src/SourceBuild/content/eng/tools/init-build.proj
+++ b/src/SourceBuild/content/eng/tools/init-build.proj
@@ -67,9 +67,7 @@
              Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid())" />
 
     <MSBuild Projects="tasks\SourceBuild.MSBuildSdkResolver\SourceBuild.MSBuildSdkResolver.csproj"
-             Targets="Build">
-      <Output TaskParameter="TargetOutputs" ItemName="SourceBuildSdkResolver" />
-    </MSBuild>
+             Targets="Build" />
 
     <MakeDir Directories="$(BaseIntermediateOutputPath)" />
     <Touch Files="$(BaseIntermediateOutputPath)BuildMSBuildSdkResolver.complete" AlwaysCreate="true">

--- a/src/SourceBuild/content/eng/tools/init-build.proj
+++ b/src/SourceBuild/content/eng/tools/init-build.proj
@@ -14,7 +14,7 @@
           DependsOnTargets="
       UnpackTarballs;
       BuildXPlatTasks;
-      BuildMSBuildSdkResolver;
+      LayoutMSBuildSdkResolver;
       BuildLeakDetection;
       ExtractToolPackage;
       GenerateRootFs;
@@ -67,7 +67,9 @@
              Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid())" />
 
     <MSBuild Projects="tasks\SourceBuild.MSBuildSdkResolver\SourceBuild.MSBuildSdkResolver.csproj"
-             Targets="Build;InstallResolver" />
+             Targets="Build">
+      <Output TaskParameter="TargetOutputs" ItemName="SourceBuildSdkResolver" />
+    </MSBuild>
 
     <MakeDir Directories="$(BaseIntermediateOutputPath)" />
     <Touch Files="$(BaseIntermediateOutputPath)BuildMSBuildSdkResolver.complete" AlwaysCreate="true">
@@ -75,9 +77,24 @@
     </Touch>
   </Target>
 
+  <PropertyGroup>
+    <SourceBuildMSBuildSdkResolverManifestPath>$([MSBuild]::NormalizePath('$(VSMSBuildSdkResolversDir)', 'SourceBuild.MSBuildSdkResolver', 'SourceBuild.MSBuildSdkResolver.xml'))</SourceBuildMSBuildSdkResolverManifestPath>
+  </PropertyGroup>
+
+  <Target Name="LayoutMSBuildSdkResolver"
+          DependsOnTargets="BuildMSBuildSdkResolver"
+          Inputs="$(MSBuildProjectFullPath)"
+          Outputs="$(SourceBuildMSBuildSdkResolverManifestPath)">
+
+    <WriteLinesToFile
+      File="$(SourceBuildMSBuildSdkResolverManifestPath)"
+      Lines="&lt;SdkResolver&gt;&lt;Path&gt;%(SourceBuildSdkResolver.FullPath)&lt;/Path&gt;&lt;/SdkResolver&gt;"
+      Overwrite="true" />
+  </Target>
+
   <!-- Build msbuild tasks. -->
   <Target Name="BuildXPlatTasks"
-          DependsOnTargets="UnpackTarballs;BuildMSBuildSdkResolver"
+          DependsOnTargets="UnpackTarballs;LayoutMSBuildSdkResolver"
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(BaseIntermediateOutputPath)BuildXPlatTasks.complete">
     <MSBuild Projects="tasks\Microsoft.DotNet.SourceBuild.Tasks.XPlat\Microsoft.DotNet.SourceBuild.Tasks.XPlat.csproj"
@@ -95,7 +112,7 @@
 
   <!-- Build msbuild tasks for the poisoning feature. -->
   <Target Name="BuildLeakDetection"
-          DependsOnTargets="ExtractToolPackage;BuildMSBuildSdkResolver"
+          DependsOnTargets="ExtractToolPackage;LayoutMSBuildSdkResolver"
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(BaseIntermediateOutputPath)BuildLeakDetection.complete"
           Condition="'$(EnablePoison)' == 'true'">

--- a/src/SourceBuild/content/eng/tools/tasks/SourceBuild.MSBuildSdkResolver/SourceBuild.MSBuildSdkResolver.csproj
+++ b/src/SourceBuild/content/eng/tools/tasks/SourceBuild.MSBuildSdkResolver/SourceBuild.MSBuildSdkResolver.csproj
@@ -18,7 +18,8 @@
   <Target Name="InstallResolver" BeforeTargets="PrepareForRun">
     <WriteLinesToFile
       File="$(SourceBuildMSBuildSdkResolverManifestPath)"
-      Lines="&lt;SdkResolver&gt;&lt;Path&gt;$(MSBuildProjectFullPath)&lt;/Path&gt;&lt;/SdkResolver&gt;"
+      Lines="&lt;SdkResolver&gt;&lt;Path&gt;$(TargetPath)&lt;/Path&gt;&lt;/SdkResolver&gt;"
       Overwrite="true" />
   </Target>
+
 </Project>

--- a/src/SourceBuild/content/eng/tools/tasks/SourceBuild.MSBuildSdkResolver/SourceBuild.MSBuildSdkResolver.csproj
+++ b/src/SourceBuild/content/eng/tools/tasks/SourceBuild.MSBuildSdkResolver/SourceBuild.MSBuildSdkResolver.csproj
@@ -4,20 +4,11 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
-  <Target Name="InstallResolver">
-    <PropertyGroup>
-      <SourceBuildMSBuildSdkResolverPath>$([MSBuild]::NormalizePath('$(DotNetRoot)', 'sdk', '$(NETCoreSdkVersion)', 'SdkResolvers', '$(MSBuildProjectName)', '$(MSBuildProjectName).dll'))</SourceBuildMSBuildSdkResolverPath>
-    </PropertyGroup>
-
-    <Copy SourceFiles="$(TargetPath)" DestinationFiles="$(SourceBuildMSBuildSdkResolverPath)" />
-    <Message Text="Adding resolver to SDK: $(MSBuildProjectName) -> $(SourceBuildMSBuildSdkResolverPath)" Importance="High"  />
-  </Target>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" />
+    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" ExcludeAssets="runtime"/>
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" ExcludeAssets="runtime" />
   </ItemGroup>
 
 </Project>

--- a/src/SourceBuild/content/eng/tools/tasks/SourceBuild.MSBuildSdkResolver/SourceBuild.MSBuildSdkResolver.csproj
+++ b/src/SourceBuild/content/eng/tools/tasks/SourceBuild.MSBuildSdkResolver/SourceBuild.MSBuildSdkResolver.csproj
@@ -11,4 +11,14 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" ExcludeAssets="runtime" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <SourceBuildMSBuildSdkResolverManifestPath>$([MSBuild]::NormalizePath('$(VSMSBuildSdkResolversDir)', '$(MSBuildProjectName)', '$(MSBuildProjectName).xml'))</SourceBuildMSBuildSdkResolverManifestPath>
+  </PropertyGroup>
+
+  <Target Name="InstallResolver" BeforeTargets="PrepareForRun">
+    <WriteLinesToFile
+      File="$(SourceBuildMSBuildSdkResolverManifestPath)"
+      Lines="&lt;SdkResolver&gt;&lt;Path&gt;$(MSBuildProjectFullPath)&lt;/Path&gt;&lt;/SdkResolver&gt;"
+      Overwrite="true" />
+  </Target>
 </Project>

--- a/src/SourceBuild/content/eng/tools/tasks/SourceBuild.MSBuildSdkResolver/SourceBuild.MSBuildSdkResolver.csproj
+++ b/src/SourceBuild/content/eng/tools/tasks/SourceBuild.MSBuildSdkResolver/SourceBuild.MSBuildSdkResolver.csproj
@@ -19,7 +19,8 @@
     <WriteLinesToFile
       File="$(SourceBuildMSBuildSdkResolverManifestPath)"
       Lines="&lt;SdkResolver&gt;&lt;Path&gt;$(TargetPath)&lt;/Path&gt;&lt;/SdkResolver&gt;"
-      Overwrite="true" />
+      Overwrite="true"
+      WriteOnlyWhenDifferent="true" />
   </Target>
 
 </Project>

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -646,6 +646,8 @@
   <Target Name="SetSourceBuiltSdkOverrides"
           Condition="'@(SourceBuiltSdkOverride)' != ''">
     <ItemGroup>
+      <!-- Set the environment variables for MSBuild to look for our additional SDK Resolvers and or our resolver to find our source-built SDKs. -->
+      <EnvironmentVariables Include="MSBUILDADDITIONALSDKRESOLVERSFOLDER=$(VSMSBuildSdkResolversDir)" />
       <EnvironmentVariables Include="SOURCE_BUILT_SDK_ID_%(SourceBuiltSdkOverride.Group)=%(SourceBuiltSdkOverride.Identity)" />
       <EnvironmentVariables Include="SOURCE_BUILT_SDK_VERSION_%(SourceBuiltSdkOverride.Group)=%(SourceBuiltSdkOverride.Version)" />
       <EnvironmentVariables Condition="'%(SourceBuiltSdkOverride.Location)' != ''" Include="SOURCE_BUILT_SDK_DIR_%(SourceBuiltSdkOverride.Group)=%(SourceBuiltSdkOverride.Location)/" />


### PR DESCRIPTION
Use the `MSBUILDADDITIONALSDKRESOLVERSFOLDER` environment variable to specify a folder with additional SDK Resolvers and Resolver manifests for both MSBuild variants instead of patching the .NET SDK layout to include the source-build SDK resolver.

- Please add description for changes you are making.
- If there is an issue related to this PR, please add the reference.

Fixes dotnet/source-build#3798 (WPF will now use the same Arcade tooling, but they won't be using Core MSBuild, which we decided to punt on).
