### PR TITLE
Add public arm64 pool variable

### DIFF
--- a/eng/pipelines/templates/variables/vmr-stage.yml
+++ b/eng/pipelines/templates/variables/vmr-stage.yml
@@ -30,24 +30,25 @@ variables:
 - ${{ if eq(variables['System.TeamProject'], 'public') }}:
   - name: defaultPoolName
     value: NetCore-Public-XL
+  - name: defaultPoolNameLinuxArm64
+    value: Docker-Linux-Arm-Public
   - name: defaultPoolDemandsLinux
     value: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
   - name: defaultPoolDemandsWindows
     value: ImageOverride -equals windows.vs2022.amd64.open
-- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+- ${{ elseif eq(variables['System.TeamProject'], 'internal') }}:
   - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
     - name: defaultPoolName
       value: NetCore1ESPool-Internal-XL
   - ${{ else }}:
     - name: defaultPoolName
       value: NetCore1ESPool-Svc-Internal
+  - name: defaultPoolNameLinuxArm64
+    value: Docker-Linux-Arm-Internal
   - name: defaultPoolDemandsLinux
     value: ImageOverride -equals Build.Ubuntu.1804.Amd64
   - name: defaultPoolDemandsWindows
     value: ImageOverride -equals windows.vs2022.amd64
-
-- name: defaultPoolNameLinuxArm64
-  value: Docker-Linux-Arm-Internal
 
 - name: defaultPoolNameMac
   value: macos-12


### PR DESCRIPTION
We hit failures building dotnet-source-build in public because it tried to use the internal pool for the arm64 jobs.
