### PR TITLE
Do not create `-ub` release VMR branches

### DIFF
--- a/eng/pipelines/vmr-sync.yml
+++ b/eng/pipelines/vmr-sync.yml
@@ -42,5 +42,5 @@ jobs:
 - ${{ if eq(parameters.vmrBranch, 'main') }}:
   - template: /eng/pipelines/templates/jobs/vmr-synchronization.yml
     parameters:
-      jobName: Synchronize_VMR_uncloacked
+      jobName: Synchronize_VMR_uncloaked
       vmrBranch: ${{ variables.VmrBranch }}-ub

--- a/eng/pipelines/vmr-sync.yml
+++ b/eng/pipelines/vmr-sync.yml
@@ -25,7 +25,7 @@ parameters:
   type: string
   default: ' '
 
-variables: 
+variables:
 - ${{ if ne(parameters.vmrBranch, ' ') }}:
   - name: VmrBranch
     value: ${{ replace(parameters.vmrBranch, ' ', '') }}
@@ -39,7 +39,8 @@ jobs:
     jobName: Synchronize_VMR
     vmrBranch: ${{ variables.VmrBranch }}
 
-- template: /eng/pipelines/templates/jobs/vmr-synchronization.yml
-  parameters:
-    jobName: Synchronize_VMR_uncloacked
-    vmrBranch: ${{ variables.VmrBranch }}-ub
+- ${{ if eq(parameters.vmrBranch, 'main') }}:
+  - template: /eng/pipelines/templates/jobs/vmr-synchronization.yml
+    parameters:
+      jobName: Synchronize_VMR_uncloacked
+      vmrBranch: ${{ variables.VmrBranch }}-ub

--- a/eng/pipelines/vmr-sync.yml
+++ b/eng/pipelines/vmr-sync.yml
@@ -39,7 +39,7 @@ jobs:
     jobName: Synchronize_VMR
     vmrBranch: ${{ variables.VmrBranch }}
 
-- ${{ if eq(parameters.vmrBranch, 'main') }}:
+- ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
   - template: /eng/pipelines/templates/jobs/vmr-synchronization.yml
     parameters:
       jobName: Synchronize_VMR_uncloaked


### PR DESCRIPTION
Preventing https://github.com/dotnet/dotnet/tree/release/9.0.1xx-preview2-ub from happening