### PR TITLE
Convert pipeline conditions to template expressions

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -134,6 +134,7 @@ jobs:
       parameters:
         vmrPath: ${{ parameters.vmrPath }}
         vmrBranch: ${{ parameters.vmrBranch }}
+        targetOS: $(Agent.OS)
         targetRef: $(Build.SourceVersion) # Synchronize the current installer commit
 
   - ${{ if parameters.buildFromArchive }}:

--- a/eng/pipelines/templates/jobs/vmr-synchronization.yml
+++ b/eng/pipelines/templates/jobs/vmr-synchronization.yml
@@ -59,6 +59,7 @@ jobs:
     parameters:
       vmrPath: $(vmrPath)
       vmrBranch: ${{ parameters.vmrBranch }}
+      targetOS: $(Agent.OS)
       targetRef: ${{ parameters.targetRef }}
 
   - ${{ if and(not(parameters.noPush), not(in(variables['Build.Reason'], 'PullRequest')), eq(variables['System.TeamProject'], 'internal')) }}:

--- a/eng/pipelines/templates/steps/vmr-pull-updates.yml
+++ b/eng/pipelines/templates/steps/vmr-pull-updates.yml
@@ -36,15 +36,14 @@ steps:
   displayName: Prepare branch ${{ parameters.vmrBranch }}
   workingDirectory: ${{ parameters.vmrPath }}
 
-- script: |
-    mkdir -p ${{ parameters.vmrPath }}/artifacts/x64/Release
-  displayName: Create artifacts folder (Unix)
-  condition: ne(variables['Agent.OS'], 'Windows_NT')
-
-- powershell: |
-    New-Item -ItemType Directory -Path ${{ parameters.vmrPath }}/artifacts/x64/Release
-  displayName: Create artifacts folder (Windows)
-  condition: eq(variables['Agent.OS'], 'Windows_NT')
+- ${{ if eq(variables['Agent.OS'], 'Windows_NT') }}:
+  - powershell: |
+      New-Item -ItemType Directory -Path ${{ parameters.vmrPath }}/artifacts/x64/Release
+    displayName: Create artifacts folder
+- ${{ else }}:
+  - script: |
+      mkdir -p ${{ parameters.vmrPath }}/artifacts/x64/Release
+    displayName: Create artifacts folder
 
 - script: |
     git config --global user.name "dotnet-maestro[bot]"
@@ -58,45 +57,44 @@ steps:
   displayName: Prepare .artifactignore
   workingDirectory: $(Agent.TempDirectory)
 
-- script: >
-    ./eng/vmr-sync.sh
-    --vmr ${{ parameters.vmrPath }}
-    --tmp $(Agent.TempDirectory)
-    --azdev-pat '$(dn-bot-all-orgs-code-r)'
-    --branch ${{ parameters.vmrBranch }}
-    --repository "installer:${{ parameters.targetRef }}"
-    --recursive
-    --remote "installer:$(Agent.BuildDirectory)/installer"
-    --component-template $(Agent.BuildDirectory)/installer/src/VirtualMonoRepo/Component.template.md
-    --tpn-template $(Agent.BuildDirectory)/installer/src/VirtualMonoRepo/THIRD-PARTY-NOTICES.template.txt
-    --debug
-    ||
-    (echo "##vso[task.logissue type=error]Failed to synchronize the VMR" && exit 1)
-  displayName: Synchronize dotnet/dotnet (Unix)
-  condition: ne(variables['Agent.OS'], 'Windows_NT')
-  workingDirectory: $(Agent.BuildDirectory)/installer
+- ${{ if eq(variables['Agent.OS'], 'Windows_NT') }}:
+  - powershell: >
+      ./eng/vmr-sync.ps1 `
+      -vmr ${{ parameters.vmrPath }} `
+      -tmp $(Agent.TempDirectory) `
+      -azdevPat '$(dn-bot-all-orgs-code-r)' `
+      -branch ${{ parameters.vmrBranch }} `
+      -repository "installer:${{ parameters.targetRef }}" `
+      -recursive `
+      # passing remote fails for some reason, but it is the default anyway
+      # -remote "installer:$(Agent.BuildDirectory)/installer"
+      -componentTemplate $(Agent.BuildDirectory)/installer/src/VirtualMonoRepo/Component.template.md `
+      -tpnTemplate $(Agent.BuildDirectory)/installer/src/VirtualMonoRepo/THIRD-PARTY-NOTICES.template.txt `
+      -debugOutput
 
-- powershell: >
-    ./eng/vmr-sync.ps1 `
-    -vmr ${{ parameters.vmrPath }} `
-    -tmp $(Agent.TempDirectory) `
-    -azdevPat '$(dn-bot-all-orgs-code-r)' `
-    -branch ${{ parameters.vmrBranch }} `
-    -repository "installer:${{ parameters.targetRef }}" `
-    -recursive `
-    # passing remote fails for some reason, but it is the default anyway
-    # -remote "installer:$(Agent.BuildDirectory)/installer"
-    -componentTemplate $(Agent.BuildDirectory)/installer/src/VirtualMonoRepo/Component.template.md `
-    -tpnTemplate $(Agent.BuildDirectory)/installer/src/VirtualMonoRepo/THIRD-PARTY-NOTICES.template.txt `
-    -debugOutput
-
-    if ($LASTEXITCODE -ne 0) {
-      echo "##vso[task.logissue type=error]Failed to synchronize the VMR"
-      exit 1
-    }
-  displayName: Synchronize dotnet/dotnet (Windows)
-  condition: eq(variables['Agent.OS'], 'Windows_NT')
-  workingDirectory: $(Agent.BuildDirectory)/installer
+      if ($LASTEXITCODE -ne 0) {
+        echo "##vso[task.logissue type=error]Failed to synchronize the VMR"
+        exit 1
+      }
+    displayName: Synchronize dotnet/dotnet
+    workingDirectory: $(Agent.BuildDirectory)/installer
+- ${{ else }}:
+  - script: >
+      ./eng/vmr-sync.sh
+      --vmr ${{ parameters.vmrPath }}
+      --tmp $(Agent.TempDirectory)
+      --azdev-pat '$(dn-bot-all-orgs-code-r)'
+      --branch ${{ parameters.vmrBranch }}
+      --repository "installer:${{ parameters.targetRef }}"
+      --recursive
+      --remote "installer:$(Agent.BuildDirectory)/installer"
+      --component-template $(Agent.BuildDirectory)/installer/src/VirtualMonoRepo/Component.template.md
+      --tpn-template $(Agent.BuildDirectory)/installer/src/VirtualMonoRepo/THIRD-PARTY-NOTICES.template.txt
+      --debug
+      ||
+      (echo "##vso[task.logissue type=error]Failed to synchronize the VMR" && exit 1)
+    displayName: Synchronize dotnet/dotnet
+    workingDirectory: $(Agent.BuildDirectory)/installer
 
 - publish: $(Agent.TempDirectory)
   artifact: $(System.JobDisplayName)_FailedPatches

--- a/eng/pipelines/templates/steps/vmr-pull-updates.yml
+++ b/eng/pipelines/templates/steps/vmr-pull-updates.yml
@@ -7,6 +7,10 @@ parameters:
   displayName: dotnet/dotnet branch to use
   type: string
 
+- name: targetOS
+  displayName: Target OS the pipeline runs on
+  type: string
+
 - name: targetRef
   displayName: Target revision in dotnet/installer to synchronize
   type: string
@@ -36,7 +40,7 @@ steps:
   displayName: Prepare branch ${{ parameters.vmrBranch }}
   workingDirectory: ${{ parameters.vmrPath }}
 
-- ${{ if eq(variables['Agent.OS'], 'Windows_NT') }}:
+- ${{ if eq(parameters.targetOS, 'Windows_NT') }}:
   - powershell: |
       New-Item -ItemType Directory -Path ${{ parameters.vmrPath }}/artifacts/x64/Release
     displayName: Create artifacts folder
@@ -57,7 +61,7 @@ steps:
   displayName: Prepare .artifactignore
   workingDirectory: $(Agent.TempDirectory)
 
-- ${{ if eq(variables['Agent.OS'], 'Windows_NT') }}:
+- ${{ if eq(parameters.targetOS, 'Windows_NT') }}:
   - powershell: >
       ./eng/vmr-sync.ps1 `
       -vmr ${{ parameters.vmrPath }} `


### PR DESCRIPTION
Utilizing template expressions eliminates skipped steps for both Windows and Linux runs.  This also makes the pipelines more consistent as template expressions are being used elsewhere to skip platform specific steps ([example](https://github.com/dotnet/installer/blob/main/eng/pipelines/templates/jobs/vmr-build.yml#L203))
