### PR TITLE
[release/8.0.1xx] Add PR version of VMR pipelines

### DIFF
--- a/eng/pipelines/vmr-build-pr.yml
+++ b/eng/pipelines/vmr-build-pr.yml
@@ -1,0 +1,56 @@
+# This is the non-1ES PR pipeline source-building the VMR used in installer PRs
+# https://dev.azure.com/dnceng-public/public/_build?definitionId=233
+
+trigger: none
+pr:
+  branches:
+    include:
+    - main
+    - release/*
+
+parameters:
+- name: vmrBranch
+  displayName: dotnet/dotnet branch to push to
+  type: string
+  default: ' '
+
+- name: disableVmrBuild
+  displayName: Skip source-building the VMR
+  type: boolean
+  default: false
+
+variables:
+- ${{ if ne(parameters.vmrBranch, ' ') }}:
+  - name: VmrBranch
+    value: ${{ replace(parameters.vmrBranch, ' ', '') }}
+- ${{ else }}:
+  - name: VmrBranch
+    value: release/8.0.1xx
+
+resources:
+  repositories:
+  - repository: vmr
+    type: github
+    name: dotnet/dotnet
+    endpoint: dotnet
+    ref: $(VmrBranch)
+
+stages:
+# You can temporarily disable the VMR Build stage by setting the disableVmrBuild variable
+- ${{ if not(parameters.disableVmrBuild) }}:
+  - template: templates/stages/vmr-build.yml
+    parameters:
+      vmrBranch: ${{ variables.VmrBranch }}
+      isBuiltFromVmr: false
+
+# In case the VMR Build stage is temporarily disabled, the VMR synchronization step is run to validate
+# that the PR can be merged and later synchronized into the VMR without problems.
+- ${{ else }}:
+  - stage: Synchronize_VMR
+    displayName: Synchronize VMR
+    dependsOn: []
+    jobs:
+    - template: templates/jobs/vmr-synchronization.yml
+      parameters:
+        vmrBranch: ${{ variables.VmrBranch }}
+        noPush: true

--- a/src/SourceBuild/content/eng/pipelines/pr.yml
+++ b/src/SourceBuild/content/eng/pipelines/pr.yml
@@ -1,0 +1,18 @@
+# This is the non-1ES PR pipeline for dotnet/dotnet
+# https://dev.azure.com/dnceng-public/public/_build?definitionId=240
+
+trigger: none
+pr:
+  branches:
+    include:
+    - main
+    - release/*
+    - internal/release/*
+
+stages:
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - template: templates/stages/vmr-scan.yml
+
+- template: /src/installer/eng/pipelines/templates/stages/vmr-build.yml
+  parameters:
+    isBuiltFromVmr: true


### PR DESCRIPTION
This only copies the YAML so that we can retarget the non-1ES pipelines.

https://github.com/dotnet/source-build/issues/4223

