### PR TITLE
Migrate to 1ES templates for internal builds

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -69,8 +69,11 @@ extends:
         os: windows
       # https://docs.opensource.microsoft.com/tools/cg/component-detection/variables/
       componentgovernance:
-        failOnAlert: false
-      #   ignoreDirectories: '.packages'
+        # This should be uncommented when a fix is available.
+        # See: https://dev.azure.com/mseng/1ES/_workitems/edit/2159448
+        # failOnAlert: false
+        # This should be removed when failOnAlert works properly.
+        ignoreDirectories: '.packages'
     customBuildTags:
     - ES365AIMigrationTooling
     stages:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -32,8 +32,8 @@ variables:
     /p:dotnetbuilds-internal-container-read-token-base64=$(dotnetbuilds-internal-container-read-token-base64)
 # Only used for tracking purposes in MicroBuild tasks.
 # See: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/650/MicroBuild-Signing?anchor=high-level-steps-to-enable-signing
-- name: TeamName
-  value: DotNetCLI
+# - name: TeamName
+#   value: DotNetCLI
 
 # Variable Groups
 - group: DotNetBuilds storage account read tokens
@@ -89,204 +89,206 @@ extends:
             targetPath: $(Build.SourcesDirectory)\eng\buildConfiguration
             artifactName: buildConfiguration
 
-      # Windows
-      - template: eng/build.yml@self
-        parameters:
-          agentOs: Windows_NT
-          jobName: Build_Release_x64
-          buildConfiguration: Release
-          buildArchitecture: x64
-          additionalBuildParameters: '/p:PublishInternalAsset=true'
-          runTests: false
-      - template: eng/build.yml@self
-        parameters:
-          agentOs: Windows_NT
-          jobName: Build_Release_x86
-          buildConfiguration: Release
-          buildArchitecture: x86
-          runTests: false
-      - template: eng/build.yml@self
-        parameters:
-          agentOs: Windows_NT
-          jobName: Build_Release_arm64
-          buildConfiguration: Release
-          buildArchitecture: arm64
-          runTests: false
+      - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+        # Windows
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Windows_NT
+            jobName: Build_Release_x64
+            buildConfiguration: Release
+            buildArchitecture: x64
+            additionalBuildParameters: '/p:PublishInternalAsset=true'
+            runTests: false
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Windows_NT
+            jobName: Build_Release_x86
+            buildConfiguration: Release
+            buildArchitecture: x86
+            runTests: false
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Windows_NT
+            jobName: Build_Release_arm64
+            buildConfiguration: Release
+            buildArchitecture: arm64
+            runTests: false
 
-      # Linux
-      - template: eng/build.yml@self
-        parameters:
-          agentOs: Linux
-          jobName: Build_Arm_Release
-          buildConfiguration: Release
-          buildArchitecture: arm
-          runtimeIdentifier: 'linux-arm'
-          linuxPortable: true
-          runTests: false
-      - template: eng/build.yml@self
-        parameters:
-          agentOs: Linux
-          jobName: Build_Arm64_Release
-          buildConfiguration: Release
-          buildArchitecture: arm64
-          runtimeIdentifier: 'linux-arm64'
-          linuxPortable: true
-          runTests: false
-      - template: eng/build.yml@self
-        parameters:
-          agentOs: Linux
-          jobName: Build_Linux_musl_Release_arm
-          container: MuslArm
-          buildConfiguration: Release
-          buildArchitecture: arm
-          runtimeIdentifier: 'linux-musl-arm'
-          additionalBuildParameters: '/p:OSName="linux-musl"'
-          linuxPortable: false
-          runTests: false
-      - template: eng/build.yml@self
-        parameters:
-          agentOs: Linux
-          jobName: Build_Linux_musl_Release_arm64
-          buildConfiguration: Release
-          buildArchitecture: arm64
-          runtimeIdentifier: 'linux-musl-arm64'
-          additionalBuildParameters: '/p:OSName="linux-musl"'
-          linuxPortable: false
-          runTests: false
-      - template: eng/build.yml@self
-        parameters:
-          agentOs: Linux
-          jobName: Build_Linux_musl_Release_x64
-          container: MuslX64
-          buildConfiguration: Release
-          buildArchitecture: x64
-          runtimeIdentifier: 'linux-musl-x64'
-          # Pass in HostOSName when running on alpine
-          additionalBuildParameters: '/p:HostOSName="linux-musl"'
-          linuxPortable: false
-          runTests: false
-      - template: eng/build.yml@self
-        parameters:
-          agentOs: Linux
-          jobName: Build_Linux_Portable_Deb_Release_x64
-          container: PortableDeb
-          buildConfiguration: Release
-          buildArchitecture: x64
-          # Do not publish zips and tarballs. The linux-x64 binaries are
-          # already published by Build_LinuxPortable_Release_x64
-          additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:BuildSdkDeb=true'
-          linuxPortable: true
-          runTests: false
-      - template: eng/build.yml@self
-        parameters:
-          agentOs: Linux
-          jobName: Build_Linux_Portable_Rpm_Release_x64
-          container: PortableRpm
-          buildConfiguration: Release
-          buildArchitecture: x64
-          # Do not publish zips and tarballs. The linux-x64 binaries are
-          # already published by Build_LinuxPortable_Release_x64
-          additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:IsRPMBasedDistro=true'
-          linuxPortable: true
-          runTests: false
-      - template: eng/build.yml@self
-        parameters:
-          agentOs: Linux
-          jobName: Build_Linux_Portable_Rpm_Release_Arm64
-          container: PortableRpm
-          buildConfiguration: Release
-          buildArchitecture: arm64
-          runtimeIdentifier: 'linux-arm64'
-          # Do not publish zips and tarballs. The linux-x64 binaries are
-          # already published by Build_LinuxPortable_Release_x64
-          additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:CLIBUILD_SKIP_TESTS=true  /p:IsRPMBasedDistro=true'
-          linuxPortable: true
-          runTests: false
-      - template: eng/build.yml@self
-        parameters:
-          agentOs: Linux
-          jobName: Build_LinuxPortable_Release_x64
-          buildConfiguration: Release
-          buildArchitecture: x64
-          linuxPortable: true
-          runTests: false
+        # Linux
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_Arm_Release
+            buildConfiguration: Release
+            buildArchitecture: arm
+            runtimeIdentifier: 'linux-arm'
+            linuxPortable: true
+            runTests: false
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_Arm64_Release
+            buildConfiguration: Release
+            buildArchitecture: arm64
+            runtimeIdentifier: 'linux-arm64'
+            linuxPortable: true
+            runTests: false
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_Linux_musl_Release_arm
+            container: MuslArm
+            buildConfiguration: Release
+            buildArchitecture: arm
+            runtimeIdentifier: 'linux-musl-arm'
+            additionalBuildParameters: '/p:OSName="linux-musl"'
+            linuxPortable: false
+            runTests: false
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_Linux_musl_Release_arm64
+            buildConfiguration: Release
+            buildArchitecture: arm64
+            runtimeIdentifier: 'linux-musl-arm64'
+            additionalBuildParameters: '/p:OSName="linux-musl"'
+            linuxPortable: false
+            runTests: false
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_Linux_musl_Release_x64
+            container: MuslX64
+            buildConfiguration: Release
+            buildArchitecture: x64
+            runtimeIdentifier: 'linux-musl-x64'
+            # Pass in HostOSName when running on alpine
+            additionalBuildParameters: '/p:HostOSName="linux-musl"'
+            linuxPortable: false
+            runTests: false
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_Linux_Portable_Deb_Release_x64
+            container: PortableDeb
+            buildConfiguration: Release
+            buildArchitecture: x64
+            # Do not publish zips and tarballs. The linux-x64 binaries are
+            # already published by Build_LinuxPortable_Release_x64
+            additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:BuildSdkDeb=true'
+            linuxPortable: true
+            runTests: false
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_Linux_Portable_Rpm_Release_x64
+            container: PortableRpm
+            buildConfiguration: Release
+            buildArchitecture: x64
+            # Do not publish zips and tarballs. The linux-x64 binaries are
+            # already published by Build_LinuxPortable_Release_x64
+            additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:IsRPMBasedDistro=true'
+            linuxPortable: true
+            runTests: false
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_Linux_Portable_Rpm_Release_Arm64
+            container: PortableRpm
+            buildConfiguration: Release
+            buildArchitecture: arm64
+            runtimeIdentifier: 'linux-arm64'
+            # Do not publish zips and tarballs. The linux-x64 binaries are
+            # already published by Build_LinuxPortable_Release_x64
+            additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:CLIBUILD_SKIP_TESTS=true  /p:IsRPMBasedDistro=true'
+            linuxPortable: true
+            runTests: false
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_LinuxPortable_Release_x64
+            buildConfiguration: Release
+            buildArchitecture: x64
+            linuxPortable: true
+            runTests: false
 
-      # MacOS
-      - template: eng/build.yml@self
-        parameters:
-          agentOs: Darwin
-          jobName: Build_Release_x64
-          buildConfiguration: Release
-          buildArchitecture: x64
-          runTests: false
-      - template: eng/build.yml@self
-        parameters:
-          agentOs: Darwin
-          jobName: Build_Release_arm64
-          runtimeIdentifier: 'osx-arm64'
-          buildConfiguration: Release
-          buildArchitecture: arm64
-          runTests: false
+        # MacOS
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Darwin
+            jobName: Build_Release_x64
+            buildConfiguration: Release
+            buildArchitecture: x64
+            runTests: false
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Darwin
+            jobName: Build_Release_arm64
+            runtimeIdentifier: 'osx-arm64'
+            buildConfiguration: Release
+            buildArchitecture: arm64
+            runTests: false
 
-      # Windows PGO Instrumentation
-      - template: eng/build.yml@self
-        parameters:
-          agentOs: Windows_NT
-          pgoInstrument: true
-          jobName: Build_Release_x64
-          buildConfiguration: Release
-          buildArchitecture: x64
-          additionalBuildParameters: '/p:PublishInternalAsset=true'
-          runTests: false
-      - template: eng/build.yml@self
-        parameters:
-          agentOs: Windows_NT
-          pgoInstrument: true
-          jobName: Build_Release_x86
-          buildConfiguration: Release
-          buildArchitecture: x86
-          runTests: false
-      - template: eng/build.yml@self
-        parameters:
-          agentOs: Windows_NT
-          pgoInstrument: true
-          jobName: Build_Release_arm64
-          buildConfiguration: Release
-          buildArchitecture: arm64
-          runTests: false
+        # Windows PGO Instrumentation
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Windows_NT
+            pgoInstrument: true
+            jobName: Build_Release_x64
+            buildConfiguration: Release
+            buildArchitecture: x64
+            additionalBuildParameters: '/p:PublishInternalAsset=true'
+            runTests: false
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Windows_NT
+            pgoInstrument: true
+            jobName: Build_Release_x86
+            buildConfiguration: Release
+            buildArchitecture: x86
+            runTests: false
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Windows_NT
+            pgoInstrument: true
+            jobName: Build_Release_arm64
+            buildConfiguration: Release
+            buildArchitecture: arm64
+            runTests: false
 
-      # Linux PGO Instrumentation
-      - template: eng/build.yml@self
-        parameters:
-          agentOs: Linux
-          pgoInstrument: true
-          jobName: Build_LinuxPortable_Release_x64
-          buildConfiguration: Release
-          buildArchitecture: x64
-          linuxPortable: true
-          runTests: false
-      - template: eng/build.yml@self
-        parameters:
-          agentOs: Linux
-          pgoInstrument: true
-          jobName: Build_Release_arm64
-          buildConfiguration: Release
-          buildArchitecture: arm64
-          linuxPortable: true
-          runTests: false
+        # Linux PGO Instrumentation
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            pgoInstrument: true
+            jobName: Build_LinuxPortable_Release_x64
+            buildConfiguration: Release
+            buildArchitecture: x64
+            linuxPortable: true
+            runTests: false
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            pgoInstrument: true
+            jobName: Build_Release_arm64
+            buildConfiguration: Release
+            buildArchitecture: arm64
+            linuxPortable: true
+            runTests: false
 
-      # Source Build
-      - template: /eng/common/templates-official/jobs/source-build.yml@self
+        # Source Build
+        - template: /eng/common/templates-official/jobs/source-build.yml@self
 
-    - stage: Publish
-      dependsOn:
-      - Build
-      jobs:
-      - template: /eng/common/templates-official/job/publish-build-assets.yml@self
-        parameters:
-          publishUsingPipelines: true
-          publishAssetsImmediately: true
-          pool:
-            ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+    - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+      - stage: Publish
+        dependsOn:
+        - Build
+        jobs:
+        - template: /eng/common/templates-official/job/publish-build-assets.yml@self
+          parameters:
+            publishUsingPipelines: true
+            publishAssetsImmediately: true
+            pool:
               name: $(DncEngInternalBuildPool)
-              demands: ImageOverride -equals windows.vs2022.amd64
+              image: 1es-windows-2022-pt
+              os: windows

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -25,11 +25,14 @@ variables:
   - group: DotNet-Installer-SDLValidation-Params
   - name: _PublishUsingPipelines
     value: true
-- group: DotNetBuilds storage account read tokens
 - name: _InternalRuntimeDownloadArgs
-  value: /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal
-    /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
-    /p:dotnetbuilds-internal-container-read-token-base64=$(dotnetbuilds-internal-container-read-token-base64)
+  value: ''
+- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+  - group: DotNetBuilds storage account read tokens
+  - name: _InternalRuntimeDownloadArgs
+    value: /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal
+      /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
+      /p:dotnetbuilds-internal-container-read-token-base64=$(dotnetbuilds-internal-container-read-token-base64)
 - template: /eng/common/templates-official/variables/pool-providers.yml
 
 resources:
@@ -91,9 +94,14 @@ extends:
       # Build Retry Configuration
       - job: Publish_Build_Configuration
         pool:
-          name: $(DncEngInternalBuildPool)
-          image: windows.vs2022preview.amd64
-          os: windows
+          ${{ if eq(variables['System.TeamProject'], 'public') }}:
+            name: $(DncEngPublicBuildPool)
+            image: windows.vs2022preview.amd64.open
+            os: windows
+          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+            name: $(DncEngInternalBuildPool)
+            image: windows.vs2022preview.amd64
+            os: windows
         steps:
         - task: 1ES.PublishPipelineArtifact@1
           displayName: Publish Build Config

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -62,22 +62,22 @@ extends:
       #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine
       # ubuntu2204DebPkg:
       #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
-      - container: alpine319WithNode
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
-      - container: cblMariner20Fpm
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
-      - container: centosStream8
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8
-      - container: debian11Amd64
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-amd64
-      - container: fedora39
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-39
-      - container: ubuntu2204
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04
-      - container: ubuntu2204CrossArmAlpine
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine
-      - container: ubuntu2204DebPkg
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
+    - container: alpine319WithNode
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
+    - container: cblMariner20Fpm
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
+    - container: centosStream8
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8
+    - container: debian11Amd64
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-amd64
+    - container: fedora39
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-39
+    - container: ubuntu2204
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04
+    - container: ubuntu2204CrossArmAlpine
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine
+    - container: ubuntu2204DebPkg
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
     sdl:
       sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -62,17 +62,17 @@ resources:
   #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
 
 extends:
-  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
-    containers:
-    - container: MuslArm
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine
-    - container: MuslX64
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
-    - container: PortableDeb
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
-    - container: PortableRpm
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
+    # containers:
+    # - container: MuslArm
+    #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine
+    # - container: MuslX64
+    #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
+    # - container: PortableDeb
+    #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
+    # - container: PortableRpm
+    #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
     sdl:
       sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)
@@ -149,7 +149,8 @@ extends:
         parameters:
           agentOs: Linux
           jobName: Build_Linux_musl_Release_arm
-          container: MuslArm
+          # container: MuslArm
+          container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine
           buildConfiguration: Release
           buildArchitecture: arm
           runtimeIdentifier: 'linux-musl-arm'
@@ -170,7 +171,8 @@ extends:
         parameters:
           agentOs: Linux
           jobName: Build_Linux_musl_Release_x64
-          container: MuslX64
+          # container: MuslX64
+          container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
           buildConfiguration: Release
           buildArchitecture: x64
           runtimeIdentifier: 'linux-musl-x64'
@@ -182,7 +184,8 @@ extends:
         parameters:
           agentOs: Linux
           jobName: Build_Linux_Portable_Deb_Release_x64
-          container: PortableDeb
+          # container: PortableDeb
+          container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
           buildConfiguration: Release
           buildArchitecture: x64
           # Do not publish zips and tarballs. The linux-x64 binaries are
@@ -194,7 +197,8 @@ extends:
         parameters:
           agentOs: Linux
           jobName: Build_Linux_Portable_Rpm_Release_x64
-          container: PortableRpm
+          # container: PortableRpm
+          container: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
           buildConfiguration: Release
           buildArchitecture: x64
           # Do not publish zips and tarballs. The linux-x64 binaries are
@@ -206,7 +210,8 @@ extends:
         parameters:
           agentOs: Linux
           jobName: Build_Linux_Portable_Rpm_Release_Arm64
-          container: PortableRpm
+          # container: PortableRpm
+          container: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
           buildConfiguration: Release
           buildArchitecture: arm64
           runtimeIdentifier: 'linux-arm64'

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -265,13 +265,13 @@ extends:
           runTests: false
 
       # Source Build
-      - template: /eng/common/templates-official/jobs/source-build.yml
+      - template: /eng/common/templates-official/jobs/source-build.yml@self
 
     - stage: Publish
       dependsOn:
       - Build
       jobs:
-      - template: /eng/common/templates-official/job/publish-build-assets.yml
+      - template: /eng/common/templates-official/job/publish-build-assets.yml@self
         parameters:
           publishUsingPipelines: true
           publishAssetsImmediately: true

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -46,42 +46,26 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
     containers:
-      # alpine319WithNode:
-      #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
-      # cblMariner20Fpm:
-      #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
-      # centosStream8:
-      #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8
-      # debian11Amd64:
-      #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-amd64
-      # fedora39:
-      #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-39
-      # ubuntu2204:
-      #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04
-      # ubuntu2204CrossArmAlpine:
-      #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine
-      # ubuntu2204DebPkg:
-      #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
-    - container: alpine319WithNode
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
-    - container: cblMariner20Fpm
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
-    - container: centosStream8
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8
-    - container: debian11Amd64
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-amd64
-    - container: fedora39
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-39
-    - container: ubuntu2204
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04
-    - container: ubuntu2204CrossArmAlpine
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine
-    - container: ubuntu2204DebPkg
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
+      alpine319WithNode:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
+      cblMariner20Fpm:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
+      centosStream8:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8
+      debian11Amd64:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-amd64
+      fedora39:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-39
+      ubuntu2204:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04
+      ubuntu2204CrossArmAlpine:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine
+      ubuntu2204DebPkg:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
     sdl:
       sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)
-        image: windows.vs2022preview.amd64
+        image: 1es-windows-2022
         os: windows
       # https://docs.opensource.microsoft.com/tools/cg/component-detection/variables/
       componentgovernance:
@@ -96,11 +80,11 @@ extends:
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: $(DncEngPublicBuildPool)
-            image: windows.vs2022preview.amd64.open
+            image: 1es-windows-2022-open
             os: windows
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
             name: $(DncEngInternalBuildPool)
-            image: windows.vs2022preview.amd64
+            image: 1es-windows-2022
             os: windows
         steps:
         - task: 1ES.PublishPipelineArtifact@1
@@ -401,5 +385,5 @@ extends:
             publishAssetsImmediately: true
             pool:
               name: $(DncEngInternalBuildPool)
-              image: windows.vs2022preview.amd64
+              image: 1es-windows-2022
               os: windows

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -43,21 +43,37 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
     containers:
-      alpine319WithNode:
+      # alpine319WithNode:
+      #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
+      # cblMariner20Fpm:
+      #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
+      # centosStream8:
+      #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8
+      # debian11Amd64:
+      #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-amd64
+      # fedora39:
+      #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-39
+      # ubuntu2204:
+      #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04
+      # ubuntu2204CrossArmAlpine:
+      #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine
+      # ubuntu2204DebPkg:
+      #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
+      - container: alpine319WithNode
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
-      cblMariner20Fpm:
+      - container: cblMariner20Fpm
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
-      centosStream8:
+      - container: centosStream8
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8
-      debian11Amd64:
+      - container: debian11Amd64
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-amd64
-      fedora39:
+      - container: fedora39
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-39
-      ubuntu2204:
+      - container: ubuntu2204
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04
-      ubuntu2204CrossArmAlpine:
+      - container: ubuntu2204CrossArmAlpine
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine
-      ubuntu2204DebPkg:
+      - container: ubuntu2204DebPkg
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
     sdl:
       sourceAnalysisPool:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -60,15 +60,6 @@ resources:
 extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
-    containers:
-      - container: MuslArm
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine
-      - container: MuslX64
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
-      - container: PortableDeb
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
-      - container: PortableRpm
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
     sdl:
       sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -79,7 +79,7 @@ extends:
           displayName: Publish Build Config
 
       # Windows
-      - template: eng/build.yml
+      - template: eng/build.yml@self
         parameters:
           agentOs: Windows_NT
           jobName: Build_Release_x64
@@ -87,14 +87,14 @@ extends:
           buildArchitecture: x64
           additionalBuildParameters: '/p:PublishInternalAsset=true'
           runTests: false
-      - template: eng/build.yml
+      - template: eng/build.yml@self
         parameters:
           agentOs: Windows_NT
           jobName: Build_Release_x86
           buildConfiguration: Release
           buildArchitecture: x86
           runTests: false
-      - template: eng/build.yml
+      - template: eng/build.yml@self
         parameters:
           agentOs: Windows_NT
           jobName: Build_Release_arm64
@@ -103,7 +103,7 @@ extends:
           runTests: false
 
       # Linux
-      - template: eng/build.yml
+      - template: eng/build.yml@self
         parameters:
           agentOs: Linux
           jobName: Build_Arm_Release
@@ -112,7 +112,7 @@ extends:
           runtimeIdentifier: 'linux-arm'
           linuxPortable: true
           runTests: false
-      - template: eng/build.yml
+      - template: eng/build.yml@self
         parameters:
           agentOs: Linux
           jobName: Build_Arm64_Release
@@ -121,7 +121,7 @@ extends:
           runtimeIdentifier: 'linux-arm64'
           linuxPortable: true
           runTests: false
-      - template: eng/build.yml
+      - template: eng/build.yml@self
         parameters:
           agentOs: Linux
           jobName: Build_Linux_musl_Release_arm
@@ -132,7 +132,7 @@ extends:
           additionalBuildParameters: '/p:OSName="linux-musl"'
           linuxPortable: false
           runTests: false
-      - template: eng/build.yml
+      - template: eng/build.yml@self
         parameters:
           agentOs: Linux
           jobName: Build_Linux_musl_Release_arm64
@@ -142,7 +142,7 @@ extends:
           additionalBuildParameters: '/p:OSName="linux-musl"'
           linuxPortable: false
           runTests: false
-      - template: eng/build.yml
+      - template: eng/build.yml@self
         parameters:
           agentOs: Linux
           jobName: Build_Linux_musl_Release_x64
@@ -154,7 +154,7 @@ extends:
           additionalBuildParameters: '/p:HostOSName="linux-musl"'
           linuxPortable: false
           runTests: false
-      - template: eng/build.yml
+      - template: eng/build.yml@self
         parameters:
           agentOs: Linux
           jobName: Build_Linux_Portable_Deb_Release_x64
@@ -166,7 +166,7 @@ extends:
           additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:BuildSdkDeb=true'
           linuxPortable: true
           runTests: false
-      - template: eng/build.yml
+      - template: eng/build.yml@self
         parameters:
           agentOs: Linux
           jobName: Build_Linux_Portable_Rpm_Release_x64
@@ -178,7 +178,7 @@ extends:
           additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:IsRPMBasedDistro=true'
           linuxPortable: true
           runTests: false
-      - template: eng/build.yml
+      - template: eng/build.yml@self
         parameters:
           agentOs: Linux
           jobName: Build_Linux_Portable_Rpm_Release_Arm64
@@ -191,7 +191,7 @@ extends:
           additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:CLIBUILD_SKIP_TESTS=true  /p:IsRPMBasedDistro=true'
           linuxPortable: true
           runTests: false
-      - template: eng/build.yml
+      - template: eng/build.yml@self
         parameters:
           agentOs: Linux
           jobName: Build_LinuxPortable_Release_x64
@@ -201,14 +201,14 @@ extends:
           runTests: false
 
       # MacOS
-      - template: eng/build.yml
+      - template: eng/build.yml@self
         parameters:
           agentOs: Darwin
           jobName: Build_Release_x64
           buildConfiguration: Release
           buildArchitecture: x64
           runTests: false
-      - template: eng/build.yml
+      - template: eng/build.yml@self
         parameters:
           agentOs: Darwin
           jobName: Build_Release_arm64
@@ -218,7 +218,7 @@ extends:
           runTests: false
 
       # Windows PGO Instrumentation
-      - template: eng/build.yml
+      - template: eng/build.yml@self
         parameters:
           agentOs: Windows_NT
           pgoInstrument: true
@@ -227,7 +227,7 @@ extends:
           buildArchitecture: x64
           additionalBuildParameters: '/p:PublishInternalAsset=true'
           runTests: false
-      - template: eng/build.yml
+      - template: eng/build.yml@self
         parameters:
           agentOs: Windows_NT
           pgoInstrument: true
@@ -235,7 +235,7 @@ extends:
           buildConfiguration: Release
           buildArchitecture: x86
           runTests: false
-      - template: eng/build.yml
+      - template: eng/build.yml@self
         parameters:
           agentOs: Windows_NT
           pgoInstrument: true
@@ -245,7 +245,7 @@ extends:
           runTests: false
 
       # Linux PGO Instrumentation
-      - template: eng/build.yml
+      - template: eng/build.yml@self
         parameters:
           agentOs: Linux
           pgoInstrument: true
@@ -254,7 +254,7 @@ extends:
           buildArchitecture: x64
           linuxPortable: true
           runTests: false
-      - template: eng/build.yml
+      - template: eng/build.yml@self
         parameters:
           agentOs: Linux
           pgoInstrument: true

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -68,7 +68,8 @@ extends:
         image: 1es-windows-2022
         os: windows
       # https://docs.opensource.microsoft.com/tools/cg/component-detection/variables/
-      # componentgovernance:
+      componentgovernance:
+        failOnAlert: false
       #   ignoreDirectories: '.packages'
     customBuildTags:
     - ES365AIMigrationTooling

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,3 +1,5 @@
+# Pipeline: https://dnceng.visualstudio.com/internal/_build?definitionId=286
+
 trigger:
   batch: true
   branches:
@@ -8,6 +10,7 @@ trigger:
     - internal/release/*
 
 variables:
+# Loose Variables
 - name: _PublishUsingPipelines
   value: false
 - ${{ if or(startswith(variables['Build.SourceBranch'], 'refs/heads/release/'), startswith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), eq(variables['Build.Reason'], 'Manual')) }}:
@@ -23,10 +26,14 @@ variables:
   - group: DotNet-Installer-SDLValidation-Params
   - name: _PublishUsingPipelines
     value: true
-
 - name: _InternalRuntimeDownloadArgs
   value: ''
+# Only used for tracking purposes in MicroBuild tasks.
+# See: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/650/MicroBuild-Signing?anchor=high-level-steps-to-enable-signing
+- name: TeamName
+  value: DotNetCLI
 
+# Variable Groups
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNetBuilds storage account read tokens
   - name: _InternalRuntimeDownloadArgs
@@ -34,328 +41,241 @@ variables:
       /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
       /p:dotnetbuilds-internal-container-read-token-base64=$(dotnetbuilds-internal-container-read-token-base64)
 
-- template: /eng/common/templates/variables/pool-providers.yml
+# Variable Templates
+- template: /eng/common/templates-official/variables/pool-providers.yml
 
-stages:
-- stage: Build
-  jobs:
-  # This job is for build retry configuration.
-  - job: Publish_Build_Configuration
-    pool:
-      ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: $(DncEngPublicBuildPool)
-        demands: ImageOverride -equals windows.vs2022preview.amd64.open
-      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+resources:
+  repositories:
+  - repository: MicroBuildTemplate
+    type: git
+    name: 1ESPipelineTemplates/MicroBuildTemplate
+    ref: refs/tags/release
+
+extends:
+  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
+  parameters:
+    sdl:
+      sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)
-        demands: ImageOverride -equals windows.vs2022preview.amd64
-    steps:
-    - publish: $(Build.SourcesDirectory)\eng\buildConfiguration
-      artifact: buildConfiguration
-      displayName: Publish Build Config
-  
-  ## PR-only jobs
-  
-  - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-    
-    ## Windows
-
-    - template: eng/build.yml
-      parameters:
-        agentOs: Windows_NT
-        jobName: Build_Debug_x64
-        buildConfiguration: Debug
-        buildArchitecture: x64
-        additionalBuildParameters: '/p:PublishInternalAsset=true'
-        runTests: true
-
-    ## Linux
-
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_Ubuntu_22_04_Debug_x64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04'
-        buildConfiguration: Debug
-        buildArchitecture: x64
-        linuxPortable: true
-        runTests: true
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_Fedora_39_Debug_x64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-39'
-        buildConfiguration: Debug
-        buildArchitecture: x64
-        linuxPortable: true
-        runTests: true
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_CentOS_8_Stream_Debug_x64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8'
-        buildConfiguration: Debug
-        buildArchitecture: x64
-        linuxPortable: false
-        runTests: true
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_Debian_11_Debug_x64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-amd64'
-        buildConfiguration: Debug
-        buildArchitecture: x64
-        additionalBuildParameters: '/p:BuildSdkDeb=true'
-        linuxPortable: false
-        runTests: true
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_Arm64_Debug
-        buildConfiguration: Debug
-        buildArchitecture: arm64
-        runtimeIdentifier: 'linux-arm64'
-        linuxPortable: true
-        # Never run tests on arm64
-        runTests: false
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_Linux_musl_Debug_x64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode'
-        buildConfiguration: Debug
-        buildArchitecture: x64
-        runtimeIdentifier: 'linux-musl-x64'
-        # Pass in HostOSName when running on alpine
-        additionalBuildParameters: '/p:HostOSName="linux-musl"'
-        linuxPortable: false
-        runTests: true
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_LinuxPortable_Release_x64
-        buildConfiguration: Release
-        buildArchitecture: x64
-        linuxPortable: true
-        runTests: true
-
-    # MacOS
-
-    - template: eng/build.yml
-      parameters:
-        agentOs: Darwin
-        jobName: Build_Release_x64
-        buildConfiguration: Release
-        buildArchitecture: x64
-        runTests: true
-
-  ## Official/PGO instrumentation Builds
-  
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    
-    ## Windows
-
-    - template: eng/build.yml
-      parameters:
-        agentOs: Windows_NT
-        jobName: Build_Release_x64
-        buildConfiguration: Release
-        buildArchitecture: x64
-        additionalBuildParameters: '/p:PublishInternalAsset=true'
-        runTests: false
-    - template: eng/build.yml
-      parameters:
-        agentOs: Windows_NT
-        jobName: Build_Release_x86
-        buildConfiguration: Release
-        buildArchitecture: x86
-        runTests: false
-    - template: eng/build.yml
-      parameters:
-        agentOs: Windows_NT
-        jobName: Build_Release_arm64
-        buildConfiguration: Release
-        buildArchitecture: arm64
-        runTests: false
-
-    ## Linux 
-
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_Arm_Release
-        buildConfiguration: Release
-        buildArchitecture: arm
-        runtimeIdentifier: 'linux-arm'
-        linuxPortable: true
-        runTests: false
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_Arm64_Release
-        buildConfiguration: Release
-        buildArchitecture: arm64
-        runtimeIdentifier: 'linux-arm64'
-        linuxPortable: true
-        runTests: false
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_Linux_musl_Release_arm
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine'
-        buildConfiguration: Release
-        buildArchitecture: arm
-        runtimeIdentifier: 'linux-musl-arm'
-        additionalBuildParameters: '/p:OSName="linux-musl"'
-        linuxPortable: false
-        runTests: false
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_Linux_musl_Release_arm64
-        buildConfiguration: Release
-        buildArchitecture: arm64
-        runtimeIdentifier: 'linux-musl-arm64'
-        additionalBuildParameters: '/p:OSName="linux-musl"'
-        linuxPortable: false
-        runTests: false
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_Linux_musl_Release_x64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode'
-        buildConfiguration: Release
-        buildArchitecture: x64
-        runtimeIdentifier: 'linux-musl-x64'
-        # Pass in HostOSName when running on alpine
-        additionalBuildParameters: '/p:HostOSName="linux-musl"'
-        linuxPortable: false
-        runTests: false
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_Linux_Portable_Deb_Release_x64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg'
-        buildConfiguration: Release
-        buildArchitecture: x64
-        # Do not publish zips and tarballs. The linux-x64 binaries are
-        # already published by Build_LinuxPortable_Release_x64
-        additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:BuildSdkDeb=true'
-        linuxPortable: true
-        runTests: false
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_Linux_Portable_Rpm_Release_x64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm'
-        buildConfiguration: Release
-        buildArchitecture: x64
-        # Do not publish zips and tarballs. The linux-x64 binaries are
-        # already published by Build_LinuxPortable_Release_x64
-        additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:IsRPMBasedDistro=true'
-        linuxPortable: true
-        runTests: false
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_Linux_Portable_Rpm_Release_Arm64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm'
-        buildConfiguration: Release
-        buildArchitecture: arm64
-        runtimeIdentifier: 'linux-arm64'
-        # Do not publish zips and tarballs. The linux-x64 binaries are
-        # already published by Build_LinuxPortable_Release_x64
-        additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:CLIBUILD_SKIP_TESTS=true  /p:IsRPMBasedDistro=true'
-        linuxPortable: true
-        runTests: false
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_LinuxPortable_Release_x64
-        buildConfiguration: Release
-        buildArchitecture: x64
-        linuxPortable: true
-        runTests: false
-
-    # MacOS
-
-    - template: eng/build.yml
-      parameters:
-        agentOs: Darwin
-        jobName: Build_Release_x64
-        buildConfiguration: Release
-        buildArchitecture: x64
-        runTests: false
-    - template: eng/build.yml
-      parameters:
-        agentOs: Darwin
-        jobName: Build_Release_arm64
-        runtimeIdentifier: 'osx-arm64'
-        buildConfiguration: Release
-        buildArchitecture: arm64
-        runTests: false
-
-    ## Windows PGO Instrumentation builds
-
-    - template: eng/build.yml
-      parameters:
-        agentOs: Windows_NT
-        pgoInstrument: true
-        jobName: Build_Release_x64
-        buildConfiguration: Release
-        buildArchitecture: x64
-        additionalBuildParameters: '/p:PublishInternalAsset=true'
-        runTests: false
-    - template: eng/build.yml
-      parameters:
-        agentOs: Windows_NT
-        pgoInstrument: true
-        jobName: Build_Release_x86
-        buildConfiguration: Release
-        buildArchitecture: x86
-        runTests: false
-    - template: eng/build.yml
-      parameters:
-        agentOs: Windows_NT
-        pgoInstrument: true
-        jobName: Build_Release_arm64
-        buildConfiguration: Release
-        buildArchitecture: arm64
-        runTests: false
-
-    ## Linux PGO Instrumentation builds
-
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        pgoInstrument: true
-        jobName: Build_LinuxPortable_Release_x64
-        buildConfiguration: Release
-        buildArchitecture: x64
-        linuxPortable: true
-        runTests: false
-
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        pgoInstrument: true
-        jobName: Build_Release_arm64
-        buildConfiguration: Release
-        buildArchitecture: arm64
-        linuxPortable: true
-        runTests: false
-
-  - template: /eng/common/templates/jobs/source-build.yml
-
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - stage: Publish
-    dependsOn:
-    - Build
-    jobs:
-    - template: /eng/common/templates/job/publish-build-assets.yml
-      parameters:
-        publishUsingPipelines: true
-        publishAssetsImmediately: true
+        image: 1es-windows-2022-pt
+        os: windows
+    customBuildTags:
+    - ES365AIMigrationTooling
+    stages:
+    - stage: Build
+      jobs:
+      # Build Retry Configuration
+      - job: Publish_Build_Configuration
         pool:
+          ${{ if eq(variables['System.TeamProject'], 'public') }}:
+            name: $(DncEngPublicBuildPool)
+            demands: ImageOverride -equals windows.vs2022preview.amd64.open
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.vs2022.amd64
+            demands: ImageOverride -equals windows.vs2022preview.amd64
+        steps:
+        - publish: $(Build.SourcesDirectory)\eng\buildConfiguration
+          artifact: buildConfiguration
+          displayName: Publish Build Config
+
+      # Windows
+      - template: eng/build.yml
+        parameters:
+          agentOs: Windows_NT
+          jobName: Build_Release_x64
+          buildConfiguration: Release
+          buildArchitecture: x64
+          additionalBuildParameters: '/p:PublishInternalAsset=true'
+          runTests: false
+      - template: eng/build.yml
+        parameters:
+          agentOs: Windows_NT
+          jobName: Build_Release_x86
+          buildConfiguration: Release
+          buildArchitecture: x86
+          runTests: false
+      - template: eng/build.yml
+        parameters:
+          agentOs: Windows_NT
+          jobName: Build_Release_arm64
+          buildConfiguration: Release
+          buildArchitecture: arm64
+          runTests: false
+
+      # Linux
+      - template: eng/build.yml
+        parameters:
+          agentOs: Linux
+          jobName: Build_Arm_Release
+          buildConfiguration: Release
+          buildArchitecture: arm
+          runtimeIdentifier: 'linux-arm'
+          linuxPortable: true
+          runTests: false
+      - template: eng/build.yml
+        parameters:
+          agentOs: Linux
+          jobName: Build_Arm64_Release
+          buildConfiguration: Release
+          buildArchitecture: arm64
+          runtimeIdentifier: 'linux-arm64'
+          linuxPortable: true
+          runTests: false
+      - template: eng/build.yml
+        parameters:
+          agentOs: Linux
+          jobName: Build_Linux_musl_Release_arm
+          container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine'
+          buildConfiguration: Release
+          buildArchitecture: arm
+          runtimeIdentifier: 'linux-musl-arm'
+          additionalBuildParameters: '/p:OSName="linux-musl"'
+          linuxPortable: false
+          runTests: false
+      - template: eng/build.yml
+        parameters:
+          agentOs: Linux
+          jobName: Build_Linux_musl_Release_arm64
+          buildConfiguration: Release
+          buildArchitecture: arm64
+          runtimeIdentifier: 'linux-musl-arm64'
+          additionalBuildParameters: '/p:OSName="linux-musl"'
+          linuxPortable: false
+          runTests: false
+      - template: eng/build.yml
+        parameters:
+          agentOs: Linux
+          jobName: Build_Linux_musl_Release_x64
+          container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode'
+          buildConfiguration: Release
+          buildArchitecture: x64
+          runtimeIdentifier: 'linux-musl-x64'
+          # Pass in HostOSName when running on alpine
+          additionalBuildParameters: '/p:HostOSName="linux-musl"'
+          linuxPortable: false
+          runTests: false
+      - template: eng/build.yml
+        parameters:
+          agentOs: Linux
+          jobName: Build_Linux_Portable_Deb_Release_x64
+          container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg'
+          buildConfiguration: Release
+          buildArchitecture: x64
+          # Do not publish zips and tarballs. The linux-x64 binaries are
+          # already published by Build_LinuxPortable_Release_x64
+          additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:BuildSdkDeb=true'
+          linuxPortable: true
+          runTests: false
+      - template: eng/build.yml
+        parameters:
+          agentOs: Linux
+          jobName: Build_Linux_Portable_Rpm_Release_x64
+          container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm'
+          buildConfiguration: Release
+          buildArchitecture: x64
+          # Do not publish zips and tarballs. The linux-x64 binaries are
+          # already published by Build_LinuxPortable_Release_x64
+          additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:IsRPMBasedDistro=true'
+          linuxPortable: true
+          runTests: false
+      - template: eng/build.yml
+        parameters:
+          agentOs: Linux
+          jobName: Build_Linux_Portable_Rpm_Release_Arm64
+          container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm'
+          buildConfiguration: Release
+          buildArchitecture: arm64
+          runtimeIdentifier: 'linux-arm64'
+          # Do not publish zips and tarballs. The linux-x64 binaries are
+          # already published by Build_LinuxPortable_Release_x64
+          additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:CLIBUILD_SKIP_TESTS=true  /p:IsRPMBasedDistro=true'
+          linuxPortable: true
+          runTests: false
+      - template: eng/build.yml
+        parameters:
+          agentOs: Linux
+          jobName: Build_LinuxPortable_Release_x64
+          buildConfiguration: Release
+          buildArchitecture: x64
+          linuxPortable: true
+          runTests: false
+
+      # MacOS
+      - template: eng/build.yml
+        parameters:
+          agentOs: Darwin
+          jobName: Build_Release_x64
+          buildConfiguration: Release
+          buildArchitecture: x64
+          runTests: false
+      - template: eng/build.yml
+        parameters:
+          agentOs: Darwin
+          jobName: Build_Release_arm64
+          runtimeIdentifier: 'osx-arm64'
+          buildConfiguration: Release
+          buildArchitecture: arm64
+          runTests: false
+
+      # Windows PGO Instrumentation
+      - template: eng/build.yml
+        parameters:
+          agentOs: Windows_NT
+          pgoInstrument: true
+          jobName: Build_Release_x64
+          buildConfiguration: Release
+          buildArchitecture: x64
+          additionalBuildParameters: '/p:PublishInternalAsset=true'
+          runTests: false
+      - template: eng/build.yml
+        parameters:
+          agentOs: Windows_NT
+          pgoInstrument: true
+          jobName: Build_Release_x86
+          buildConfiguration: Release
+          buildArchitecture: x86
+          runTests: false
+      - template: eng/build.yml
+        parameters:
+          agentOs: Windows_NT
+          pgoInstrument: true
+          jobName: Build_Release_arm64
+          buildConfiguration: Release
+          buildArchitecture: arm64
+          runTests: false
+
+      # Linux PGO Instrumentation
+      - template: eng/build.yml
+        parameters:
+          agentOs: Linux
+          pgoInstrument: true
+          jobName: Build_LinuxPortable_Release_x64
+          buildConfiguration: Release
+          buildArchitecture: x64
+          linuxPortable: true
+          runTests: false
+      - template: eng/build.yml
+        parameters:
+          agentOs: Linux
+          pgoInstrument: true
+          jobName: Build_Release_arm64
+          buildConfiguration: Release
+          buildArchitecture: arm64
+          linuxPortable: true
+          runTests: false
+
+      # Source Build
+      - template: /eng/common/templates-official/jobs/source-build.yml
+
+    - stage: Publish
+      dependsOn:
+      - Build
+      jobs:
+      - template: /eng/common/templates-official/job/publish-build-assets.yml
+        parameters:
+          publishUsingPipelines: true
+          publishAssetsImmediately: true
+          pool:
+            ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+              name: $(DncEngInternalBuildPool)
+              demands: ImageOverride -equals windows.vs2022.amd64

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -60,7 +60,15 @@ resources:
 extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
-    containers: ${{ resources.containers }}
+    containers:
+      - container: MuslArm
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine
+      - container: MuslX64
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
+      - container: PortableDeb
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
+      - container: PortableRpm
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
     sdl:
       sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -68,8 +68,8 @@ extends:
         image: 1es-windows-2022
         os: windows
       # https://docs.opensource.microsoft.com/tools/cg/component-detection/variables/
-      componentgovernance:
-        ignoreDirectories: '.packages'
+      # componentgovernance:
+      #   ignoreDirectories: '.packages'
     customBuildTags:
     - ES365AIMigrationTooling
     stages:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -51,14 +51,18 @@ resources:
 extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
+    # TODO: Temporary
+    enableComponentGovernanceScan: false
     sdl:
       sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)
         image: 1es-windows-2022-pt
         os: windows
       # TODO: Temporary
+      # https://docs.opensource.microsoft.com/tools/cg/component-detection/variables/
       componentgovernance:
         failOnAlert: false
+        alertWarningLevel: Never
     customBuildTags:
     - ES365AIMigrationTooling
     stages:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -47,10 +47,10 @@ resources:
     type: git
     name: 1ESPipelineTemplates/MicroBuildTemplate
     ref: refs/tags/release
-  # - repository: 1esPipelines
-  #   type: git
-  #   name: 1ESPipelineTemplates/1ESPipelineTemplates
-  #   ref: refs/tags/release
+  - repository: 1esPipelines
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
   # containers:
   # - container: MuslArm
   #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine
@@ -62,7 +62,8 @@ resources:
   #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
 
 extends:
-  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
+  # template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
     # containers:
     # - container: MuslArm
@@ -73,6 +74,15 @@ extends:
     #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
     # - container: PortableRpm
     #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
+    containers:
+      MuslArm:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine
+      MuslX64:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
+      PortableDeb:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
+      PortableRpm:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
     sdl:
       sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)
@@ -149,8 +159,8 @@ extends:
         parameters:
           agentOs: Linux
           jobName: Build_Linux_musl_Release_arm
-          # container: MuslArm
-          container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine
+          container: MuslArm
+          # container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine
           buildConfiguration: Release
           buildArchitecture: arm
           runtimeIdentifier: 'linux-musl-arm'
@@ -171,8 +181,8 @@ extends:
         parameters:
           agentOs: Linux
           jobName: Build_Linux_musl_Release_x64
-          # container: MuslX64
-          container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
+          container: MuslX64
+          # container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
           buildConfiguration: Release
           buildArchitecture: x64
           runtimeIdentifier: 'linux-musl-x64'
@@ -184,8 +194,8 @@ extends:
         parameters:
           agentOs: Linux
           jobName: Build_Linux_Portable_Deb_Release_x64
-          # container: PortableDeb
-          container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
+          container: PortableDeb
+          # container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
           buildConfiguration: Release
           buildArchitecture: x64
           # Do not publish zips and tarballs. The linux-x64 binaries are
@@ -197,8 +207,8 @@ extends:
         parameters:
           agentOs: Linux
           jobName: Build_Linux_Portable_Rpm_Release_x64
-          # container: PortableRpm
-          container: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
+          container: PortableRpm
+          # container: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
           buildConfiguration: Release
           buildArchitecture: x64
           # Do not publish zips and tarballs. The linux-x64 binaries are
@@ -210,8 +220,8 @@ extends:
         parameters:
           agentOs: Linux
           jobName: Build_Linux_Portable_Rpm_Release_Arm64
-          # container: PortableRpm
-          container: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
+          container: PortableRpm
+          # container: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
           buildConfiguration: Release
           buildArchitecture: arm64
           runtimeIdentifier: 'linux-arm64'

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -47,19 +47,32 @@ resources:
     type: git
     name: 1ESPipelineTemplates/MicroBuildTemplate
     ref: refs/tags/release
-  containers:
-  - container: MuslArm
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine
-  - container: MuslX64
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
-  - container: PortableDeb
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
-  - container: PortableRpm
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
+  - repository: 1esPipelines
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+  # containers:
+  # - container: MuslArm
+  #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine
+  # - container: MuslX64
+  #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
+  # - container: PortableDeb
+  #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
+  # - container: PortableRpm
+  #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
 
 extends:
-  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
+    containers:
+    - container: MuslArm
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine
+    - container: MuslX64
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
+    - container: PortableDeb
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
+    - container: PortableRpm
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
     sdl:
       sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -60,6 +60,7 @@ resources:
 extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
+    containers: ${{ resources.containers }}
     sdl:
       sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -52,7 +52,7 @@ extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
     # TODO: Temporary
-    enableComponentGovernanceScan: false
+    skipSDL: true
     sdl:
       sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -10,7 +10,6 @@ trigger:
     - internal/release/*
 
 variables:
-# Loose Variables
 - name: _PublishUsingPipelines
   value: false
 - ${{ if or(startswith(variables['Build.SourceBranch'], 'refs/heads/release/'), startswith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), eq(variables['Build.Reason'], 'Manual')) }}:
@@ -26,19 +25,11 @@ variables:
   - group: DotNet-Installer-SDLValidation-Params
   - name: _PublishUsingPipelines
     value: true
+- group: DotNetBuilds storage account read tokens
 - name: _InternalRuntimeDownloadArgs
   value: /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal
     /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
     /p:dotnetbuilds-internal-container-read-token-base64=$(dotnetbuilds-internal-container-read-token-base64)
-# Only used for tracking purposes in MicroBuild tasks.
-# See: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/650/MicroBuild-Signing?anchor=high-level-steps-to-enable-signing
-# - name: TeamName
-#   value: DotNetCLI
-
-# Variable Groups
-- group: DotNetBuilds storage account read tokens
-
-# Variable Templates
 - template: /eng/common/templates-official/variables/pool-providers.yml
 
 resources:
@@ -52,24 +43,29 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
     containers:
-      MuslArm:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine
-      MuslX64:
+      alpine319WithNode:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
-      PortableDeb:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
-      PortableRpm:
+      cblMariner20Fpm:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
+      centosStream8:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8
+      debian11Amd64:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-amd64
+      fedora39:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-39
+      ubuntu2204:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04
+      ubuntu2204CrossArmAlpine:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine
+      ubuntu2204DebPkg:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
     sdl:
       sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)
         image: 1es-windows-2022-pt
         os: windows
-      # TODO: Temporary
       # https://docs.opensource.microsoft.com/tools/cg/component-detection/variables/
       componentgovernance:
-        # failOnAlert: false
-        # alertWarningLevel: Never
         ignoreDirectories: '.packages'
     customBuildTags:
     - ES365AIMigrationTooling
@@ -89,7 +85,98 @@ extends:
             targetPath: $(Build.SourcesDirectory)\eng\buildConfiguration
             artifactName: buildConfiguration
 
-      - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+        # PR-only jobs
+      - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+        # Windows
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Windows_NT
+            jobName: Build_Debug_x64
+            buildConfiguration: Debug
+            buildArchitecture: x64
+            additionalBuildParameters: '/p:PublishInternalAsset=true'
+            runTests: true
+
+        # Linux
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_Ubuntu_22_04_Debug_x64
+            container: ubuntu2204
+            buildConfiguration: Debug
+            buildArchitecture: x64
+            linuxPortable: true
+            runTests: true
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_Fedora_39_Debug_x64
+            container: fedora39
+            buildConfiguration: Debug
+            buildArchitecture: x64
+            linuxPortable: true
+            runTests: true
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_CentOS_8_Stream_Debug_x64
+            container: centosStream8
+            buildConfiguration: Debug
+            buildArchitecture: x64
+            linuxPortable: false
+            runTests: true
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_Debian_11_Debug_x64
+            container: debian11Amd64
+            buildConfiguration: Debug
+            buildArchitecture: x64
+            additionalBuildParameters: '/p:BuildSdkDeb=true'
+            linuxPortable: false
+            runTests: true
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_Arm64_Debug
+            buildConfiguration: Debug
+            buildArchitecture: arm64
+            runtimeIdentifier: 'linux-arm64'
+            linuxPortable: true
+            # Never run tests on arm64
+            runTests: false
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_Linux_musl_Debug_x64
+            container: alpine319WithNode
+            buildConfiguration: Debug
+            buildArchitecture: x64
+            runtimeIdentifier: 'linux-musl-x64'
+            # Pass in HostOSName when running on alpine
+            additionalBuildParameters: '/p:HostOSName="linux-musl"'
+            linuxPortable: false
+            runTests: true
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_LinuxPortable_Release_x64
+            buildConfiguration: Release
+            buildArchitecture: x64
+            linuxPortable: true
+            runTests: true
+
+        # MacOS
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Darwin
+            jobName: Build_Release_x64
+            buildConfiguration: Release
+            buildArchitecture: x64
+            runTests: true
+
+      # Official/PGO instrumentation Builds
+      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         # Windows
         - template: eng/build.yml@self
           parameters:
@@ -137,7 +224,7 @@ extends:
           parameters:
             agentOs: Linux
             jobName: Build_Linux_musl_Release_arm
-            container: MuslArm
+            container: ubuntu2204CrossArmAlpine
             buildConfiguration: Release
             buildArchitecture: arm
             runtimeIdentifier: 'linux-musl-arm'
@@ -158,7 +245,7 @@ extends:
           parameters:
             agentOs: Linux
             jobName: Build_Linux_musl_Release_x64
-            container: MuslX64
+            container: alpine319WithNode
             buildConfiguration: Release
             buildArchitecture: x64
             runtimeIdentifier: 'linux-musl-x64'
@@ -170,7 +257,7 @@ extends:
           parameters:
             agentOs: Linux
             jobName: Build_Linux_Portable_Deb_Release_x64
-            container: PortableDeb
+            container: ubuntu2204DebPkg
             buildConfiguration: Release
             buildArchitecture: x64
             # Do not publish zips and tarballs. The linux-x64 binaries are
@@ -182,7 +269,7 @@ extends:
           parameters:
             agentOs: Linux
             jobName: Build_Linux_Portable_Rpm_Release_x64
-            container: PortableRpm
+            container: cblMariner20Fpm
             buildConfiguration: Release
             buildArchitecture: x64
             # Do not publish zips and tarballs. The linux-x64 binaries are
@@ -194,7 +281,7 @@ extends:
           parameters:
             agentOs: Linux
             jobName: Build_Linux_Portable_Rpm_Release_Arm64
-            container: PortableRpm
+            container: cblMariner20Fpm
             buildConfiguration: Release
             buildArchitecture: arm64
             runtimeIdentifier: 'linux-arm64'
@@ -279,7 +366,7 @@ extends:
         # Source Build
         - template: /eng/common/templates-official/jobs/source-build.yml@self
 
-    - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - stage: Publish
         dependsOn:
         - Build

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -74,9 +74,11 @@ extends:
             name: $(DncEngInternalBuildPool)
             demands: ImageOverride -equals windows.vs2022preview.amd64
         steps:
-        - publish: $(Build.SourcesDirectory)\eng\buildConfiguration
-          artifact: buildConfiguration
+        - task: 1ES.PublishPipelineArtifact@1
           displayName: Publish Build Config
+          inputs:
+            targetPath: $(Build.SourcesDirectory)\eng\buildConfiguration
+            artifactName: buildConfiguration
 
       # Windows
       - template: eng/build.yml@self

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -62,7 +62,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)
-        image: 1es-windows-2022-pt
+        image: windows.vs2022preview.amd64
         os: windows
       # https://docs.opensource.microsoft.com/tools/cg/component-detection/variables/
       componentgovernance:
@@ -76,7 +76,7 @@ extends:
       - job: Publish_Build_Configuration
         pool:
           name: $(DncEngInternalBuildPool)
-          image: 1es-windows-2022-pt
+          image: windows.vs2022preview.amd64
           os: windows
         steps:
         - task: 1ES.PublishPipelineArtifact@1
@@ -377,5 +377,5 @@ extends:
             publishAssetsImmediately: true
             pool:
               name: $(DncEngInternalBuildPool)
-              image: 1es-windows-2022-pt
+              image: windows.vs2022preview.amd64
               os: windows

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -27,19 +27,16 @@ variables:
   - name: _PublishUsingPipelines
     value: true
 - name: _InternalRuntimeDownloadArgs
-  value: ''
+  value: /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal
+    /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
+    /p:dotnetbuilds-internal-container-read-token-base64=$(dotnetbuilds-internal-container-read-token-base64)
 # Only used for tracking purposes in MicroBuild tasks.
 # See: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/650/MicroBuild-Signing?anchor=high-level-steps-to-enable-signing
 - name: TeamName
   value: DotNetCLI
 
 # Variable Groups
-- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-  - group: DotNetBuilds storage account read tokens
-  - name: _InternalRuntimeDownloadArgs
-    value: /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal
-      /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
-      /p:dotnetbuilds-internal-container-read-token-base64=$(dotnetbuilds-internal-container-read-token-base64)
+- group: DotNetBuilds storage account read tokens
 
 # Variable Templates
 - template: /eng/common/templates-official/variables/pool-providers.yml
@@ -67,12 +64,9 @@ extends:
       # Build Retry Configuration
       - job: Publish_Build_Configuration
         pool:
-          ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            name: $(DncEngPublicBuildPool)
-            demands: ImageOverride -equals windows.vs2022preview.amd64.open
-          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-            name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.vs2022preview.amd64
+          name: $(DncEngInternalBuildPool)
+          image: 1es-windows-2022-pt
+          os: windows
         steps:
         - task: 1ES.PublishPipelineArtifact@1
           displayName: Publish Build Config

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -34,9 +34,6 @@ variables:
 # See: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/650/MicroBuild-Signing?anchor=high-level-steps-to-enable-signing
 - name: TeamName
   value: DotNetCLI
-# TODO: TEMPORARY
-- name: skipComponentGovernanceDetection
-  value: true
 
 # Variable Groups
 - group: DotNetBuilds storage account read tokens
@@ -59,6 +56,9 @@ extends:
         name: $(DncEngInternalBuildPool)
         image: 1es-windows-2022-pt
         os: windows
+      # TODO: Temporary
+      componentgovernance:
+        failOnAlert: false
     customBuildTags:
     - ES365AIMigrationTooling
     stages:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -51,8 +51,6 @@ resources:
 extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
-    # TODO: Temporary
-    skipSDL: true
     sdl:
       sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)
@@ -63,6 +61,7 @@ extends:
       componentgovernance:
         failOnAlert: false
         alertWarningLevel: Never
+        ignoreDirectories: '.packages'
     customBuildTags:
     - ES365AIMigrationTooling
     stages:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -47,10 +47,10 @@ resources:
     type: git
     name: 1ESPipelineTemplates/MicroBuildTemplate
     ref: refs/tags/release
-  - repository: 1esPipelines
-    type: git
-    name: 1ESPipelineTemplates/1ESPipelineTemplates
-    ref: refs/tags/release
+  # - repository: 1esPipelines
+  #   type: git
+  #   name: 1ESPipelineTemplates/1ESPipelineTemplates
+  #   ref: refs/tags/release
   # containers:
   # - container: MuslArm
   #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -34,6 +34,9 @@ variables:
 # See: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/650/MicroBuild-Signing?anchor=high-level-steps-to-enable-signing
 - name: TeamName
   value: DotNetCLI
+# TODO: TEMPORARY
+- name: skipComponentGovernanceDetection
+  value: true
 
 # Variable Groups
 - group: DotNetBuilds storage account read tokens

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -43,37 +43,14 @@ variables:
 
 resources:
   repositories:
-  - repository: MicroBuildTemplate
-    type: git
-    name: 1ESPipelineTemplates/MicroBuildTemplate
-    ref: refs/tags/release
   - repository: 1esPipelines
     type: git
     name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
-  # containers:
-  # - container: MuslArm
-  #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine
-  # - container: MuslX64
-  #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
-  # - container: PortableDeb
-  #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
-  # - container: PortableRpm
-  #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
 
 extends:
-  # template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
-    # containers:
-    # - container: MuslArm
-    #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine
-    # - container: MuslX64
-    #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
-    # - container: PortableDeb
-    #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
-    # - container: PortableRpm
-    #   image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
     containers:
       MuslArm:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine
@@ -91,8 +68,8 @@ extends:
       # TODO: Temporary
       # https://docs.opensource.microsoft.com/tools/cg/component-detection/variables/
       componentgovernance:
-        failOnAlert: false
-        alertWarningLevel: Never
+        # failOnAlert: false
+        # alertWarningLevel: Never
         ignoreDirectories: '.packages'
     customBuildTags:
     - ES365AIMigrationTooling
@@ -160,7 +137,6 @@ extends:
           agentOs: Linux
           jobName: Build_Linux_musl_Release_arm
           container: MuslArm
-          # container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine
           buildConfiguration: Release
           buildArchitecture: arm
           runtimeIdentifier: 'linux-musl-arm'
@@ -182,7 +158,6 @@ extends:
           agentOs: Linux
           jobName: Build_Linux_musl_Release_x64
           container: MuslX64
-          # container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
           buildConfiguration: Release
           buildArchitecture: x64
           runtimeIdentifier: 'linux-musl-x64'
@@ -195,7 +170,6 @@ extends:
           agentOs: Linux
           jobName: Build_Linux_Portable_Deb_Release_x64
           container: PortableDeb
-          # container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
           buildConfiguration: Release
           buildArchitecture: x64
           # Do not publish zips and tarballs. The linux-x64 binaries are
@@ -208,7 +182,6 @@ extends:
           agentOs: Linux
           jobName: Build_Linux_Portable_Rpm_Release_x64
           container: PortableRpm
-          # container: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
           buildConfiguration: Release
           buildArchitecture: x64
           # Do not publish zips and tarballs. The linux-x64 binaries are
@@ -221,7 +194,6 @@ extends:
           agentOs: Linux
           jobName: Build_Linux_Portable_Rpm_Release_Arm64
           container: PortableRpm
-          # container: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
           buildConfiguration: Release
           buildArchitecture: arm64
           runtimeIdentifier: 'linux-arm64'

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -47,6 +47,15 @@ resources:
     type: git
     name: 1ESPipelineTemplates/MicroBuildTemplate
     ref: refs/tags/release
+  containers:
+  - container: MuslArm
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine
+  - container: MuslX64
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
+  - container: PortableDeb
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
+  - container: PortableRpm
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
 
 extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
@@ -127,7 +136,7 @@ extends:
         parameters:
           agentOs: Linux
           jobName: Build_Linux_musl_Release_arm
-          container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine'
+          container: MuslArm
           buildConfiguration: Release
           buildArchitecture: arm
           runtimeIdentifier: 'linux-musl-arm'
@@ -148,7 +157,7 @@ extends:
         parameters:
           agentOs: Linux
           jobName: Build_Linux_musl_Release_x64
-          container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode'
+          container: MuslX64
           buildConfiguration: Release
           buildArchitecture: x64
           runtimeIdentifier: 'linux-musl-x64'
@@ -160,7 +169,7 @@ extends:
         parameters:
           agentOs: Linux
           jobName: Build_Linux_Portable_Deb_Release_x64
-          container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg'
+          container: PortableDeb
           buildConfiguration: Release
           buildArchitecture: x64
           # Do not publish zips and tarballs. The linux-x64 binaries are
@@ -172,7 +181,7 @@ extends:
         parameters:
           agentOs: Linux
           jobName: Build_Linux_Portable_Rpm_Release_x64
-          container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm'
+          container: PortableRpm
           buildConfiguration: Release
           buildArchitecture: x64
           # Do not publish zips and tarballs. The linux-x64 binaries are
@@ -184,7 +193,7 @@ extends:
         parameters:
           agentOs: Linux
           jobName: Build_Linux_Portable_Rpm_Release_Arm64
-          container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm'
+          container: PortableRpm
           buildConfiguration: Release
           buildArchitecture: arm64
           runtimeIdentifier: 'linux-arm64'

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -1,3 +1,5 @@
+# Pipeline: https://dev.azure.com/dnceng-public/public/_build?definitionId=20
+
 trigger:
   batch: true
   branches:
@@ -59,7 +61,7 @@ stages:
     
     ## Windows
 
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Windows_NT
         jobName: Build_Debug_x64
@@ -70,7 +72,7 @@ stages:
 
     ## Linux
 
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_Ubuntu_22_04_Debug_x64
@@ -79,7 +81,7 @@ stages:
         buildArchitecture: x64
         linuxPortable: true
         runTests: true
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_Fedora_39_Debug_x64
@@ -88,7 +90,7 @@ stages:
         buildArchitecture: x64
         linuxPortable: true
         runTests: true
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_CentOS_8_Stream_Debug_x64
@@ -97,7 +99,7 @@ stages:
         buildArchitecture: x64
         linuxPortable: false
         runTests: true
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_Debian_11_Debug_x64
@@ -107,7 +109,7 @@ stages:
         additionalBuildParameters: '/p:BuildSdkDeb=true'
         linuxPortable: false
         runTests: true
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_Arm64_Debug
@@ -117,7 +119,7 @@ stages:
         linuxPortable: true
         # Never run tests on arm64
         runTests: false
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_Linux_musl_Debug_x64
@@ -129,7 +131,7 @@ stages:
         additionalBuildParameters: '/p:HostOSName="linux-musl"'
         linuxPortable: false
         runTests: true
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_LinuxPortable_Release_x64
@@ -140,7 +142,7 @@ stages:
 
     # MacOS
 
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Darwin
         jobName: Build_Release_x64
@@ -154,7 +156,7 @@ stages:
     
     ## Windows
 
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Windows_NT
         jobName: Build_Release_x64
@@ -162,14 +164,14 @@ stages:
         buildArchitecture: x64
         additionalBuildParameters: '/p:PublishInternalAsset=true'
         runTests: false
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Windows_NT
         jobName: Build_Release_x86
         buildConfiguration: Release
         buildArchitecture: x86
         runTests: false
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Windows_NT
         jobName: Build_Release_arm64
@@ -179,7 +181,7 @@ stages:
 
     ## Linux 
 
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_Arm_Release
@@ -188,7 +190,7 @@ stages:
         runtimeIdentifier: 'linux-arm'
         linuxPortable: true
         runTests: false
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_Arm64_Release
@@ -197,7 +199,7 @@ stages:
         runtimeIdentifier: 'linux-arm64'
         linuxPortable: true
         runTests: false
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_Linux_musl_Release_arm
@@ -208,7 +210,7 @@ stages:
         additionalBuildParameters: '/p:OSName="linux-musl"'
         linuxPortable: false
         runTests: false
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_Linux_musl_Release_arm64
@@ -218,7 +220,7 @@ stages:
         additionalBuildParameters: '/p:OSName="linux-musl"'
         linuxPortable: false
         runTests: false
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_Linux_musl_Release_x64
@@ -230,7 +232,7 @@ stages:
         additionalBuildParameters: '/p:HostOSName="linux-musl"'
         linuxPortable: false
         runTests: false
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_Linux_Portable_Deb_Release_x64
@@ -242,7 +244,7 @@ stages:
         additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:BuildSdkDeb=true'
         linuxPortable: true
         runTests: false
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_Linux_Portable_Rpm_Release_x64
@@ -254,7 +256,7 @@ stages:
         additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:IsRPMBasedDistro=true'
         linuxPortable: true
         runTests: false
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_Linux_Portable_Rpm_Release_Arm64
@@ -267,7 +269,7 @@ stages:
         additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:CLIBUILD_SKIP_TESTS=true  /p:IsRPMBasedDistro=true'
         linuxPortable: true
         runTests: false
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_LinuxPortable_Release_x64
@@ -278,14 +280,14 @@ stages:
 
     # MacOS
 
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Darwin
         jobName: Build_Release_x64
         buildConfiguration: Release
         buildArchitecture: x64
         runTests: false
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Darwin
         jobName: Build_Release_arm64
@@ -296,7 +298,7 @@ stages:
 
     ## Windows PGO Instrumentation builds
 
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Windows_NT
         pgoInstrument: true
@@ -305,7 +307,7 @@ stages:
         buildArchitecture: x64
         additionalBuildParameters: '/p:PublishInternalAsset=true'
         runTests: false
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Windows_NT
         pgoInstrument: true
@@ -313,7 +315,7 @@ stages:
         buildConfiguration: Release
         buildArchitecture: x86
         runTests: false
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Windows_NT
         pgoInstrument: true
@@ -324,7 +326,7 @@ stages:
 
     ## Linux PGO Instrumentation builds
 
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         pgoInstrument: true
@@ -334,7 +336,7 @@ stages:
         linuxPortable: true
         runTests: false
 
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         pgoInstrument: true

--- a/eng/build-pr.yml
+++ b/eng/build-pr.yml
@@ -1,9 +1,9 @@
 parameters:
-# Agent OS identifier and used as job name
+  # Agent OS identifier and used as job name
 - name: agentOs
   type: string
 
-# Job name
+  # Job name
 - name: jobName
   type: string
 
@@ -12,7 +12,7 @@ parameters:
   type: string
   default: ''
 
-# Job timeout
+  # Job timeout
 - name: timeoutInMinutes
   type: number
   default: 180
@@ -32,7 +32,7 @@ parameters:
   - arm64
   - x64
   - x86
-
+  
 # Linux portable. If true, passes portable switch to build
 - name: linuxPortable
   type: boolean
@@ -69,7 +69,7 @@ parameters:
   default: false
 
 jobs:
-- template: common/templates-official/job/job.yml
+- template: common/templates/job/job.yml
   parameters:
     # Set up the name of the job.
     ${{ if parameters.pgoInstrument }}:
@@ -77,17 +77,24 @@ jobs:
     ${{ if not(parameters.pgoInstrument) }}:
       name: ${{ parameters.agentOs }}_${{ parameters.jobName }}
     
-    # Set up the pool/machine info to be used based on the Agent OS
+    ## Set up the pool/machine info to be used based on the Agent OS
     ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
       enableMicrobuild: true
       pool:
-        name: $(DncEngInternalBuildPool)
-        image: 1es-windows-2022-pt
-        os: windows
+        ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          name: $(DncEngPublicBuildPool)
+          demands: ImageOverride -equals windows.vs2022.amd64.open
+        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          name: $(DncEngInternalBuildPool)
+          demands: ImageOverride -equals windows.vs2022.amd64
     ${{ if eq(parameters.agentOs, 'Linux') }}:
       pool:
-        name: $(DncEngInternalBuildPool)
-        demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+        ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          name: $(DncEngPublicBuildPool)
+          demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
+        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          name: $(DncEngInternalBuildPool)
+          demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
       container: ${{ parameters.container }}
     ${{ if eq(parameters.agentOs, 'Darwin') }}:
       pool:
@@ -104,8 +111,8 @@ jobs:
     workspace:
       clean: all
 
+# Test parameters
     variables:
-    # Test variables
     - ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
       - _PackArg: '-pack'
       - ${{ if parameters.runTests }}:
@@ -151,7 +158,7 @@ jobs:
                 $(_PgoInstrument)
     - ${{ else }}:
       - installerRoot: '$(Build.SourcesDirectory)'
-      - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         - group: DotNet-HelixApi-Access
         - _PushToVSFeed: true
         - _SignType: real
@@ -161,13 +168,13 @@ jobs:
                   /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
                   $(_PgoInstrument)
 
-    - template: /eng/common/templates-official/variables/pool-providers.yml
+    - template: /eng/common/templates/variables/pool-providers.yml
 
     steps:
     - checkout: self
       clean: true
     - ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
-      - ${{ if not(parameters.isBuiltFromVmr) }}:
+      - ${{ if and(not(parameters.isBuiltFromVmr), ne(variables['System.TeamProject'], 'public')) }}:
         - task: PowerShell@2
           displayName: Setup Private Feeds Credentials
           inputs:
@@ -188,7 +195,7 @@ jobs:
           DOTNET_CLI_UI_LANGUAGE: ${{ parameters.dotnetCLIUILanguage }}
 
     - ${{ if ne(parameters.agentOs, 'Windows_NT') }}:
-      - ${{ if not(parameters.isBuiltFromVmr) }}:
+      - ${{ if and(not(parameters.isBuiltFromVmr), ne(variables['System.TeamProject'], 'public')) }}:
         - task: Bash@3
           displayName: Setup Private Feeds Credentials
           inputs:

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -87,7 +87,8 @@ jobs:
     ${{ if eq(parameters.agentOs, 'Linux') }}:
       pool:
         name: $(DncEngInternalBuildPool)
-        demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+        image: 1es-ubuntu-2204-pt
+        os: linux
       container: ${{ parameters.container }}
     ${{ if eq(parameters.agentOs, 'Darwin') }}:
       pool:

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -244,7 +244,7 @@ jobs:
       continueOnError: true
       condition: always()
 
-    - task: PublishBuildArtifacts@1
+    - task: 1ES.PublishBuildArtifacts@1
       displayName: Publish Logs to VSTS
       inputs:
         PathtoPublish: '$(Build.ArtifactStagingDirectory)'

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -87,7 +87,7 @@ jobs:
     ${{ if eq(parameters.agentOs, 'Linux') }}:
       pool:
         name: $(DncEngInternalBuildPool)
-        image: 1es-ubuntu-2204-pt
+        image: 1es-mariner-2-pt
         os: linux
       containers:
         default_linux_container:

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -87,7 +87,7 @@ jobs:
     ${{ if eq(parameters.agentOs, 'Linux') }}:
       pool:
         name: $(DncEngInternalBuildPool)
-        image: 1es-ubuntu-2204-pt
+        image: 1es-ubuntu-2004-pt
         os: linux
       container: ${{ parameters.container }}
     ${{ if eq(parameters.agentOs, 'Darwin') }}:

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -82,12 +82,12 @@ jobs:
       enableMicrobuild: true
       pool:
         name: $(DncEngInternalBuildPool)
-        image: 1es-windows-2022-pt
+        image: 1es-windows-2022
         os: windows
     ${{ if eq(parameters.agentOs, 'Linux') }}:
       pool:
         name: $(DncEngInternalBuildPool)
-        image: 1es-ubuntu-2004-pt
+        image: 1es-ubuntu-1804
         os: linux
       container: ${{ parameters.container }}
     ${{ if eq(parameters.agentOs, 'Darwin') }}:

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -154,7 +154,7 @@ jobs:
                 $(_PgoInstrument)
     - ${{ else }}:
       - installerRoot: '$(Build.SourcesDirectory)'
-      - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         - group: DotNet-HelixApi-Access
         - _PushToVSFeed: true
         - _SignType: real
@@ -170,7 +170,7 @@ jobs:
     - checkout: self
       clean: true
     - ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
-      - ${{ if not(parameters.isBuiltFromVmr) }}:
+      - ${{ if and(not(parameters.isBuiltFromVmr), ne(variables['System.TeamProject'], 'public')) }}:
         - task: PowerShell@2
           displayName: Setup Private Feeds Credentials
           inputs:
@@ -191,7 +191,7 @@ jobs:
           DOTNET_CLI_UI_LANGUAGE: ${{ parameters.dotnetCLIUILanguage }}
 
     - ${{ if ne(parameters.agentOs, 'Windows_NT') }}:
-      - ${{ if not(parameters.isBuiltFromVmr) }}:
+      - ${{ if and(not(parameters.isBuiltFromVmr), ne(variables['System.TeamProject'], 'public')) }}:
         - task: Bash@3
           displayName: Setup Private Feeds Credentials
           inputs:

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -87,11 +87,9 @@ jobs:
     ${{ if eq(parameters.agentOs, 'Linux') }}:
       pool:
         name: $(DncEngInternalBuildPool)
-        image: 1es-mariner-2-pt
+        image: 1es-ubuntu-2204-pt
         os: linux
-      containers:
-        default_linux_container:
-          image: ${{ parameters.container }}
+      container: ${{ parameters.container }}
     ${{ if eq(parameters.agentOs, 'Darwin') }}:
       pool:
         name: Azure Pipelines

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -83,17 +83,17 @@ jobs:
       pool:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: $(DncEngPublicBuildPool)
-          image: windows.vs2022.amd64.open
+          image: 1es-windows-2022-open
           os: windows
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: $(DncEngInternalBuildPool)
-          image: windows.vs2022preview.amd64
+          image: 1es-windows-2022
           os: windows
     ${{ if eq(parameters.agentOs, 'Linux') }}:
       pool:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: $(DncEngPublicBuildPool)
-          image: build.ubuntu.2204.amd64.open
+          image: 1es-ubuntu-2004-open
           os: linux
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: $(DncEngInternalBuildPool)

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -76,7 +76,7 @@ jobs:
       name: PGO_${{ parameters.agentOs }}_${{ parameters.jobName }}
     ${{ if not(parameters.pgoInstrument) }}:
       name: ${{ parameters.agentOs }}_${{ parameters.jobName }}
-    
+
     # Set up the pool/machine info to be used based on the Agent OS
     ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
       enableMicrobuild: true

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -82,14 +82,16 @@ jobs:
       enableMicrobuild: true
       pool:
         name: $(DncEngInternalBuildPool)
-        image: 1es-windows-2022
+        image: 1es-windows-2022-pt
         os: windows
     ${{ if eq(parameters.agentOs, 'Linux') }}:
       pool:
         name: $(DncEngInternalBuildPool)
-        image: 1es-ubuntu-1804
+        image: 1es-ubuntu-2204-pt
         os: linux
-      container: ${{ parameters.container }}
+      containers:
+        default_linux_container:
+          image: ${{ parameters.container }}
     ${{ if eq(parameters.agentOs, 'Darwin') }}:
       pool:
         name: Azure Pipelines

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -82,12 +82,12 @@ jobs:
       enableMicrobuild: true
       pool:
         name: $(DncEngInternalBuildPool)
-        image: 1es-windows-2022-pt
+        image: windows.vs2022preview.amd64
         os: windows
     ${{ if eq(parameters.agentOs, 'Linux') }}:
       pool:
         name: $(DncEngInternalBuildPool)
-        image: 1es-ubuntu-2204-pt
+        image: build.ubuntu.2204.amd64
         os: linux
       container: ${{ parameters.container }}
     ${{ if eq(parameters.agentOs, 'Darwin') }}:

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -92,7 +92,9 @@ jobs:
       container: ${{ parameters.container }}
     ${{ if eq(parameters.agentOs, 'Darwin') }}:
       pool:
-        vmImage: 'macOS-latest'
+        name: Azure Pipelines
+        image: macOS-latest
+        os: macOS
 
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     ${{ if parameters.isBuiltFromVmr }}:

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -81,14 +81,24 @@ jobs:
     ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
       enableMicrobuild: true
       pool:
-        name: $(DncEngInternalBuildPool)
-        image: windows.vs2022preview.amd64
-        os: windows
+        ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          name: $(DncEngPublicBuildPool)
+          image: windows.vs2022.amd64.open
+          os: windows
+        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          name: $(DncEngInternalBuildPool)
+          image: windows.vs2022preview.amd64
+          os: windows
     ${{ if eq(parameters.agentOs, 'Linux') }}:
       pool:
-        name: $(DncEngInternalBuildPool)
-        image: build.ubuntu.2204.amd64
-        os: linux
+        ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          name: $(DncEngPublicBuildPool)
+          image: build.ubuntu.2204.amd64.open
+          os: linux
+        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          name: $(DncEngInternalBuildPool)
+          image: 1es-ubuntu-2204
+          os: linux
       container: ${{ parameters.container }}
     ${{ if eq(parameters.agentOs, 'Darwin') }}:
       pool:

--- a/eng/localization.yml
+++ b/eng/localization.yml
@@ -1,6 +1,4 @@
-#
-# See https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema for details on this file.
-#
+# Pipeline: https://dnceng.visualstudio.com/internal/_build?definitionId=1224
 
 schedules:
 # Cron timezone is UTC.
@@ -21,7 +19,7 @@ variables:
 
 jobs:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.Reason'], 'Manual'))) }}:
-  - template: /eng/common/templates/job/onelocbuild.yml
+  - template: /eng/common/templates-official/job/onelocbuild.yml
     parameters:
       CreatePr: ${{ ne(variables['Build.Reason'], 'Manual') }}
       LclPackageId: 'LCL-JUNO-PROD-DOTNETINSTALLER'

--- a/eng/localization.yml
+++ b/eng/localization.yml
@@ -19,7 +19,7 @@ variables:
 
 jobs:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.Reason'], 'Manual'))) }}:
-  - template: /eng/common/templates-official/job/onelocbuild.yml
+  - template: /eng/common/templates/job/onelocbuild.yml
     parameters:
       CreatePr: ${{ ne(variables['Build.Reason'], 'Manual') }}
       LclPackageId: 'LCL-JUNO-PROD-DOTNETINSTALLER'

--- a/src/redist/targets/Crossgen.targets
+++ b/src/redist/targets/Crossgen.targets
@@ -8,7 +8,7 @@
     <PropertyGroup>
       <RuntimeNETCoreAppPackageName>microsoft.netcore.app.runtime.$(SharedFrameworkRid)</RuntimeNETCoreAppPackageName>
       <RuntimeNETCrossgenPackageName>microsoft.netcore.app.crossgen2.$(Crossgen2Rid)</RuntimeNETCrossgenPackageName>
-      <CrossgenPath>$(NuGetPackageRoot)/$(RuntimeNETCrossgenPackageName)/$(MicrosoftNETCoreAppRuntimePackageVersion)/tools/crossgen2$(ExeExtension)</CrossgenPath>
+      <CrossgenPath>$(NuGetPackageRoot)$(RuntimeNETCrossgenPackageName)/$(MicrosoftNETCoreAppRuntimePackageVersion)/tools/crossgen2$(ExeExtension)</CrossgenPath>
       <!-- When ingesting stable pgo instrumented binaries, the shared framework will be a non-stable version,
            as will the archive file names themselves. -->
       <SharedFrameworkNameVersionPath Condition=" '$(PgoInstrument)' != 'true' ">$(RedistLayoutPath)shared/$(SharedFrameworkName)/$(MicrosoftNETCoreAppRuntimePackageVersion)</SharedFrameworkNameVersionPath>


### PR DESCRIPTION
## Summary
This effort is to migrate to the 1ES pipeline templates (1ES PT). This repo shows a migration to these templates with a repo that uses Arcade. Arcade pushed an update for their pipeline templates that work with the 1ES templates. This PR extends the 1ES PT and updates the internal pipeline to use the updated Arcade templates. Our internal pipeline uses `.vsts-ci.yml` and our external (PR) pipeline uses `.vsts-pr.yml`.

Below, I've included my notes on the process as I went through the process of adopting these templates. Note that these notes may have some specifics that apply to only Arcade repos or only this repo, so these instructions aren't complete for every situation.

## High-Level Notes

- ~~I used this PR as a reference: https://dnceng.visualstudio.com/internal/_git/dotnet-symreader/pullrequest/37739~~
  - ~~This isn't a great reference as some of the information is wrong/inaccurate, so take it with a grain of salt~~
  - This is a bad example. Use this PR itself as an example.
- In VSCode/your editor of choice, turn on `View -> Appearance -> Render Whitespace`
  - This helps with seeing correct indentation, which is required for YAML.
- Verify you have the ability to create internal branches on your repo for testing
- Prior to this PR being merged, switch the PR pipeline to new `pr` yml file
- You may need to do split-diff view AND ignore whitespace changes on this PR to view it, since indentation gets shifted around

## Process

### Extend 1ES PT
- Add the 1ESPipelineTemplates repo as a resource
  - Note: You may already have a `resources:` node or even `repositories:` under it. This is an additional `repository` object in that array.

#### Example
```yml
resources:
  repositories:
  - repository: 1esPipelines
    type: git
    name: 1ESPipelineTemplates/1ESPipelineTemplates
    ref: refs/tags/release
```

- Extend the 1ES template and indent `stages:` as a `parameters:` property
  - The `template:` is referencing the repository above and the YAML file in that repo
  - The `sourceAnalysisPool:` sets the pool information for running the SDL tools. See the section on updating build pools for more context.
  - The `customBuildTags:` adds tags to your pipeline runs for 1ES.

#### Before
```yml
stages:
- stage: Build
  jobs:
...
```

#### After
```yml
extends:
  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
  parameters:
    sdl:
      sourceAnalysisPool:
        name: $(DncEngInternalBuildPool)
        image: 1es-windows-2022
        os: windows
    customBuildTags:
    - ES365AIMigrationTooling
    stages:
    - stage: Build
      jobs:
...
```

### Update local template paths
- Replace **ALL** Arcade template references of path `/eng/common/templates` with `/eng/common/templates-official`
- Add `@self` to the end of all local (in-repo) template paths (including the Arcade templates)
  - The `@self` lets the 1ES PT template know to access this file path from within your repository, not the 1ES PT repo.
  - More info on that here: https://learn.microsoft.com/en-us/azure/devops/pipelines/process/templates?view=azure-devops&pivots=templates-includes#use-other-repositories

#### Arcade Templates
#### Before
```yml
template: /eng/common/templates/job/job.yml
```

#### After
```yml
template: /eng/common/templates-official/job/job.yml@self
```

#### Non-Arcade Templates
#### Before
```yml
template: eng/build.yml
```

#### After
```yml
template: eng/build.yml@self
```

### Update pool information
- Update the image information
  - For Windows, images starting with `windows.vs2022` or `1es` will work with 1ES PT.
  - For Linux, images starting with `1es` will work with 1ES PT.
  - For MacOS, the only working image is from the public Azure Pipelines pool. Additional information (see example below) is required for using this with 1ES PT.
  - Image information can be found here: https://helix.dot.net/#1esPools

#### Before (Windows)
```yml
name: $(DncEngInternalBuildPool)
demands: ImageOverride -equals windows.vs2022preview.amd64
```

#### After (Windows)
```yml
name: $(DncEngInternalBuildPool)
image: windows.vs2022preview.amd64
os: windows
```

#### Before (Linux)
```yml
name: $(DncEngInternalBuildPool)
demands: ImageOverride -equals build.ubuntu.1804.amd64
```

#### After (Linux)
```yml
name: $(DncEngInternalBuildPool)
image: 1es-ubuntu-1804
os: linux
```

#### Before (Mac)
```yml
vmImage: 'macOS-latest'
```

#### After (Mac)
```yml
name: Azure Pipelines
image: macOS-latest
os: macOS
```

- If your pipeline did not use the `$(DncEngInternalBuildPool)` variable for the pool name previously, you will need to add this variable template to your `variables:` section

### Example
```yml
variables:
...
- template: /eng/common/templates-official/variables/pool-providers.yml
```
### Update publish tasks
- Replace `publish:` tasks with `task: 1ES.PublishPipelineArtifact@1`

#### Before
```yml
- publish: $(Build.SourcesDirectory)\eng\buildConfiguration
  artifact: buildConfiguration
  displayName: Publish Build Config
```

#### After
```yml
- task: 1ES.PublishPipelineArtifact@1
  displayName: Publish Build Config
  inputs:
    targetPath: $(Build.SourcesDirectory)\eng\buildConfiguration
    artifactName: buildConfiguration
```

- Replace the task `PublishBuildArtifacts@1` with `1ES.PublishBuildArtifacts@1` (just prepend `1ES.` to the name)
  - No task values *should* need to change beyond the task name
  - If you have task errors, you may need to investigate them accordingly

## Other Notes (but might apply to you)
- I needed to duplicate the local `eng/build.yml` to `eng/build-pr.yml` so that the PR pipeline uses the original (non-1ES PT) logic
  - I updated the `.vsts-pr.yml` to reference the `eng/build-pr.yml` template.
  - Different repos may need to handle their local templates differently, depending on how they are used and what they contain.

## Builds
- ~~https://dnceng.visualstudio.com/internal/_build/results?buildId=2403255~~
- ~~https://dnceng.visualstudio.com/internal/_build/results?buildId=2404420~~
- https://dnceng.visualstudio.com/internal/_build/results?buildId=2405780