### PR TITLE
Ignore false positive license ref in SBRP

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseExclusions.txt
@@ -230,6 +230,7 @@ src/source-build-externals/src/spectre-console/README.md|unknown-license-referen
 #
 
 # False positive
+src/source-build-reference-packages/src/targetPacks/ILsrc/microsoft.aspnetcore.app.ref/8.0.0/THIRD-PARTY-NOTICES.TXT|unknown
 src/source-build-reference-packages/src/targetPacks/ILsrc/microsoft.netcore.app.ref/3.*/THIRD-PARTY-NOTICES.TXT|codesourcery-2004
 src/source-build-reference-packages/src/targetPacks/ILsrc/netstandard.library/1.6.1/ThirdPartyNotices.txt|unknown
 src/source-build-reference-packages/src/targetPacks/ILsrc/netstandard.library/2.0.*/THIRD-PARTY-NOTICES.TXT|unknown


### PR DESCRIPTION
The license scanner is interpreting this text from as an unknown license reference: [`See the file "PATENTS.TXT" for Microsoft's patent grant on the Mono codebase`](https://github.com/dotnet/source-build-reference-packages/blob/9af3d3655226a7218ad9e05649ed67632f359ecf/src/targetPacks/ILsrc/microsoft.aspnetcore.app.ref/8.0.0/THIRD-PARTY-NOTICES.TXT#L385-L386). Marking this as a false positive.