### PR TITLE
Condition copy inner built restore package on source-build

### DIFF
--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -495,7 +495,7 @@
   <!-- Copy restored packages from inner build to ensure they're included in the
        main build prebuilt check -->
   <Target Name="CopyInnerBuildRestoredPackages"
-          Condition="'$(IsUtilityProject)' != 'true'">
+          Condition="'$(IsUtilityProject)' != 'true' and '$(DotNetBuildSourceOnly)' == 'true'">
     <ItemGroup>
       <_InnerPackageCacheFiles Include="$(ProjectDirectory)artifacts/sb/package-cache/**/*" />
     </ItemGroup>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/4194

Prebuilt detection is already conditioned on source-only in build.sourcebuild.targets. Condition this target at all.
