### PR TITLE
Generate a props file that can be used to detect MSBuild version mismatches

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -2,7 +2,7 @@
 
   <Target Name="GenerateBundledVersions"
           Condition="'$(PgoInstrument)' != 'true'"
-          DependsOnTargets="GenerateBundledVersionsProps;GenerateBundledCliToolsProps" >
+          DependsOnTargets="GenerateBundledVersionsProps;GenerateBundledCliToolsProps;GenerateBundledMSBuildProps" >
 
     <WriteLinesToFile
       File="$(ArtifactsShippingPackagesDir)productVersion.txt"
@@ -1244,6 +1244,52 @@ Copyright (c) .NET Foundation. All rights reserved.
     <WriteLinesToFile File="$(SdkOutputDirectory)$(BundledBundledCliToolsPropsFileName)"
                       Lines="$(BundledBundledCliToolsPropsContent)"
                       Overwrite="true" />
+  </Target>
+
+  <Target Name="GenerateBundledMSBuildProps" DependsOnTargets="SetupBundledComponents">
+    <PropertyGroup>
+      <BundledMSBuildPropsFileName>Microsoft.NETCoreSdk.BundledMSBuildInformation.props</BundledMSBuildPropsFileName>
+      <MinimumMSBuildVersionFile Condition="$([System.Text.RegularExpressions.Regex]::Match(%(SDKInternalFiles.Identity),'.*minimumMSBuildVersion').Success) ">%(SDKInternalFiles.Identity)</MinimumMSBuildVersionFile>
+      <BundledMSBuildVersion>$(MSBuildVersion)</BundledMSBuildVersion>
+    </PropertyGroup>
+
+    <ReadLinesFromFile File="$(MinimumMSBuildVersionFile)">
+      <Output TaskParameter="Lines" PropertyName="MinimumMSBuildVersion"/>
+    </ReadLinesFromFile>
+
+    <PropertyGroup>
+      <_BundledMSBuildVersionMajorMinor>$([System.Version]::Parse('$(BundledMSBuildVersion)').ToString(2))</_BundledMSBuildVersionMajorMinor>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <BundledMSBuildPropsFileContent>
+<![CDATA[
+<!--
+***********************************************************************************************
+$(BundledMSBuildPropsFileName)
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project>
+  <PropertyGroup>
+    <MinimumMSBuildVersion>$(MinimumMSBuildVersion)</MinimumMSBuildVersion>
+    <BundledMSBuildVersion>$(BundledMSBuildVersion)</BundledMSBuildVersion>
+    <_MSBuildVersionMajorMinor>%24([System.Version]::Parse('%24(MSBuildVersion)').ToString(2))</_MSBuildVersionMajorMinor>
+    <_IsDisjointMSBuildVersion>%24([MSBuild]::VersionGreaterThan('%24(_MSBuildVersionMajorMinor)', '$(_BundledMSBuildVersionMajorMinor)'))</_IsDisjointMSBuildVersion>
+  </PropertyGroup>
+</Project>
+]]>
+      </BundledMSBuildPropsFileContent>
+    </PropertyGroup>
+
+  <WriteLinesToFile File="$(SdkOutputDirectory)$(BundledMSBuildPropsFileName)"
+    Lines="$(BundledMSBuildPropsFileContent)"
+    Overwrite="true" />
   </Target>
 
   <ItemGroup>


### PR DESCRIPTION
This is part of a comprehensive fix to address scenarios where users may use full-framework MSBuild to build projects with an SDK that is mismatched or not compatible with the IDE's expected Roslyn/Razor tooling. In case of a mismatch, we'd like to automatically inject a PackageReference to the Roslyn toolset package, but we need to know when such a mismatch has happened. A fast and simple way to do this is to 'stamp' the 'expected' version of MSBuild during product construction and compare that to the 'current' version being used during the actual user-facing build.

This PR adds the stamping and props-file generation, and a matching PR in the SDK repo will be required to actually consume this file and add the new condition to the existing toolset compilers check.
