### PR TITLE
Update sync script reference in VMR readme

### DIFF
--- a/src/SourceBuild/content/README.md
+++ b/src/SourceBuild/content/README.md
@@ -173,7 +173,7 @@ Alternatively, you can also provide a manifest file where this information can b
 
 Sometimes you want to make a change in a repository and test that change in the VMR. You could of course make the change in the VMR directly (locally, as the VMR is read-only for now) but in case it's already available in your repository, you can synchronize it into the VMR (again locally).
 
-To do this, you can either start a [dotnet/dotnet](https://github.com/dotnet/dotnet) Codespace - you will see instructions right after it starts. Alternatively, you can clone the repository locally and use the [eng/vmr-sync.sh](../../eng/vmr-sync.sh) or [eng/vmr-sync.ps1](../../eng/vmr-sync.ps1) script to pull your changes in. Please refer to the documentation in the script for more details.
+To do this, you can either start a [dotnet/dotnet](https://github.com/dotnet/dotnet) Codespace - you will see instructions right after it starts. Alternatively, you can clone the repository locally and use the [vmr-sync.sh](src/installer/eng/vmr-sync.sh) or [vmr-sync.ps1](src/installer/eng/vmr-sync.ps1) script to pull your changes in. Please refer to the documentation in the script for more details.
 
 ## List of components
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/3976.

Updated the links to be relative in the context of the VMR.  This was the previously established pattern (see the Code Flow section.