### PR TITLE
Update SDK diff baseline

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdkFiles.diff
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdkFiles.diff
@@ -45,14 +45,6 @@ index ------------
  ./packs/Microsoft.NETCore.App.Ref/x.y.z/
  ./packs/Microsoft.NETCore.App.Ref/x.y.z/analyzers/
 @@ ------------ @@
- ./sdk-manifests/x.y.z/
- ./sdk-manifests/x.y.z/
- ./sdk-manifests/x.y.z/
--./sdk-manifests/x.y.z/
- ./sdk-manifests/x.y.z/microsoft.net.sdk.aspire/
- ./sdk-manifests/x.y.z/microsoft.net.sdk.aspire/x.y.z/
- ./sdk-manifests/x.y.z/microsoft.net.sdk.aspire/x.y.z/WorkloadManifest.Aspire.targets
-@@ ------------ @@
  ./sdk/x.y.z/Containers/build/
  ./sdk/x.y.z/Containers/build/Microsoft.NET.Build.Containers.props
  ./sdk/x.y.z/Containers/build/Microsoft.NET.Build.Containers.targets


### PR DESCRIPTION
Resolves https://github.com/dotnet/source-build/issues/4162

Update the SDK diff test baseline according to failures in https://dev.azure.com/dnceng/internal/_build/results?buildId=2387599&view=results