### PR TITLE
Allow new WPF binaries in the VMR

### DIFF
--- a/src/SourceBuild/content/eng/allowed-vmr-binaries.txt
+++ b/src/SourceBuild/content/eng/allowed-vmr-binaries.txt
@@ -132,3 +132,9 @@ src/winforms/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTes
 src/winforms/src/System.Windows.Forms/tests/UnitTests/bitmaps/milkmateya01.emf
 src/winforms/src/System.Windows.Forms/tests/UnitTests/TestResources/VB6/SimpleControl.vb6
 src/winforms/src/System.Windows.Forms*/**/*.wmf
+
+# wpf
+src/wpf/src/Microsoft.DotNet.Wpf/src/ReachFramework/Resources/generated/*.resources
+src/wpf/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/Hyphenation/Hyphen_en.lex
+src/wpf/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/Hyphenation/Hyphen_en.hdict
+src/wpf/src/Microsoft.DotNet.Wpf/src/Shared/Tracing/resources/*.BIN


### PR DESCRIPTION
Closes https://github.com/dotnet/source-build/issues/3746

Allows the following WPF binaries into the VMR:

```
src/wpf/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/Hyphenation/Hyphen_en.hdict
src/wpf/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/Hyphenation/Hyphen_en.lex
src/wpf/src/Microsoft.DotNet.Wpf/src/ReachFramework/Resources/generated/Schemas_ContentTypes.resources
src/wpf/src/Microsoft.DotNet.Wpf/src/ReachFramework/Resources/generated/Schemas_CoreProperties.resources
src/wpf/src/Microsoft.DotNet.Wpf/src/ReachFramework/Resources/generated/Schemas_DiscardControl.resources
src/wpf/src/Microsoft.DotNet.Wpf/src/ReachFramework/Resources/generated/Schemas_DocStructure.resources
src/wpf/src/Microsoft.DotNet.Wpf/src/ReachFramework/Resources/generated/Schemas_OPC_DigSig.resources
src/wpf/src/Microsoft.DotNet.Wpf/src/ReachFramework/Resources/generated/Schemas_Relationships.resources
src/wpf/src/Microsoft.DotNet.Wpf/src/ReachFramework/Resources/generated/Schemas_S0.resources
src/wpf/src/Microsoft.DotNet.Wpf/src/ReachFramework/Resources/generated/Schemas_SignatureDefinitions.resources
src/wpf/src/Microsoft.DotNet.Wpf/src/ReachFramework/Resources/generated/Schemas_Versioning.resources
src/wpf/src/Microsoft.DotNet.Wpf/src/ReachFramework/Resources/generated/Schemas_xmldsig-core-schema.resources
src/wpf/src/Microsoft.DotNet.Wpf/src/Shared/Tracing/resources/MSG00001.bin
src/wpf/src/Microsoft.DotNet.Wpf/src/Shared/Tracing/resources/wpf-etwTEMP.BIN
```