### PR TITLE
Fix intermediate runtime dependency

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -52,7 +52,7 @@
       <Sha>d40c654c274fe4f4afe66328f0599130f3eb2ea6</Sha>
     </Dependency>
     <!-- Intermediate is necessary for source build. -->
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.runtime" Version="9.0.0-preview.2.24080.1" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.runtime.linux-x64" Version="9.0.0-preview.2.24080.1" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>d40c654c274fe4f4afe66328f0599130f3eb2ea6</Sha>
       <SourceBuild RepoName="runtime" ManagedOnly="false" />


### PR DESCRIPTION
Runtime intermediate is needs `.linux-x64`. This was missed in https://github.com/dotnet/installer/pull/18511
