### PR TITLE
Move nested VMR artifacts to root

### DIFF
--- a/eng/pipelines/templates/jobs/sdk-diff-tests.yml
+++ b/eng/pipelines/templates/jobs/sdk-diff-tests.yml
@@ -75,6 +75,10 @@ jobs:
       displayName: Download Source Built Artifacts
 
   - script: |
+      find $(Pipeline.Workspace)/Artifacts -type f -exec mv {} $(Pipeline.Workspace)/Artifacts \;
+    displayName: Move Artifacts to root
+
+  - script: |
       platform="linux"
       if [[ ${{ parameters.targetRid }} =~ "alpine" ]]; then
         platform="$platform-musl"


### PR DESCRIPTION
Closes https://github.com/dotnet/source-build/issues/4282

The SDK diff tests were failing because the VMR artifacts had been nested into `assets/Release`. This PR moves the downloaded artifacts to `$(Pipeline.Workspace)/Artifacts` so that if the artifacts get relocated again, the sdk diff tests can always find them at `$(Pipeline.Workspace)/Artifacts`

[Sample run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2422001&view=logs&j=c2a3fba4-babc-5882-e82a-8e0dc9edd6ec) (internal Microsoft link)