### PR TITLE
Cloak Non-OSS licensed Winforms test

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseExclusions.txt
@@ -275,13 +275,6 @@ src/vstest/src/package/Microsoft.CodeCoverage/ThirdPartyNoticesCodeCoverage.txt
 src/vstest/src/package/Microsoft.VisualStudio.TestTools.TestPlatform.V2.CLI/License.rtf
 
 #
-# winforms
-#
-
-# ISSUE: Winforms repo bringing in a non-open source license (https://github.com/dotnet/source-build/issues/3772)
-src/winforms/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/LICENSE.txt
-
-#
 # wpf
 #
 

--- a/src/VirtualMonoRepo/source-mappings.json
+++ b/src/VirtualMonoRepo/source-mappings.json
@@ -186,7 +186,11 @@
         },
         {
             "name": "winforms",
-            "defaultRemote": "https://github.com/dotnet/winforms"
+            "defaultRemote": "https://github.com/dotnet/winforms",
+            "exclude": [
+                // Non-OSS license - https://github.com/dotnet/source-build/issues/3772
+                "src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/**"
+            ]
         },
         {
             "name": "wpf",


### PR DESCRIPTION
Resolves https://github.com/dotnet/winforms/issues/10779

The [original changes for removing the offending Non-OSS licensed code](https://github.com/dotnet/installer/pull/18280) were only added to .NET 9 preview 1.

Since the rule is that code that does not meet the license requirements must be excluded when syncing code into the VMR, we should cloak the offending code for main.
