### PR TITLE
Move the source-build script back to the root of the repo

### DIFF
--- a/.devcontainer/vmr-source-build/init.sh
+++ b/.devcontainer/vmr-source-build/init.sh
@@ -27,4 +27,4 @@ vmr_branch=$(git -C "$installer_dir" log --pretty=format:'%D' HEAD^ \
 
 "$workspace_dir/synchronize-vmr.sh" --branch "$vmr_branch" --debug
 
-(cd "$vmr_dir" && ./eng/prep-source-build.sh)
+(cd "$vmr_dir" && ./prep-source-build.sh)

--- a/eng/pipelines/source-build-license-scan.yml
+++ b/eng/pipelines/source-build-license-scan.yml
@@ -68,7 +68,7 @@ jobs:
     matrix: $[ dependencies.Setup.outputs['GetMatrix.matrix'] ]
   steps:
 
-  - script: $(Build.SourcesDirectory)/eng/prep-source-build.sh --no-artifacts --no-bootstrap --no-prebuilts --no-binary-tooling
+  - script: $(Build.SourcesDirectory)/prep-source-build.sh --no-artifacts --no-bootstrap --no-prebuilts --no-binary-tooling
     displayName: 'Install .NET SDK'
 
   - task: PipAuthenticate@1

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -245,7 +245,7 @@ jobs:
             echo "##vso[task.setvariable variable=additionalBuildArgs]--with-sdk /vmr/.dotnet"
           fi
 
-          docker run --rm -v "$(sourcesPath):/vmr" -w /vmr ${{ parameters.container }} ./eng/prep-source-build.sh $customPrepArgs
+          docker run --rm -v "$(sourcesPath):/vmr" -w /vmr ${{ parameters.container }} ./prep-source-build.sh $customPrepArgs
         displayName: Prep the Build
 
     - script: |

--- a/src/SourceBuild/content/.devcontainer/README.md
+++ b/src/SourceBuild/content/.devcontainer/README.md
@@ -24,7 +24,7 @@ or
 
 ```bash
 # Building from source only
-./eng/prep-source-build.sh && ./build.sh -sb
+./prep-source-build.sh && ./build.sh -sb
 ```
 
 > Please note that, at this time, the build modifies some of the checked-in sources so it might

--- a/src/SourceBuild/content/.devcontainer/prebuilt-sdk/init.sh
+++ b/src/SourceBuild/content/.devcontainer/prebuilt-sdk/init.sh
@@ -3,7 +3,7 @@
 source="${BASH_SOURCE[0]}"
 script_root="$( cd -P "$( dirname "$source" )" && pwd )"
 
-"$script_root"/../../eng/prep-source-build.sh
+"$script_root"/../../prep-source-build.sh
 
 cp "$script_root/../synchronize-vmr.sh" "/workspaces/"
 "$script_root"/../../build.sh --online --clean-while-building || exit 0

--- a/src/SourceBuild/content/README.md
+++ b/src/SourceBuild/content/README.md
@@ -103,7 +103,7 @@ In case you don't want to / cannot prepare your environment per the requirements
         ```bash
         # Prep the source to build on your distro.
         # This downloads a .NET SDK and a number of .NET packages needed to build .NET from source.
-        ./eng/prep-source-build.sh
+        ./prep-source-build.sh
 
         # Build the .NET SDK
         ./build.sh -sb --clean-while-building
@@ -149,7 +149,7 @@ git clone https://github.com/dotnet/dotnet .
 ./build.sh --clean-while-building
 
 # - Building from source
-./eng/prep-source-build.sh && ./build.sh -sb --clean-while-building
+./prep-source-build.sh && ./build.sh -sb --clean-while-building
 
 mkdir -p $HOME/.dotnet
 tar -zxf artifacts/assets/Release/dotnet-sdk-9.0.100-centos.8-x64.tar.gz -C $HOME/.dotnet

--- a/src/SourceBuild/content/prep-source-build.sh
+++ b/src/SourceBuild/content/prep-source-build.sh
@@ -36,7 +36,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 source="${BASH_SOURCE[0]}"
-REPO_ROOT="$( cd -P "$( dirname "$0" )/../" && pwd )"
+REPO_ROOT="$( cd -P "$( dirname "$0" )" && pwd )"
 
 function print_help () {
     sed -n '/^### /,/^$/p' "$source" | cut -b 5-

--- a/src/SourceBuild/content/prep-source-build.sh
+++ b/src/SourceBuild/content/prep-source-build.sh
@@ -191,7 +191,7 @@ function ParseBinaryArgs {
   # or a pre-existing .dotnet SDK directory must exist.
   if [ "$dotnetSdk" == "$defaultDotnetSdk" ] && [ ! -d "$dotnetSdk" ]; then
     echo "  ERROR: A pre-existing .dotnet SDK directory is needed if --with-sdk is not provided. \
-    Please either supply an SDK using --with-sdk or execute ./eng/prep-source-build.sh before proceeding. Exiting..."
+    Please either supply an SDK using --with-sdk or execute ./prep-source-build.sh before proceeding. Exiting..."
     exit 1
   fi
 
@@ -200,7 +200,7 @@ function ParseBinaryArgs {
   if [ "$packagesSourceFeed" == "$defaultPackagesDir" ] && [ ! -d "$packagesSourceFeed" ]; then
     echo "  ERROR: A pre-existing packages directory is needed if --with-packages is not provided. \
     Please either supply a packages directory using --with-packages or \
-    execute ./eng/prep-source-build.sh with download artifacts enabled before proceeding. Exiting..."
+    execute ./prep-source-build.sh with download artifacts enabled before proceeding. Exiting..."
     exit 1
   fi
 
@@ -229,7 +229,7 @@ function ParseBinaryArgs {
       packagesSourceFeed="$previouslyBuiltPackagesDir"
     else
       echo "  ERROR: A pre-existing package archive is needed if --with-packages is not provided. \
-      Please either supply a source-feed using --with-packages or execute ./eng/prep-source-build.sh \
+      Please either supply a source-feed using --with-packages or execute ./prep-source-build.sh \
       with download artifacts enabled before proceeding. Exiting..."
       exit 1
     fi


### PR DESCRIPTION
This reverts the changes made in https://github.com/dotnet/installer/pull/18840 to move the source-build prep script from the root of the VMR into the eng folder.  The rename to the script renames.  The reasoning is related to keeping source-build as a first class scenario.  See https://github.com/dotnet/source-build/issues/4174 for additional discussion.

Fixes https://github.com/dotnet/source-build/issues/4174
