### PR TITLE
Export the custom SDK resolvers dir in build.sh

### DIFF
--- a/src/SourceBuild/content/build.sh
+++ b/src/SourceBuild/content/build.sh
@@ -226,6 +226,9 @@ function Build {
       # kill off the MSBuild server so that on future invocations we pick up our custom SDK Resolver
       "$CLI_ROOT/dotnet" build-server shutdown
 
+      # Point MSBuild to the custom SDK resolvers folder, so it will pick up our custom SDK Resolver
+      export MSBUILDADDITIONALSDKRESOLVERSFOLDER="$scriptroot/artifacts/toolset/VSSdkResolvers/"
+
       "$CLI_ROOT/dotnet" msbuild "$scriptroot/build.proj" -bl:"$scriptroot/artifacts/log/$configuration/Build.binlog" -flp:"LogFile=$scriptroot/artifacts/log/$configuration/Build.log" $properties
     fi
 


### PR DESCRIPTION
This enables our custom SDK resolver in the outer build.

Fixes failures introduced by #18505 and discovered in #18173.

cc: @MichaelSimons