### PR TITLE
Skip checking out vmr branch except when syncing

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -51,7 +51,7 @@ parameters:
   default: false
 
 # Name of a previous job (from the same template as this) whose output will be used to build this job
-# The SDK from its artifacts is copied to $(vmrPath)/.dotnet
+# The SDK from its artifacts is copied to $(sourcesPath)/.dotnet
 - name: reuseBuildArtifactsFrom
   type: string
   default: ''

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -51,7 +51,7 @@ parameters:
   default: false
 
 # Name of a previous job (from the same template as this) whose output will be used to build this job
-# The SDK from its artifacts is copied to vmr/.dotnet
+# The SDK from its artifacts is copied to $(vmrPath)/.dotnet
 - name: reuseBuildArtifactsFrom
   type: string
   default: ''
@@ -108,7 +108,7 @@ jobs:
 
   - ${{ if parameters.isBuiltFromVmr }}:
     - name: vmrPath
-      value: $(Agent.BuildDirectory)
+      value: $(Build.SourcesDirectory)
   - ${{ else }}:
     - name: vmrPath
       value: $(Agent.BuildDirectory)/vmr
@@ -172,7 +172,7 @@ jobs:
       inputs:
         SourceFolder: $(Pipeline.Workspace)/${{ parameters.reuseBuildArtifactsFrom }}_${{ parameters.architecture }}_Artifacts
         Contents: '*.tar.gz'
-        TargetFolder: ${{ variables.sourcesPath }}/prereqs/packages/archive/
+        TargetFolder: $(sourcesPath)/prereqs/packages/archive/
 
   - ${{ if eq(parameters.withPreviousSDK, 'true') }}:
     - script: |
@@ -183,7 +183,7 @@ jobs:
            exit 1
         fi
 
-        packageVersionsPath="${{ variables.sourcesPath }}/eng/Versions.props"
+        packageVersionsPath="$(sourcesPath)/eng/Versions.props"
         notFoundMessage="No source-built SDK found to download..."
 
         echo "Looking for source-built SDK to download..."
@@ -390,12 +390,12 @@ jobs:
       inputs:
         testRunner: vSTest
         testResultsFiles: 'test/**/*.trx'
-        searchFolder: ${{ variables.sourcesPath }}
+        searchFolder: $(sourcesPath)
         mergeTestResults: true
         publishRunAttachments: true
         testRunTitle: SourceBuild_SmokeTests_$(Agent.JobName)
 
-  - publish: '${{ variables.sourcesPath }}/artifacts/${{ parameters.architecture }}/Release/'
+  - publish: '$(sourcesPath)/artifacts/${{ parameters.architecture }}/Release/'
     artifact: $(Agent.JobName)_Artifacts
     displayName: Publish Artifacts
     condition: succeededOrFailed()

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -1,5 +1,5 @@
 ### This job builds https://github.com/dotnet/dotnet with given parameters
-### If run in a PR, new changes are applied to a local copy of the VMR, then it is built and tested
+### If run in an installer PR, new changes are applied to a local copy of the VMR, then it is built and tested
 
 parameters:
 - name: architecture
@@ -19,10 +19,6 @@ parameters:
   type: string
   default: ''
 
-- name: isBuiltFromVmr
-  displayName: True when build is running from dotnet/dotnet directly
-  type: boolean
-
 - name: pool
   type: object
 
@@ -33,15 +29,6 @@ parameters:
 - name: targetArchitecture
   type: string
   default: ''
-
-- name: vmrPath
-  type: string
-  default: $(Agent.BuildDirectory)/vmr
-
-- name: vmrBranch
-  displayName: dotnet/dotnet branch to use
-  type: string
-  default: $(Build.SourceBranch)
 
 #### SOURCE-ONLY parameters ####
 
@@ -88,6 +75,16 @@ parameters:
   type: boolean
   default: false
 
+#### INSTALLER parameters ####
+
+- name: isBuiltFromVmr
+  displayName: True when build is running from dotnet/dotnet directly
+  type: boolean
+
+- name: vmrBranch
+  displayName: dotnet/dotnet branch to use
+  type: string
+
 jobs:
 - job: ${{ parameters.buildName }}_${{ parameters.architecture }}
   timeoutInMinutes: 150
@@ -109,6 +106,13 @@ jobs:
   - name: additionalBuildArgs
     value: ''
 
+  - ${{ if parameters.isBuiltFromVmr }}:
+    - name: vmrPath
+      value: $(Agent.BuildDirectory)
+  - ${{ else }}:
+    - name: vmrPath
+      value: $(Agent.BuildDirectory)/vmr
+
   # Location of the VMR sources
   # We either build the repo directly, or we extract them outside (which is what partners do)
   - ${{ if parameters.buildFromArchive }}:
@@ -116,30 +120,29 @@ jobs:
       value: $(Build.StagingDirectory)/dotnet-sources/
   - ${{ else }}:
     - name: sourcesPath
-      value: ${{ parameters.vmrPath }}
+      value: $(vmrPath)
 
   steps:
-  - template: ../steps/vmr-prepare.yml
-    parameters:
-      ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-        vmrBranch: $(System.PullRequest.TargetBranch)
-      ${{ else }}:
-        vmrBranch: ${{ parameters.vmrBranch }}
-      isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-      skipComponentGovernanceDetection: true
-
-  # Synchronize new content in the VMR during PRs (we expect this to come
-  - ${{ if and(not(parameters.isBuiltFromVmr), eq(variables['Build.Reason'], 'PullRequest')) }}:
-    - template: ../steps/vmr-pull-updates.yml
+  - ${{ if not(parameters.isBuiltFromVmr) }}:
+    - template: ../steps/vmr-prepare.yml
       parameters:
-        vmrPath: ${{ parameters.vmrPath }}
-        vmrBranch: ${{ parameters.vmrBranch }}
-        targetRef: $(Build.SourceVersion) # Synchronize the current installer commit
+        ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+          vmrBranch: $(System.PullRequest.TargetBranch)
+        ${{ else }}:
+          vmrBranch: ${{ parameters.vmrBranch }}
+
+    # Synchronize new content in the VMR during PRs (we expect this to come
+    - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+      - template: ../steps/vmr-pull-updates.yml
+        parameters:
+          vmrPath: $(vmrPath)
+          vmrBranch: ${{ parameters.vmrBranch }}
+          targetRef: $(Build.SourceVersion) # Synchronize the current installer commit
 
   - ${{ if parameters.buildFromArchive }}:
     - script: |
         set -ex
-        cp -r "${{ parameters.vmrPath }}" "$(sourcesPath)"
+        cp -r "$(vmrPath)" "$(sourcesPath)"
         rm -rf "$(sourcesPath)/.git"
       displayName: Export VMR sources
       workingDirectory: $(Build.StagingDirectory)
@@ -255,7 +258,7 @@ jobs:
 
         if [[ '${{ parameters.buildFromArchive }}' == 'True' ]]; then
           customBuildArgs="$customBuildArgs --source-repository https://github.com/dotnet/dotnet"
-          customBuildArgs="$customBuildArgs --source-version $(git -C "${{ parameters.vmrPath }}" rev-parse HEAD)"
+          customBuildArgs="$customBuildArgs --source-version $(git -C "$(vmrPath)" rev-parse HEAD)"
         fi
 
         if [[ '${{ parameters.buildSourceOnly }}' == 'True' ]]; then

--- a/eng/pipelines/templates/jobs/vmr-synchronization.yml
+++ b/eng/pipelines/templates/jobs/vmr-synchronization.yml
@@ -53,8 +53,15 @@ jobs:
   - template: ../steps/vmr-prepare.yml
     parameters:
       vmrBranch: ${{ parameters.vmrBranch }}
-      isBuiltFromVmr: false
       checkoutToBranch: true
+    
+  # TODO (https://github.com/dotnet/arcade/issues/11332): Allow full CG?
+  # Currently, we ignore dirs of individual repos - they have been scanned before
+  - ${{ if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal')) }}:
+    - task: ComponentGovernanceComponentDetection@0
+      inputs:
+        sourceScanPath: $(Agent.BuildDirectory)/vmr
+        ignoreDirectories: $(Agent.BuildDirectory)/vmr/src
 
   - template: ../steps/vmr-pull-updates.yml
     parameters:

--- a/eng/pipelines/templates/jobs/vmr-synchronization.yml
+++ b/eng/pipelines/templates/jobs/vmr-synchronization.yml
@@ -53,7 +53,6 @@ jobs:
   - template: ../steps/vmr-prepare.yml
     parameters:
       vmrBranch: ${{ parameters.vmrBranch }}
-      checkoutToBranch: true
     
   # TODO (https://github.com/dotnet/arcade/issues/11332): Allow full CG?
   # Currently, we ignore dirs of individual repos - they have been scanned before

--- a/eng/pipelines/templates/jobs/vmr-synchronization.yml
+++ b/eng/pipelines/templates/jobs/vmr-synchronization.yml
@@ -54,6 +54,7 @@ jobs:
     parameters:
       vmrBranch: ${{ parameters.vmrBranch }}
       isBuiltFromVmr: false
+      checkoutToBranch: true
 
   - template: ../steps/vmr-pull-updates.yml
     parameters:

--- a/eng/pipelines/templates/steps/vmr-prepare.yml
+++ b/eng/pipelines/templates/steps/vmr-prepare.yml
@@ -11,6 +11,11 @@ parameters:
   type: string
   default: $(Build.SourceBranch)
 
+- name: checkoutToBranch
+  displayName: Check out the repo to the specified vmrBranch
+  type: boolean
+  default: false
+
 - name: skipComponentGovernanceDetection
   type: boolean
   default: false
@@ -28,11 +33,12 @@ steps:
     path: vmr
     clean: true
 
-- script: |
-    git checkout --track origin/${{ parameters.vmrBranch }}
-    echo "##vso[task.setvariable variable=vmrBranch]${{ parameters.vmrBranch }}"
-  displayName: Check out ${{ parameters.vmrBranch }}
-  workingDirectory: $(Agent.BuildDirectory)/vmr
+- ${{ if parameters.checkoutToBranch }}:
+  - script: |
+      git checkout --track origin/${{ parameters.vmrBranch }}
+      echo "##vso[task.setvariable variable=vmrBranch]${{ parameters.vmrBranch }}"
+    displayName: Check out ${{ parameters.vmrBranch }}
+    workingDirectory: $(Agent.BuildDirectory)/vmr
 
 # TODO (https://github.com/dotnet/arcade/issues/11332): Allow full CG?
 # Currently, we ignore dirs of individual repos - they have been scanned before

--- a/eng/pipelines/templates/steps/vmr-prepare.yml
+++ b/eng/pipelines/templates/steps/vmr-prepare.yml
@@ -1,14 +1,9 @@
-### These steps clone the VMR (https://github.com/dotnet/dotnet) into $(Agent.BuildDirectory)/vmr
+### These steps clone the VMR (https://github.com/dotnet/dotnet) into $(Agent.BuildDirectory)/vmr for installer
 
 parameters:
 - name: vmrBranch
   displayName: dotnet/dotnet branch to use
   type: string
-
-- name: checkoutToBranch
-  displayName: Check out the repo to the specified vmrBranch
-  type: boolean
-  default: false
 
 steps:
   - checkout: vmr
@@ -16,7 +11,6 @@ steps:
     path: vmr
     clean: true
 
-- ${{ if parameters.checkoutToBranch }}:
   - script: |
       git checkout --track origin/${{ parameters.vmrBranch }}
       echo "##vso[task.setvariable variable=vmrBranch]${{ parameters.vmrBranch }}"

--- a/eng/pipelines/templates/steps/vmr-prepare.yml
+++ b/eng/pipelines/templates/steps/vmr-prepare.yml
@@ -1,33 +1,16 @@
 ### These steps clone the VMR (https://github.com/dotnet/dotnet) into $(Agent.BuildDirectory)/vmr
-### Component Governance scan is also triggered over the VMR's non-repo sources
 
 parameters:
-- name: isBuiltFromVmr
-  displayName: True when build is running from dotnet/dotnet directly
-  type: boolean
-
 - name: vmrBranch
   displayName: dotnet/dotnet branch to use
   type: string
-  default: $(Build.SourceBranch)
 
 - name: checkoutToBranch
   displayName: Check out the repo to the specified vmrBranch
   type: boolean
   default: false
 
-- name: skipComponentGovernanceDetection
-  type: boolean
-  default: false
-
 steps:
-- ${{ if parameters.isBuiltFromVmr }}:
-  - checkout: self
-    displayName: Clone dotnet/dotnet
-    path: vmr
-    clean: true
-
-- ${{ else }}:
   - checkout: vmr
     displayName: Clone dotnet/dotnet
     path: vmr
@@ -39,11 +22,3 @@ steps:
       echo "##vso[task.setvariable variable=vmrBranch]${{ parameters.vmrBranch }}"
     displayName: Check out ${{ parameters.vmrBranch }}
     workingDirectory: $(Agent.BuildDirectory)/vmr
-
-# TODO (https://github.com/dotnet/arcade/issues/11332): Allow full CG?
-# Currently, we ignore dirs of individual repos - they have been scanned before
-- ${{ if and(not(parameters.skipComponentGovernanceDetection), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal')) }}:
-  - task: ComponentGovernanceComponentDetection@0
-    inputs:
-      sourceScanPath: $(Agent.BuildDirectory)/vmr
-      ignoreDirectories: $(Agent.BuildDirectory)/vmr/src


### PR DESCRIPTION
Works around a problem where we'd try to check out "refs/heads/main" in the internal unified build