### PR TITLE
Allow Winforms DesignSurface project files

### DIFF
--- a/src/VirtualMonoRepo/source-mappings.json
+++ b/src/VirtualMonoRepo/source-mappings.json
@@ -191,7 +191,10 @@
             "defaultRemote": "https://github.com/dotnet/winforms",
             "exclude": [
                 // Non-OSS license - https://github.com/dotnet/source-build/issues/3772
-                "src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/**"
+                "src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/**/*.cs",
+                "src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/**/*.ico",
+                "src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/**/*.resx",
+                "src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/LICENSE.txt"
             ]
         },
         {


### PR DESCRIPTION
In order to [remove the non-OSS licensed winforms files from the VMR](https://github.com/dotnet/dotnet/pull/86), we need to keep the project files. This PR updates the cloaking to specify that all files in `src/System.Windows.Forms/tests/IntegrationTests/DesignSurface` should be cloaked except for the project files.