### PR TITLE
Update artifact size baseline for Centos8

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/ArtifactsSizes/centos.8-x64.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/ArtifactsSizes/centos.8-x64.txt
@@ -3096,7 +3096,7 @@ sdk/x.y.z/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_7_recommen
 sdk/x.y.z/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_8_all_warnaserror.globalconfig: 29701
 sdk/x.y.z/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_8_all.globalconfig: 27752
 sdk/x.y.z/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_8_default_warnaserror.globalconfig: 3272
-sdk/x.y.z/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_8_default.globalconfig: 584
+sdk/x.y.z/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_8_default.globalconfig: 829
 sdk/x.y.z/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_8_minimum_warnaserror.globalconfig: 11410
 sdk/x.y.z/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_8_minimum.globalconfig: 9089
 sdk/x.y.z/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_8_none_warnaserror.globalconfig: 16373
@@ -3446,7 +3446,7 @@ sdk/x.y.z/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevelperformance
 sdk/x.y.z/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevelperformance_8_all_warnaserror.globalconfig: 6211
 sdk/x.y.z/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevelperformance_8_all.globalconfig: 6040
 sdk/x.y.z/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevelperformance_8_default_warnaserror.globalconfig: 726
-sdk/x.y.z/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevelperformance_8_default.globalconfig: 340
+sdk/x.y.z/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevelperformance_8_default.globalconfig: 461
 sdk/x.y.z/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevelperformance_8_minimum_warnaserror.globalconfig: 4702
 sdk/x.y.z/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevelperformance_8_minimum.globalconfig: 4497
 sdk/x.y.z/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevelperformance_8_none_warnaserror.globalconfig: 5165


### PR DESCRIPTION
Resolves https://github.com/dotnet/source-build/issues/4173

Based on test failure in latest SDK diff run for `main`: https://dev.azure.com/dnceng/internal/_build/results?buildId=2389644&view=ms.vss-test-web.build-test-results-tab&runId=53144717&resultId=100001&paneView=attachments

