### PR TITLE
Temporarily disable CredScan

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -70,6 +70,10 @@ extends:
         name: $(DncEngInternalBuildPool)
         image: 1es-windows-2022
         os: windows
+      # Temporary to workaround MicroBuild issues.
+      credscan:
+        enabled: false
+        justificationForDisabling: 'CredScan is failing on the MicroBuild signing plugin. "MicroBuild/Plugins/nuget.config" has changing content and thus cannot be baselined.'
     stages:
     - stage: Build
       jobs:


### PR DESCRIPTION
## Summary
Our internal builds are failing after merging the [1ES PT migration PR](https://github.com/dotnet/installer/pull/19016). This is because the CredScan tool scans the MicroBuild signing plugin, which is installed by Arcade to do signing on our builds. Normally, the [baselining files](https://github.com/dotnet/installer/pull/19127) would have solved this issue. However, the `MicroBuild/Plugins/nuget.config` has dynamic content which causes the baselining to produce a new signature hash, and thus cannot be baselined. For the time being, we'll just disable CredScan until either:
1. Arcade is updated to use the new version of the MicroBuild plugin, where it has been adjusted to install these files into a temporary location.
3. We spent the effort to properly review the SDL tool settings, and set the scanning locations accordingly to not include these files.

I validated this works on a different branch also doing the 1ES PT migration:
- https://dnceng.visualstudio.com/internal/_build/results?buildId=2412315