### PR TITLE
Increase timeout of UB Windows legs to 12 hours

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -98,7 +98,7 @@ jobs:
   # Currently, CodeQL slows the build down too much
   # https://github.com/dotnet/source-build/issues/4276
   ${{ if and(parameters.isBuiltFromVmr, startswith(parameters.buildName, 'Windows'), eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
-    timeoutInMinutes: 360
+    timeoutInMinutes: 720
   ${{ else }}:
     timeoutInMinutes: 150
 


### PR DESCRIPTION
6 hours wasn't enough for CodeQL:
https://dev.azure.com/dnceng/internal/_build/results?buildId=2418975&view=logs&j=9050e078-31bf-5111-d8ec-8b6fa95caf9c&t=a4061dd7-1bf7-5cb6-d99a-c96b0df02bbb
