### PR TITLE
[VMR] Correctly pass TargetArchitecture in emsdk.proj

### DIFF
--- a/src/SourceBuild/content/repo-projects/emsdk.proj
+++ b/src/SourceBuild/content/repo-projects/emsdk.proj
@@ -6,7 +6,7 @@
 
     <BuildArgs>$(BuildArgs) /p:PackageRid=$(TargetRid)</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:AssetManifestOS=$(TargetOS)</BuildArgs>
-    <BuildArgs>$(BuildArgs) /p:PlatformName=$(TargetArch)</BuildArgs>
+    <BuildArgs>$(BuildArgs) /p:PlatformName=$(TargetArchitecture)</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:ForceBuildManifestOnly=true</BuildArgs>
   </PropertyGroup>
 


### PR DESCRIPTION
I noticed we passed an empty PlatformName in the VMR build, this is because we were using `TargetArch` instead of `TargetArchitecture`
