### PR TITLE
Remove unnecessary runtime installation

### DIFF
--- a/src/SourceBuild/content/prep.sh
+++ b/src/SourceBuild/content/prep.sh
@@ -176,9 +176,6 @@ if [ "$installDotnet" == true ]; then
   echo "  Installing dotnet..."
   use_installed_dotnet_cli=false
   (source ./eng/common/tools.sh && InitializeDotNetCli true)
-
-  # TODO: Remove once runtime dependency is gone (https://github.com/dotnet/runtime/issues/93666)
-  bash .dotnet/dotnet-install.sh --install-dir "$SCRIPT_ROOT/.dotnet" --channel 8.0 --runtime dotnet
 fi
 
 # Read the eng/Versions.props to get the archives to download and download them


### PR DESCRIPTION
Related to https://github.com/dotnet/runtime/issues/93666.  

Runtime must have addressed https://github.com/dotnet/runtime/issues/93666 as this workaround no longer appears required.  The build is prebuilt clean.