### PR TITLE
Set the CrossBuild property instead of the CROSSCOMPILE environment variable

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -277,7 +277,9 @@ jobs:
 
         if [[ -n "${{ parameters.crossRootFs }}" ]]; then
           customEnvVars="$customEnvVars ROOTFS_DIR=${{ parameters.crossRootFs}}"
-          extraBuildProperties="$extraBuildProperties /p:CrossBuild=true"
+          if [[ '${{ parameters.targetArchitecture }}' != 'wasm' ]]; then
+            extraBuildProperties="$extraBuildProperties /p:CrossBuild=true"
+          fi
         fi
 
         if [[ ! -z '${{ parameters.targetOS }}' ]]; then

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -277,9 +277,7 @@ jobs:
 
         if [[ -n "${{ parameters.crossRootFs }}" ]]; then
           customEnvVars="$customEnvVars ROOTFS_DIR=${{ parameters.crossRootFs}}"
-          if [[ '${{ parameters.targetArchitecture }}' != 'wasm' ]]; then
-            customEnvVars="$customEnvVars CROSSCOMPILE=1"
-          fi
+          extraBuildProperties="$extraBuildProperties /p:CrossBuild=true"
         fi
 
         if [[ ! -z '${{ parameters.targetOS }}' ]]; then

--- a/src/SourceBuild/patches/runtime/0001-Forward-the-cross-argument-from-the-outer-build-to-t.patch
+++ b/src/SourceBuild/patches/runtime/0001-Forward-the-cross-argument-from-the-outer-build-to-t.patch
@@ -1,0 +1,26 @@
+From e4cba32b28bac042e53fc6b8a1a9e4126f50f221 Mon Sep 17 00:00:00 2001
+From: Jeremy Koritzinsky <jekoritz@microsoft.com>
+Date: Thu, 7 Mar 2024 14:39:30 -0800
+Subject: [PATCH] Forward the cross argument from the outer build to the inner
+ build
+
+Backport: TBD
+---
+ eng/DotNetBuild.props | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/eng/DotNetBuild.props b/eng/DotNetBuild.props
+index a6350c7fea9..127d6a5d12b 100644
+--- a/eng/DotNetBuild.props
++++ b/eng/DotNetBuild.props
+@@ -54,6 +54,7 @@
+       <InnerBuildArgs>$(InnerBuildArgs) $(FlagParameterPrefix)nodereuse $(ArcadeFalseBoolBuildArg)</InnerBuildArgs>
+       <InnerBuildArgs>$(InnerBuildArgs) $(FlagParameterPrefix)warnAsError $(ArcadeFalseBoolBuildArg)</InnerBuildArgs>
+       <InnerBuildArgs Condition="'$(SourceBuildUseMonoRuntime)' == 'true'">$(InnerBuildArgs) $(FlagParameterPrefix)usemonoruntime</InnerBuildArgs>
++      <InnerBuildArgs Condition="'$(CrossBuild)' == 'true'">$(InnerBuildArgs) $(FlagParameterPrefix)cross</InnerBuildArgs>
+       <!-- TODO: This parameter is only available on the Unix script. Intentional? -->
+       <InnerBuildArgs Condition="'$(OS)' != 'Windows_NT'">$(InnerBuildArgs) --outputrid $(TargetRid)</InnerBuildArgs>
+       <!-- PackageOS and ToolsOS control the rids of prebuilts consumed by the build.
+-- 
+2.44.0.windows.1
+


### PR DESCRIPTION
By setting `CROSSCOMPILE`, we're forcing all CoreCLR build steps to use the rootfs. We should pass the `CrossBuild` property instead which will allow the dotnet/runtime build targets to correctly specify which build steps will use the rootfs and which ones should use the host.

Fixes https://github.com/dotnet/source-build/issues/3698