### PR TITLE
Change BuildWithDesktopMSBuild to ForceDotNetMSBuildEngine

### DIFF
--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- Force use of dotnet msbuild (ignoring global.json contents) unless BuildWithDesktopMSBuild is explicitly set in the repo project. -->
-    <BuildArgs Condition="'$(BuildOS)' == 'windows' and '$(BuildWithDesktopMSBuild)' != 'true'">$(BuildArgs) $(FlagParameterPrefix)msbuildEngine dotnet</BuildArgs>
+    <!-- Force use of dotnet msbuild (ignoring global.json contents) unless ForceDotNetMSBuildEngine is explicitly set in the repo project. -->
+    <BuildArgs Condition="'$(BuildOS)' == 'windows' and '$(ForceDotNetMSBuildEngine)' != 'false'">$(BuildArgs) $(FlagParameterPrefix)msbuildEngine dotnet</BuildArgs>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/SourceBuild/content/repo-projects/aspnetcore.proj
+++ b/src/SourceBuild/content/repo-projects/aspnetcore.proj
@@ -11,7 +11,7 @@
     <BuildActions Condition="'$(BuildOS)' != 'windows'">$(BuildActions) $(FlagParameterPrefix)no-build-java</BuildActions>
 
     <BuildArgs>$(BuildArgs) $(FlagParameterPrefix)arch $(TargetArchitecture)</BuildArgs>
-    <BuildWithDesktopMSBuild>true</BuildWithDesktopMSBuild>
+    <ForceDotNetMSBuildEngine>false</ForceDotNetMSBuildEngine>
 
     <LogVerbosityOptOut>true</LogVerbosityOptOut>
   </PropertyGroup>

--- a/src/SourceBuild/content/repo-projects/wpf.proj
+++ b/src/SourceBuild/content/repo-projects/wpf.proj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <LogVerbosityOptOut>true</LogVerbosityOptOut>
-    <BuildWithDesktopMSBuild>true</BuildWithDesktopMSBuild>
+    <ForceDotNetMSBuildEngine>false</ForceDotNetMSBuildEngine>
 
     <BuildArgs>$(BuildArgs) $(FlagParameterPrefix)v $(LogVerbosity)</BuildArgs>
     <BuildArgs>$(BuildArgs) $(FlagParameterPrefix)warnAsError $(ArcadeFalseBoolBuildArg)</BuildArgs>


### PR DESCRIPTION
Change the name of the property and invert it to make its meaning a bit more clear. In some repos where BuildWithDesktopMSBuild was set to false, dotnet msbuild was still in use, it was just that the repo was making its own choices.