### PR TITLE
Make prep.sh fail when it fails to download archives

### DIFF
--- a/src/SourceBuild/content/prep.sh
+++ b/src/SourceBuild/content/prep.sh
@@ -135,7 +135,7 @@ function DownloadArchive {
     archiveUrl="https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.$archiveType.$archiveVersion.$archiveRid.tar.gz"
 
     echo "  Downloading source-built $archiveType from $archiveUrl..."
-    (cd "$packagesArchiveDir" && curl --retry 5 -O "$archiveUrl")
+    (cd "$packagesArchiveDir" && curl -f --retry 5 -O "$archiveUrl")
   elif [ "$isRequired" == true ]; then
     echo "  ERROR: $notFoundMessage"
     exit 1


### PR DESCRIPTION
The -f/--fail flag makes curl fail on server errors (like 404). Otherwise curl behaves as if everything worked.

Fixes: https://github.com/dotnet/source-build/issues/3975