### PR TITLE
Update Assembly Exclusions

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkAssemblyVersionDiffExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkAssemblyVersionDiffExclusions.txt
@@ -26,6 +26,8 @@
 ./sdk/x.y.z/System.Security.Cryptography.Xml.dll
 
 # These assemblies are lifted to a higher version naturally via SB
+./sdk/x.y.z/DotnetTools/dotnet-format/dotnet-format.dll
+./sdk/x.y.z/DotnetTools/dotnet-format/*/dotnet-format.resources.dll
 ./sdk/x.y.z/DotnetTools/dotnet-format/*/Microsoft.CodeAnalysis.*
 ./sdk/x.y.z/DotnetTools/dotnet-format/Humanizer.dll
 ./sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.Build.Locator.dll


### PR DESCRIPTION
Fixes the following assembly diff found in [test run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2392877&view=results) (internal link)

```
diff --git a/msft_assemblyversions.txt b/sb_assemblyversions.txt
index ------------
--- a/msft_assemblyversions.txt
+++ b/sb_assemblyversions.txt
@@ ------------ @@ sdk/x.y.z/de/System.CommandLine.resources.dll - 2.0.0
 sdk/x.y.z/de/vstest.console.resources.dll - 15.0.0
 sdk/x.y.z/dotnet.dll - 8.0.102
 sdk/x.y.z/DotnetTools/dotnet-dev-certs/x.y.z/tools/netx.y/any/dotnet-dev-certs.dll - 8.0.2
-sdk/x.y.z/DotnetTools/dotnet-format/cs/dotnet-format.resources.dll - 8.0.9
+sdk/x.y.z/DotnetTools/dotnet-format/cs/dotnet-format.resources.dll - 8.0.10
 sdk/x.y.z/DotnetTools/dotnet-format/cs/System.CommandLine.resources.dll - 2.0.0
-sdk/x.y.z/DotnetTools/dotnet-format/de/dotnet-format.resources.dll - 8.0.9
+sdk/x.y.z/DotnetTools/dotnet-format/de/dotnet-format.resources.dll - 8.0.10
 sdk/x.y.z/DotnetTools/dotnet-format/de/System.CommandLine.resources.dll - 2.0.0
-sdk/x.y.z/DotnetTools/dotnet-format/dotnet-format.dll - 8.0.9
-sdk/x.y.z/DotnetTools/dotnet-format/es/dotnet-format.resources.dll - 8.0.9
+sdk/x.y.z/DotnetTools/dotnet-format/dotnet-format.dll - 8.0.10
+sdk/x.y.z/DotnetTools/dotnet-format/es/dotnet-format.resources.dll - 8.0.10
 sdk/x.y.z/DotnetTools/dotnet-format/es/System.CommandLine.resources.dll - 2.0.0
-sdk/x.y.z/DotnetTools/dotnet-format/fr/dotnet-format.resources.dll - 8.0.9
+sdk/x.y.z/DotnetTools/dotnet-format/fr/dotnet-format.resources.dll - 8.0.10
 sdk/x.y.z/DotnetTools/dotnet-format/fr/System.CommandLine.resources.dll - 2.0.0
-sdk/x.y.z/DotnetTools/dotnet-format/it/dotnet-format.resources.dll - 8.0.9
+sdk/x.y.z/DotnetTools/dotnet-format/it/dotnet-format.resources.dll - 8.0.10
 sdk/x.y.z/DotnetTools/dotnet-format/it/System.CommandLine.resources.dll - 2.0.0
-sdk/x.y.z/DotnetTools/dotnet-format/ja/dotnet-format.resources.dll - 8.0.9
+sdk/x.y.z/DotnetTools/dotnet-format/ja/dotnet-format.resources.dll - 8.0.10
 sdk/x.y.z/DotnetTools/dotnet-format/ja/System.CommandLine.resources.dll - 2.0.0
-sdk/x.y.z/DotnetTools/dotnet-format/ko/dotnet-format.resources.dll - 8.0.9
+sdk/x.y.z/DotnetTools/dotnet-format/ko/dotnet-format.resources.dll - 8.0.10
 sdk/x.y.z/DotnetTools/dotnet-format/ko/System.CommandLine.resources.dll - 2.0.0
 sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.Bcl.AsyncInterfaces.dll - 8.0.0
 sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.Extensions.DependencyInjection.Abstractions.dll - 8.0.0
@@ ------------ @@ sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.Extensions.Logging.Abstractions.dl
 sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.Extensions.Logging.dll - 8.0.0
 sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.Extensions.Options.dll - 8.0.0
 sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.Extensions.Primitives.dll - 8.0.0
-sdk/x.y.z/DotnetTools/dotnet-format/pl/dotnet-format.resources.dll - 8.0.9
+sdk/x.y.z/DotnetTools/dotnet-format/pl/dotnet-format.resources.dll - 8.0.10
 sdk/x.y.z/DotnetTools/dotnet-format/pl/System.CommandLine.resources.dll - 2.0.0
-sdk/x.y.z/DotnetTools/dotnet-format/pt-BR/dotnet-format.resources.dll - 8.0.9
+sdk/x.y.z/DotnetTools/dotnet-format/pt-BR/dotnet-format.resources.dll - 8.0.10
 sdk/x.y.z/DotnetTools/dotnet-format/pt-BR/System.CommandLine.resources.dll - 2.0.0
-sdk/x.y.z/DotnetTools/dotnet-format/ru/dotnet-format.resources.dll - 8.0.9
+sdk/x.y.z/DotnetTools/dotnet-format/ru/dotnet-format.resources.dll - 8.0.10
 sdk/x.y.z/DotnetTools/dotnet-format/ru/System.CommandLine.resources.dll - 2.0.0
 sdk/x.y.z/DotnetTools/dotnet-format/System.CommandLine.dll - 2.0.0
 sdk/x.y.z/DotnetTools/dotnet-format/System.CommandLine.Rendering.dll - 0.4.0
-sdk/x.y.z/DotnetTools/dotnet-format/tr/dotnet-format.resources.dll - 8.0.9
+sdk/x.y.z/DotnetTools/dotnet-format/tr/dotnet-format.resources.dll - 8.0.10
 sdk/x.y.z/DotnetTools/dotnet-format/tr/System.CommandLine.resources.dll - 2.0.0
-sdk/x.y.z/DotnetTools/dotnet-format/zh-Hans/dotnet-format.resources.dll - 8.0.9
+sdk/x.y.z/DotnetTools/dotnet-format/zh-Hans/dotnet-format.resources.dll - 8.0.10
 sdk/x.y.z/DotnetTools/dotnet-format/zh-Hans/System.CommandLine.resources.dll - 2.0.0
-sdk/x.y.z/DotnetTools/dotnet-format/zh-Hant/dotnet-format.resources.dll - 8.0.9
+sdk/x.y.z/DotnetTools/dotnet-format/zh-Hant/dotnet-format.resources.dll - 8.0.10
 sdk/x.y.z/DotnetTools/dotnet-format/zh-Hant/System.CommandLine.resources.dll - 2.0.0
 sdk/x.y.z/DotnetTools/dotnet-user-jwts/x.y.z/tools/netx.y/any/dotnet-user-jwts.dll - 8.0.2
 sdk/x.y.z/DotnetTools/dotnet-user-jwts/x.y.z/tools/netx.y/any/Microsoft.Extensions.Configuration.Abstractions.dll - 8.0.0
```