### PR TITLE
Revert "[release/8.0.2xx] NGEN Microsoft.DotNet.MSBuildSdkResolver.dll and its dependencies (#17750)"

### DIFF
--- a/src/core-sdk-tasks/GenerateMSBuildExtensionsSWR.cs
+++ b/src/core-sdk-tasks/GenerateMSBuildExtensionsSWR.cs
@@ -24,8 +24,7 @@ namespace Microsoft.DotNet.Cli.Build
 
             AddFolder(sb,
                       @"MSBuildSdkResolver",
-                      @"MSBuild\Current\Bin\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver",
-                      ngenAssemblies: true);
+                      @"MSBuild\Current\Bin\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver");
 
             AddFolder(sb,
                       @"msbuildExtensions",
@@ -40,7 +39,7 @@ namespace Microsoft.DotNet.Cli.Build
             return true;
         }
 
-        private void AddFolder(StringBuilder sb, string relativeSourcePath, string swrInstallDir, bool ngenAssemblies = false)
+        private void AddFolder(StringBuilder sb, string relativeSourcePath, string swrInstallDir)
         {
             string sourceFolder = Path.Combine(MSBuildExtensionsLayoutDirectory, relativeSourcePath);
             var files = Directory.GetFiles(sourceFolder)
@@ -56,16 +55,7 @@ namespace Microsoft.DotNet.Cli.Build
                 {
                     sb.Append(@"  file source=""$(PkgVS_Redist_Common_Net_Core_SDK_MSBuildExtensions)\");
                     sb.Append(Path.Combine(relativeSourcePath, Path.GetFileName(file)));
-                    sb.Append('"');
-
-                    if (ngenAssemblies && file.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-                    {
-                        sb.Append(@" vs.file.ngenApplications=""[installDir]\Common7\IDE\vsn.exe""");
-                        sb.Append(@" vs.file.ngenApplications=""[installDir]\MSBuild\Current\Bin\MSBuild.exe""");
-                        sb.Append(" vs.file.ngenArchitecture=all");
-                    }
-
-                    sb.AppendLine();
+                    sb.AppendLine("\"");
                 }
 
                 sb.AppendLine();
@@ -77,7 +67,6 @@ namespace Microsoft.DotNet.Cli.Build
                 string newRelativeSourcePath = Path.Combine(relativeSourcePath, subfolderName);
                 string newSwrInstallDir = Path.Combine(swrInstallDir, subfolderName);
 
-                // Don't propagate ngenAssemblies to subdirectories.
                 AddFolder(sb, newRelativeSourcePath, newSwrInstallDir);
             }
         }


### PR DESCRIPTION
This reverts commit f0c4e4e14ca748d9c489562cfc32f29e8d5b0afe.

Fixes [AB#1994786](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1994786/)

The MSBuild change which took advantage of this was reverted in 17.9 because it introduced issues in installations that don't have the .NET SDK component installed. We are fixing the bug in 9.0 by making changes to the dependencies of `Microsoft.DotNet.MSBuildSdkResolver` (see https://github.com/dotnet/sdk/pull/39573) so this should stay in main. I am reverting it only in 8.0.3xx / 17.10 to fix the `Build_Ngen_InvalidAssemblyCount` counter which was flagged as a regression by PerfDDRITs.