### PR TITLE
Pass TargetRid to Razor's build for the VMR

### DIFF
--- a/src/SourceBuild/content/repo-projects/razor.proj
+++ b/src/SourceBuild/content/repo-projects/razor.proj
@@ -4,6 +4,8 @@
     <!-- The toolset compiler doesn't get killed with 'build-server shutdown'.
          Instead of disabling shared compilation, disable the toolset compiler package. -->
     <BuildArgs>$(BuildArgs) /p:UsingToolMicrosoftNetCompilers=false</BuildArgs>
+    <!-- Pass down the target RID so we can create the correct apphost for the language servers. -->
+    <BuildArgs>$(BuildArgs) /p:TargetRid=$(TargetRid)</BuildArgs>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Needed to support https://github.com/dotnet/razor/pull/10017 (determining which RID to publish the language servers for)