### PR TITLE
Add support for removing binaries

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -210,7 +210,7 @@ jobs:
       - script: |
           set -x
 
-          customPrepArgs="--no-binaries"
+          customPrepArgs=""
           prepSdk=true
 
           if [[ -n '${{ parameters.artifactsRid }}' ]]; then

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -210,7 +210,7 @@ jobs:
       - script: |
           set -x
 
-          customPrepArgs=""
+          customPrepArgs="--no-binaries"
           prepSdk=true
 
           if [[ -n '${{ parameters.artifactsRid }}' ]]; then

--- a/src/SourceBuild/content/prep.sh
+++ b/src/SourceBuild/content/prep.sh
@@ -7,10 +7,10 @@
 ###
 ### Options:
 ###   --no-artifacts              Exclude the download of the previously source-built artifacts archive
-###   --keep-binaries             Do not remove the binaries before building.
 ###   --no-bootstrap              Don't replace portable packages in the download source-built artifacts
 ###   --no-prebuilts              Exclude the download of the prebuilts archive
 ###   --no-sdk                    Exclude the download of the .NET SDK
+###   --keep-binaries             Do not remove the binaries before building.
 ###   --artifacts-rid             The RID of the previously source-built artifacts archive to download
 ###                               Default is centos.8-x64
 ###   --runtime-source-feed       URL of a remote server or a local directory, from which SDKs and

--- a/src/SourceBuild/content/prep.sh
+++ b/src/SourceBuild/content/prep.sh
@@ -200,5 +200,6 @@ fi
 
 if [ "$keepBinaries" == false ]; then
   echo "  Removing all checked-in binaries before building..."
+  git config --global --add safe.directory /vmr
   git ls-files | grep -i '\.\(dll\|exe\|mdb\|nupkg|\pbd\|tgz\|zip\)$' | xargs rm -f
 fi

--- a/src/SourceBuild/content/prep.sh
+++ b/src/SourceBuild/content/prep.sh
@@ -7,6 +7,7 @@
 ###
 ### Options:
 ###   --no-artifacts              Exclude the download of the previously source-built artifacts archive
+###   --no-binaries               Remove the binaries before building. This is necessary for source-building.
 ###   --no-bootstrap              Don't replace portable packages in the download source-built artifacts
 ###   --no-prebuilts              Exclude the download of the prebuilts archive
 ###   --no-sdk                    Exclude the download of the .NET SDK
@@ -32,6 +33,7 @@ buildBootstrap=true
 downloadArtifacts=true
 downloadPrebuilts=true
 installDotnet=true
+keepBinaries=true
 artifactsRid=$defaultArtifactsRid
 runtime_source_feed='' # IBM requested these to support s390x scenarios
 runtime_source_feed_key='' # IBM requested these to support s390x scenarios
@@ -45,6 +47,9 @@ while :; do
     "-?"|-h|--help)
       print_help
       exit 0
+      ;;
+    --no-binaries)
+      keepBinaries=false
       ;;
     --no-bootstrap)
       buildBootstrap=false
@@ -191,4 +196,9 @@ fi
 
 if [ "$downloadPrebuilts" == true ]; then
   DownloadArchive Prebuilts false $artifactsRid
+fi
+
+if [ "$keepBinaries" == false ]; then
+  echo "  Removing all checked-in binaries before building..."
+  git ls-files | grep -i '\.\(dll\|exe\|mdb\|nupkg|\pbd\|tgz\|zip\)$' | xargs rm -f
 fi

--- a/src/SourceBuild/content/prep.sh
+++ b/src/SourceBuild/content/prep.sh
@@ -199,7 +199,12 @@ if [ "$downloadPrebuilts" == true ]; then
 fi
 
 if [ "$keepBinaries" == false ]; then
-  echo "  Removing all checked-in binaries before building..."
   git config --global --add safe.directory /vmr
-  git ls-files | grep -i '\.\(dll\|exe\|mdb\|nupkg|\pbd\|tgz\|zip\)$' | xargs rm -f
+  
+  if git ls-files | grep -q -i '\.\(dll\|exe\|mdb\|nupkg|\pbd\|tgz\|zip\)$'; then
+    echo "  Removing all checked-in binaries before building..."
+    git ls-files | grep -i '\.\(dll\|exe\|mdb\|nupkg|\pbd\|tgz\|zip\)$' | xargs rm -rf
+  else
+      echo "  No checked-in binaries found...no binaries were removed"
+  fi
 fi


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4089

This PR adds the ability to remove all checked-in binaries when prepping the build. This is necessary for source building, so it should be configured to run when doing a source-build of the VMR in pipeline. This change to the pipeline is also included in this PR.