### PR TITLE
Fixup parsing installer sha from VMR build tag

### DIFF
--- a/eng/pipelines/templates/jobs/sdk-diff-tests.yml
+++ b/eng/pipelines/templates/jobs/sdk-diff-tests.yml
@@ -38,7 +38,7 @@ jobs:
       
       echo "Dotnet-dotnet build: https://dev.azure.com/dnceng/internal/_build/results?buildId=$dotnet_dotnet_build&view=results"
 
-      installer_sha=$(az pipelines build tag list --organization '$(AZDO_ORG)' --project '$(AZDO_PROJECT)' --build-id $dotnet_dotnet_build --output tsv | sed "s,installer ,,g")
+      installer_sha=$(az pipelines build tag list --organization '$(AZDO_ORG)' --project '$(AZDO_PROJECT)' --build-id $dotnet_dotnet_build --query "[?contains(@, 'installer')]" --output tsv | sed "s,installer ,,g")
       installer_build=$(az pipelines runs list --organization '$(AZDO_ORG)' --project '$(AZDO_PROJECT)' --pipeline-ids '$(INSTALLER_OFFICIAL_CI_PIPELINE_ID)' --query "[?sourceVersion == '$installer_sha'].id" --output tsv)
       if [[ -z "$installer_build" ]]; then
         echo "Could not find a build of installer for commit '$installer_sha'"


### PR DESCRIPTION
Resolves https://github.com/dotnet/source-build/issues/4275

Fixes `installer` sha parsing not accounting for the VMR build having multiple tags