### PR TITLE
Allow razor test binary in VMR

### DIFF
--- a/src/SourceBuild/content/eng/allowed-vmr-binaries.txt
+++ b/src/SourceBuild/content/eng/allowed-vmr-binaries.txt
@@ -63,6 +63,7 @@ src/nuget-client/test/TestUtilities/Test.Utility/compiler/resources/*.zip
 
 # razor
 src/razor/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/TestFiles/BlazorProject.zip
+src/razor/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Resources/project.razor.bin
 
 # roslyn
 src/roslyn/src/Compilers/Test/Resources/Core/**/*.metadata


### PR DESCRIPTION
Closes https://github.com/dotnet/source-build/issues/4265

This PR permits a new binary into the VMR by adding it to the allowed-vmr-binaries.txt file. It is important to note that this is a test binary, so we should not allow it for SB.