### PR TITLE
Adjust license filtering for app-insights versions

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
@@ -59,6 +59,7 @@ public class LicenseScanTests : TestBase
         "bzip2-libbzip-2010", // https://github.com/nexB/scancode-toolkit/blob/develop/src/licensedcode/data/licenses/bzip2-libbzip-2010.LICENSE
         "cc0-1.0", // https://creativecommons.org/publicdomain/zero/1.0/legalcode
         "cc-by-3.0", // https://creativecommons.org/licenses/by/3.0/legalcode
+        "cc-by-3.0-us", // https://creativecommons.org/licenses/by/3.0/us/legalcode
         "cc-by-4.0", // https://creativecommons.org/licenses/by/4.0/legalcode
         "cc-by-sa-3.0", // https://creativecommons.org/licenses/by-sa/3.0/legalcode
         "cc-by-sa-4.0", // https://creativecommons.org/licenses/by-sa/4.0/legalcode

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseExclusions.txt
@@ -204,7 +204,7 @@ src/runtime/src/mono/sample/wasm/browser-webpack/package-lock.json
 
 # False positive
 src/source-build-externals/src/abstractions-xunit/README.md|free-unknown
-src/source-build-externals/src/application-insights/NETCORE/ThirdPartyNotices.txt|unknown
+src/source-build-externals/src/application-insights-2.2*.0/NETCORE/ThirdPartyNotices.txt|unknown
 src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/benchmark/Microsoft.IdentityModel.Benchmarks/CreateTokenTests.cs|proprietary-license
 src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/src/Microsoft.IdentityModel.JsonWebTokens/JsonClaimValueTypes.cs|proprietary-license
 src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/src/Microsoft.IdentityModel.Tokens.Saml/Saml/ClaimProperties.cs|proprietary-license
@@ -218,7 +218,7 @@ src/source-build-externals/src/xunit/src/xunit.assert/Asserts/README.md|free-unk
 src/source-build-externals/src/xunit/xunit.sln|json
 
 # A patch which removes the license usage but contains references to the removed license as part of the patch reference lines
-src/source-build-externals/patches/application-insights/0002-Remove-WebGrease-from-TPN-2816.patch
+src/source-build-externals/patches/application-insights-2.2*.0/0002-Remove-WebGrease-from-TPN-2816.patch
 
 # Scanner is identifying the https://github.com/SixLabors/ImageSharp/blob/master/LICENSE license as unknown. But this license is not applicable because we're
 # relying on the Spectre.Console distribution.

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/licenses/Licenses.source-build-externals.json
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/licenses/Licenses.source-build-externals.json
@@ -1,12 +1,20 @@
 {
   "files": [
     {
-      "path": "src/application-insights/LOGGING/ThirdPartyNotices.txt",
+      "path": "src/application-insights-2.21.0/LOGGING/ThirdPartyNotices.txt",
       "detected_license_expression": "unknown AND apache-2.0 AND mit AND bsd-new"
     },
     {
-      "path": "src/application-insights/WEB/ThirdPartyNotices.txt",
+      "path": "src/application-insights-2.21.0/LOGGING/test/Shared/CustomTelemetryChannel.cs",
+      "detected_license_expression": "proprietary-license"
+    },
+    {
+      "path": "src/application-insights-2.21.0/WEB/ThirdPartyNotices.txt",
       "detected_license_expression": "bsd-new AND mit AND ms-pl AND apache-2.0 AND (cc-by-3.0-us AND cc-by-3.0 AND mit) AND ms-net-library AND ms-rl"
+    },
+    {
+      "path": "src/application-insights-2.22.0/LOGGING/ThirdPartyNotices.txt",
+      "detected_license_expression": "unknown AND apache-2.0 AND mit AND bsd-new"
     }
   ]
 }


### PR DESCRIPTION
Backport of https://github.com/dotnet/installer/pull/18968

But this also includes filters to handle AppInsights 2.21.0

Related to https://github.com/dotnet/source-build/issues/4252