### PR TITLE
Update the nuget and msbuild ref versions for the installer tasks to the matching version we ship

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -93,7 +93,12 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/NuGet/NuGet.Client -->
-    <NuGetVersioningPackageVersion>5.8.0</NuGetVersioningPackageVersion>
+    <NuGetBuildTasksPackageVersion>6.0.6-rc.4</NuGetBuildTasksPackageVersion>
+    <NuGetVersioningPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetVersioningPackageVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <!-- Dependencies from https://github.com/dotnet/msbuild -->
+    <MicrosoftBuildPackageVersion>17.0.1</MicrosoftBuildPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Cross-release dependency versions -->

--- a/src/core-sdk-tasks/core-sdk-tasks.csproj
+++ b/src/core-sdk-tasks/core-sdk-tasks.csproj
@@ -9,12 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="15.7.179" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.7.179" />
+    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NuGet.Versioning" Version="$(NuGetVersioningPackageVersion)" />
     <PackageReference Include="NuGet.Packaging" Version="$(NuGetVersioningPackageVersion)" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.4.2" />
+    <PackageReference Include="System.Reflection.Metadata" Version="1.6.0" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" Condition="'$(DotNetBuildFromSource)' != 'true'" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>


### PR DESCRIPTION
Looks like these versions got hardcoded long ago. They aren't used during the execution of the tasks but only the build of the task but better to clean them up.
