### PR TITLE
Add Exclusion File Validation & Consistency

### DIFF
--- a/eng/pipelines/vmr-license-scan.yml
+++ b/eng/pipelines/vmr-license-scan.yml
@@ -109,6 +109,8 @@ jobs:
       find artifacts/ -type f -name "BuildTests*.binlog" -exec cp {} --parents -t ${targetFolder} \;
       find artifacts/ -type f -name "BuildTests*.log" -exec cp {} --parents -t ${targetFolder} \;
       echo "Updated:"
+      find test/ -type f -name "UpdatedLicenseExclusions.txt"
+      find test/ -type f -name "UpdatedLicenseExclusions.txt" -exec cp {} --parents -t ${targetFolder} \;
       find test/ -type f -name "Updated*.json"
       find test/ -type f -name "Updated*.json" -exec cp {} --parents -t ${targetFolder} \;
       echo "Results:"

--- a/eng/pipelines/vmr-license-scan.yml
+++ b/eng/pipelines/vmr-license-scan.yml
@@ -109,8 +109,8 @@ jobs:
       find artifacts/ -type f -name "BuildTests*.binlog" -exec cp {} --parents -t ${targetFolder} \;
       find artifacts/ -type f -name "BuildTests*.log" -exec cp {} --parents -t ${targetFolder} \;
       echo "Updated:"
-      find test/ -type f -name "UpdatedLicenseExclusions.txt"
-      find test/ -type f -name "UpdatedLicenseExclusions.txt" -exec cp {} --parents -t ${targetFolder} \;
+      find test/ -type f -name "UpdatedLicenseExclusions*.txt"
+      find test/ -type f -name "UpdatedLicenseExclusions*.txt" -exec cp {} --parents -t ${targetFolder} \;
       find test/ -type f -name "Updated*.json"
       find test/ -type f -name "Updated*.json" -exec cp {} --parents -t ${targetFolder} \;
       echo "Results:"

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/ExclusionsHelper.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/ExclusionsHelper.cs
@@ -1,0 +1,179 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.FileSystemGlobbing;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.SourceBuild.SmokeTests;
+
+internal static class ExclusionsHelper
+{
+    private static Dictionary<string, Dictionary<string, HashSet<string>>> FileToSuffixToExclusionsMap = new();
+
+    private static Dictionary<string, Dictionary<string, HashSet<string>>> FileToSuffixToUnusedExclusionsMap = new();
+    
+    private const string NullSuffix = "NULL_SUFFIX";
+
+    // Use this to narrow down the scope of exclusions to a specific category.
+    // For instance, setting this to "test-templates" will consider 
+    // "src/test-templates/exclusions.txt" but not "src/arcade/exclusions.txt".
+    public static Regex ExclusionRegex;
+
+    static ExclusionsHelper()
+    {
+        AppDomain.CurrentDomain.ProcessExit += onProcessExit;
+    }
+
+    private static void onProcessExit(object? sender, EventArgs e)
+    {
+        RemoveUnusedExclusionsFromBaselines();
+    }
+
+    internal static bool IsFileExcluded(string filePath, string exclusionsFileName, string suffix = NullSuffix)
+    {
+        // If a specific suffix is provided, check that first. If it is not found, check the default suffix.
+        return CheckAndRemoveIfExcluded(filePath, exclusionsFileName, suffix) ||
+            (suffix != NullSuffix && CheckAndRemoveIfExcluded(filePath, exclusionsFileName, NullSuffix));
+    }
+
+    private static bool CheckAndRemoveIfExcluded(string filePath, string exclusionsFileName, string suffix = NullSuffix)
+    {
+        Dictionary<string, HashSet<string>> exclusions = GetExclusions(exclusionsFileName);
+
+        if (exclusions.TryGetValue(suffix, out HashSet<string> suffixExclusionList))
+        {
+            foreach (string exclusion in suffixExclusionList)
+            {
+                Matcher matcher = new();
+                matcher.AddInclude(exclusion);
+                if (matcher.Match(filePath).HasMatches)
+                {
+                    RemoveUsedExclusion(exclusionsFileName, exclusion, suffix);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static Dictionary<string, HashSet<string>> GetExclusions(string exclusionsFileName)
+    {
+        if (!FileToSuffixToExclusionsMap.TryGetValue(exclusionsFileName, out Dictionary<string, HashSet<string>> exclusions))
+        {
+            exclusions = ParseExclusionsFile(exclusionsFileName);
+            FileToSuffixToExclusionsMap[exclusionsFileName] = exclusions;
+            FileToSuffixToUnusedExclusionsMap[exclusionsFileName] = new Dictionary<string, HashSet<string>>(
+                exclusions.ToDictionary(pair => pair.Key, pair => new HashSet<string>(pair.Value)));
+        }
+
+        return exclusions;
+    }
+
+    private static Dictionary<string, HashSet<string>> ParseExclusionsFile(string exclusionsFileName)
+    {
+        string exclusionsFilePath = Path.Combine(BaselineHelper.GetAssetsDirectory(), exclusionsFileName);
+        return File.ReadAllLines(exclusionsFilePath)
+            .Select(line =>
+            {
+                // Ignore comments
+                var index = line.IndexOf('#');
+                return index >= 0 ? line[..index].TrimEnd() : line;
+            })
+            .Where(line => !string.IsNullOrEmpty(line))
+            .Select(line => line.Split('|'))
+            .Where(parts =>
+            {
+                // Only include exclusions that match the exclusion regex
+                return ExclusionRegex is null || ExclusionRegex.IsMatch(parts[0]);
+            })
+            .Select(parts => new
+            {
+                // Split the line into the exclusion and the suffixes
+                Line = parts[0],
+                Suffixes = parts.Length > 1
+                    ? parts[1].Split(',').Select(suffix => suffix.Trim())
+                    : new string[] { NullSuffix }
+            })
+            .SelectMany(parts =>
+                // Create a new object for each suffix
+                parts.Suffixes.Select(suffix => new
+                {
+                    parts.Line,
+                    Suffix = suffix
+                })
+            )
+            .GroupBy(
+                parts => parts.Suffix,
+                parts => parts.Line
+            )
+            .ToDictionary(
+                group => group.Key,
+                group => new HashSet<string>(group)
+            );
+    }
+
+    private static void RemoveUsedExclusion(string exclusionsFileName, string exclusion, string suffix)
+    {
+        if (FileToSuffixToUnusedExclusionsMap.TryGetValue(exclusionsFileName, out Dictionary<string, HashSet<string>> suffixToExclusions)
+            && suffixToExclusions.TryGetValue(suffix, out HashSet<string> exclusions))
+        {
+            exclusions.Remove(exclusion);
+        }
+    }
+
+    private static void RemoveUnusedExclusionsFromBaselines()
+    {
+
+        foreach (KeyValuePair<string, Dictionary<string, HashSet<string>>> fileToUnusedExclusions in FileToSuffixToUnusedExclusionsMap)
+        {
+            string exclusionsFileName = fileToUnusedExclusions.Key;
+            string exclusionsFilePath = Path.Combine(BaselineHelper.GetAssetsDirectory(), exclusionsFileName);
+            var suffixesToUnusedExclusions = fileToUnusedExclusions.Value;
+
+            string[] lines = File.ReadAllLines(exclusionsFilePath);
+
+            var newLines = lines
+                .Select(line =>
+                {
+                    if (suffixesToUnusedExclusions.Values.All(exclusions => exclusions.All(exclusion => !line.Contains(exclusion))))
+                    {
+                        // Line does not contain an unused exclusion, so we can keep it as is
+                        return line;
+                    }
+
+                    string exclusion = line.Split('|')[0];
+                    var unusedSuffixes = suffixesToUnusedExclusions.Where(pair => pair.Value.Contains(exclusion)).Select(pair => pair.Key).ToList();
+
+                    if (unusedSuffixes.Count == 1 && unusedSuffixes[0] == NullSuffix)
+                    {
+                        // Line does not contain any suffixes, so we can remove it entirely
+                        return null;
+                    }
+
+                    string suffixString = line.Split('|')[1].Split('#')[0];
+                    var originalSuffixes = suffixString.Split(',').Select(suffix => suffix.Trim()).ToList();
+                    var newSuffixes = originalSuffixes.Except(unusedSuffixes).ToList();
+
+                    if (newSuffixes.Count == 0)
+                    {
+                        // All suffixes were unused, so we can remove the line entirely
+                        return null;
+                    }
+
+                    return line.Replace(suffixString, string.Join(",", newSuffixes));
+                })
+                .Where(line => line is not null);
+
+            string actualFilePath = Path.Combine(TestBase.LogsDirectory, $"Updated{exclusionsFileName}");
+            File.WriteAllLines(actualFilePath, newLines);
+        }
+    }
+}

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
@@ -185,7 +185,7 @@ public class LicenseScanTests : TestBase
         // Once the license expression filtering has been applied, if a file has any licenses left, it will be included in the baseline.
         // In that case, the baseline will list all of the licenses for that file, even if some were originally excluded during this processing.
         // In other words, the baseline will be fully representative of the licenses that apply to the files that are listed there.
-        
+
         // We only care about the license expressions that are in the target repo.
         ExclusionsHelper exclusionsHelper = new("LicenseExclusions.txt", _targetRepo);
 

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
@@ -230,7 +230,7 @@ public class LicenseScanTests : TestBase
                 }
             }
         }
-        exclusionsHelper.GenerateNewBaselineFile();
+        exclusionsHelper.GenerateNewBaselineFile(_targetRepo);
     }
 
     private class ScancodeResults

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
@@ -185,9 +185,9 @@ public class LicenseScanTests : TestBase
         // Once the license expression filtering has been applied, if a file has any licenses left, it will be included in the baseline.
         // In that case, the baseline will list all of the licenses for that file, even if some were originally excluded during this processing.
         // In other words, the baseline will be fully representative of the licenses that apply to the files that are listed there.
-
+        
         // We only care about the license expressions that are in the target repo.
-        ExclusionsHelper.ExclusionRegex = new Regex(_targetRepo);
+        ExclusionsHelper exclusionsHelper = new("LicenseExclusions.txt", _targetRepo);
 
         for (int i = scancodeResults.Files.Count - 1; i >= 0; i--)
         {
@@ -222,7 +222,7 @@ public class LicenseScanTests : TestBase
                 // target repo within the VMR. So we need to add back the beginning part of the path.
                 string fullRelativePath = Path.Combine(_relativeRepoPath, file.Path);
 
-                var remainingLicenses = disallowedLicenses.Where(license => !ExclusionsHelper.IsFileExcluded(fullRelativePath, "LicenseExclusions.txt", license));
+                var remainingLicenses = disallowedLicenses.Where(license => !exclusionsHelper.IsFileExcluded(fullRelativePath, license));
 
                 if (!remainingLicenses.Any())
                 {
@@ -230,9 +230,8 @@ public class LicenseScanTests : TestBase
                 }
             }
         }
+        exclusionsHelper.GenerateNewBaselineFile();
     }
-
-    private record LicenseExclusion(string Repo, string Path, IEnumerable<string> LicenseExpressions);
 
     private class ScancodeResults
     {

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
@@ -112,10 +112,16 @@ public class LicenseScanTests : TestBase
 
     private readonly string _targetRepo;
 
+    private readonly string _relativeRepoPath;
+
     public LicenseScanTests(ITestOutputHelper outputHelper) : base(outputHelper)
     {
         Assert.NotNull(Config.LicenseScanPath);
         _targetRepo = new DirectoryInfo(Config.LicenseScanPath).Name;
+        
+        Match relativeRepoPathMatch = Regex.Match(Config.LicenseScanPath, @"(src/)[^/]+");
+        Assert.True(relativeRepoPathMatch.Success);
+        _relativeRepoPath = relativeRepoPathMatch.Value;
     }
 
     [SkippableFact(Config.LicenseScanPathEnv, skipOnNullOrWhiteSpaceEnv: true)]
@@ -169,43 +175,8 @@ public class LicenseScanTests : TestBase
         BaselineHelper.CompareFiles(expectedFilePath, actualFilePath, OutputHelper, Config.WarnOnLicenseScanDiffs);
     }
 
-    private LicenseExclusion ParseLicenseExclusion(string rawExclusion)
-    {
-        string[] parts = rawExclusion.Split('|', StringSplitOptions.RemoveEmptyEntries);
-
-        Match repoNameMatch = Regex.Match(parts[0], @"(?<=src/)[^/]+");
-
-        Assert.True(repoNameMatch.Success);
-
-        // The path in the exclusion file is rooted from the VMR. But the path in the scancode results is rooted from the
-        // target repo within the VMR. So we need to strip off the beginning part of the path.
-        Match restOfPathMatch = Regex.Match(parts[0], @"(?<=src/[^/]+/).*");
-        string path = restOfPathMatch.Value;
-
-        if (parts.Length == 0 || parts.Length > 2)
-        {
-            throw new Exception($"Invalid license exclusion: '{rawExclusion}'");
-        }
-
-        if (parts.Length > 1)
-        {
-            string[] licenseExpressions = parts[1].Split(',', StringSplitOptions.RemoveEmptyEntries);
-            return new LicenseExclusion(repoNameMatch.Value, path, licenseExpressions);
-        }
-        else
-        {
-            return new LicenseExclusion(repoNameMatch.Value, path, Enumerable.Empty<string>());
-        }
-    }
-
     private void FilterFiles(ScancodeResults scancodeResults)
     {
-        IEnumerable<string> rawExclusions = Utilities.ParseExclusionsFile("LicenseExclusions.txt");
-        IEnumerable<LicenseExclusion> exclusions = rawExclusions
-            .Select(exclusion => ParseLicenseExclusion(exclusion))
-            .Where(exclusion => exclusion.Repo == _targetRepo)
-            .ToList();
-
         // This will filter out files that we don't want to include in the baseline.
         // Filtering can happen in two ways:
         //   1. There are a set of allowed license expressions that apply to all files. If a file has a match on one of those licenses,
@@ -214,6 +185,9 @@ public class LicenseScanTests : TestBase
         // Once the license expression filtering has been applied, if a file has any licenses left, it will be included in the baseline.
         // In that case, the baseline will list all of the licenses for that file, even if some were originally excluded during this processing.
         // In other words, the baseline will be fully representative of the licenses that apply to the files that are listed there.
+
+        // We only care about the license expressions that are in the target repo.
+        ExclusionsHelper.ExclusionRegex = new Regex(_targetRepo);
 
         for (int i = scancodeResults.Files.Count - 1; i >= 0; i--)
         {
@@ -244,23 +218,15 @@ public class LicenseScanTests : TestBase
             {
                 // There are some licenses that are not allowed. Now check whether the file is excluded.
 
-                IEnumerable<LicenseExclusion> matchingExclusions =
-                    Utilities.GetMatchingFileExclusions(file.Path, exclusions, exclusion => exclusion.Path);
+                // The path in the exclusion file is rooted from the VMR. But the path in the scancode results is rooted from the
+                // target repo within the VMR. So we need to add back the beginning part of the path.
+                string fullRelativePath = Path.Combine(_relativeRepoPath, file.Path);
 
-                IEnumerable<string> excludedLicenses = matchingExclusions.SelectMany(exclusion => exclusion.LicenseExpressions);
-                // If no licenses are explicitly specified, it means they're all excluded.
-                if (matchingExclusions.Any() && !excludedLicenses.Any())
+                var remainingLicenses = disallowedLicenses.Where(license => !ExclusionsHelper.IsFileExcluded(fullRelativePath, "LicenseExclusions.txt", license));
+
+                if (!remainingLicenses.Any())
                 {
                     scancodeResults.Files.Remove(file);
-                }
-                else
-                {
-                    IEnumerable<string> remainingLicenses = disallowedLicenses.Except(excludedLicenses);
-
-                    if (!remainingLicenses.Any())
-                    {
-                        scancodeResults.Files.Remove(file);
-                    }
                 }
             }
         }

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SdkContentTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SdkContentTests.cs
@@ -36,15 +36,16 @@ public class SdkContentTests : SdkTests
     {
         const string msftFileListingFileName = "msftSdkFiles.txt";
         const string sbFileListingFileName = "sbSdkFiles.txt";
-
         ExclusionsHelper exclusionsHelper = new ExclusionsHelper("SdkFileDiffExclusions.txt");
+
         WriteTarballFileList(Config.MsftSdkTarballPath, msftFileListingFileName, isPortable: true, MsftSdkType, exclusionsHelper);
         WriteTarballFileList(Config.SdkTarballPath, sbFileListingFileName, isPortable: false, SourceBuildSdkType, exclusionsHelper);
-        exclusionsHelper.GenerateNewBaselineFile("FileList");
 
         string diff = BaselineHelper.DiffFiles(msftFileListingFileName, sbFileListingFileName, OutputHelper);
         diff = RemoveDiffMarkers(diff);
         BaselineHelper.CompareBaselineContents("MsftToSbSdkFiles.diff", diff, OutputHelper, Config.WarnOnSdkContentDiffs);
+
+        exclusionsHelper.GenerateNewBaselineFile("FileList");
     }
 
     [SkippableFact(new[] { Config.MsftSdkTarballPathEnv, Config.SdkTarballPathEnv }, skipOnNullOrWhiteSpaceEnv: true)]

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SdkContentTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SdkContentTests.cs
@@ -53,7 +53,7 @@ public class SdkContentTests : SdkTests, IClassFixture<SdkTestsExclusionsHelperF
     {
         Assert.NotNull(Config.MsftSdkTarballPath);
         Assert.NotNull(Config.SdkTarballPath);
-        
+
         DirectoryInfo tempDir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()));
         try
         {

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/Utilities.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/Utilities.cs
@@ -19,37 +19,6 @@ namespace Microsoft.DotNet.SourceBuild.SmokeTests;
 
 public static class Utilities
 {
-    /// <summary>
-    /// Returns whether the given file path is excluded by the given exclusions using glob file matching.
-    /// </summary>
-    public static bool IsFileExcluded(string filePath, IEnumerable<string> exclusions) =>
-        GetMatchingFileExclusions(filePath, exclusions, exclusion => exclusion).Any();
-
-    public static IEnumerable<T> GetMatchingFileExclusions<T>(string filePath, IEnumerable<T> exclusions, Func<T, string> getExclusionExpression) =>
-        exclusions.Where(exclusion => FileSystemName.MatchesSimpleExpression(getExclusionExpression(exclusion), filePath));
-
-    /// <summary>
-    /// Parses a common file format in the test suite for listing file exclusions.
-    /// </summary>
-    /// <param name="exclusionsFileName">Name of the exclusions file.</param>
-    /// <param name="prefix">When specified, filters the exclusions to those that begin with the prefix value.</param>
-    public static IEnumerable<string> ParseExclusionsFile(string exclusionsFileName, string? prefix = null)
-    {
-        string exclusionsFilePath = Path.Combine(BaselineHelper.GetAssetsDirectory(), exclusionsFileName);
-        int prefixSkip = prefix?.Length + 1 ?? 0;
-        return File.ReadAllLines(exclusionsFilePath)
-            // process only specific exclusions if a prefix is provided
-            .Where(line => prefix is null || line.StartsWith(prefix + ","))
-            .Select(line =>
-            {
-                // Ignore comments
-                var index = line.IndexOf('#');
-                return index >= 0 ? line[prefixSkip..index].TrimEnd() : line[prefixSkip..];
-            })
-            .Where(line => !string.IsNullOrEmpty(line))
-            .ToList();
-    }
-    
     public static void ExtractTarball(string tarballPath, string outputDir, ITestOutputHelper outputHelper)
     {
         // TarFile doesn't properly handle hard links (https://github.com/dotnet/runtime/pull/85378#discussion_r1221817490),

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseExclusions.txt
@@ -177,11 +177,7 @@ src/runtime/src/libraries/System.ServiceModel.Syndication/tests/BasicScenarioTes
 src/runtime/src/mono/mono/mini/mini-posix.c|unknown-license-reference
 src/runtime/src/mono/mono/mini/mini-windows.c|unknown-license-reference
 src/runtime/src/native/external/libunwind/doc/libunwind-ia64.*|generic-exception
-src/runtime/src/tests/GC/Scenarios/GCBench/THIRD-PARTY-NOTICES|unknown-license-reference
-src/runtime/src/tests/JIT/Performance/CodeQuality/Benchstones/BenchF/LLoops/THIRD-PARTY-NOTICES|unknown-license-reference
-src/runtime/src/tests/JIT/Performance/CodeQuality/Benchstones/MDBenchF/MDLLoops/THIRD-PARTY-NOTICES|unknown-license-reference
 src/runtime/src/tests/JIT/Performance/CodeQuality/V8/Crypto/Crypto.cs|unknown-license-reference
-src/runtime/src/tests/JIT/Performance/CodeQuality/V8/Richards/THIRD-PARTY-NOTICES|unknown-license-reference
 
 # Test data
 src/runtime/src/libraries/System.Private.Xml.Linq/tests/XDocument.Common/InputSpace.cs|other-permissive

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkAssemblyVersionDiffExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkAssemblyVersionDiffExclusions.txt
@@ -6,8 +6,8 @@
 # This list is processed using FileSystemName.MatchesSimpleExpression
 #
 # Examples
-# 'folder/*' matches 'folder/' and 'folder/abc'
-# 'folder/?*' matches 'folder/abc' but not 'folder/'
+# 'folder/*' matches 'folder/' and 'folder/abc' but not folder/abc/def/'
+# 'folder/' is equivalent to folder/**. It matches 'folder/', 'folder/abc', and 'folder/abc/def/'
 #
 # We do not want to filter-out folder entries, therefore, we should use: '?*' and not just '*'
 

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkAssemblyVersionDiffExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkAssemblyVersionDiffExclusions.txt
@@ -5,11 +5,14 @@
 #
 # This list is processed using FileSystemName.MatchesSimpleExpression
 #
-# Examples
-# 'folder/*' matches 'folder/' and 'folder/abc' but not 'folder/abc/def/'
-# 'folder/' is equivalent to folder/**. It matches 'folder/', 'folder/abc', and 'folder/abc/def/'
+# '*' in exclusions match zero or more characters.
+# '*' will match files and directory names but it will not match separator characters.
 #
-# We do not want to filter-out folder entries, therefore, we should use: '?*' and not just '*'
+# '/' will be evaluated as '/**' if it is the last character.
+#
+# Examples
+# 'folder/*' matches all files and directories in 'folder/'. It will not match 'folder/abc/def'
+# 'folder/' is equivalent to 'folder/**. It matches 'folder/', 'folder/abc', and 'folder/abc/def/'
 
 # Referenced 6.0/7.0 assemblies (https://github.com/dotnet/sdk/issues/34245)
 ./sdk/x.y.z/Microsoft.Extensions.FileProviders.Abstractions.dll

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkAssemblyVersionDiffExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkAssemblyVersionDiffExclusions.txt
@@ -7,7 +7,6 @@
 #
 # '*' in exclusions match zero or more characters.
 # '*' will match files and directory names but it will not match separator characters.
-#
 # '/' will be evaluated as '/**' if it is the last character.
 #
 # Examples

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkAssemblyVersionDiffExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkAssemblyVersionDiffExclusions.txt
@@ -12,8 +12,6 @@
 # We do not want to filter-out folder entries, therefore, we should use: '?*' and not just '*'
 
 # Referenced 6.0/7.0 assemblies (https://github.com/dotnet/sdk/issues/34245)
-./sdk/x.y.z/Containers/tasks/netx.y/runtimes/win/lib/netx.y/?*
-./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Composition.*
 ./sdk/x.y.z/Microsoft.Extensions.FileProviders.Abstractions.dll
 ./sdk/x.y.z/Microsoft.Extensions.FileSystemGlobbing.dll
 ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Razor/source-generators/System.Collections.Immutable.dll
@@ -24,43 +22,3 @@
 ./sdk/**/System.Security.Cryptography.Pkcs.dll
 ./sdk/**/System.Security.Cryptography.ProtectedData.dll
 ./sdk/x.y.z/System.Security.Cryptography.Xml.dll
-
-# These assemblies are lifted to a higher version naturally via SB (https://github.com/dotnet/source-build/issues/3922)
-./sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/Humanizer.dll
-./sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/Microsoft.Build.Locator.dll
-./sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/Microsoft.Extensions.*
-./sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/System.Composition.*
-./sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/System.IO.Pipelines.dll
-./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/BuildHost-netcore/Humanizer.dll
-./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/BuildHost-netcore/Microsoft.Build.Locator.dll
-./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/BuildHost-netcore/Microsoft.Extensions.*
-./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/BuildHost-netcore/System.Composition.*
-./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/BuildHost-netcore/System.IO.Pipelines.dll
-
-# These assemblies are lifted to 9.0 (https://github.com/dotnet/source-build/issues/4013)
-./sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/runtimes/browser/lib/netx.y/System.Text.Encodings.Web.dll
-./sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/System.Collections.Immutable.dll
-./sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/System.Reflection.Metadata.dll
-./sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/System.Text.Encodings.Web.dll
-./sdk/x.y.z/DotnetTools/dotnet-format/BuildHost-netcore/System.Text.Json.dll
-./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/BuildHost-netcore/System.Collections.Immutable.dll
-./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/BuildHost-netcore/System.Reflection.Metadata.dll
-
-# These assemblies are lifted to a higher version naturally via SB
-./sdk/x.y.z/DotnetTools/dotnet-format/dotnet-format.dll
-./sdk/x.y.z/DotnetTools/dotnet-format/*/dotnet-format.resources.dll
-./sdk/x.y.z/DotnetTools/dotnet-format/*/Microsoft.CodeAnalysis.*
-./sdk/x.y.z/DotnetTools/dotnet-format/Humanizer.dll
-./sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.Build.Locator.dll
-./sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.CodeAnalysis.*
-./sdk/x.y.z/DotnetTools/dotnet-format/Microsoft.DiaSymReader.dll
-./sdk/x.y.z/DotnetTools/dotnet-format/System.CodeDom.dll
-./sdk/x.y.z/DotnetTools/dotnet-format/System.Composition.*
-./sdk/x.y.z/DotnetTools/dotnet-format/System.IO.Pipelines.dll
-./sdk/x.y.z/DotnetTools/dotnet-format/System.Resources.Extensions.dll
-./sdk/x.y.z/DotnetTools/dotnet-format/System.Security.Cryptography.Xml.dll
-./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Humanizer.dll
-./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Microsoft.Build.Locator.dll
-./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Microsoft.CodeAnalysis.AnalyzerUtilities.dll
-./sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Microsoft.DiaSymReader.dll
-./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Razor/source-generators/Microsoft.CodeAnalysis.ExternalAccess.RazorCompiler.dll

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkAssemblyVersionDiffExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkAssemblyVersionDiffExclusions.txt
@@ -6,7 +6,7 @@
 # This list is processed using FileSystemName.MatchesSimpleExpression
 #
 # Examples
-# 'folder/*' matches 'folder/' and 'folder/abc' but not folder/abc/def/'
+# 'folder/*' matches 'folder/' and 'folder/abc' but not 'folder/abc/def/'
 # 'folder/' is equivalent to folder/**. It matches 'folder/', 'folder/abc', and 'folder/abc/def/'
 #
 # We do not want to filter-out folder entries, therefore, we should use: '?*' and not just '*'

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkFileDiffExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkFileDiffExclusions.txt
@@ -9,8 +9,8 @@
 #   sb   = source-built SDK
 #
 # Examples
-# 'folder/*' matches 'folder/' and 'folder/abc but not folder/abc/def/'
-# 'folder/' matches 'folder/abc', 'folder/abc, and folder/abc/def/'
+# 'folder/*' matches 'folder/' and 'folder/abc' but not folder/abc/def/'
+# 'folder/' is equivalent to folder/**. It matches 'folder/', 'folder/abc', and 'folder/abc/def/'
 #
 # We do not want to filter-out folder entries, therefore, we should use: '?*' and not just '*'
 
@@ -18,27 +18,27 @@
 ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/|msft   # Intentional - explicitly excluded from source-build
 
 # netfx tooling and tasks, not building in source-build - https://github.com/dotnet/source-build/issues/3514
-./sdk/x.y.z/Sdks/Microsoft.Build.Tasks.Git/tools/net472/|msft   
-./sdk/x.y.z/Sdks/Microsoft.NET.Sdk/tools/net472/|msft   
-./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.BlazorWebAssembly/tools/net472/|msft   
-./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/|msft   
-./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Razor/tasks/net472/|msft   
-./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.StaticWebAssets/tasks/net472/|msft   
-./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Web/tools/net472/|msft   
-./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Web.ProjectSystem/tools/net472/|msft   
-./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WebAssembly/tools/net472/|msft   
+./sdk/x.y.z/Sdks/Microsoft.Build.Tasks.Git/tools/net472/|msft
+./sdk/x.y.z/Sdks/Microsoft.NET.Sdk/tools/net472/|msft
+./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.BlazorWebAssembly/tools/net472/|msft
+./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/|msft
+./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Razor/tasks/net472/|msft
+./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.StaticWebAssets/tasks/net472/|msft
+./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Web/tools/net472/|msft
+./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Web.ProjectSystem/tools/net472/|msft
+./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WebAssembly/tools/net472/|msft
 ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Worker/tools/net472/|msft
-./sdk/x.y.z/Sdks/Microsoft.SourceLink.AzureRepos.Git/tools/net472/|msft   
-./sdk/x.y.z/Sdks/Microsoft.SourceLink.Bitbucket.Git/tools/net472/|msft   
-./sdk/x.y.z/Sdks/Microsoft.SourceLink.Common/tools/net472/|msft   
-./sdk/x.y.z/Sdks/Microsoft.SourceLink.GitHub/tools/net472/|msft   
+./sdk/x.y.z/Sdks/Microsoft.SourceLink.AzureRepos.Git/tools/net472/|msft
+./sdk/x.y.z/Sdks/Microsoft.SourceLink.Bitbucket.Git/tools/net472/|msft
+./sdk/x.y.z/Sdks/Microsoft.SourceLink.Common/tools/net472/|msft
+./sdk/x.y.z/Sdks/Microsoft.SourceLink.GitHub/tools/net472/|msft
 ./sdk/x.y.z/Sdks/Microsoft.SourceLink.GitLab/tools/net472/|msft 
 
 # vstest localization is disabled in Linux builds - https://github.com/dotnet/source-build/issues/3517
 ./sdk/x.y.z/*/Microsoft.CodeCoverage.IO.resources.dll|msft
 
 # nuget localization is not available for Linux builds - https://github.com/NuGet/Home/issues/12440
-./sdk/x.y.z/*/NuGet.*.resources.dll|msft   
+./sdk/x.y.z/*/NuGet.*.resources.dll|msft
 ./sdk/x.y.z/*/Test.Utility.resources.dll|msft
 
 # ILMerge is not supported in Linux builds - excluding the whole NuGet.Build.Tasks.Pack directory, to avoid a noisy diff
@@ -53,7 +53,7 @@
 ./sdk-manifests/x.y.z/microsoft.net.sdk.tvos/|msft
 
 # linux runtimes are included in source-build for self-contained apps - https://github.com/dotnet/source-build/issues/3507
-./packs/Microsoft.AspNetCore.App.Runtime.*/|sb   
+./packs/Microsoft.AspNetCore.App.Runtime.*/|sb
 ./packs/Microsoft.NETCore.App.Runtime.*/|sb
 
 # Exclude format and watch tools due to too much noise
@@ -80,7 +80,7 @@
 ./sdk/x.y.z/FSharp/Microsoft.VisualStudio.Setup.Configuration.Interop.dll|msft
 
 # runtime components in roslyn layout - https://github.com/dotnet/source-build/issues/4016
-./sdk/x.y.z/Roslyn/bincore/System.Collections.Immutable.dll|sb   
+./sdk/x.y.z/Roslyn/bincore/System.Collections.Immutable.dll|sb
 ./sdk/x.y.z/Roslyn/bincore/System.Reflection.Metadata.dll|sb
 
 # https://github.com/dotnet/source-build/issues/4079

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkFileDiffExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkFileDiffExclusions.txt
@@ -10,7 +10,6 @@
 #
 # '*' in exclusions match zero or more characters.
 # '*' will match files and directory names but it will not match separator characters.
-#
 # '/' will be evaluated as '/**' if it is the last character.
 #
 # Examples

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkFileDiffExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkFileDiffExclusions.txt
@@ -8,11 +8,14 @@
 #   msft = Microsoft built SDK
 #   sb   = source-built SDK
 #
-# Examples
-# 'folder/*' matches 'folder/' and 'folder/abc' but not 'folder/abc/def/'
-# 'folder/' is equivalent to folder/**. It matches 'folder/', 'folder/abc', and 'folder/abc/def/'
+# '*' in exclusions match zero or more characters.
+# '*' will match files and directory names but it will not match separator characters.
 #
-# We do not want to filter-out folder entries, therefore, we should use: '?*' and not just '*'
+# '/' will be evaluated as '/**' if it is the last character.
+#
+# Examples
+# 'folder/*' matches all files and directories in 'folder/'. It will not match 'folder/abc/def'
+# 'folder/' is equivalent to 'folder/**. It matches 'folder/', 'folder/abc', and 'folder/abc/def/'
 
 ./sdk/x.y.z/TestHostNetFramework/|msft   # Intentional - MSFT build includes test-host that targets netcoreapp3.1
 ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/|msft   # Intentional - explicitly excluded from source-build

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkFileDiffExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkFileDiffExclusions.txt
@@ -9,7 +9,7 @@
 #   sb   = source-built SDK
 #
 # Examples
-# 'folder/*' matches 'folder/' and 'folder/abc' but not folder/abc/def/'
+# 'folder/*' matches 'folder/' and 'folder/abc' but not 'folder/abc/def/'
 # 'folder/' is equivalent to folder/**. It matches 'folder/', 'folder/abc', and 'folder/abc/def/'
 #
 # We do not want to filter-out folder entries, therefore, we should use: '?*' and not just '*'

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkFileDiffExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/SdkFileDiffExclusions.txt
@@ -1,95 +1,95 @@
 # This list is processed using FileSystemName.MatchesSimpleExpression
 #
 # Format
-# {msft|sb},<path> [# comment]
-# msft = Microsoft built SDK
-# sb   = source-built SDK
+#   Exclude the path entirely: 
+#     <path> [# comment]
+#   Exclude a path from a specific sdk:
+#     <path>|{msft|sb} [# comment]
+#   msft = Microsoft built SDK
+#   sb   = source-built SDK
 #
 # Examples
-# 'folder/*' matches 'folder/' and 'folder/abc'
-# 'folder/?*' matches 'folder/abc' but not 'folder/'
+# 'folder/*' matches 'folder/' and 'folder/abc but not folder/abc/def/'
+# 'folder/' matches 'folder/abc', 'folder/abc, and folder/abc/def/'
 #
 # We do not want to filter-out folder entries, therefore, we should use: '?*' and not just '*'
 
-msft,./sdk/x.y.z/TestHostNetFramework/?*   # Intentional - MSFT build includes test-host that targets netcoreapp3.1
-msft,./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/?*   # Intentional - explicitly excluded from source-build
+./sdk/x.y.z/TestHostNetFramework/|msft   # Intentional - MSFT build includes test-host that targets netcoreapp3.1
+./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/|msft   # Intentional - explicitly excluded from source-build
 
 # netfx tooling and tasks, not building in source-build - https://github.com/dotnet/source-build/issues/3514
-msft,./sdk/x.y.z/Sdks/Microsoft.Build.Tasks.Git/tools/net472/*
-msft,./sdk/x.y.z/Sdks/Microsoft.NET.Sdk/tools/net472/*
-msft,./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.BlazorWebAssembly/tools/net472/*
-msft,./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/*
-msft,./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Razor/tasks/net472/*
-msft,./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.StaticWebAssets/tasks/net472/*
-msft,./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Web/tools/net472/*
-msft,./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Web.ProjectSystem/tools/net472/*
-msft,./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WebAssembly/tools/net472/*
-msft,./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Worker/tools/net472/*
-msft,./sdk/x.y.z/Sdks/Microsoft.SourceLink.AzureRepos.Git/tools/net472/*
-msft,./sdk/x.y.z/Sdks/Microsoft.SourceLink.Bitbucket.Git/tools/net472/*
-msft,./sdk/x.y.z/Sdks/Microsoft.SourceLink.Common/tools/net472/*
-msft,./sdk/x.y.z/Sdks/Microsoft.SourceLink.GitHub/tools/net472/*
-msft,./sdk/x.y.z/Sdks/Microsoft.SourceLink.GitLab/tools/net472/*
+./sdk/x.y.z/Sdks/Microsoft.Build.Tasks.Git/tools/net472/|msft   
+./sdk/x.y.z/Sdks/Microsoft.NET.Sdk/tools/net472/|msft   
+./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.BlazorWebAssembly/tools/net472/|msft   
+./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Publish/tools/net472/|msft   
+./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Razor/tasks/net472/|msft   
+./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.StaticWebAssets/tasks/net472/|msft   
+./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Web/tools/net472/|msft   
+./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Web.ProjectSystem/tools/net472/|msft   
+./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WebAssembly/tools/net472/|msft   
+./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Worker/tools/net472/|msft
+./sdk/x.y.z/Sdks/Microsoft.SourceLink.AzureRepos.Git/tools/net472/|msft   
+./sdk/x.y.z/Sdks/Microsoft.SourceLink.Bitbucket.Git/tools/net472/|msft   
+./sdk/x.y.z/Sdks/Microsoft.SourceLink.Common/tools/net472/|msft   
+./sdk/x.y.z/Sdks/Microsoft.SourceLink.GitHub/tools/net472/|msft   
+./sdk/x.y.z/Sdks/Microsoft.SourceLink.GitLab/tools/net472/|msft 
 
 # vstest localization is disabled in Linux builds - https://github.com/dotnet/source-build/issues/3517
-msft,./sdk/x.y.z/*?/Microsoft.CodeCoverage.IO.resources.dll
+./sdk/x.y.z/*/Microsoft.CodeCoverage.IO.resources.dll|msft
 
 # nuget localization is not available for Linux builds - https://github.com/NuGet/Home/issues/12440
-msft,./sdk/x.y.z/*?/NuGet.*?.resources.dll
-msft,./sdk/x.y.z/*?/Microsoft.Build.NuGetSdkResolver.resources.dll
-msft,./sdk/x.y.z/*?/Test.Utility.resources.dll
+./sdk/x.y.z/*/NuGet.*.resources.dll|msft   
+./sdk/x.y.z/*/Test.Utility.resources.dll|msft
 
 # ILMerge is not supported in Linux builds - excluding the whole NuGet.Build.Tasks.Pack directory, to avoid a noisy diff
-msft,./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/*?
-sb,./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/*?
+./sdk/x.y.z/Sdks/NuGet.Build.Tasks.Pack/
 
 # missing workload manifests - https://github.com/dotnet/source-build/issues/3242
-msft,./sdk-manifests/x.y.z/microsoft.net.sdk.android/*
-msft,./sdk-manifests/x.y.z/microsoft.net.sdk.ios/*
-msft,./sdk-manifests/x.y.z/microsoft.net.sdk.maccatalyst/*
-msft,./sdk-manifests/x.y.z/microsoft.net.sdk.macos/*
-msft,./sdk-manifests/x.y.z/microsoft.net.sdk.maui/*
-msft,./sdk-manifests/x.y.z/microsoft.net.sdk.tvos/*
+./sdk-manifests/x.y.z/microsoft.net.sdk.android/|msft
+./sdk-manifests/x.y.z/microsoft.net.sdk.ios/|msft
+./sdk-manifests/x.y.z/microsoft.net.sdk.maccatalyst/|msft
+./sdk-manifests/x.y.z/microsoft.net.sdk.macos/|msft
+./sdk-manifests/x.y.z/microsoft.net.sdk.maui/|msft
+./sdk-manifests/x.y.z/microsoft.net.sdk.tvos/|msft
 
 # linux runtimes are included in source-build for self-contained apps - https://github.com/dotnet/source-build/issues/3507
-sb,./packs/Microsoft.AspNetCore.App.Runtime.*/*
-sb,./packs/Microsoft.NETCore.App.Runtime.*/*
-
-# netfx tooling - dumpminitool - https://github.com/dotnet/source-build/issues/3289
-msft,./sdk/x.y.z/Extensions/dump/*
-
-# https://github.com/dotnet/msbuild/issues/9213
-msft,./sdk/x.y.z/**/System.Windows.Extensions.dll
-msft,./sdk/x.y.z/**/System.Security.Permissions.dll
+./packs/Microsoft.AspNetCore.App.Runtime.*/|sb   
+./packs/Microsoft.NETCore.App.Runtime.*/|sb
 
 # Exclude format and watch tools due to too much noise
-msft,./sdk/x.y.z/DotnetTools/dotnet-format/**
-sb,./sdk/x.y.z/DotnetTools/dotnet-format/**
-msft,./sdk/x.y.z/DotnetTools/dotnet-watch/**
-sb,./sdk/x.y.z/DotnetTools/dotnet-watch/**
+./sdk/x.y.z/DotnetTools/dotnet-format/
+./sdk/x.y.z/DotnetTools/dotnet-watch/
+
+./sdk/x.y.z/Extensions/cs/|msft
+./sdk/x.y.z/Extensions/de/|msft
+./sdk/x.y.z/Extensions/es/|msft
+./sdk/x.y.z/Extensions/fr/|msft
+./sdk/x.y.z/Extensions/it/|msft
+./sdk/x.y.z/Extensions/ja/|msft
+./sdk/x.y.z/Extensions/ko/|msft
+./sdk/x.y.z/Extensions/pl/|msft
+./sdk/x.y.z/Extensions/pt-BR/|msft
+./sdk/x.y.z/Extensions/ru/|msft
+./sdk/x.y.z/Extensions/tr/|msft
+./sdk/x.y.z/Extensions/zh-Hans/|msft
+./sdk/x.y.z/Extensions/zh-Hant/|msft
+
+./sdk/x.y.z/*/dump/|msft
 
 # netfx runtimes for fsharp - https://github.com/dotnet/source-build/issues/3290
-msft,./sdk/x.y.z/FSharp/Microsoft.VisualStudio.Setup.Configuration.Interop.dll
-msft,./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/Microsoft.Win32.SystemEvents.dll
-msft,./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/System.Drawing.Common.dll
-msft,./sdk/x.y.z/FSharp/runtimes/win/lib/netx.y/System.Security.Cryptography.ProtectedData.dll
-
-# windows components - https://github.com/dotnet/source-build/issues/3526
-msft,./sdk/x.y.z/runtimes/win/lib/netx.y/Microsoft.Win32.SystemEvents.dll
-msft,./sdk/x.y.z/runtimes/win/lib/netx.y/System.Drawing.Common.dll
+./sdk/x.y.z/FSharp/Microsoft.VisualStudio.Setup.Configuration.Interop.dll|msft
 
 # runtime components in roslyn layout - https://github.com/dotnet/source-build/issues/4016
-sb,./sdk/x.y.z/Roslyn/bincore/System.Collections.Immutable.dll
-sb,./sdk/x.y.z/Roslyn/bincore/System.Reflection.Metadata.dll
+./sdk/x.y.z/Roslyn/bincore/System.Collections.Immutable.dll|sb   
+./sdk/x.y.z/Roslyn/bincore/System.Reflection.Metadata.dll|sb
 
 # https://github.com/dotnet/source-build/issues/4079
-sb,./sdk/x.y.z/*/Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll
-sb,./sdk/x.y.z/*/Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll
-sb,./sdk/x.y.z/*/Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll
-sb,./sdk/x.y.z/*/Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll
-sb,./sdk/x.y.z/*/Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll
-msft,./sdk/x.y.z/Extensions/*/*
+./sdk/x.y.z/*/Microsoft.TestPlatform.Extensions.BlameDataCollector.resources.dll|sb
+./sdk/x.y.z/*/Microsoft.TestPlatform.Extensions.EventLogCollector.resources.dll|sb
+./sdk/x.y.z/*/Microsoft.TestPlatform.TestHostRuntimeProvider.resources.dll|sb
+./sdk/x.y.z/*/Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.resources.dll|sb
+./sdk/x.y.z/*/Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.resources.dll|sb
 
 # https://github.com/dotnet/source-build/issues/3510
-msft,./sdk/x.y.z/Containers/containerize/**
-msft,./sdk/x.y.z/Containers/tasks/net472/**
+./sdk/x.y.z/Containers/containerize/|msft
+./sdk/x.y.z/Containers/tasks/net472/|msft

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdkFiles.diff
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdkFiles.diff
@@ -52,19 +52,3 @@ index ------------
  ./sdk/x.y.z/Microsoft.Common.CrossTargeting.targets
  ./sdk/x.y.z/Microsoft.Common.CurrentVersion.targets
  ./sdk/x.y.z/Microsoft.Common.overridetasks
-@@ ------------ @@
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WebAssembly/tools/
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WebAssembly/tools/netx.y/
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WebAssembly/tools/netx.y/Microsoft.NET.Sdk.WebAssembly.Tasks.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Worker/
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Worker/Sdk/
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Worker/Sdk/Sdk.props
-@@ ------------ @@
- ./sdk/x.y.z/testhost-latest.runtimeconfig.json
- ./sdk/x.y.z/testhost.deps.json
- ./sdk/x.y.z/testhost.dll
--./sdk/x.y.z/TestHostNetFramework/
- ./sdk/x.y.z/tr/
- ./sdk/x.y.z/tr/dotnet.resources.dll
- ./sdk/x.y.z/tr/Microsoft.Build.resources.dll


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/3646

This PR introduces consistency for using exclusions files in source-build smoke tests.

- `ExclusionsHelper.cs` exposes functionality for checking if a single file (and suffix, if specified) has been excluded by a specific exclusions file. Internally, methods in the `ExclusionsHelper.cs` work to parse, load, and clean the file as necessary. More specifically, the file is parsed only once on the first use of `IsFileExcluded` (the only exposed method) for a given file and then obtained from a dictionary that stores a mapping of filenames to suffixes and exclusions. Every exclusion that is used gets removed from a dictionary that tracks all unused exclusions. On the exit of the test, there is a clean-up method is called automatically. This clean-up method updates the baseline by removing any unused exclusions.

- Previously existing methods for parsing and using exclusion files/patterns have been replaced by `ExclusionsHelper` and its methods in this PR.

- For additional consistency, this PR updates also the exclusion files to remove unused exclusions and follow a consistent pattern that supports suffixes (suffixes can be licenses, specific sdks, etc).

- All updated exclusion files are called "Updated{exclusionsFileName}" and can be found located with other test artifacts. The license scanner yml has been updated to account for this new artifact.

[License scanner test run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2418434&view=results) (internal Microsoft link)
[Sdk diff test run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2418435&view=results) (internal Microsoft link)