### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,5 +4,5 @@
 /.devcontainer/ @dotnet/source-build-internal
 /eng/SourceBuild* @dotnet/source-build-internal
 /src/snaps/ @rbhanda
-/src/SourceBuild/ @dotnet/source-build-internal
+/src/SourceBuild/ @dotnet/source-build-internal @dotnet/product-construction
 /src/VirtualMonoRepo/ @dotnet/product-construction


### PR DESCRIPTION
Add @dotnet/product-construction as owner of `src/SourceBuild/*` so that we get notifications for new PRs.