### PR TITLE
Run stages in parallel in vmr-build.yml

### DIFF
--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -33,6 +33,7 @@ stages:
 - ${{ if parameters.isSourceOnlyBuild }}:
   - stage: VMR_SourceOnly_Build
     displayName: VMR Source-Only Build
+    dependsOn: []
     variables:
     - template: ../variables/vmr-stage.yml
       parameters:
@@ -313,6 +314,7 @@ stages:
 - ${{ if not(parameters.isSourceOnlyBuild) }}:
   - stage: VMR_Vertical_Build
     displayName: VMR Vertical Build
+    dependsOn: []
     variables:
     - template: ../variables/vmr-stage.yml
       parameters:


### PR DESCRIPTION
Stages by default run sequentially, we can pass `dependsOn: []` to disable that since our stages are independent.

Contributes to https://github.com/dotnet/source-build/issues/4094