### PR TITLE
Arcade and Runtime Doc License Exceptions

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseExclusions.txt
@@ -13,8 +13,8 @@
 #
 
 # False positive
-src/arcade/Documentation/UnifiedBuild/VMR-Permissible-Sources.md|free-unknown
 src/arcade/Documentation/UnifiedBuild/Foundational-Concepts.md
+src/arcade/Documentation/UnifiedBuild/VMR-Permissible-Sources.md|free-unknown
 src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/src/BuildFPMToolPreReqs.cs|json
 src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/rpm_templates/copyright|cecill-c
 src/arcade/src/Microsoft.DotNet.XUnitAssert/src/README.md|free-unknown
@@ -157,8 +157,8 @@ src/runtime/docs/project/copyright.md
 src/runtime/docs/project/glossary.md
 
 # Doc that references a license, not applicable to source
-src/runtime/src/coreclr/nativeaot/docs/compiling.md|openssl-ssleay
 src/runtime/docs/design/mono/web/llvm-backend.md|llvm-exception
+src/runtime/src/coreclr/nativeaot/docs/compiling.md|openssl-ssleay
 
 # Installer asset, not applicable to source
 src/runtime/src/installer/pkg/LICENSE-MSFT.TXT

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseExclusions.txt
@@ -158,6 +158,7 @@ src/runtime/docs/project/glossary.md
 
 # Doc that references a license, not applicable to source
 src/runtime/src/coreclr/nativeaot/docs/compiling.md|openssl-ssleay
+src/runtime/docs/design/mono/web/llvm-backend.md|llvm-exception
 
 # Installer asset, not applicable to source
 src/runtime/src/installer/pkg/LICENSE-MSFT.TXT

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseExclusions.txt
@@ -13,6 +13,7 @@
 #
 
 # False positive
+src/arcade/Documentation/UnifiedBuild/VMR-Permissible-Sources.md|free-unknown
 src/arcade/Documentation/UnifiedBuild/Foundational-Concepts.md
 src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/src/BuildFPMToolPreReqs.cs|json
 src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/rpm_templates/copyright|cecill-c


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4251

The arcade doc added in https://github.com/dotnet/arcade/pull/14547 was considered to have a "free-unknown" license exception. This is a false positive because the document describes licenses but does not contain any non-OSS licenses.

The runtime doc added in https://github.com/dotnet/runtime/pull/99755 references an "llvm-exception" on [line 158](https://github.com/dotnet/runtime/blob/785d62bda7956fdce050211f65f19d0312a20473/docs/design/mono/web/llvm-backend.md?plain=1#L158). The document describes the exception but does not actually contain the exception.