### PR TITLE
[wasm] Use current SDK pack for down level TFM

### DIFF
--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -97,7 +97,6 @@
       
       <_NET80RuntimePackVersion>8.0.$(VersionFeature80)</_NET80RuntimePackVersion>
       <_NET80TargetingPackVersion>8.0.$(VersionFeature80)</_NET80TargetingPackVersion>
-      <_NET80WebAssemblyPackVersion>8.0.$(VersionFeature80)</_NET80WebAssemblyPackVersion>
       <_WindowsDesktop80RuntimePackVersion>8.0.$(VersionFeature80)</_WindowsDesktop80RuntimePackVersion>
       <_WindowsDesktop80TargetingPackVersion>8.0.$(VersionFeature80)</_WindowsDesktop80TargetingPackVersion>
       <_AspNet80RuntimePackVersion>8.0.$(VersionFeature80)</_AspNet80RuntimePackVersion>
@@ -695,7 +694,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     
     <KnownWebAssemblySdkPack Include="Microsoft.NET.Sdk.WebAssembly.Pack"
                              TargetFramework="net8.0"
-                             WebAssemblySdkPackVersion="$(_NET80WebAssemblyPackVersion)" />
+                             WebAssemblySdkPackVersion="$(MicrosoftNETCoreAppRuntimePackageVersion)" />
 
     <KnownRuntimePack Include="Microsoft.NETCore.App"
                       TargetFramework="net8.0"
@@ -796,7 +795,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <KnownWebAssemblySdkPack Include="Microsoft.NET.Sdk.WebAssembly.Pack"
                              TargetFramework="net7.0"
-                             WebAssemblySdkPackVersion="$(_NET80WebAssemblyPackVersion)" />
+                             WebAssemblySdkPackVersion="$(MicrosoftNETCoreAppRuntimePackageVersion)" />
 
     <KnownRuntimePack Include="Microsoft.NETCore.App"
                       TargetFramework="net7.0"
@@ -890,7 +889,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <KnownWebAssemblySdkPack Include="Microsoft.NET.Sdk.WebAssembly.Pack"
                              TargetFramework="net6.0"
-                             WebAssemblySdkPackVersion="$(_NET80WebAssemblyPackVersion)" />
+                             WebAssemblySdkPackVersion="$(MicrosoftNETCoreAppRuntimePackageVersion)" />
 
     <KnownRuntimePack Include="Microsoft.NETCore.App"
                       TargetFramework="net6.0"


### PR DESCRIPTION
Originally I wanted to have a fixed version for down level TFM, so that "current" code doesn't have to deal with state required for previous versions. This idea goes the opposite direction than the rest of the SDK. After dicussion with Javier and changes to Static Web Assets, this would require to backport parts of Static Web Assets to down level Wasm SDK pack to that it will work current version of Static Web Assets.

My updated thinking is that aligning versioning with the rest of the SDK is better idea.