### PR TITLE
Enable templating and roslyn-analyzers in UB

### DIFF
--- a/eng/pipelines/vmr-build.yml
+++ b/eng/pipelines/vmr-build.yml
@@ -56,9 +56,9 @@ stages:
       isBuiltFromVmr: false
       isSourceOnlyBuild: ${{ variables.isSourceOnlyBuild }}
       ${{ if eq(variables.isSourceOnlyBuild, 'true') }}:
-        scope: ultralite
+        scope: full
       ${{ else }}:
-        scope: lite
+        scope: full
 
 # In case the VMR Build stage is temporarily disabled, the VMR synchronization step is run to validate
 # that the PR can be merged and later synchronized into the VMR without problems.

--- a/eng/pipelines/vmr-build.yml
+++ b/eng/pipelines/vmr-build.yml
@@ -56,7 +56,7 @@ stages:
       isBuiltFromVmr: false
       isSourceOnlyBuild: ${{ variables.isSourceOnlyBuild }}
       ${{ if eq(variables.isSourceOnlyBuild, 'true') }}:
-        scope: full
+        scope: ultralite
       ${{ else }}:
         scope: full
 

--- a/eng/pipelines/vmr-build.yml
+++ b/eng/pipelines/vmr-build.yml
@@ -58,7 +58,7 @@ stages:
       ${{ if eq(variables.isSourceOnlyBuild, 'true') }}:
         scope: ultralite
       ${{ else }}:
-        scope: full
+        scope: lite
 
 # In case the VMR Build stage is temporarily disabled, the VMR synchronization step is run to validate
 # that the PR can be merged and later synchronized into the VMR without problems.

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -36,13 +36,11 @@
     <RepositoryReference Remove="msbuild" />
     <RepositoryReference Remove="sdk" />
     <RepositoryReference Remove="wpf" />
-    <RepositoryReference Remove="roslyn-analyzers" />
     <RepositoryReference Remove="aspnetcore" />
     <RepositoryReference Remove="razor" />
     <RepositoryReference Remove="deployment-tools" />
     <RepositoryReference Remove="format" />
     <RepositoryReference Remove="nuget-client" />
-    <RepositoryReference Remove="templating" />
     <RepositoryReference Remove="test-templates" />
     <RepositoryReference Remove="fsharp" />
     <RepositoryReference Remove="vstest" />


### PR DESCRIPTION
These two repos now build successfully: https://github.com/dotnet/dotnet/pull/65