### PR TITLE
Remove _x64_Cross suffix from OSX arm64 builds

### DIFF
--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -729,7 +729,7 @@ stages:
 
         - template: ../jobs/vmr-build.yml
           parameters:
-            buildName: OSX_x64_Cross
+            buildName: OSX
             isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
             vmrBranch: ${{ variables.VmrBranch }}
             architecture: arm64


### PR DESCRIPTION
We're building both x64 and arm64 on the same Mac machines so this is confusing since we're using x64 hosts in public and arm64 hosts in internal.
