### PR TITLE
Do not copy restored package content if already exists

### DIFF
--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -413,7 +413,7 @@
 
     <Copy SourceFiles="@(_InnerPackageCacheFiles)"
           DestinationFiles="$(NuGetPackageRoot)%(RecursiveDir)%(Filename)%(Extension)"
-          Condition=" '@(_InnerPackageCacheFiles)' != '' " />
+          Condition="'@(_InnerPackageCacheFiles)' != '' and !Exists('$(NuGetPackageRoot)%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
 
   <Target Name="CleanupRepo"

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -413,7 +413,8 @@
 
     <Copy SourceFiles="@(_InnerPackageCacheFiles)"
           DestinationFiles="$(NuGetPackageRoot)%(RecursiveDir)%(Filename)%(Extension)"
-          Condition="'@(_InnerPackageCacheFiles)' != '' and !Exists('$(NuGetPackageRoot)%(RecursiveDir)%(Filename)%(Extension)')" />
+          SkipUnchangedFiles="true"
+          Condition="'@(_InnerPackageCacheFiles)' != ''" />
   </Target>
 
   <Target Name="CleanupRepo"


### PR DESCRIPTION
In some cases, we may be trying to copy over files that are loaded by the root build process.
