### PR TITLE
Update Application-Insights licenses

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseExclusions.txt
@@ -210,7 +210,7 @@ src/sdk/THIRD-PARTY-NOTICES.TXT|unknown-license-reference
 
 # False positive
 src/source-build-externals/src/abstractions-xunit/README.md|free-unknown
-src/source-build-externals/src/application-insights-2.22.0/NETCORE/ThirdPartyNotices.txt|unknown
+src/source-build-externals/src/application-insights/NETCORE/ThirdPartyNotices.txt|unknown
 src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/benchmark/Microsoft.IdentityModel.Benchmarks/CreateTokenTests.cs|proprietary-license
 src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/src/Microsoft.IdentityModel.JsonWebTokens/JsonClaimValueTypes.cs|proprietary-license
 src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/src/Microsoft.IdentityModel.Tokens.Saml/Saml/ClaimProperties.cs|proprietary-license
@@ -222,9 +222,6 @@ src/source-build-externals/src/humanizer/NuSpecs/*.nuspec*
 src/source-build-externals/src/xunit/README.md|free-unknown
 src/source-build-externals/src/xunit/src/xunit.assert/Asserts/README.md|free-unknown
 src/source-build-externals/src/xunit/xunit.sln|json
-
-# A patch which removes the license usage but contains references to the removed license as part of the patch reference lines
-src/source-build-externals/patches/application-insights-2.22.0/0002-Remove-WebGrease-from-TPN-2816.patch
 
 # Scanner is identifying the https://github.com/SixLabors/ImageSharp/blob/master/LICENSE license as unknown. But this license is not applicable because we're
 # relying on the Spectre.Console distribution.

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/licenses/Licenses.source-build-externals.json
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/licenses/Licenses.source-build-externals.json
@@ -1,7 +1,7 @@
 {
   "files": [
     {
-      "path": "src/application-insights-2.22.0/LOGGING/ThirdPartyNotices.txt",
+      "path": "src/application-insights/LOGGING/ThirdPartyNotices.txt",
       "detected_license_expression": "unknown AND apache-2.0 AND mit AND bsd-new"
     }
   ]


### PR DESCRIPTION
Closes https://github.com/dotnet/source-build/issues/4252

With the [removal of application-insights 2.21](https://github.com/dotnet/source-build-externals/pull/302), the licenses should be updated to reflect the submodule's name change from "application-insights-2.22.0" to "application-insights".