### PR TITLE
Run CodeQL in VMR's SDL stage

### DIFF
--- a/src/SourceBuild/content/eng/pipelines/ci.yml
+++ b/src/SourceBuild/content/eng/pipelines/ci.yml
@@ -61,6 +61,13 @@ extends:
         image: 1es-windows-2022
         os: windows
 
+      codeql:
+        compiled:
+          enabled: true
+        # Runs analysis in the SDL stage and not every job
+        # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/sdlanalysis/codeql#improving-codeql-performance
+        runSourceLanguagesInSourceAnalysis: true
+
       baseline:
         baselineFile: $(Build.SourcesDirectory)\.config\guardian\.gdnbaselines
 


### PR DESCRIPTION
CodeQL takes 8.5 hours to complete: https://dev.azure.com/dnceng/internal/_build/results?buildId=2422696&view=results

We can run some of the analysis in the SDL stage instaed.