### PR TITLE
Cloak Aspire samples directory in 8.0

### DIFF
--- a/src/VirtualMonoRepo/source-mappings.json
+++ b/src/VirtualMonoRepo/source-mappings.json
@@ -65,7 +65,7 @@
             "defaultRemote": "https://github.com/dotnet/aspire",
             "exclude": [
                 "src/Aspire.Dashboard/**/*",
-                "playground/**/*"
+                "samples/**/*"
             ]
         },
         {


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/installer/pull/18524#event-11736755928

8.0.1xx uses the "samples" directory. 9.0xx and main use "playground". This was an oversight made in https://github.com/dotnet/installer/pull/18524#event-11736755928