### PR TITLE
Allow using Traversal and NoTargets SDK in VMR orchestrator

### DIFF
--- a/src/SourceBuild/content/Directory.Build.props
+++ b/src/SourceBuild/content/Directory.Build.props
@@ -169,10 +169,10 @@
     <KeysDir>$([MSBuild]::NormalizeDirectory('$(PrereqsDir)', 'keys'))</KeysDir>
     <PrereqsPackagesDir>$([MSBuild]::NormalizeDirectory('$(PrereqsDir)', 'packages'))</PrereqsPackagesDir>
 
-    <!-- When SB mode, the initial arcade is unzipped to the "ArcadeBootstrapPackage" dir.
-         When running in VBPOC, the bootstrap package is the arcade restored at the beginning of the build. -->
-    <ArcadeBootstrapPackageDir Condition="'$(DotNetBuildSourceOnly)' == 'true'">$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'ArcadeBootstrapPackage'))</ArcadeBootstrapPackageDir>
-    <ArcadeBootstrapPackageDir Condition="'$(DotNetBuildSourceOnly)' != 'true'">$(NuGetPackageRoot)</ArcadeBootstrapPackageDir>
+    <!-- When SB mode, the initial toolsets are unzipped to the "BootstrapPackages" dir.
+         When running in non-source-build, the bootstrap package is the one restored at the beginning of the build. -->
+    <BootstrapPackagesDir Condition="'$(DotNetBuildSourceOnly)' == 'true'">$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'BootstrapPackages'))</BootstrapPackagesDir>
+    <BootstrapPackagesDir Condition="'$(DotNetBuildSourceOnly)' != 'true'">$(NuGetPackageRoot)</BootstrapPackagesDir>
 
     <VSMSBuildSdkResolversDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'toolset', 'VSSdkResolvers'))</VSMSBuildSdkResolversDir>
     <IntermediateSymbolsRootDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsObjDir)', 'Symbols'))</IntermediateSymbolsRootDir>

--- a/src/SourceBuild/content/build.sh
+++ b/src/SourceBuild/content/build.sh
@@ -225,7 +225,7 @@ function Build {
     if [ "$test" == "true" ]; then
       "$CLI_ROOT/dotnet" msbuild "$scriptroot/build.proj" -bl:"$scriptroot/artifacts/log/$configuration/BuildTests.binlog" -flp:"LogFile=$scriptroot/artifacts/log/$configuration/BuildTests.log" -clp:v=m $properties
     else
-      "$CLI_ROOT/dotnet" msbuild "$scriptroot/eng/tools/init-build.proj" -bl:"$scriptroot/artifacts/log/$configuration/BuildMSBuildSdkResolver.binlog" -flp:LogFile="$scriptroot/artifacts/log/$configuration/BuildMSBuildSdkResolver.log" /t:ExtractToolPackage,BuildMSBuildSdkResolver $properties
+      "$CLI_ROOT/dotnet" msbuild "$scriptroot/eng/tools/init-build.proj" -bl:"$scriptroot/artifacts/log/$configuration/BuildMSBuildSdkResolver.binlog" -flp:LogFile="$scriptroot/artifacts/log/$configuration/BuildMSBuildSdkResolver.log" /t:ExtractToolsetPackages,BuildMSBuildSdkResolver $properties
 
       # kill off the MSBuild server so that on future invocations we pick up our custom SDK Resolver
       "$CLI_ROOT/dotnet" build-server shutdown

--- a/src/SourceBuild/content/build.sh
+++ b/src/SourceBuild/content/build.sh
@@ -351,20 +351,46 @@ if [[ "$sourceOnly" == "true" ]]; then
     exit 1
   fi
 
+  # Extract toolset packages
+
+  # Ensure that by default, the bootstrap version of the toolset SDK is used. Source-build infra
+  # projects use bootstrap toolset SDKs, and would fail to find it in the build. The repo
+  # projects overwrite this so that they use the source-built toolset SDK instad.
+
+  # 1. Microsoft.DotNet.Arcade.Sdk
   arcadeSdkLine=$(grep -m 1 'MicrosoftDotNetArcadeSdkVersion' "$packageVersionsPath")
-  versionPattern="<MicrosoftDotNetArcadeSdkVersion>(.*)</MicrosoftDotNetArcadeSdkVersion>"
-  if [[ $arcadeSdkLine =~ $versionPattern ]]; then
+  arcadeSdkPattern="<MicrosoftDotNetArcadeSdkVersion>(.*)</MicrosoftDotNetArcadeSdkVersion>"
+  if [[ $arcadeSdkLine =~ $arcadeSdkPattern ]]; then
     export ARCADE_BOOTSTRAP_VERSION=${BASH_REMATCH[1]}
 
-    # Ensure that by default, the bootstrap version of the Arcade SDK is used. Source-build infra
-    # projects use bootstrap Arcade SDK, and would fail to find it in the build. The repo
-    # projects overwrite this so that they use the source-built Arcade SDK instad.
     export SOURCE_BUILT_SDK_ID_ARCADE=Microsoft.DotNet.Arcade.Sdk
     export SOURCE_BUILT_SDK_VERSION_ARCADE=$ARCADE_BOOTSTRAP_VERSION
-    export SOURCE_BUILT_SDK_DIR_ARCADE=$packagesRestoredDir/ArcadeBootstrapPackage/microsoft.dotnet.arcade.sdk/$ARCADE_BOOTSTRAP_VERSION
+    export SOURCE_BUILT_SDK_DIR_ARCADE=$packagesRestoredDir/BootstrapPackages/microsoft.dotnet.arcade.sdk/$ARCADE_BOOTSTRAP_VERSION
   fi
 
-  echo "Found bootstrap SDK $SDK_VERSION, bootstrap Arcade $ARCADE_BOOTSTRAP_VERSION"
+  # 2. Microsoft.Build.NoTargets
+  notargetsSdkLine=$(grep -m 1 'Microsoft.Build.NoTargets' "$scriptroot/global.json")
+  notargetsSdkPattern="\"Microsoft\.Build\.NoTargets\" *: *\"(.*)\""
+  if [[ $notargetsSdkLine =~ $notargetsSdkPattern ]]; then
+    export NOTARGETS_BOOTSTRAP_VERSION=${BASH_REMATCH[1]}
+
+    export SOURCE_BUILT_SDK_ID_NOTARGETS=Microsoft.Build.NoTargets
+    export SOURCE_BUILT_SDK_VERSION_NOTARGETS=$NOTARGETS_BOOTSTRAP_VERSION
+    export SOURCE_BUILT_SDK_DIR_NOTARGETS=$packagesRestoredDir/BootstrapPackages/microsoft.build.notargets/$NOTARGETS_BOOTSTRAP_VERSION
+  fi
+
+  # 3. Microsoft.Build.Traversal
+  traversalSdkLine=$(grep -m 1 'Microsoft.Build.Traversal' "$scriptroot/global.json")
+  traversalSdkPattern="\"Microsoft\.Build\.Traversal\" *: *\"(.*)\""
+  if [[ $traversalSdkLine =~ $traversalSdkPattern ]]; then
+    export TRAVERSAL_BOOTSTRAP_VERSION=${BASH_REMATCH[1]}
+
+    export SOURCE_BUILT_SDK_ID_TRAVERSAL=Microsoft.Build.Traversal
+    export SOURCE_BUILT_SDK_VERSION_TRAVERSAL=$TRAVERSAL_BOOTSTRAP_VERSION
+    export SOURCE_BUILT_SDK_DIR_TRAVERSAL=$packagesRestoredDir/BootstrapPackages/microsoft.build.traversal/$TRAVERSAL_BOOTSTRAP_VERSION
+  fi
+
+  echo "Found bootstrap versions: SDK $SDK_VERSION, Arcade $ARCADE_BOOTSTRAP_VERSION, NoTargets $NOTARGETS_BOOTSTRAP_VERSION and Traversal $TRAVERSAL_BOOTSTRAP_VERSION"
 fi
 
 Build

--- a/src/SourceBuild/content/eng/tools/init-build.proj
+++ b/src/SourceBuild/content/eng/tools/init-build.proj
@@ -17,7 +17,7 @@
       BuildMSBuildSdkResolver;
       RestoreUnifiedBuildValidationTests;
       BuildLeakDetection;
-      ExtractToolPackage;
+      ExtractToolsetPackages;
       GenerateRootFs;
       PoisonPrebuiltPackages" />
 
@@ -97,7 +97,7 @@
   <!-- Build msbuild tasks for the poisoning feature even when EnablePoison!=true to validate that the task project
        builds as EnablePoison=true isn't exercised in PR validation. -->
   <Target Name="BuildLeakDetection"
-          DependsOnTargets="ExtractToolPackage;BuildMSBuildSdkResolver"
+          DependsOnTargets="ExtractToolsetPackages;BuildMSBuildSdkResolver"
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(BaseIntermediateOutputPath)BuildLeakDetection.complete">
     <MSBuild Projects="tasks\Microsoft.DotNet.SourceBuild.Tasks.LeakDetection\Microsoft.DotNet.SourceBuild.Tasks.LeakDetection.csproj"
@@ -133,12 +133,12 @@
           Condition="'$(TargetArchitecture)' == 'armel'" />
   </Target>
 
-  <!-- Extract Arcade prebuilt package into the bootstrap folder and prepare it. -->
-  <Target Name="ExtractToolPackage"
+  <!-- Extract toolset packages into the bootstrap folder -->
+  <Target Name="ExtractToolsetPackages"
           Condition="'$(DotNetBuildSourceOnly)' == 'true'"
           DependsOnTargets="UnpackTarballs"
           Inputs="$(MSBuildProjectFullPath)"
-          Outputs="$(BaseIntermediateOutputPath)ExtractToolPackage.complete">
+          Outputs="$(BaseIntermediateOutputPath)ExtractToolsetPackages.complete">
     <ItemGroup>
       <ToolsetPackage Include="Microsoft.DotNet.Arcade.Sdk" SourceFolder="$(PrebuiltSourceBuiltPackagesPath)" Version="$(ARCADE_BOOTSTRAP_VERSION)" />
       <ToolsetPackage Include="Microsoft.Build.NoTargets" SourceFolder="$(ReferencePackagesDir)" Version="$(NOTARGETS_BOOTSTRAP_VERSION)" />
@@ -150,7 +150,7 @@
            SkipUnchangedFiles="true" />
 
     <MakeDir Directories="$(BaseIntermediateOutputPath)" />
-    <Touch Files="$(BaseIntermediateOutputPath)ExtractToolPackage.complete" AlwaysCreate="true">
+    <Touch Files="$(BaseIntermediateOutputPath)ExtractToolsetPackages.complete" AlwaysCreate="true">
       <Output TaskParameter="TouchedFiles" ItemName="FileWrites" />
     </Touch>
   </Target>

--- a/src/SourceBuild/content/eng/tools/init-build.proj
+++ b/src/SourceBuild/content/eng/tools/init-build.proj
@@ -139,8 +139,19 @@
           DependsOnTargets="UnpackTarballs"
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(BaseIntermediateOutputPath)ExtractToolPackage.complete">
+    <!-- Microsoft.DotNet.Arcade.Sdk -->
     <Unzip SourceFiles="$(PrebuiltSourceBuiltPackagesPath)Microsoft.DotNet.Arcade.Sdk.$(ARCADE_BOOTSTRAP_VERSION).nupkg"
-           DestinationFolder="$(ArcadeBootstrapPackageDir)microsoft.dotnet.arcade.sdk/$(ARCADE_BOOTSTRAP_VERSION)/"
+           DestinationFolder="$(BootstrapPackagesDir)microsoft.dotnet.arcade.sdk/$(ARCADE_BOOTSTRAP_VERSION)/"
+           SkipUnchangedFiles="true" />
+
+    <!-- Microsoft.Build.NoTargets -->
+    <Unzip SourceFiles="$(ReferencePackagesDir)Microsoft.Build.NoTargets.$(NOTARGETS_BOOTSTRAP_VERSION).nupkg"
+           DestinationFolder="$(BootstrapPackagesDir)microsoft.build.notargets/$(NOTARGETS_BOOTSTRAP_VERSION)/"
+           SkipUnchangedFiles="true" />
+
+    <!-- Microsoft.Build.Traversal -->
+    <Unzip SourceFiles="$(ReferencePackagesDir)Microsoft.Build.Traversal.$(TRAVERSAL_BOOTSTRAP_VERSION).nupkg"
+           DestinationFolder="$(BootstrapPackagesDir)microsoft.build.traversal/$(TRAVERSAL_BOOTSTRAP_VERSION)/"
            SkipUnchangedFiles="true" />
 
     <MakeDir Directories="$(BaseIntermediateOutputPath)" />

--- a/src/SourceBuild/content/eng/tools/init-build.proj
+++ b/src/SourceBuild/content/eng/tools/init-build.proj
@@ -139,19 +139,14 @@
           DependsOnTargets="UnpackTarballs"
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(BaseIntermediateOutputPath)ExtractToolPackage.complete">
-    <!-- Microsoft.DotNet.Arcade.Sdk -->
-    <Unzip SourceFiles="$(PrebuiltSourceBuiltPackagesPath)Microsoft.DotNet.Arcade.Sdk.$(ARCADE_BOOTSTRAP_VERSION).nupkg"
-           DestinationFolder="$(BootstrapPackagesDir)microsoft.dotnet.arcade.sdk/$(ARCADE_BOOTSTRAP_VERSION)/"
-           SkipUnchangedFiles="true" />
+    <ItemGroup>
+      <ToolsetPackage Include="Microsoft.DotNet.Arcade.Sdk" SourceFolder="$(PrebuiltSourceBuiltPackagesPath)" Version="$(ARCADE_BOOTSTRAP_VERSION)" />
+      <ToolsetPackage Include="Microsoft.Build.NoTargets" SourceFolder="$(ReferencePackagesDir)" Version="$(NOTARGETS_BOOTSTRAP_VERSION)" />
+      <ToolsetPackage Include="Microsoft.Build.Traversal" SourceFolder="$(ReferencePackagesDir)" Version="$(TRAVERSAL_BOOTSTRAP_VERSION)" />
+    </ItemGroup>
 
-    <!-- Microsoft.Build.NoTargets -->
-    <Unzip SourceFiles="$(ReferencePackagesDir)Microsoft.Build.NoTargets.$(NOTARGETS_BOOTSTRAP_VERSION).nupkg"
-           DestinationFolder="$(BootstrapPackagesDir)microsoft.build.notargets/$(NOTARGETS_BOOTSTRAP_VERSION)/"
-           SkipUnchangedFiles="true" />
-
-    <!-- Microsoft.Build.Traversal -->
-    <Unzip SourceFiles="$(ReferencePackagesDir)Microsoft.Build.Traversal.$(TRAVERSAL_BOOTSTRAP_VERSION).nupkg"
-           DestinationFolder="$(BootstrapPackagesDir)microsoft.build.traversal/$(TRAVERSAL_BOOTSTRAP_VERSION)/"
+    <Unzip SourceFiles="%(ToolsetPackage.SourceFolder)%(ToolsetPackage.Identity).%(ToolsetPackage.Version).nupkg"
+           DestinationFolder="$(BootstrapPackagesDir)$([System.String]::Copy('%(ToolsetPackage.Identity)').ToLowerInvariant())/%(ToolsetPackage.Version)"
            SkipUnchangedFiles="true" />
 
     <MakeDir Directories="$(BaseIntermediateOutputPath)" />

--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -54,13 +54,6 @@
     <ArcadeBootstrapVersion>$([MSBuild]::ValueOrDefault('$(ARCADE_BOOTSTRAP_VERSION)', '$(ArcadeSdkVersion)'))</ArcadeBootstrapVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
-    <!-- Get Microsoft.Build.NoTargets and Microsoft.Build.Traversal versions from VMR's global.json -->
-    <VMRGlobalJsonContents>$([System.IO.File]::ReadAllText($(RepoRoot)global.json))</VMRGlobalJsonContents>
-    <NoTargetsSdkVersion>$([System.Text.RegularExpressions.Regex]::Match($(VMRGlobalJsonContents), '"Microsoft.Build.NoTargets": "([^"]*)"').Groups.get_Item(1))</NoTargetsSdkVersion>
-    <TraversalSdkVersion>$([System.Text.RegularExpressions.Regex]::Match($(VMRGlobalJsonContents), '"Microsoft.Build.Traversal": "([^"]*)"').Groups.get_Item(1))</TraversalSdkVersion>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(BuildOS)' == 'windows'">
     <FlagParameterPrefix>-</FlagParameterPrefix>
     <ArcadeFalseBoolBuildArg>0</ArcadeFalseBoolBuildArg>
@@ -201,7 +194,7 @@
 
     <SourceBuiltSdkOverride Include="@(ArcadeSdkOverride)"
                             Version="$(ArcadeBootstrapVersion)"
-                            Location="$(ArcadeBootstrapPackageDir)microsoft.dotnet.arcade.sdk/$(ArcadeBootstrapVersion)"
+                            Location="$(BootstrapPackagesDir)microsoft.dotnet.arcade.sdk/$(ArcadeBootstrapVersion)"
                             Condition="'$(UseBootstrapArcade)' == 'true'" />
 
     <!-- When not bootstrapping, use the just-built versions. -->
@@ -221,8 +214,8 @@
       RestoreConfigFile property. MSBuild uses NuGetSdkResolver to restore missing SDKs, which doesn't honor
       RestoreConfigFile property and uses NuGet.config file from repo's root which has online feeds.
     -->
-    <NoTargetsSdkOverride Include="Microsoft.Build.NoTargets" Group="NOTARGETS" Version="$(NoTargetsSdkVersion)" />
-    <TraversalSdkOverride Include="Microsoft.Build.Traversal" Group="TRAVERSAL" Version="$(TraversalSdkVersion)" />
+    <NoTargetsSdkOverride Include="Microsoft.Build.NoTargets" Group="NOTARGETS" Version="$(NOTARGETS_BOOTSTRAP_VERSION)" />
+    <TraversalSdkOverride Include="Microsoft.Build.Traversal" Group="TRAVERSAL" Version="$(TRAVERSAL_BOOTSTRAP_VERSION)" />
     <SourceBuiltSdkOverride Include="@(NoTargetsSdkOverride)" Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(RepositoryName)' != 'source-build-reference-packages'" />
     <SourceBuiltSdkOverride Include="@(TraversalSdkOverride)" Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(RepositoryName)' != 'source-build-reference-packages'" />
   </ItemGroup>


### PR DESCRIPTION
We want to use the `Microsoft.Build.NoTargets` and `Microsoft.Build.Traversal` msbuild sdks in the VMR orchestrator, i.e. for the repo-projects and the traversal entry point projects.

To support this in source-build where prebuilts are disallowed, follow the same approach for these two msbuild sdks as with the Arcade msbuild sdk. Extract their nuget packages into a well known location and register them for our custom msbuild sdk resolver.

https://github.com/dotnet/installer/pull/19290 starts using the Microsoft.Build.Traversal msbuild sdk in build.proj.