### PR TITLE
Add win-x86 to known ILCompiler and NativeAOT runtime packs

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -378,6 +378,7 @@
         @(Net80ILCompilerSupportedRids);
         linux-arm;
         linux-musl-arm;
+        win-x86;
         " />
 
       <!-- The subset of ILCompiler target RIDs that are officially supported. Should be a subset of
@@ -411,6 +412,7 @@
           linux-musl-x64;
           linux-musl-arm;
           linux-musl-arm64;
+          win-x86;
           win-x64;
           win-arm64;
           browser-wasm;


### PR DESCRIPTION
Related to https://github.com/dotnet/runtime/issues/86573