### PR TITLE
Arcade patch to ignore std error warning format

### DIFF
--- a/src/SourceBuild/patches/arcade/0001-Ignore-standard-error-warning-format-in-SB-inner-com.patch
+++ b/src/SourceBuild/patches/arcade/0001-Ignore-standard-error-warning-format-in-SB-inner-com.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matt Thalman <mthalman@microsoft.com>
+Date: Thu, 22 Feb 2024 14:05:54 -0600
+Subject: [PATCH] Ignore standard error warning format in SB inner command
+
+Backport: https://github.com/dotnet/arcade/pull/14496
+---
+ .../tools/SourceBuild/SourceBuildArcadeBuild.targets             | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
+index 6ef44082..72b9c688 100644
+--- a/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
++++ b/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeBuild.targets
+@@ -214,6 +214,7 @@
+     <Exec
+       Command="$(BaseInnerSourceBuildCommand) $(InnerBuildArgs)"
+       WorkingDirectory="$(InnerSourceBuildRepoRoot)"
++      IgnoreStandardErrorWarningFormat="true"
+       EnvironmentVariables="@(InnerBuildEnv)" />
+   </Target>
+ 


### PR DESCRIPTION
This is implemented in https://github.com/dotnet/arcade/pull/14496. Rather than waiting for Arcade to flow to installer, having a patch now will help identify further issues in the VMR build.