### PR TITLE
Removing native tools workarounds

### DIFF
--- a/eng/configure-toolset.ps1
+++ b/eng/configure-toolset.ps1
@@ -1,6 +1,3 @@
 # SdkTests do not currently work with globally installed CLI as they use dotnet-install.ps1 to install more runtimes
 
 $script:useInstalledDotNetCli = $false
-
-# Add CMake to the path.
-$env:PATH = "$PSScriptRoot\..\.tools\bin;$env:PATH"

--- a/eng/configure-toolset.sh
+++ b/eng/configure-toolset.sh
@@ -1,3 +1,6 @@
 # SdkTests do not currently work with globally installed CLI as they use dotnet-install.ps1 to install more runtimes
 
 useInstalledDotNetCli="false"
+
+# Working around issue https://github.com/dotnet/arcade/issues/7327
+DisableNativeToolsetInstalls=true

--- a/eng/configure-toolset.sh
+++ b/eng/configure-toolset.sh
@@ -1,6 +1,3 @@
 # SdkTests do not currently work with globally installed CLI as they use dotnet-install.ps1 to install more runtimes
 
 useInstalledDotNetCli="false"
-
-# Working around issue https://github.com/dotnet/arcade/issues/7327
-DisableNativeToolsetInstalls=true


### PR DESCRIPTION
## Summary

[This PR](https://github.com/dotnet/installer/pull/18525) updated the way in which Arcade handles using native tools. Instead of acquiring them, it will use the ones available on the agent/machine itself. There were a couple of workarounds that have been in the repo for a long time to assist in using the tools. Hopefully, these workarounds should no longer be necessary. Documentation on the Arcade change can be [found here](https://github.com/dotnet/arcade/blob/main/Documentation/NativeToolsOnMachine.md).


