### PR TITLE
Don't run binary tooling during license scan setup

### DIFF
--- a/eng/pipelines/source-build-license-scan.yml
+++ b/eng/pipelines/source-build-license-scan.yml
@@ -68,7 +68,7 @@ jobs:
     matrix: $[ dependencies.Setup.outputs['GetMatrix.matrix'] ]
   steps:
 
-  - script: $(Build.SourcesDirectory)/eng/prep-source-build.sh --no-artifacts --no-bootstrap --no-prebuilts
+  - script: $(Build.SourcesDirectory)/eng/prep-source-build.sh --no-artifacts --no-bootstrap --no-prebuilts --no-binary-tooling
     displayName: 'Install .NET SDK'
 
   - task: PipAuthenticate@1


### PR DESCRIPTION
As part of https://github.com/dotnet/installer/pull/18726, binary tooling runs automatically as part of `eng/prep-source-build.sh` unless `--no-binary-tooling` is passed.

The license scan currently makes use of `eng/prep-source-build.sh` with binary tooling enabled, but it should not make use of the binary tooling. In fact, when it attempts to set up for the binary tooling, the following error is received due to the args currently passed to `eng/prep-source-build.sh` in the pipeline:

```
ERROR: A pre-existing package archive is needed if --with-packages is not provided. Please either supply a source-feed using --with-packages or execute ./eng/prep-source-build.sh with download artifacts enabled before proceeding. Exiting...
```

This can be fixed by passing `--no-binary-tooling` to `eng/prep-souce-build.sh` when license scanning.

[Link to failing run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2401704&view=logs&j=280a01c8-006d-5537-2980-fc0860fb6840&t=e68a658c-f5af-5151-59ca-363bd9a50cbb&l=29) (internal link)

[Link to successful run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2401842&view=logs&j=e270fe85-15dd-5bc7-2c45-d05ee72dd816) (internal link)