### PR TITLE
Cloak Non-OSS licensed vstest binary

### DIFF
--- a/src/VirtualMonoRepo/source-mappings.json
+++ b/src/VirtualMonoRepo/source-mappings.json
@@ -167,7 +167,9 @@
             "defaultRemote": "https://github.com/microsoft/vstest",
             "exclude": [
                 // Non-OSS license used in VS specific build configurations.
-                "src/package/licenses/LICENSE_VS.txt"
+                // Non-OSS license - https://github.com/dotnet/source-build/issues/4255
+                "src/package/licenses/LICENSE_VS.txt",
+                "test/Microsoft.TestPlatform.CoreUtilities.UnitTests/TestAssets/dotnetWinX86.exe"
             ]
         },
         {


### PR DESCRIPTION
Resolves https://github.com/dotnet/source-build/issues/4255

This PR cloaks a non-OSS licensed binary in vstest.
