### PR TITLE
Revert "Patch has landed, no longer needed (#18570)"

### DIFF
--- a/src/SourceBuild/patches/runtime/0002-short-stack-support.patch
+++ b/src/SourceBuild/patches/runtime/0002-short-stack-support.patch
@@ -1,0 +1,48 @@
+From 6e36330872998c791a2c0d31b688e1bdece2451f Mon Sep 17 00:00:00 2001
+From: Jo Shields <joshield@microsoft.com>
+Date: Fri, 2 Feb 2024 06:56:20 -0500
+Subject: [PATCH] Source built short stack support (#97725)
+
+Backport: https://github.com/dotnet/runtime/pull/97725
+
+--- a/eng/SourceBuild.props	2024-02-07 11:01:33.807337902 -0500
++++ b/eng/SourceBuild.props	2024-02-05 16:48:58.219933758 -0500
+@@ -15,6 +15,7 @@
+     <!-- Split e.g. 'fedora.33-x64' into 'fedora.33' and 'x64'. -->
+     <_targetRidPlatformIndex>$(TargetRid.LastIndexOf('-'))</_targetRidPlatformIndex>
+     <TargetArch>$(TargetRid.Substring($(_targetRidPlatformIndex)).TrimStart('-'))</TargetArch>
++    <TargetOS>$(TargetRid.Substring(0, $(_targetRidPlatformIndex)))</TargetOS>
+ 
+     <_hostRidPlatformIndex>$(_hostRid.LastIndexOf('-'))</_hostRidPlatformIndex>
+     <_hostArch>$(_hostRid.Substring($(_hostRidPlatformIndex)).TrimStart('-'))</_hostArch>
+@@ -22,6 +23,17 @@
+     <LogVerbosity Condition="'$(LogVerbosity)' == ''">minimal</LogVerbosity>
+   </PropertyGroup>
+ 
++  <PropertyGroup Label="ShortStacks">
++    <ShortStack Condition="'$(TargetOS)' == 'wasi'">true</ShortStack>
++    <ShortStack Condition="'$(TargetOS)' == 'browser'">true</ShortStack>
++    <ShortStack Condition="'$(TargetOS)' == 'ios'">true</ShortStack>
++    <ShortStack Condition="'$(TargetOS)' == 'iossimulator'">true</ShortStack>
++    <ShortStack Condition="'$(TargetOS)' == 'tvos'">true</ShortStack>
++    <ShortStack Condition="'$(TargetOS)' == 'tvossimulator'">true</ShortStack>
++    <ShortStack Condition="'$(TargetOS)' == 'maccatalyst'">true</ShortStack>
++    <ShortStack Condition="'$(TargetOS)' == 'android'">true</ShortStack>
++  </PropertyGroup>
++
+   <Target Name="GetRuntimeSourceBuildCommandConfiguration"
+           BeforeTargets="GetSourceBuildCommandConfiguration">
+     <PropertyGroup>
+@@ -29,9 +41,10 @@
+            This allows to build the repository using './build.sh <args> /p:DotNetBuildFromSource=true'.
+            Properties that control flags from source-build, and the expected output for source-build should be added to this file. -->
+       <InnerBuildArgs>$(InnerBuildArgs) $(FlagParameterPrefix)arch $(TargetArch)</InnerBuildArgs>
+-      <InnerBuildArgs Condition=" '$(TargetArch)' != '$(_hostArch)' ">$(InnerBuildArgs) $(FlagParameterPrefix)cross</InnerBuildArgs>
++      <InnerBuildArgs>$(InnerBuildArgs) $(FlagParameterPrefix)os $(TargetOS)</InnerBuildArgs>
++      <InnerBuildArgs Condition="'$(TargetArch)' != '$(_hostArch)' and '$(ShortStack)' != 'true'">$(InnerBuildArgs) $(FlagParameterPrefix)cross</InnerBuildArgs>
+       <InnerBuildArgs>$(InnerBuildArgs) $(FlagParameterPrefix)configuration $(Configuration)</InnerBuildArgs>
+-      <InnerBuildArgs>$(InnerBuildArgs) $(FlagParameterPrefix)allconfigurations</InnerBuildArgs>
++      <InnerBuildArgs Condition="'$(ShortStack)' != 'true'">$(InnerBuildArgs) $(FlagParameterPrefix)allconfigurations</InnerBuildArgs>
+       <InnerBuildArgs>$(InnerBuildArgs) $(FlagParameterPrefix)verbosity $(LogVerbosity)</InnerBuildArgs>
+       <InnerBuildArgs>$(InnerBuildArgs) $(FlagParameterPrefix)nodereuse $(ArcadeFalseBoolBuildArg)</InnerBuildArgs>
+       <InnerBuildArgs>$(InnerBuildArgs) $(FlagParameterPrefix)warnAsError $(ArcadeFalseBoolBuildArg)</InnerBuildArgs>


### PR DESCRIPTION
This reverts commit c69a5e3e877f9fa766ebd32c8b6f81dc33a2753e.

I was wrong, this is still needed.

Seems our ability to see how up to date repos in the VMR is is _very_ non-obvious.