### PR TITLE
Scan binaries for licenses

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
@@ -103,34 +103,7 @@ public class LicenseScanTests : TestBase
         "zlib" // https://opensource.org/license/zlib/
     };
 
-    private static readonly string[] s_ignoredFilePatterns = new string[]
-    {
-        "*.bin",
-        "*.bmp",
-        "*.bson",
-        "*.db",
-        "*.dic",
-        "*.eot",
-        "*.gif",
-        "*.ico",
-        "*.jpg",
-        "*.il",
-        "*.ildump",
-        "*.lss",
-        "*.nlp",
-        "*.otf",
-        "*.pdf",
-        "*.pfx",
-        "*.png",
-        "*.snk",
-        "*.ttf",
-        "*.vsd",
-        "*.vsdx",
-        "*.winmd",
-        "*.woff",
-        "*.woff2",
-        "*.xlsx",
-    };
+    private static readonly string[] s_ignoredFilePatterns = new string[] { };
 
     private readonly string _targetRepo;
 

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
@@ -103,7 +103,10 @@ public class LicenseScanTests : TestBase
         "zlib" // https://opensource.org/license/zlib/
     };
 
-    private static readonly string[] s_ignoredFilePatterns = new string[] { };
+    private static readonly string[] s_ignoredFilePatterns = new string[]
+    {
+        "*.ildump",
+    };
 
     private readonly string _targetRepo;
 


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/4255#issuecomment-2018963401

This enables scanning binaries for non-OSS licenses.
