### PR TITLE
Disables test-templates build again

### DIFF
--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -41,6 +41,7 @@
     <RepositoryReference Remove="format" />
     <RepositoryReference Remove="nuget-client" />
     <RepositoryReference Remove="templating" />
+    <RepositoryReference Remove="test-templates" />
     <RepositoryReference Remove="fsharp" />
     <RepositoryReference Remove="vstest" />
     <RepositoryReference Remove="sdk" />


### PR DESCRIPTION
This is currently failing in PRs, i.e. https://github.com/dotnet/installer/pull/18590