### PR TITLE
Build sdkArchiveDiff only when we'll run it

### DIFF
--- a/src/SourceBuild/content/eng/tools/init-build.proj
+++ b/src/SourceBuild/content/eng/tools/init-build.proj
@@ -118,7 +118,7 @@
   </Target>
 
   <Target Name="BuildSdkArchiveDiff"
-          Condition="'$(ShortStack)' != 'true' and '$(PortableBuild)' == 'true'" >
+          Condition="'$(ShortStack)' != 'true' and '$(PortableBuild)' == 'true' and '$(PgoInstrument)' != 'true'" >
     <MSBuild Projects="tasks\Microsoft.DotNet.SourceBuild.Tasks.SdkArchiveDiff\Microsoft.DotNet.SourceBuild.Tasks.SdkArchiveDiff.csproj"
              Targets="Restore"
              Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid())" />


### PR DESCRIPTION
I missed this comment: https://github.com/dotnet/installer/pull/18918#pullrequestreview-1924158639 before merging that PR, so following up with this.