### PR TITLE
Move sdkArchiveDiff into installer.proj

### DIFF
--- a/src/SourceBuild/content/build.proj
+++ b/src/SourceBuild/content/build.proj
@@ -26,7 +26,6 @@
   </Target>
 
   <Import Project="$(RepositoryEngineeringDir)build.sourcebuild.targets" Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
-  <Import Project="$(RepositoryEngineeringDir)sdkArchiveDiff.targets" Condition="'$(ShortStack)' != 'true' and '$(PortableBuild)' == 'true' and '$(PgoInstrument)' != 'true'" />
 
   <!-- Intentionally below the import to appear at the end. -->
   <Target Name="LogBuildOutputFolders"

--- a/src/SourceBuild/content/repo-projects/installer.proj
+++ b/src/SourceBuild/content/repo-projects/installer.proj
@@ -148,6 +148,6 @@
           UseHardlinksIfPossible="true" />
   </Target>
 
-  <Import Project="$(RepositoryEngineeringDir)sdkArchiveDiff.targets" Condition="'$(PortableBuild)' == 'true' and '$(PgoInstrument)' != 'true'" />
+  <Import Project="$(RepositoryEngineeringDir)sdkArchiveDiff.targets" Condition="'$(PortableBuild)' == 'true' and '$(PgoInstrument)' != 'true' and '$(DotNetBuildSourceOnly)' != 'true'" />
 
 </Project>

--- a/src/SourceBuild/content/repo-projects/installer.proj
+++ b/src/SourceBuild/content/repo-projects/installer.proj
@@ -148,4 +148,6 @@
           UseHardlinksIfPossible="true" />
   </Target>
 
+  <Import Project="$(RepositoryEngineeringDir)sdkArchiveDiff.targets" Condition="'$(PortableBuild)' == 'true' and '$(PgoInstrument)' != 'true'" />
+
 </Project>


### PR DESCRIPTION
This fixes local builds that pass `/p:RootRepo=...` in to only build a portion of the VMR.