### PR TITLE
Fix the VMR synchronization 1ES pipeline

### DIFF
--- a/eng/pipelines/vmr-sync-internal.yml
+++ b/eng/pipelines/vmr-sync-internal.yml
@@ -41,12 +41,12 @@ variables:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
-    pool:
-      name: $(DncEngInternalBuildPool)
-      image: 1es-windows-2022-pt
-      os: windows
-
     sdl:
+      sourceAnalysisPool:
+        name: $(DncEngInternalBuildPool)
+        image: 1es-windows-2022
+        os: windows
+
       sourceRepositoriesToScan:
         exclude:
         - repository: vmr
@@ -59,6 +59,6 @@ extends:
     - stage: VMRSynchronization
       displayName: VMR Synchronization
       jobs:
-      - template: templates/jobs/vmr-synchronization.yml@self
+      - template: /eng/pipelines/templates/jobs/vmr-synchronization.yml@self
         parameters:
           vmrBranch: ${{ variables.VmrBranch }}

--- a/eng/pipelines/vmr-sync.yml
+++ b/eng/pipelines/vmr-sync.yml
@@ -43,12 +43,12 @@ variables:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
-    pool:
-      name: $(DncEngInternalBuildPool)
-      image: 1es-windows-2022-pt
-      os: windows
-
     sdl:
+      sourceAnalysisPool:
+        name: $(DncEngInternalBuildPool)
+        image: 1es-windows-2022
+        os: windows
+
       sourceRepositoriesToScan:
         exclude:
         - repository: vmr
@@ -63,5 +63,4 @@ extends:
       jobs:
       - template: /eng/pipelines/templates/jobs/vmr-synchronization.yml@self
         parameters:
-          jobName: Synchronize_VMR
           vmrBranch: ${{ variables.VmrBranch }}


### PR DESCRIPTION
Fixes a breaking clash with the `jobName` parameter that was removed in https://github.com/dotnet/installer/pull/18564