### PR TITLE
Add linux-bionic-arm to native AOT runtime packs

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -407,6 +407,7 @@
           linux-x64;
           linux-arm;
           linux-arm64;
+          linux-bionic-arm;
           linux-musl-x64;
           linux-musl-arm;
           linux-musl-arm64;


### PR DESCRIPTION
Corresponds to https://github.com/dotnet/runtime/pull/99667.

Cc @dotnet/ilc-contrib 