### PR TITLE
Remove dead code

### DIFF
--- a/src/SourceBuild/content/Directory.Build.props
+++ b/src/SourceBuild/content/Directory.Build.props
@@ -1,7 +1,6 @@
 <Project>
 
   <PropertyGroup>
-    <_SuppressSdkImports Condition="'$(DotNetBuildSourceOnly)' == 'true'">true</_SuppressSdkImports>
     <Configuration Condition="$(Configuration) == ''">Release</Configuration>
     <DotNetBuildOrchestrator>true</DotNetBuildOrchestrator>
   </PropertyGroup>
@@ -71,7 +70,7 @@
 
   <!-- Init basic Arcade props, if the project importing this file doesn't use Arcade.
        Keep in sync with props/targets in the Arcade.Sdk. -->
-  <PropertyGroup Condition="'$(_SuppressSdkImports)' == 'true' or '$(SkipArcadeSdkImport)' == 'true'">
+  <PropertyGroup Condition="'$(SkipArcadeSdkImport)' == 'true'">
     <!-- RepoLayout.props -->
     <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' != ''">$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)'))</NuGetPackageRoot>
     <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == '' and '$(NUGET_PACKAGES)' != ''">$([MSBuild]::NormalizeDirectory('$(NUGET_PACKAGES)'))</NuGetPackageRoot>
@@ -117,8 +116,7 @@
   </PropertyGroup>
 
   <!-- Manually import the Versions.props file when the Arcade SDK isn't used. -->
-  <Import Project="$(RepositoryEngineeringDir)Versions.props"
-          Condition="'$(_SuppressSdkImports)' == 'true' or '$(SkipArcadeSdkImport)' == 'true'" />
+  <Import Project="$(RepositoryEngineeringDir)Versions.props" Condition="'$(SkipArcadeSdkImport)' == 'true'" />
 
   <PropertyGroup>
     <!-- We have no projects targeting multiple frameworks, so don't include in output path. -->

--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -15,7 +15,6 @@
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
 
     <ProjectDirectory>$([MSBuild]::NormalizeDirectory('$(SrcDir)', '$(RepositoryName)'))</ProjectDirectory>
-    <PackagesOutput>$([MSBuild]::NormalizeDirectory('$(ProjectDirectory)', 'artifacts', 'packages', '$(Configuration)', 'NonShipping'))</PackagesOutput>
 
     <!-- Paths to the version props files -->
     <PackageVersionPropsPath>$(SharedIntermediateOutputPath)PackageVersions.$(RepositoryName).props</PackageVersionPropsPath>

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -451,7 +451,7 @@
   </Target>
 
   <Target Name="ExtractToolPackage"
-          AfterTargets="Build"
+          AfterTargets="CopyRepoArtifacts"
           Condition="'@(BuiltSdkPackageOverride)' != ''"
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(BaseIntermediateOutputPath)ExtractToolPackage.complete">

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -408,40 +408,6 @@
           Condition=" '@(_InnerPackageCacheFiles)' != '' " />
   </Target>
 
-  <Target Name="RemoveBuiltPackagesFromCache"
-          AfterTargets="Package"
-          Condition="'@(RepoManifestNonShippingPackage)' != ''"
-          DependsOnTargets="CopyRepoArtifacts"
-          Inputs="$(MSBuildProjectFullPath)"
-          Outputs="$(BaseIntermediateOutputPath)RemoveBuiltPackagesFromCache.complete">
-    <ItemGroup>
-      <!-- Excluding Arcade here will keep it in the cache, because that's where we're running from.
-           Subsequent projects will get Arcade from eng/source-built-sdks. -->
-      <PackagePaths Include="@(RepoManifestNonShippingPackage)"
-                    Condition="!$([System.String]::Copy('%(Filename)').StartsWith('Microsoft.DotNet.Arcade.Sdk'))" />
-    </ItemGroup>
-
-    <ReadNuGetPackageInfos PackagePaths="@(PackagePaths)">
-      <Output TaskParameter="PackageInfoItems" ItemName="_BuiltPackageInfos" />
-    </ReadNuGetPackageInfos>
-
-    <!-- Copy built nupkgs from nuget packages cache directory to the previouslyRestored directory
-         and then delete all expanded files and the nupkg from the package cache so the next time
-         the package is used, it will reload the source-built version -->
-    <ItemGroup>
-      <_FilesToCopy Include="$(NuGetPackageRoot)$([System.String]::copy('%(_BuiltPackageInfos.PackageId)').ToLowerInvariant())/%(_BuiltPackageInfos.PackageVersion)/**/*.nupkg" />
-      <_FilesToDelete Include="$(NuGetPackageRoot)$([System.String]::copy('%(_BuiltPackageInfos.PackageId)').ToLowerInvariant())/%(_BuiltPackageInfos.PackageVersion)/**/*.*" />
-    </ItemGroup>
-
-    <Copy SourceFiles="@(_FilesToCopy)" DestinationFolder="$(PreviouslyRestoredPackagesPath)$(RepositoryName)/" />
-    <Delete Files="@(_FilesToDelete)" />
-
-    <MakeDir Directories="$(BaseIntermediateOutputPath)" />
-    <Touch Files="$(BaseIntermediateOutputPath)RemoveBuiltPackagesFromCache.complete" AlwaysCreate="true">
-      <Output TaskParameter="TouchedFiles" ItemName="FileWrites" />
-    </Touch>
-  </Target>
-
   <Target Name="CleanupRepo"
           AfterTargets="RemoveBuiltPackagesFromCache"
           Condition="'$(CleanWhileBuilding)' == 'true' and Exists('$(ProjectDirectory)artifacts')">

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -337,14 +337,6 @@
 
   <Target Name="Package" AfterTargets="Build" />
 
-  <Target Name="GatherBuiltPackages">
-    <ItemGroup>
-      <!-- Filter out packages for WriteVersions -->
-      <_BuiltPackages Condition="'$(PackagesOutput)' != ''" Include="$(PackagesOutput)/*.nupkg" Exclude="$(PackagesOutput)/*.symbols.nupkg"/>
-      <_BuiltPackages Condition="'@(PackagesOutputList)' != ''" Include="%(PackagesOutputList.Identity)/*.nupkg" Exclude="%(PackagesOutputList.Identity)/*.symbols.nupkg"/>
-    </ItemGroup>
-  </Target>
-
   <Target Name="CopyRepoArtifacts"
           AfterTargets="Package"
           Condition="'$(IsUtilityProject)' != 'true'"
@@ -416,26 +408,17 @@
           Condition=" '@(_InnerPackageCacheFiles)' != '' " />
   </Target>
 
-  <Target Name="CopyPackage"
-          AfterTargets="Package"
-          Condition="'$(PackagesOutput)' != '' OR '@(PackagesOutputList)' != ''"
-          DependsOnTargets="GatherBuiltPackages">
-    <Copy SourceFiles="@(_BuiltPackages)"
-          DestinationFolder="$(SourceBuiltPackagesPath)"
-          Condition="'@(_BuiltPackages)'!=''"
-          SkipUnchangedFiles="true" />
-  </Target>
-
   <Target Name="RemoveBuiltPackagesFromCache"
           AfterTargets="Package"
-          Condition="'@(_BuiltPackages)'!=''"
-          DependsOnTargets="GatherBuiltPackages"
+          Condition="'@(RepoManifestNonShippingPackage)' != ''"
+          DependsOnTargets="CopyRepoArtifacts"
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(BaseIntermediateOutputPath)RemoveBuiltPackagesFromCache.complete">
     <ItemGroup>
       <!-- Excluding Arcade here will keep it in the cache, because that's where we're running from.
            Subsequent projects will get Arcade from eng/source-built-sdks. -->
-      <PackagePaths Include="@(_BuiltPackages)" Exclude="$(PackagesOutput)/Microsoft.DotNet.Arcade.Sdk.*.nupkg" />
+      <PackagePaths Include="@(RepoManifestNonShippingPackage)"
+                    Condition="!$([System.String]::Copy('%(Filename)').StartsWith('Microsoft.DotNet.Arcade.Sdk'))" />
     </ItemGroup>
 
     <ReadNuGetPackageInfos PackagePaths="@(PackagePaths)">
@@ -502,7 +485,6 @@
   </Target>
 
   <Target Name="ExtractToolPackage"
-          DependsOnTargets="GatherBuiltPackages"
           AfterTargets="Build"
           Condition="'@(BuiltSdkPackageOverride)' != ''"
           Inputs="$(MSBuildProjectFullPath)"
@@ -564,7 +546,7 @@
       <_PackagesNotCreatedReason Include="^ There may have been a silent failure in the submodule build. To confirm, check the build log file for undetected errors that may have prevented package creation: $(RepoConsoleLogFile)" />
       <_PackagesNotCreatedReason Include="^ This error might be a false positive if $(RepositoryName) intentionally builds no nuget packages. If so, set the SkipEnsurePackagesCreated property to true in $(MSBuildProjectFullPath)" />
       <_PackagesNotCreatedReason Include="^ The 'bin' directory might be dirty from a previous build and the package files already existed. If so, perform a clean build, or check which packages were already in 'bin' by opening $(CurrentSourceBuiltPackageVersionPropsPath)" />
-      <_PackagesNotCreatedReason Include="^ The packages may have been written to an unexpected directory. For example, some repos used bin/ and changed to artifacts/ to match Arcade. Check PackagesOutput in $(MSBuildProjectFullPath) (currently '$(PackagesOutput)')" />
+      <_PackagesNotCreatedReason Include="^ The packages may have been written to an unexpected directory. For example, some repos used bin/ and changed to artifacts/ to match Arcade. Check RepoManifestFile in $(MSBuildProjectFullPath) (currently '$(RepoManifestFile)')" />
     </ItemGroup>
 
     <Error Condition="'@(JustSourceBuiltPackages)' == ''"

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -496,7 +496,7 @@
   </Target>
 
   <Target Name="EnsurePackagesCreated"
-          AfterTargets="CopyPackage"
+          AfterTargets="CopyRepoArtifacts"
           Condition="'$(SkipEnsurePackagesCreated)' != 'true' and '$(IsUtilityProject)' != 'true'"
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(BaseIntermediateOutputPath)EnsurePackagesCreated.complete">

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -503,9 +503,7 @@
     <ItemGroup>
       <JustSourceBuiltPackages
         Include="$(SourceBuiltPackagesPath)*.nupkg"
-        Exclude="
-          $(SourceBuiltPackagesPath)*.symbols.nupkg;
-          @(PreviouslySourceBuiltPackages)" />
+        Exclude="$(SourceBuiltPackagesPath)*.symbols.nupkg" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -335,10 +335,16 @@
 
   <Target Name="Build" DependsOnTargets="BuildRepoReferences;RepoBuild" />
 
-  <Target Name="Package" AfterTargets="Build" />
+  <Target Name="Package"
+          AfterTargets="Build"
+          DependsOnTargets="
+    CopyRepoArtifacts;
+    CopyInnerBuildRestoredPackages;
+    EnsurePackagesCreated;
+    ExtractToolPackage;
+    CleanupRepo" />
 
   <Target Name="CopyRepoArtifacts"
-          AfterTargets="Package"
           Condition="'$(IsUtilityProject)' != 'true'"
           Inputs="$(RepoManifestFile)"
           Outputs="$(BaseIntermediateOutputPath)ArtifactsCopy.complete">
@@ -397,8 +403,7 @@
 
   <!-- Copy restored packages from inner build to ensure they're included in the
        main build prebuilt check -->
-  <Target Name="CopyInnerBuildRestoredPackages"
-          AfterTargets="Package">
+  <Target Name="CopyInnerBuildRestoredPackages">
     <ItemGroup>
       <_InnerPackageCacheFiles Include="$(ProjectDirectory)artifacts/sb/package-cache/**/*" />
     </ItemGroup>
@@ -409,7 +414,6 @@
   </Target>
 
   <Target Name="CleanupRepo"
-          AfterTargets="RemoveBuiltPackagesFromCache"
           Condition="'$(CleanWhileBuilding)' == 'true' and Exists('$(ProjectDirectory)artifacts')">
     <PropertyGroup>
       <BuildLogsDir>$([MSBuild]::NormalizeDirectory('$(ProjectDirectory)', 'artifacts', 'buildLogs'))</BuildLogsDir>
@@ -451,7 +455,7 @@
   </Target>
 
   <Target Name="ExtractToolPackage"
-          AfterTargets="CopyRepoArtifacts"
+          DependsOnTargets="CopyRepoArtifacts"
           Condition="'@(BuiltSdkPackageOverride)' != ''"
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(BaseIntermediateOutputPath)ExtractToolPackage.complete">
@@ -496,7 +500,7 @@
   </Target>
 
   <Target Name="EnsurePackagesCreated"
-          AfterTargets="CopyRepoArtifacts"
+          DependsOnTargets="CopyRepoArtifacts"
           Condition="'$(SkipEnsurePackagesCreated)' != 'true' and '$(IsUtilityProject)' != 'true'"
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(BaseIntermediateOutputPath)EnsurePackagesCreated.complete">

--- a/src/SourceBuild/content/repo-projects/runtime.proj
+++ b/src/SourceBuild/content/repo-projects/runtime.proj
@@ -41,13 +41,4 @@
     <ExtraPackageVersionPropsPackageInfo Include="MicrosoftCodeAnalysisVersion_LatestVS" Version="%24(MicrosoftCodeAnalysisVersion)" />
   </ItemGroup>
 
-  <Target Name="SetOutputList"
-          AfterTargets="Package"
-          BeforeTargets="GatherBuiltPackages">
-    <ItemGroup>
-      <PackagesOutputList Include="$(ShippingPackagesOutput)" />
-      <PackagesOutputList Include="$(NonShippingPackagesOutput)" />
-    </ItemGroup>
-  </Target>
-
 </Project>


### PR DESCRIPTION
The _SuppressSdkImports setting had no affect as Arcade overrides it unconditionally.

The target in runtime.proj didn't do anything as
`ShippingPackagesOutput` and `NonShippingPackagesOutput` aren't defined anywhere anymore.

The copy package target isn't required anymore as that's already handled by the manifest target.
