### PR TITLE
Skip Omnisharp.cs and WebScenarioTests.cs for PublishComplex action

### DIFF
--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetHelper.cs
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetHelper.cs
@@ -20,7 +20,7 @@ internal class DotNetHelper
     public static string ProjectsDirectory { get; } = Path.Combine(Directory.GetCurrentDirectory(), $"projects-{DateTime.Now:yyyyMMddHHmmssffff}");
 
     private ITestOutputHelper OutputHelper { get; }
-    private bool IsMonoRuntime { get; }
+    public bool IsMonoRuntime { get; }
 
     public DotNetHelper(ITestOutputHelper outputHelper)
     {
@@ -256,4 +256,6 @@ internal class DotNetHelper
     }
 
     private static string GetProjectDirectory(string projectName) => Path.Combine(ProjectsDirectory, projectName);
+    public static bool ShouldPublishComplex() =>
+        string.Equals(Config.TargetArchitecture,"ppc64le") || string.Equals(Config.TargetArchitecture,"s390x");
 }

--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetHelper.cs
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetHelper.cs
@@ -20,7 +20,7 @@ internal class DotNetHelper
     public static string ProjectsDirectory { get; } = Path.Combine(Directory.GetCurrentDirectory(), $"projects-{DateTime.Now:yyyyMMddHHmmssffff}");
 
     private ITestOutputHelper OutputHelper { get; }
-    public bool IsMonoRuntime { get; }
+    private bool IsMonoRuntime { get; }
 
     public DotNetHelper(ITestOutputHelper outputHelper)
     {

--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/OmniSharpTests.cs
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/OmniSharpTests.cs
@@ -22,7 +22,7 @@ public class OmniSharpTests : SmokeTests
 
     public OmniSharpTests(ITestOutputHelper outputHelper) : base(outputHelper) { }
 
-    [SkippableTheory(Config.ExcludeOmniSharpEnv, skipOnTrue: true)]
+    [SkippableTheory(Config.ExcludeOmniSharpEnv, skipOnTrueEnv: true, skipArchitectures: new[] { "ppc64le", "s390x" })]
     [InlineData(DotNetTemplate.BlazorWasm)]
     [InlineData(DotNetTemplate.BlazorServer)]
     [InlineData(DotNetTemplate.ClassLib)]

--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/PoisonTests.cs
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/PoisonTests.cs
@@ -13,8 +13,8 @@ namespace Microsoft.DotNet.SourceBuild.SmokeTests
     {
         public PoisonTests(ITestOutputHelper outputHelper) : base(outputHelper) { }
 
-        [SkippableFact(Config.PoisonReportPathEnv, skipOnNullOrWhiteSpace: true)]
-        public void VerifyUsage()
+        [SkippableFact(Config.PoisonReportPathEnv, skipOnNullOrWhiteSpaceEnv: true)]
+	public void VerifyUsage()
         {
             if (!File.Exists(Config.PoisonReportPath))
             {

--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/PoisonTests.cs
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/PoisonTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.SourceBuild.SmokeTests
         public PoisonTests(ITestOutputHelper outputHelper) : base(outputHelper) { }
 
         [SkippableFact(Config.PoisonReportPathEnv, skipOnNullOrWhiteSpaceEnv: true)]
-	public void VerifyUsage()
+	    public void VerifyUsage()
         {
             if (!File.Exists(Config.PoisonReportPath))
             {

--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SdkContentTests.cs
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SdkContentTests.cs
@@ -23,7 +23,7 @@ public class SdkContentTests : SmokeTests
     /// This makes the baseline durable between releases.  This does mean however, entries
     /// in the baseline may appear identical if the diff is version specific.
     /// </Summary>
-    [SkippableFact(new[] { Config.MsftSdkTarballPathEnv, Config.SdkTarballPathEnv }, skipOnNullOrWhiteSpace: true)]
+    [SkippableFact(new[] { Config.MsftSdkTarballPathEnv, Config.SdkTarballPathEnv }, skipOnNullOrWhiteSpaceEnv: true)]
     public void CompareMsftToSb()
     {
         const string msftFileListingFileName = "msftSdkFiles.txt";
@@ -35,7 +35,6 @@ public class SdkContentTests : SmokeTests
         diff = RemoveDiffMarkers(diff);
         BaselineHelper.CompareContents("MsftToSbSdk.diff", diff, OutputHelper, Config.WarnOnSdkContentDiffs);
     }
-
     private void WriteTarballFileList(string? tarballPath, string outputFileName, bool isPortable, string sdkType)
     {
         if (!File.Exists(tarballPath))

--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SdkContentTests.cs
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SdkContentTests.cs
@@ -35,6 +35,7 @@ public class SdkContentTests : SmokeTests
         diff = RemoveDiffMarkers(diff);
         BaselineHelper.CompareContents("MsftToSbSdk.diff", diff, OutputHelper, Config.WarnOnSdkContentDiffs);
     }
+    
     private void WriteTarballFileList(string? tarballPath, string outputFileName, bool isPortable, string sdkType)
     {
         if (!File.Exists(tarballPath))

--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SkippableFactAttribute.cs
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SkippableFactAttribute.cs
@@ -4,7 +4,7 @@
 
 using System;
 using Xunit;
-
+using System.Linq;
 namespace Microsoft.DotNet.SourceBuild.SmokeTests;
 
 /// <summary>
@@ -12,28 +12,34 @@ namespace Microsoft.DotNet.SourceBuild.SmokeTests;
 /// </summary>
 internal class SkippableFactAttribute : FactAttribute
 {
-    public SkippableFactAttribute(string envName, bool skipOnNullOrWhiteSpace = false, bool skipOnTrue = false) =>
-        CheckEnvs(skipOnNullOrWhiteSpace, skipOnTrue, (skip) => Skip = skip, envName);
-
-    public SkippableFactAttribute(string[] envNames, bool skipOnNullOrWhiteSpace = false, bool skipOnTrue = false) =>
-        CheckEnvs(skipOnNullOrWhiteSpace, skipOnTrue, (skip) => Skip = skip, envNames);
-
-    public static void CheckEnvs(bool skipOnNullOrWhiteSpace, bool skipOnTrue, Action<string> setSkip, params string[] envNames)
+    public SkippableFactAttribute(string envName, bool skipOnNullOrWhiteSpaceEnv = false, bool skipOnTrueEnv = false, string[] skipArchitectures = null) =>
+	            EvaluateSkips(skipOnNullOrWhiteSpaceEnv, skipOnTrueEnv, skipArchitectures, (skip) => Skip = skip, envName);
+     public SkippableFactAttribute(string[] envNames, bool skipOnNullOrWhiteSpaceEnv = false, bool skipOnTrueEnv = false, string[] skipArchitectures = null) =>
+		        EvaluateSkips(skipOnNullOrWhiteSpaceEnv, skipOnTrueEnv, skipArchitectures, (skip) => Skip = skip, envNames);
+   
+     public static void EvaluateSkips(bool skipOnNullOrWhiteSpaceEnv, bool skipOnTrueEnv, string[] skipArchitectures, Action<string> setSkip, params string[] envNames)
     {
         foreach (string envName in envNames)
         {
             string? envValue = Environment.GetEnvironmentVariable(envName);
 
-            if (skipOnNullOrWhiteSpace && string.IsNullOrWhiteSpace(envValue))
-            {
+            if (skipOnNullOrWhiteSpaceEnv && string.IsNullOrWhiteSpace(envValue))
+	    {
                 setSkip($"Skipping because `{envName}` is null or whitespace");
                 break;
             }
-            else if (skipOnTrue && bool.TryParse(envValue, out bool boolValue) && boolValue)
-            {
+	    else if (skipOnTrueEnv && bool.TryParse(envValue, out bool boolValue) && boolValue)
+	    {
                 setSkip($"Skipping because `{envName}` is set to True");
                 break;
             }
         }
+       if (skipArchitectures != null) {
+	                   string? arch = Config.TargetArchitecture;
+			               if (skipArchitectures.Contains(arch))
+					                   {
+								                   setSkip($"Skipping because arch is `{arch}`");
+										               }
+				               }
     }
 }

--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SkippableFactAttribute.cs
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SkippableFactAttribute.cs
@@ -13,9 +13,9 @@ namespace Microsoft.DotNet.SourceBuild.SmokeTests;
 internal class SkippableFactAttribute : FactAttribute
 {
     public SkippableFactAttribute(string envName, bool skipOnNullOrWhiteSpaceEnv = false, bool skipOnTrueEnv = false, string[] skipArchitectures = null) =>
-	            EvaluateSkips(skipOnNullOrWhiteSpaceEnv, skipOnTrueEnv, skipArchitectures, (skip) => Skip = skip, envName);
+	    EvaluateSkips(skipOnNullOrWhiteSpaceEnv, skipOnTrueEnv, skipArchitectures, (skip) => Skip = skip, envName);
      public SkippableFactAttribute(string[] envNames, bool skipOnNullOrWhiteSpaceEnv = false, bool skipOnTrueEnv = false, string[] skipArchitectures = null) =>
-		        EvaluateSkips(skipOnNullOrWhiteSpaceEnv, skipOnTrueEnv, skipArchitectures, (skip) => Skip = skip, envNames);
+		 EvaluateSkips(skipOnNullOrWhiteSpaceEnv, skipOnTrueEnv, skipArchitectures, (skip) => Skip = skip, envNames);
    
      public static void EvaluateSkips(bool skipOnNullOrWhiteSpaceEnv, bool skipOnTrueEnv, string[] skipArchitectures, Action<string> setSkip, params string[] envNames)
     {
@@ -24,22 +24,23 @@ internal class SkippableFactAttribute : FactAttribute
             string? envValue = Environment.GetEnvironmentVariable(envName);
 
             if (skipOnNullOrWhiteSpaceEnv && string.IsNullOrWhiteSpace(envValue))
-	    {
+	        {
                 setSkip($"Skipping because `{envName}` is null or whitespace");
                 break;
             }
 	    else if (skipOnTrueEnv && bool.TryParse(envValue, out bool boolValue) && boolValue)
-	    {
+	        {
                 setSkip($"Skipping because `{envName}` is set to True");
                 break;
             }
         }
-       if (skipArchitectures != null) {
-	                   string? arch = Config.TargetArchitecture;
-			               if (skipArchitectures.Contains(arch))
-					                   {
-								                   setSkip($"Skipping because arch is `{arch}`");
-										               }
-				               }
+       
+        if (skipArchitectures != null) {
+	        string? arch = Config.TargetArchitecture;
+			if (skipArchitectures.Contains(arch))
+			{
+				setSkip($"Skipping because arch is `{arch}`");
+			}
+		}
     }
 }

--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SkippableTheoryAttribute.cs
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SkippableTheoryAttribute.cs
@@ -11,9 +11,8 @@ namespace Microsoft.DotNet.SourceBuild.SmokeTests;
 /// </summary>
 internal class SkippableTheoryAttribute : TheoryAttribute
 {
-    public SkippableTheoryAttribute(string envName, bool skipOnNullOrWhiteSpace = false, bool skipOnTrue = false) =>
-        SkippableFactAttribute.CheckEnvs(skipOnNullOrWhiteSpace, skipOnTrue, (skip) => Skip = skip, envName);
-
-    public SkippableTheoryAttribute(string[] envNames, bool skipOnNullOrWhiteSpace = false, bool skipOnTrue = false) =>
-        SkippableFactAttribute.CheckEnvs(skipOnNullOrWhiteSpace, skipOnTrue, (skip) => Skip = skip, envNames);
+    public SkippableTheoryAttribute(string envName, bool skipOnNullOrWhiteSpaceEnv = false, bool skipOnTrueEnv = false, string[] skipArchitectures = null) =>
+	            SkippableFactAttribute.EvaluateSkips(skipOnNullOrWhiteSpaceEnv, skipOnTrueEnv, skipArchitectures, (skip) => Skip = skip, envName);
+    public SkippableTheoryAttribute(string[] envNames, bool skipOnNullOrWhiteSpaceEnv = false, bool skipOnTrueEnv = false, string[] skipArchitectures = null) =>
+	            SkippableFactAttribute.EvaluateSkips(skipOnNullOrWhiteSpaceEnv, skipOnTrueEnv, skipArchitectures, (skip) => Skip = skip, envNames);
 }

--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/WebScenarioTests.cs
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/WebScenarioTests.cs
@@ -28,7 +28,7 @@ public class WebScenarioTests : SmokeTests
     {
         foreach (DotNetLanguage language in new[] { DotNetLanguage.CSharp, DotNetLanguage.FSharp })
         {
-            yield return new(nameof(WebScenarioTests), language, DotNetTemplate.Web,    DotNetActions.Build | DotNetActions.Run | DotNetActions.PublishComplex);
+            yield return new(nameof(WebScenarioTests), language, DotNetTemplate.Web,    DotNetActions.Build | DotNetActions.Run | (DotNetHelper.ShouldPublishComplex() ? DotNetActions.None : DotNetActions.PublishComplex));		
             yield return new(nameof(WebScenarioTests), language, DotNetTemplate.Mvc,    DotNetActions.Build | DotNetActions.Run | DotNetActions.Publish) { NoHttps = true };
             yield return new(nameof(WebScenarioTests), language, DotNetTemplate.WebApi, DotNetActions.Build | DotNetActions.Run | DotNetActions.Publish);
         }


### PR DESCRIPTION
In reference with  https://github.com/dotnet/source-build/issues/3614 dotnet 8 skipped smoke test for ppc and s390x
This PR is to skip omnisharp.cs and WebScenarioTests.cs test cases for ppc64le and s390x arch in dotnet7.

cc @Swapnali911  @omajid  @tmds  @alhad-deshpande @janani66