### PR TITLE
ExtractArchiveToDirectory: open .tar.gz archives read-only

### DIFF
--- a/src/core-sdk-tasks/ExtractArchiveToDirectory.cs
+++ b/src/core-sdk-tasks/ExtractArchiveToDirectory.cs
@@ -113,7 +113,7 @@ namespace Microsoft.DotNet.Build.Tasks
                             retVal = base.Execute();
 #else
                             // Decompress GZip content
-                            using FileStream compressedFileStream = File.Open(SourceArchive, FileMode.Open);
+                            using FileStream compressedFileStream = File.OpenRead(SourceArchive);
                             using var decompressor = new GZipStream(compressedFileStream, CompressionMode.Decompress);
                             using var decompressedStream = new MemoryStream();
                             decompressor.CopyTo(decompressedStream);


### PR DESCRIPTION
When given a file:// url, the arcade DownloadFile task does a File.Copy, which preserves permissions. If the source file is read-only, it will fail to extract.

The error is:

```
src/redist/targets/GenerateLayout.targets(455,5): error MSB4018: The "ExtractArchiveToDirectory" task failed unexpectedly. [src/redist/redist.csproj]
src/redist/targets/GenerateLayout.targets(455,5): error MSB4018: System.UnauthorizedAccessException: Access to the path 'artifacts/obj/redist/Release/downloads/aspnetcore-runtime-8.0.2-linux-x64.tar.gz' is denied. [src/redist/redist.csproj]
src/redist/targets/GenerateLayout.targets(455,5): error MSB4018:  ---> System.IO.IOException: Permission denied [src/redist/redist.csproj]
src/redist/targets/GenerateLayout.targets(455,5): error MSB4018:    --- End of inner exception stack trace --- [src/redist/redist.csproj]
src/redist/targets/GenerateLayout.targets(455,5): error MSB4018:    at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirError) [src/redist/redist.csproj]
src/redist/targets/GenerateLayout.targets(455,5): error MSB4018:    at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String path, OpenFlags flags, Int32 mode, Boolean failForSymlink, Boolean& wasSymlink, Func`4 createOpenException) [src/redist/redist.csproj]
src/redist/targets/GenerateLayout.targets(455,5): error MSB4018:    at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, UnixFileMode openPermissions, Int64& fileLength, UnixFileMode& filePermissions, Boolean failForSymlink, Boolean& wasSymlink, Func`4 createOpenException) [src/redist/redist.csproj]
src/redist/targets/GenerateLayout.targets(455,5): error MSB4018:    at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode) [src/redist/redist.csproj]
src/redist/targets/GenerateLayout.targets(455,5): error MSB4018:    at System.IO.File.Open(String path, FileMode mode) [src/redist/redist.csproj]
src/redist/targets/GenerateLayout.targets(455,5): error MSB4018:    at Microsoft.DotNet.Build.Tasks.ExtractArchiveToDirectory.Execute() in src/core-sdk-tasks/ExtractArchiveToDirectory.cs:line 116 [src/redist/redist.csproj]
src/redist/targets/GenerateLayout.targets(455,5): error MSB4018:    at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute() [src/redist/redist.csproj]
src/redist/targets/GenerateLayout.targets(455,5): error MSB4018:    at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(ITaskExecutionHost taskExecutionHost, TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode howToExecuteTask) [src/redist/redist.csproj]
```