### PR TITLE
Fix indentation for log copy

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -251,8 +251,8 @@ jobs:
       inputs:
         SourceFolder: '$(installerRoot)/artifacts'
         Contents: |
-         log/${{ parameters.buildConfiguration }}/**/*
-         TestResults/${{ parameters.buildConfiguration }}/**/*
+          log/${{ parameters.buildConfiguration }}/**/*
+          TestResults/${{ parameters.buildConfiguration }}/**/*
         TargetFolder: '$(Build.ArtifactStagingDirectory)'
       continueOnError: true
       condition: always()


### PR DESCRIPTION
## Summary
This indentation is incorrectly spaced. It functions, but if you indent the entire task in/out, it will break because it won't be aligned properly. Having it 2 spaces in is the correct indentation.
