### PR TITLE
Exclude format/watch from SDK diff

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkFileDiffExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkFileDiffExclusions.txt
@@ -62,61 +62,11 @@ msft,./sdk/x.y.z/Extensions/dump/*
 msft,./sdk/x.y.z/**/System.Windows.Extensions.dll
 msft,./sdk/x.y.z/**/System.Security.Permissions.dll
 
-# netfx runtimes for dotnet-watch - https://github.com/dotnet/source-build/issues/3285
-msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Microsoft.CodeAnalysis.Elfie.dll
-msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Microsoft.Win32.SystemEvents.dll
-msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/runtimes/*
-msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Configuration.ConfigurationManager.dll
-msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Drawing.Common.dll
-msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Security.Cryptography.ProtectedData.dll
-msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Security.Permissions.dll
-msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Windows.Extensions.dll
-
-# netfx runtimes for dotnet-watch - https://github.com/dotnet/source-build/issues/3999
-msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/BuildHost-net472/*
-msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/BuildHost-netcore/System.Threading.Channels.dll
-msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Microsoft.VisualStudio.Setup.Configuration.Interop.dll
-sb,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/runtimes/*
-sb,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Configuration.ConfigurationManager.dll
-sb,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.IO.Pipelines.dll
-sb,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Security.Cryptography.ProtectedData.dll
-
-# netfx runtimes for dotnet-watch - https://github.com/dotnet/source-build/issues/4035
-sb,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/BuildHost-netcore/runtimes/*
-sb,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/BuildHost-netcore/System.Text.Encodings.Web.dll
-sb,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/BuildHost-netcore/System.Text.Json.dll
-msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Microsoft.Extensions.DependencyInjection.Abstractions.dll
-msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Microsoft.Extensions.Logging.Abstractions.dll
-msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Security.Cryptography.Pkcs.dll
-msft,./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Security.Cryptography.Xml.dll
-
-# netfx runtimes for dotnet-format - https://github.com/dotnet/source-build/issues/3509
-msft,./sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.CodeAnalysis.Elfie.dll
-msft,./sdk/x.y.z/DotnetTools/dotnet-format/runtimes/*
-
-# netfx runtimes for dotnet-format - https://github.com/dotnet/source-build/issues/3998
-msft,./sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-net472/*
-msft,./sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/System.Threading.Channels.dll
-sb,./sdk/x.y.z/DotnetTools/dotnet-format/System.Security.Permissions.dll
-sb,./sdk/x.y.z/DotnetTools/dotnet-format/System.Windows.Extensions.dll
-
-# netfx runtimes for dotnet-format - https://github.com/dotnet/source-build/issues/4034
-sb,./sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.deps.json
-sb,./sdk/x.y.z/DotnetTools/dotnet-format/runtimes/*
-sb,./sdk/x.y.z/DotnetTools/dotnet-format/System.Collections.Immutable.dll
-sb,./sdk/x.y.z/DotnetTools/dotnet-format/System.Reflection.Metadata.dll
-sb,./sdk/x.y.z/DotnetTools/dotnet-format/System.Text.Encodings.Web.dll
-sb,./sdk/x.y.z/DotnetTools/dotnet-format/System.Text.Json.dll
-
-# https://github.com/dotnet/source-build/issues/3922
-msft,./sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.Win32.SystemEvents.dll
-msft,./sdk/x.y.z/DotnetTools/dotnet-format/System.Drawing.Common.dll
-sb,./sdk/x.y.z/DotnetTools/dotnet-format/System.Diagnostics.EventLog.dll
-sb,./sdk/x.y.z/DotnetTools/dotnet-format/System.Formats.Asn1.dll
-sb,./sdk/x.y.z/DotnetTools/dotnet-format/System.Threading.Tasks.Dataflow.dll
-
-# version coherency issue in dotnet-format - https://github.com/dotnet/source-build/issues/4016#issuecomment-1908996093
-msft,./sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.CodeAnalysis.ExternalAccess.RazorCompiler.dll
+# Exclude format and watch tools due to too much noise
+msft,./sdk/x.y.z/DotnetTools/dotnet-format/**
+sb,./sdk/x.y.z/DotnetTools/dotnet-format/**
+msft,./sdk/x.y.z/DotnetTools/dotnet-watch/**
+sb,./sdk/x.y.z/DotnetTools/dotnet-watch/**
 
 # netfx runtimes for fsharp - https://github.com/dotnet/source-build/issues/3290
 msft,./sdk/x.y.z/FSharp/Microsoft.VisualStudio.Setup.Configuration.Interop.dll

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdkFiles.diff
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdkFiles.diff
@@ -45,6 +45,14 @@ index ------------
  ./packs/Microsoft.NETCore.App.Ref/x.y.z/
  ./packs/Microsoft.NETCore.App.Ref/x.y.z/analyzers/
 @@ ------------ @@
+ ./sdk-manifests/x.y.z/
+ ./sdk-manifests/x.y.z/
+ ./sdk-manifests/x.y.z/
+-./sdk-manifests/x.y.z/
+ ./sdk-manifests/x.y.z/microsoft.net.sdk.aspire/
+ ./sdk-manifests/x.y.z/microsoft.net.sdk.aspire/x.y.z/
+ ./sdk-manifests/x.y.z/microsoft.net.sdk.aspire/x.y.z/WorkloadManifest.Aspire.targets
+@@ ------------ @@
  ./sdk/x.y.z/Containers/build/
  ./sdk/x.y.z/Containers/build/Microsoft.NET.Build.Containers.props
  ./sdk/x.y.z/Containers/build/Microsoft.NET.Build.Containers.targets


### PR DESCRIPTION
The dotnet-format and dotnet-watch tools often bring other dependencies into the SDK. These dependencies are often not in alignment between the Microsoft and SB SDKs. Further, these dependencies often change over time as version updates and other changes are made. This creates a lot of churn in order to keep evaluating the diffs. This work has just been overhead without getting much benefit.

These changes propose the exclusion of all the dotnet-format and dotnet-watch content from the SDK diff test in order to eliminate this overhead. The baseline was also updated with one minor sdk-manifests version directory change.