### PR TITLE
Use the VMR commit hash for dotnet --info

### DIFF
--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -138,15 +138,6 @@
     <EnvironmentVariables Include="DotNetUseShippingVersions=true" />
     <EnvironmentVariables Include="PreReleaseVersionLabel=$(PreReleaseVersionLabel)" />
     <EnvironmentVariables Include="PackageVersionStamp=$(PreReleaseVersionLabel)" />
-
-    <!-- Give build access to commit info without necessarily requiring git queries. -->
-    <EnvironmentVariables Include="GitCommitHash=$(GitCommitHash)" Condition="'$(GitCommitHash)' != ''" />
-    <EnvironmentVariables Include="GitInfoCommitHash=$(GitCommitHash)" Condition="'$(GitCommitHash)' != ''" />
-    <EnvironmentVariables Include="SourceRevisionId=$(GitCommitHash)" Condition="'$(GitCommitHash)' != ''" />
-    <EnvironmentVariables Include="RepositoryCommit=$(GitCommitHash)" Condition="'$(GitCommitHash)' != ''" />
-    <EnvironmentVariables Include="COMMIT_SHA=$(GitCommitHash)" Condition="'$(GitCommitHash)' != ''" />
-    <EnvironmentVariables Include="GIT_COMMIT=$(GitCommitHash)" Condition="'$(GitCommitHash)' != ''" />
-    <EnvironmentVariables Include="RepositoryType=Git" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Remove the logic that overrides the git commit info for each repo. Let each repo infer the VMR's git commit (via sourcelink).

That will let the installer and sdk repos use the VMR's commit hash and show that in `dotnet --info`.

This works for both when building the VMR out of git, as well as when building it from a tarball/archive thanks to sourcelink's support for minimal git metadata [1].

[1] https://github.com/dotnet/sourcelink/tree/main/docs#minimal-git-repository-metadata
    
Fixes: dotnet/source-build#3643

---

Original PR description:

This defines a new environment variable `DotNetGitCommitHash` which contains the commit hash of the VMR. Individual repositories can use this to find the VMR's commit hash and then embed/use it as appropriate.

It then uses this hash when generating the SDK's .version file, so dotnet --info shows this as the SDK version.

Contributes to https://github.com/dotnet/source-build/issues/3643