### PR TITLE
Update vmr-build.yml step for SDK copy

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -203,7 +203,7 @@ jobs:
     - task: CopyFiles@2
       displayName: Copy Previous Build
       inputs:
-        SourceFolder: $(Pipeline.Workspace)/${{ parameters.reuseBuildArtifactsFrom }}_${{ parameters.architecture }}_Artifacts
+        SourceFolder: $(Pipeline.Workspace)/${{ parameters.reuseBuildArtifactsFrom }}_${{ parameters.architecture }}_Artifacts/assets/Release
         Contents: '*.tar.gz'
         TargetFolder: $(sourcesPath)/prereqs/packages/archive/
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/4281

Last-week's VMR publishing changes introduced a change in artifacts layout to match match the layout on build machine - sdk tarball is in `assets/Release` sub-directory - https://dev.azure.com/dnceng/internal/_build/results?buildId=2416861&view=artifacts&pathAsName=false&type=publishedArtifacts

Verification build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2419333&view=results