### PR TITLE
[8.0.1xx] Migrate to 1ES templates for internal builds

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,3 +1,5 @@
+# Pipeline: https://dnceng.visualstudio.com/internal/_build?definitionId=286
+
 trigger:
   batch: true
   branches:
@@ -23,339 +25,363 @@ variables:
   - group: DotNet-Installer-SDLValidation-Params
   - name: _PublishUsingPipelines
     value: true
-
 - name: _InternalRuntimeDownloadArgs
   value: ''
-
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNetBuilds storage account read tokens
   - name: _InternalRuntimeDownloadArgs
     value: /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal
       /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
       /p:dotnetbuilds-internal-container-read-token-base64=$(dotnetbuilds-internal-container-read-token-base64)
-
 - template: /eng/common/templates/variables/pool-providers.yml
 
-stages:
-- stage: Build
-  jobs:
-  # This job is for build retry configuration.
-  - job: Publish_Build_Configuration
-    pool:
-      ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: $(DncEngPublicBuildPool)
-        demands: ImageOverride -equals windows.vs2022preview.amd64.open
-      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+resources:
+  repositories:
+  - repository: 1esPipelines
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+    template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+  ${{ else }}:
+    template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
+  parameters:
+    containers:
+      alpine315WithNode:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.15-WithNode
+      cblMariner20Fpm:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
+      centosStream8:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8
+      debianStretch:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch
+      fedora36:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-36
+      ubuntu2204:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04
+      ubuntu1804Cross:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross
+      ubuntu2204DebPkg:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
+    sdl:
+      sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)
-        demands: ImageOverride -equals windows.vs2022preview.amd64
-    steps:
-    - publish: $(Build.SourcesDirectory)\eng\buildConfiguration
-      artifact: buildConfiguration
-      displayName: Publish Build Config
-  
-  ## PR-only jobs
-  
-  - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-    
-    ## Windows
-
-    - template: eng/build.yml
-      parameters:
-        agentOs: Windows_NT
-        jobName: Build_Debug_x64
-        buildConfiguration: Debug
-        buildArchitecture: x64
-        additionalBuildParameters: '/p:PublishInternalAsset=true'
-        runTests: true
-
-    ## Linux
-
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_Ubuntu_22_04_Debug_x64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04'
-        buildConfiguration: Debug
-        buildArchitecture: x64
-        linuxPortable: true
-        runTests: true
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_Fedora_36_Debug_x64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-36'
-        buildConfiguration: Debug
-        buildArchitecture: x64
-        linuxPortable: true
-        runTests: true
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_CentOS_8_Stream_Debug_x64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8'
-        buildConfiguration: Debug
-        buildArchitecture: x64
-        linuxPortable: false
-        runTests: true
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_Debian_Stretch_Debug_x64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch'
-        buildConfiguration: Debug
-        buildArchitecture: x64
-        additionalBuildParameters: '/p:BuildSdkDeb=true'
-        linuxPortable: false
-        runTests: true
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_Arm64_Debug
-        buildConfiguration: Debug
-        buildArchitecture: arm64
-        runtimeIdentifier: 'linux-arm64'
-        linuxPortable: true
-        # Never run tests on arm64
-        runTests: false
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_Linux_musl_Debug_x64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.15-WithNode'
-        buildConfiguration: Debug
-        buildArchitecture: x64
-        runtimeIdentifier: 'linux-musl-x64'
-        # Pass in HostOSName when running on alpine
-        additionalBuildParameters: '/p:HostOSName="linux-musl"'
-        linuxPortable: false
-        runTests: true
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_LinuxPortable_Release_x64
-        buildConfiguration: Release
-        buildArchitecture: x64
-        linuxPortable: true
-        runTests: true
-
-    # MacOS
-
-    - template: eng/build.yml
-      parameters:
-        agentOs: Darwin
-        jobName: Build_Release_x64
-        buildConfiguration: Release
-        buildArchitecture: x64
-        runTests: true
-
-  ## Official/PGO instrumentation Builds
-  
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    
-    ## Windows
-
-    - template: eng/build.yml
-      parameters:
-        agentOs: Windows_NT
-        jobName: Build_Release_x64
-        buildConfiguration: Release
-        buildArchitecture: x64
-        additionalBuildParameters: '/p:PublishInternalAsset=true'
-        runTests: false
-    - template: eng/build.yml
-      parameters:
-        agentOs: Windows_NT
-        jobName: Build_Release_x86
-        buildConfiguration: Release
-        buildArchitecture: x86
-        runTests: false
-    - template: eng/build.yml
-      parameters:
-        agentOs: Windows_NT
-        jobName: Build_Release_arm64
-        buildConfiguration: Release
-        buildArchitecture: arm64
-        runTests: false
-
-    ## Linux 
-
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_Arm_Release
-        buildConfiguration: Release
-        buildArchitecture: arm
-        runtimeIdentifier: 'linux-arm'
-        linuxPortable: true
-        runTests: false
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_Arm64_Release
-        buildConfiguration: Release
-        buildArchitecture: arm64
-        runtimeIdentifier: 'linux-arm64'
-        linuxPortable: true
-        runTests: false
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_Linux_musl_Release_arm
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross'
-        buildConfiguration: Release
-        buildArchitecture: arm
-        runtimeIdentifier: 'linux-musl-arm'
-        additionalBuildParameters: '/p:OSName="linux-musl"'
-        linuxPortable: false
-        runTests: false
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_Linux_musl_Release_arm64
-        buildConfiguration: Release
-        buildArchitecture: arm64
-        runtimeIdentifier: 'linux-musl-arm64'
-        additionalBuildParameters: '/p:OSName="linux-musl"'
-        linuxPortable: false
-        runTests: false
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_Linux_musl_Release_x64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.15-WithNode'
-        buildConfiguration: Release
-        buildArchitecture: x64
-        runtimeIdentifier: 'linux-musl-x64'
-        # Pass in HostOSName when running on alpine
-        additionalBuildParameters: '/p:HostOSName="linux-musl"'
-        linuxPortable: false
-        runTests: false
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_Linux_Portable_Deb_Release_x64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg'
-        buildConfiguration: Release
-        buildArchitecture: x64
-        # Do not publish zips and tarballs. The linux-x64 binaries are
-        # already published by Build_LinuxPortable_Release_x64
-        additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:BuildSdkDeb=true'
-        linuxPortable: true
-        runTests: false
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_Linux_Portable_Rpm_Release_x64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm'
-        buildConfiguration: Release
-        buildArchitecture: x64
-        # Do not publish zips and tarballs. The linux-x64 binaries are
-        # already published by Build_LinuxPortable_Release_x64
-        additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:IsRPMBasedDistro=true'
-        linuxPortable: true
-        runTests: false
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_Linux_Portable_Rpm_Release_Arm64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm'
-        buildConfiguration: Release
-        buildArchitecture: arm64
-        runtimeIdentifier: 'linux-arm64'
-        # Do not publish zips and tarballs. The linux-x64 binaries are
-        # already published by Build_LinuxPortable_Release_x64
-        additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:CLIBUILD_SKIP_TESTS=true  /p:IsRPMBasedDistro=true'
-        linuxPortable: true
-        runTests: false
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        jobName: Build_LinuxPortable_Release_x64
-        buildConfiguration: Release
-        buildArchitecture: x64
-        linuxPortable: true
-        runTests: false
-
-    # MacOS
-
-    - template: eng/build.yml
-      parameters:
-        agentOs: Darwin
-        jobName: Build_Release_x64
-        buildConfiguration: Release
-        buildArchitecture: x64
-        runTests: false
-    - template: eng/build.yml
-      parameters:
-        agentOs: Darwin
-        jobName: Build_Release_arm64
-        runtimeIdentifier: 'osx-arm64'
-        buildConfiguration: Release
-        buildArchitecture: arm64
-        runTests: false
-
-    ## Windows PGO Instrumentation builds
-
-    - template: eng/build.yml
-      parameters:
-        agentOs: Windows_NT
-        pgoInstrument: true
-        jobName: Build_Release_x64
-        buildConfiguration: Release
-        buildArchitecture: x64
-        additionalBuildParameters: '/p:PublishInternalAsset=true'
-        runTests: false
-    - template: eng/build.yml
-      parameters:
-        agentOs: Windows_NT
-        pgoInstrument: true
-        jobName: Build_Release_x86
-        buildConfiguration: Release
-        buildArchitecture: x86
-        runTests: false
-    - template: eng/build.yml
-      parameters:
-        agentOs: Windows_NT
-        pgoInstrument: true
-        jobName: Build_Release_arm64
-        buildConfiguration: Release
-        buildArchitecture: arm64
-        runTests: false
-
-    ## Linux PGO Instrumentation builds
-
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        pgoInstrument: true
-        jobName: Build_LinuxPortable_Release_x64
-        buildConfiguration: Release
-        buildArchitecture: x64
-        linuxPortable: true
-        runTests: false
-
-    - template: eng/build.yml
-      parameters:
-        agentOs: Linux
-        pgoInstrument: true
-        jobName: Build_Release_arm64
-        buildConfiguration: Release
-        buildArchitecture: arm64
-        linuxPortable: true
-        runTests: false
-
-  - template: /eng/common/templates/jobs/source-build.yml
-
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - stage: Publish
-    dependsOn:
-    - Build
-    jobs:
-    - template: /eng/common/templates/job/publish-build-assets.yml
-      parameters:
-        publishUsingPipelines: true
-        publishAssetsImmediately: true
+        image: 1es-windows-2022
+        os: windows
+    stages:
+    - stage: Build
+      jobs:
+      # Build Retry Configuration
+      - job: Publish_Build_Configuration
         pool:
+          ${{ if eq(variables['System.TeamProject'], 'public') }}:
+            name: $(DncEngPublicBuildPool)
+            image: 1es-windows-2022-open
+            os: windows
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.vs2022.amd64
+            image: 1es-windows-2022
+            os: windows
+        steps:
+        - task: 1ES.PublishPipelineArtifact@1
+          displayName: Publish Build Config
+          inputs:
+            targetPath: $(Build.SourcesDirectory)\eng\buildConfiguration
+            artifactName: buildConfiguration
+
+      # PR-only jobs
+      - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+        # Windows
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Windows_NT
+            jobName: Build_Debug_x64
+            buildConfiguration: Debug
+            buildArchitecture: x64
+            additionalBuildParameters: '/p:PublishInternalAsset=true'
+            runTests: true
+
+        # Linux
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_Ubuntu_22_04_Debug_x64
+            container: ubuntu2204
+            buildConfiguration: Debug
+            buildArchitecture: x64
+            linuxPortable: true
+            runTests: true
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_Fedora_36_Debug_x64
+            container: fedora36
+            buildConfiguration: Debug
+            buildArchitecture: x64
+            linuxPortable: true
+            runTests: true
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_CentOS_8_Stream_Debug_x64
+            container: centosStream8
+            buildConfiguration: Debug
+            buildArchitecture: x64
+            linuxPortable: false
+            runTests: true
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_Debian_Stretch_Debug_x64
+            container: debianStretch
+            buildConfiguration: Debug
+            buildArchitecture: x64
+            additionalBuildParameters: '/p:BuildSdkDeb=true'
+            linuxPortable: false
+            runTests: true
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_Arm64_Debug
+            buildConfiguration: Debug
+            buildArchitecture: arm64
+            runtimeIdentifier: 'linux-arm64'
+            linuxPortable: true
+            # Never run tests on arm64
+            runTests: false
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_Linux_musl_Debug_x64
+            container: alpine315WithNode
+            buildConfiguration: Debug
+            buildArchitecture: x64
+            runtimeIdentifier: 'linux-musl-x64'
+            # Pass in HostOSName when running on alpine
+            additionalBuildParameters: '/p:HostOSName="linux-musl"'
+            linuxPortable: false
+            runTests: true
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_LinuxPortable_Release_x64
+            buildConfiguration: Release
+            buildArchitecture: x64
+            linuxPortable: true
+            runTests: true
+
+        # MacOS
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Darwin
+            jobName: Build_Release_x64
+            buildConfiguration: Release
+            buildArchitecture: x64
+            runTests: true
+
+      # Official/PGO instrumentation Builds
+      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+        # Windows
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Windows_NT
+            jobName: Build_Release_x64
+            buildConfiguration: Release
+            buildArchitecture: x64
+            additionalBuildParameters: '/p:PublishInternalAsset=true'
+            runTests: false
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Windows_NT
+            jobName: Build_Release_x86
+            buildConfiguration: Release
+            buildArchitecture: x86
+            runTests: false
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Windows_NT
+            jobName: Build_Release_arm64
+            buildConfiguration: Release
+            buildArchitecture: arm64
+            runTests: false
+
+        # Linux
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_Arm_Release
+            buildConfiguration: Release
+            buildArchitecture: arm
+            runtimeIdentifier: 'linux-arm'
+            linuxPortable: true
+            runTests: false
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_Arm64_Release
+            buildConfiguration: Release
+            buildArchitecture: arm64
+            runtimeIdentifier: 'linux-arm64'
+            linuxPortable: true
+            runTests: false
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_Linux_musl_Release_arm
+            container: ubuntu1804Cross
+            buildConfiguration: Release
+            buildArchitecture: arm
+            runtimeIdentifier: 'linux-musl-arm'
+            additionalBuildParameters: '/p:OSName="linux-musl"'
+            linuxPortable: false
+            runTests: false
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_Linux_musl_Release_arm64
+            buildConfiguration: Release
+            buildArchitecture: arm64
+            runtimeIdentifier: 'linux-musl-arm64'
+            additionalBuildParameters: '/p:OSName="linux-musl"'
+            linuxPortable: false
+            runTests: false
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_Linux_musl_Release_x64
+            container: alpine315WithNode
+            buildConfiguration: Release
+            buildArchitecture: x64
+            runtimeIdentifier: 'linux-musl-x64'
+            # Pass in HostOSName when running on alpine
+            additionalBuildParameters: '/p:HostOSName="linux-musl"'
+            linuxPortable: false
+            runTests: false
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_Linux_Portable_Deb_Release_x64
+            container: ubuntu2204DebPkg
+            buildConfiguration: Release
+            buildArchitecture: x64
+            # Do not publish zips and tarballs. The linux-x64 binaries are
+            # already published by Build_LinuxPortable_Release_x64
+            additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:BuildSdkDeb=true'
+            linuxPortable: true
+            runTests: false
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_Linux_Portable_Rpm_Release_x64
+            container: cblMariner20Fpm
+            buildConfiguration: Release
+            buildArchitecture: x64
+            # Do not publish zips and tarballs. The linux-x64 binaries are
+            # already published by Build_LinuxPortable_Release_x64
+            additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:IsRPMBasedDistro=true'
+            linuxPortable: true
+            runTests: false
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_Linux_Portable_Rpm_Release_Arm64
+            container: cblMariner20Fpm
+            buildConfiguration: Release
+            buildArchitecture: arm64
+            runtimeIdentifier: 'linux-arm64'
+            # Do not publish zips and tarballs. The linux-x64 binaries are
+            # already published by Build_LinuxPortable_Release_x64
+            additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:CLIBUILD_SKIP_TESTS=true  /p:IsRPMBasedDistro=true'
+            linuxPortable: true
+            runTests: false
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            jobName: Build_LinuxPortable_Release_x64
+            buildConfiguration: Release
+            buildArchitecture: x64
+            linuxPortable: true
+            runTests: false
+
+        # MacOS
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Darwin
+            jobName: Build_Release_x64
+            buildConfiguration: Release
+            buildArchitecture: x64
+            runTests: false
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Darwin
+            jobName: Build_Release_arm64
+            runtimeIdentifier: 'osx-arm64'
+            buildConfiguration: Release
+            buildArchitecture: arm64
+            runTests: false
+
+        # Windows PGO Instrumentation builds
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Windows_NT
+            pgoInstrument: true
+            jobName: Build_Release_x64
+            buildConfiguration: Release
+            buildArchitecture: x64
+            additionalBuildParameters: '/p:PublishInternalAsset=true'
+            runTests: false
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Windows_NT
+            pgoInstrument: true
+            jobName: Build_Release_x86
+            buildConfiguration: Release
+            buildArchitecture: x86
+            runTests: false
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Windows_NT
+            pgoInstrument: true
+            jobName: Build_Release_arm64
+            buildConfiguration: Release
+            buildArchitecture: arm64
+            runTests: false
+
+        # Linux PGO Instrumentation builds
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            pgoInstrument: true
+            jobName: Build_LinuxPortable_Release_x64
+            buildConfiguration: Release
+            buildArchitecture: x64
+            linuxPortable: true
+            runTests: false
+        - template: eng/build.yml@self
+          parameters:
+            agentOs: Linux
+            pgoInstrument: true
+            jobName: Build_Release_arm64
+            buildConfiguration: Release
+            buildArchitecture: arm64
+            linuxPortable: true
+            runTests: false
+
+      # Source Build
+      - template: /eng/common/templates-official/jobs/source-build.yml@self
+
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - stage: Publish
+        dependsOn:
+        - Build
+        jobs:
+        - template: /eng/common/templates-official/job/publish-build-assets.yml@self
+          parameters:
+            publishUsingPipelines: true
+            publishAssetsImmediately: true
+            pool:
+              name: $(DncEngInternalBuildPool)
+              image: 1es-windows-2022
+              os: windows

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -59,7 +59,7 @@ stages:
     
     ## Windows
 
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Windows_NT
         jobName: Build_Debug_x64
@@ -70,7 +70,7 @@ stages:
 
     ## Linux
 
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_Ubuntu_22_04_Debug_x64
@@ -79,7 +79,7 @@ stages:
         buildArchitecture: x64
         linuxPortable: true
         runTests: true
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_Fedora_36_Debug_x64
@@ -88,7 +88,7 @@ stages:
         buildArchitecture: x64
         linuxPortable: true
         runTests: true
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_CentOS_8_Stream_Debug_x64
@@ -97,7 +97,7 @@ stages:
         buildArchitecture: x64
         linuxPortable: false
         runTests: true
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_Debian_Stretch_Debug_x64
@@ -107,7 +107,7 @@ stages:
         additionalBuildParameters: '/p:BuildSdkDeb=true'
         linuxPortable: false
         runTests: true
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_Arm64_Debug
@@ -117,7 +117,7 @@ stages:
         linuxPortable: true
         # Never run tests on arm64
         runTests: false
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_Linux_musl_Debug_x64
@@ -129,7 +129,7 @@ stages:
         additionalBuildParameters: '/p:HostOSName="linux-musl"'
         linuxPortable: false
         runTests: true
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_LinuxPortable_Release_x64
@@ -140,7 +140,7 @@ stages:
 
     # MacOS
 
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Darwin
         jobName: Build_Release_x64
@@ -154,7 +154,7 @@ stages:
     
     ## Windows
 
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Windows_NT
         jobName: Build_Release_x64
@@ -162,14 +162,14 @@ stages:
         buildArchitecture: x64
         additionalBuildParameters: '/p:PublishInternalAsset=true'
         runTests: false
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Windows_NT
         jobName: Build_Release_x86
         buildConfiguration: Release
         buildArchitecture: x86
         runTests: false
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Windows_NT
         jobName: Build_Release_arm64
@@ -179,7 +179,7 @@ stages:
 
     ## Linux 
 
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_Arm_Release
@@ -188,7 +188,7 @@ stages:
         runtimeIdentifier: 'linux-arm'
         linuxPortable: true
         runTests: false
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_Arm64_Release
@@ -197,7 +197,7 @@ stages:
         runtimeIdentifier: 'linux-arm64'
         linuxPortable: true
         runTests: false
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_Linux_musl_Release_arm
@@ -208,7 +208,7 @@ stages:
         additionalBuildParameters: '/p:OSName="linux-musl"'
         linuxPortable: false
         runTests: false
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_Linux_musl_Release_arm64
@@ -218,7 +218,7 @@ stages:
         additionalBuildParameters: '/p:OSName="linux-musl"'
         linuxPortable: false
         runTests: false
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_Linux_musl_Release_x64
@@ -230,7 +230,7 @@ stages:
         additionalBuildParameters: '/p:HostOSName="linux-musl"'
         linuxPortable: false
         runTests: false
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_Linux_Portable_Deb_Release_x64
@@ -242,7 +242,7 @@ stages:
         additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:BuildSdkDeb=true'
         linuxPortable: true
         runTests: false
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_Linux_Portable_Rpm_Release_x64
@@ -254,7 +254,7 @@ stages:
         additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:IsRPMBasedDistro=true'
         linuxPortable: true
         runTests: false
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_Linux_Portable_Rpm_Release_Arm64
@@ -267,7 +267,7 @@ stages:
         additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:CLIBUILD_SKIP_TESTS=true  /p:IsRPMBasedDistro=true'
         linuxPortable: true
         runTests: false
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         jobName: Build_LinuxPortable_Release_x64
@@ -278,14 +278,14 @@ stages:
 
     # MacOS
 
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Darwin
         jobName: Build_Release_x64
         buildConfiguration: Release
         buildArchitecture: x64
         runTests: false
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Darwin
         jobName: Build_Release_arm64
@@ -296,7 +296,7 @@ stages:
 
     ## Windows PGO Instrumentation builds
 
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Windows_NT
         pgoInstrument: true
@@ -305,7 +305,7 @@ stages:
         buildArchitecture: x64
         additionalBuildParameters: '/p:PublishInternalAsset=true'
         runTests: false
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Windows_NT
         pgoInstrument: true
@@ -313,7 +313,7 @@ stages:
         buildConfiguration: Release
         buildArchitecture: x86
         runTests: false
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Windows_NT
         pgoInstrument: true
@@ -324,7 +324,7 @@ stages:
 
     ## Linux PGO Instrumentation builds
 
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         pgoInstrument: true
@@ -334,7 +334,7 @@ stages:
         linuxPortable: true
         runTests: false
 
-    - template: eng/build.yml
+    - template: eng/build-pr.yml
       parameters:
         agentOs: Linux
         pgoInstrument: true
@@ -344,7 +344,7 @@ stages:
         linuxPortable: true
         runTests: false
 
-  - template: /eng/common/templates/jobs/source-build.yml
+  - template: /eng/common/templates/jobs/source-build-pr.yml
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - stage: Publish

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -1,9 +1,9 @@
 parameters:
-  # Agent OS identifier and used as job name
+# Agent OS identifier and used as job name
 - name: agentOs
   type: string
 
-  # Job name
+# Job name
 - name: jobName
   type: string
 
@@ -12,7 +12,7 @@ parameters:
   type: string
   default: ''
 
-  # Job timeout
+# Job timeout
 - name: timeoutInMinutes
   type: number
   default: 180
@@ -69,36 +69,42 @@ parameters:
   default: false
 
 jobs:
-- template: common/templates/job/job.yml
+- template: common/templates-official/job/job.yml
   parameters:
     # Set up the name of the job.
     ${{ if parameters.pgoInstrument }}:
       name: PGO_${{ parameters.agentOs }}_${{ parameters.jobName }}
     ${{ if not(parameters.pgoInstrument) }}:
       name: ${{ parameters.agentOs }}_${{ parameters.jobName }}
-    
-    ## Set up the pool/machine info to be used based on the Agent OS
+
+    # Set up the pool/machine info to be used based on the Agent OS
     ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
       enableMicrobuild: true
       pool:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals windows.vs2019.amd64.open
+          image: 1es-windows-2019-open
+          os: windows
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: $(DncEngInternalBuildPool)
-          demands: ImageOverride -equals windows.vs2019.amd64
+          image: 1es-windows-2019
+          os: windows
     ${{ if eq(parameters.agentOs, 'Linux') }}:
       pool:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
+          image: 1es-ubuntu-1804-open
+          os: linux
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: $(DncEngInternalBuildPool)
-          demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+          image: 1es-ubuntu-1804
+          os: linux
       container: ${{ parameters.container }}
     ${{ if eq(parameters.agentOs, 'Darwin') }}:
       pool:
-        vmImage: 'macOS-latest'
+        name: Azure Pipelines
+        image: macOS-latest
+        os: macOS
 
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     ${{ if parameters.isBuiltFromVmr }}:
@@ -111,8 +117,8 @@ jobs:
     workspace:
       clean: all
 
-# Test parameters
     variables:
+    # Test variables
     - ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
       - _PackArg: '-pack'
       - ${{ if parameters.runTests }}:
@@ -168,7 +174,7 @@ jobs:
                   /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
                   $(_PgoInstrument)
 
-    - template: /eng/common/templates/variables/pool-providers.yml
+    - template: /eng/common/templates-official/variables/pool-providers.yml
 
     steps:
     - checkout: self
@@ -245,13 +251,13 @@ jobs:
       inputs:
         SourceFolder: '$(installerRoot)/artifacts'
         Contents: |
-         log/${{ parameters.buildConfiguration }}/**/*
-         TestResults/${{ parameters.buildConfiguration }}/**/*
+          log/${{ parameters.buildConfiguration }}/**/*
+          TestResults/${{ parameters.buildConfiguration }}/**/*
         TargetFolder: '$(Build.ArtifactStagingDirectory)'
       continueOnError: true
       condition: always()
 
-    - task: PublishBuildArtifacts@1
+    - task: 1ES.PublishBuildArtifacts@1
       displayName: Publish Logs to VSTS
       inputs:
         PathtoPublish: '$(Build.ArtifactStagingDirectory)'

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -93,11 +93,11 @@ jobs:
       pool:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: $(DncEngPublicBuildPool)
-          image: 1es-ubuntu-1804-open
+          image: 1es-ubuntu-2004-open
           os: linux
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: $(DncEngInternalBuildPool)
-          image: 1es-ubuntu-1804
+          image: 1es-ubuntu-2004
           os: linux
       container: ${{ parameters.container }}
     ${{ if eq(parameters.agentOs, 'Darwin') }}:


### PR DESCRIPTION
Related: https://github.com/dotnet/installer/pull/19016
Related: https://github.com/dotnet/installer/pull/19104

## Summary
This is the same work as the related PR for `main`, but in `release/8.0.1xx`. Some minor differences but basically the exact same work.