### PR TITLE
Allow Winforms binary in VMR

### DIFF
--- a/src/SourceBuild/content/eng/allowed-vmr-binaries.txt
+++ b/src/SourceBuild/content/eng/allowed-vmr-binaries.txt
@@ -132,3 +132,4 @@ src/winforms/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTes
 src/winforms/src/System.Windows.Forms/tests/UnitTests/bitmaps/milkmateya01.emf
 src/winforms/src/System.Windows.Forms/tests/UnitTests/TestResources/VB6/SimpleControl.vb6
 src/winforms/src/System.Windows.Forms*/**/*.wmf
+src/winforms/src/System.Windows.Forms.Design/src/Resources/colordlg.data


### PR DESCRIPTION
Closes https://github.com/dotnet/source-build/issues/4096

Allows the following Winforms binary into the VMR:

```
src/winforms/src/System.Windows.Forms.Design/src/Resources/colordlg.data
```