### PR TITLE
Add 1ES PT baseline for VMR

### DIFF
--- a/src/SourceBuild/content/.config/guardian/.gdnbaselines
+++ b/src/SourceBuild/content/.config/guardian/.gdnbaselines
@@ -1,0 +1,1899 @@
+{
+  "hydrated": true,
+  "properties": {
+    "helpUri": "https://eng.ms/docs/microsoft-security/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/microsoft-guardian/general/baselines",
+    "hydrationStatus": "This file contains identifying data. It is **NOT** safe to check into your repo. To dehydrate this file, run `guardian dehydrate --help` and follow the guidance."
+  },
+  "version": "1.0.0",
+  "baselines": {
+    "default": {
+      "name": "default",
+      "createdDate": "2024-04-03 14:41:43Z",
+      "lastUpdatedDate": "2024-04-03 14:41:43Z"
+    }
+  },
+  "results": {
+    "5f3b52e23f96eb01bcfd73ead3cbaa2e1430de0006e5103109dd39bf9f292165": {
+      "signature": "5f3b52e23f96eb01bcfd73ead3cbaa2e1430de0006e5103109dd39bf9f292165",
+      "alternativeSignatures": [],
+      "target": "src/nuget-client/docs/cross-platform-debugging.md",
+      "line": 66,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0060",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "72b28f655eadc78b21ab36a7f572708315d8d909d1b460162511e37086288e30": {
+      "signature": "72b28f655eadc78b21ab36a7f572708315d8d909d1b460162511e37086288e30",
+      "alternativeSignatures": [
+        "60efb04c6e0431e477e792a96d32b30b3a309b4ee19fad084a015e2946985459"
+      ],
+      "target": "src/roslyn/eng/build.ps1",
+      "line": 343,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingConvertToSecureStringWithPlainText",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "08dcdf31a316917a50c97d16d8d4eca5dbd7528b8cfe8c9bd8b29fdd4dc3eb85": {
+      "signature": "08dcdf31a316917a50c97d16d8d4eca5dbd7528b8cfe8c9bd8b29fdd4dc3eb85",
+      "alternativeSignatures": [
+        "c6b795bd087762188cd476b81ccdb474a25495b86b8080e1ab15c5592628b8af"
+      ],
+      "target": "src/aspire/eng/common/SetupNugetSources.ps1",
+      "line": 38,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "62e5fe288e1e21307317edab5d08f047ecdd01eac5c19660bab6c9ae96f8c8b5": {
+      "signature": "62e5fe288e1e21307317edab5d08f047ecdd01eac5c19660bab6c9ae96f8c8b5",
+      "alternativeSignatures": [
+        "631ff94fe085c9754b83bd9fc2a15dccccccd067392cea1f520398874266248a"
+      ],
+      "target": "src/aspire/eng/common/SetupNugetSources.ps1",
+      "line": 56,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "6d4429751838adeb1f1b097b6b974a6a47d744871980ee54faeb7a4536183597": {
+      "signature": "6d4429751838adeb1f1b097b6b974a6a47d744871980ee54faeb7a4536183597",
+      "alternativeSignatures": [
+        "c4538b540d00c41b9828ade572431cfd476ae40ebd4c6cfc635d06ac185972e3"
+      ],
+      "target": "src/aspire/eng/common/SetupNugetSources.ps1",
+      "line": 88,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "93735e0dba704ad832d7b3fdabfcda2875dee9adb24e3cd676fce3b612d116c3": {
+      "signature": "93735e0dba704ad832d7b3fdabfcda2875dee9adb24e3cd676fce3b612d116c3",
+      "alternativeSignatures": [],
+      "target": "src/aspire/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/ConformanceTests_Pooling.cs",
+      "line": 21,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0030",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "a5142e7bafbf664fdcb2d4d7071ca8427c7da0c8ba66cc7706c9c07b816f1201": {
+      "signature": "a5142e7bafbf664fdcb2d4d7071ca8427c7da0c8ba66cc7706c9c07b816f1201",
+      "alternativeSignatures": [],
+      "target": "src/aspire/tests/Aspire.Npgsql.Tests/ConformanceTests.cs",
+      "line": 17,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0030",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "1ee555192f99f2751398509614249023216a98d148e57de41317ec60715374b0": {
+      "signature": "1ee555192f99f2751398509614249023216a98d148e57de41317ec60715374b0",
+      "alternativeSignatures": [
+        "5d82fd3437c708ec3bfe674016099e5465194ebc53f7dd72061b98d7257a951f"
+      ],
+      "target": "src/aspnetcore/eng/common/SetupNugetSources.ps1",
+      "line": 38,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "be4c5e062093fa08fe93f0753c3090b63af74dc4af4c04d781fddf9ec41db0d4": {
+      "signature": "be4c5e062093fa08fe93f0753c3090b63af74dc4af4c04d781fddf9ec41db0d4",
+      "alternativeSignatures": [
+        "bafe4e1a197b7af8b8cfda4cafd8250a4a66a0ca18b82817e12d5a4d17350589"
+      ],
+      "target": "src/aspnetcore/eng/common/SetupNugetSources.ps1",
+      "line": 56,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "c704b27a3590a23b240e9c261dc93c8f3c7871e4d471b5688c3609880396f672": {
+      "signature": "c704b27a3590a23b240e9c261dc93c8f3c7871e4d471b5688c3609880396f672",
+      "alternativeSignatures": [
+        "0880869d43948d2f7050955aeb76733bc12ab82839563cbabff0dd36d0880a39"
+      ],
+      "target": "src/aspnetcore/eng/common/SetupNugetSources.ps1",
+      "line": 88,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "b6aecc1d8697beab291f9925633b5ec3e37a088033efc7e93928fd9cac96cda4": {
+      "signature": "b6aecc1d8697beab291f9925633b5ec3e37a088033efc7e93928fd9cac96cda4",
+      "alternativeSignatures": [
+        "985838b2d1518f507c85ae0f635951bad92dde58eb24c252d7e56fb6ccda6191"
+      ],
+      "target": "src/aspnetcore/src/DataProtection/CreateTestCert.ps1",
+      "line": 11,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingConvertToSecureStringWithPlainText",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "ed7c9f876d0784c23991b9ce1abc7c0df6229e7eed8cda08e56315b5fdeb5fa0": {
+      "signature": "ed7c9f876d0784c23991b9ce1abc7c0df6229e7eed8cda08e56315b5fdeb5fa0",
+      "alternativeSignatures": [
+        "d2f6b006ae6b54ff39886db273b9ffc9ba23f0a84861bbe028aa54343fb5c55b"
+      ],
+      "target": "src/cecil/eng/common/SetupNugetSources.ps1",
+      "line": 38,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "ae448b96e62d898485a9df57a24a920740c5504d4854e85e8060a1ba94752dbb": {
+      "signature": "ae448b96e62d898485a9df57a24a920740c5504d4854e85e8060a1ba94752dbb",
+      "alternativeSignatures": [
+        "6590282ea3895180725cbb97a9e565571bb27b596bb6a6d1087b62078ed1d683"
+      ],
+      "target": "src/cecil/eng/common/SetupNugetSources.ps1",
+      "line": 56,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "2e86a1d345364972a25bfe0a38237afa382766115808bb86bac8ca03e4cca304": {
+      "signature": "2e86a1d345364972a25bfe0a38237afa382766115808bb86bac8ca03e4cca304",
+      "alternativeSignatures": [
+        "c079fd753fcba1568d79c4bef9fd6200b494f1552bedc1e91902ec8f01081fd7"
+      ],
+      "target": "src/cecil/eng/common/SetupNugetSources.ps1",
+      "line": 88,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "5c349e8f183364d99cde545c6da7549c9d6227957c820fcde8e8beb2b40de39c": {
+      "signature": "5c349e8f183364d99cde545c6da7549c9d6227957c820fcde8e8beb2b40de39c",
+      "alternativeSignatures": [
+        "8546393d391f4010c04ed43788c36626f870b02028937cf390014c660f657f7b"
+      ],
+      "target": "src/command-line-api/eng/common/SetupNugetSources.ps1",
+      "line": 38,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "a9e7b46f71cc21fd96e3bbb1c30a7beb36470f0a4c857794b4444856e54ffc2b": {
+      "signature": "a9e7b46f71cc21fd96e3bbb1c30a7beb36470f0a4c857794b4444856e54ffc2b",
+      "alternativeSignatures": [
+        "34597b8dc5d2e482d7178a50440f3b8815c44e510906dd92a4d31d434c87053b"
+      ],
+      "target": "src/command-line-api/eng/common/SetupNugetSources.ps1",
+      "line": 56,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "3df69ea15defeb820ba0823dc80513e75a79b049dee023b51dee4419cd1d2276": {
+      "signature": "3df69ea15defeb820ba0823dc80513e75a79b049dee023b51dee4419cd1d2276",
+      "alternativeSignatures": [
+        "deb5cfe250ae8f9c1bbcdf230c425dc071067ee26cc7b3d41b9fc078782febfc"
+      ],
+      "target": "src/command-line-api/eng/common/SetupNugetSources.ps1",
+      "line": 88,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "c2b86ae10a9ad117f56bf792ae0a8a99bfbe1945254d156dd685e41dc74dd5ed": {
+      "signature": "c2b86ae10a9ad117f56bf792ae0a8a99bfbe1945254d156dd685e41dc74dd5ed",
+      "alternativeSignatures": [
+        "7c13381c5c5bf98666c53e6497f0d6c8b2463fd2d7e0a0084edce348edb2a98b"
+      ],
+      "target": "src/deployment-tools/eng/common/SetupNugetSources.ps1",
+      "line": 38,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "7ec5369cb17143314826ef4e433320ab257e00485568fed9ca59d6ddf1ad166a": {
+      "signature": "7ec5369cb17143314826ef4e433320ab257e00485568fed9ca59d6ddf1ad166a",
+      "alternativeSignatures": [
+        "7e1528556c5286830d73b23164ea8c99103c6344228bb91390c9943cb6090ff3"
+      ],
+      "target": "src/deployment-tools/eng/common/SetupNugetSources.ps1",
+      "line": 56,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "e71596904ef990bac717b0973b8fd3e36d52b3a45713bf8babb88f1ab0493360": {
+      "signature": "e71596904ef990bac717b0973b8fd3e36d52b3a45713bf8babb88f1ab0493360",
+      "alternativeSignatures": [
+        "ff25e34637fb05921a126d3143eef03b8006f580e993ef5a7d2e27ec5178ee9a"
+      ],
+      "target": "src/deployment-tools/eng/common/SetupNugetSources.ps1",
+      "line": 88,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "32eb952e8561b331092ec83b626102388202071d192f9eb22c233b06ea90d2a1": {
+      "signature": "32eb952e8561b331092ec83b626102388202071d192f9eb22c233b06ea90d2a1",
+      "alternativeSignatures": [
+        "cce04b0a7c54b775c1464a32d85804de7d1777ac2a6d21da8b080c29ac46162c"
+      ],
+      "target": "src/diagnostics/eng/common/SetupNugetSources.ps1",
+      "line": 38,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "7d3c27b6bd42f58e624890a1669c188c6afee080e6330673942d364641876d52": {
+      "signature": "7d3c27b6bd42f58e624890a1669c188c6afee080e6330673942d364641876d52",
+      "alternativeSignatures": [
+        "29d9fec9e2b10d721512bb68a68759baa33b6bbc0683a2d3d5cdcb74894917ee"
+      ],
+      "target": "src/diagnostics/eng/common/SetupNugetSources.ps1",
+      "line": 56,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "42c9ee2033a50a53e2fcc83cb08b3a8c38a5c9e2230414ae0590d3c8f45a9a8d": {
+      "signature": "42c9ee2033a50a53e2fcc83cb08b3a8c38a5c9e2230414ae0590d3c8f45a9a8d",
+      "alternativeSignatures": [
+        "44e2cd3b2773d63b155f2093202415744b74f8b5c47612ad92f2ffee3939cb2f"
+      ],
+      "target": "src/diagnostics/eng/common/SetupNugetSources.ps1",
+      "line": 88,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "ea00dd596b6f25ad7fb56f8433aa4889808c48a9d753eeb896438d871f1bbadf": {
+      "signature": "ea00dd596b6f25ad7fb56f8433aa4889808c48a9d753eeb896438d871f1bbadf",
+      "alternativeSignatures": [
+        "e6e7be75b6234262188b18265bdef3aca61e7ad4b9e0712b34ad9af2605ff5bf"
+      ],
+      "target": "src/emsdk/eng/common/SetupNugetSources.ps1",
+      "line": 38,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "b4e3d369cd32329e640bc7984528cdda54a9bdea2b52a5c3ed026fc57be64afd": {
+      "signature": "b4e3d369cd32329e640bc7984528cdda54a9bdea2b52a5c3ed026fc57be64afd",
+      "alternativeSignatures": [
+        "8f19b3c3b99054f4c34e62dbb042d4505190bae61f7c815659e825e1e3f6585d"
+      ],
+      "target": "src/emsdk/eng/common/SetupNugetSources.ps1",
+      "line": 56,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "869eabde635eff83abaf3ceae639a4dfe5b6e1fc2be56bde177999b341ee7fa7": {
+      "signature": "869eabde635eff83abaf3ceae639a4dfe5b6e1fc2be56bde177999b341ee7fa7",
+      "alternativeSignatures": [
+        "879cee54b1ce34bf674d7bea56317d5e606a8a6d1909e28831a801c3c760547c"
+      ],
+      "target": "src/emsdk/eng/common/SetupNugetSources.ps1",
+      "line": 88,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "c30ea658de240cc77f43da72a2ae66a8300716df1a36e5aad2ccf0041405512b": {
+      "signature": "c30ea658de240cc77f43da72a2ae66a8300716df1a36e5aad2ccf0041405512b",
+      "alternativeSignatures": [
+        "f9010fdbf887fec3fb12dc784714ae4993cfbb0c279ceb32de179be14113851c"
+      ],
+      "target": "src/format/eng/common/SetupNugetSources.ps1",
+      "line": 38,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "29a080743f4448e5fb1c2556f824a2f4950ec05ae1d5baa76157bc6425e08a1e": {
+      "signature": "29a080743f4448e5fb1c2556f824a2f4950ec05ae1d5baa76157bc6425e08a1e",
+      "alternativeSignatures": [
+        "f6f78c526c85382e749badcc83d5d3e81976879e727417fef1b81b83faec67f0"
+      ],
+      "target": "src/format/eng/common/SetupNugetSources.ps1",
+      "line": 56,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "5c1de06651f26dcbfaa7256b674dc725934d1892a58ab1655fed98c7d062c84c": {
+      "signature": "5c1de06651f26dcbfaa7256b674dc725934d1892a58ab1655fed98c7d062c84c",
+      "alternativeSignatures": [
+        "6435a356edc13cd3ae7609656ff1920116c1f944e1d63b2ceec921d4e3f6464d"
+      ],
+      "target": "src/format/eng/common/SetupNugetSources.ps1",
+      "line": 88,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "dd15f0a91faa86197e2bc286d99e9b0e5e625930ad53a5fae4e0a8c2b80b91ee": {
+      "signature": "dd15f0a91faa86197e2bc286d99e9b0e5e625930ad53a5fae4e0a8c2b80b91ee",
+      "alternativeSignatures": [
+        "6252f589ff1cb3d68f758c8f081fd3e59d8cc56bfaa29441b9e26b1cd5726faa"
+      ],
+      "target": "src/fsharp/eng/common/SetupNugetSources.ps1",
+      "line": 38,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "3db9957bb879335816149b88a3fed78468210e7480dd31db37845b97d28078ad": {
+      "signature": "3db9957bb879335816149b88a3fed78468210e7480dd31db37845b97d28078ad",
+      "alternativeSignatures": [
+        "4c6e2de131da98d97f9f4ab9a07fb90f6ca478f578d0bd4da7a7551683c886d7"
+      ],
+      "target": "src/fsharp/eng/common/SetupNugetSources.ps1",
+      "line": 56,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "cda6b64f47374712a1488b1ca527f54310e135ceb7e4611e75f28aed7f4edd43": {
+      "signature": "cda6b64f47374712a1488b1ca527f54310e135ceb7e4611e75f28aed7f4edd43",
+      "alternativeSignatures": [
+        "c7c9b966693a21385b7c2f4a36c5c3c6a410cda29716d1c10537f6463cb852af"
+      ],
+      "target": "src/fsharp/eng/common/SetupNugetSources.ps1",
+      "line": 88,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "61eab78163233a43bc21bf8a2a762496cd63758852ed1afcfe73d4ebd90532e9": {
+      "signature": "61eab78163233a43bc21bf8a2a762496cd63758852ed1afcfe73d4ebd90532e9",
+      "alternativeSignatures": [
+        "2584c057a56958edc47e8f9ed26ed2e4b2fbee706d4a5fe6793d42044754f016"
+      ],
+      "target": "src/msbuild/eng/common/SetupNugetSources.ps1",
+      "line": 38,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "201a1737b9cd0a61c986dc37678141a290fe56e518c4d7401443d83f89635758": {
+      "signature": "201a1737b9cd0a61c986dc37678141a290fe56e518c4d7401443d83f89635758",
+      "alternativeSignatures": [
+        "3b2032f4ca90c12c9b5ea35ac6e85ba10a32f7d018b39369e044ae4d039e000b"
+      ],
+      "target": "src/msbuild/eng/common/SetupNugetSources.ps1",
+      "line": 56,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "bcb0788172282f0f5ab22907ec5070573092309654c8eb07dc92fb4e676ded80": {
+      "signature": "bcb0788172282f0f5ab22907ec5070573092309654c8eb07dc92fb4e676ded80",
+      "alternativeSignatures": [
+        "8c37a63c016612477d48726a77b74eb798e45c09e6c2212fbd57ca10aa88dd59"
+      ],
+      "target": "src/msbuild/eng/common/SetupNugetSources.ps1",
+      "line": 88,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "5dc266c64bff96e86a1a3907386531e16f0dcf38f5b1bcdba22f45e7965c6bf7": {
+      "signature": "5dc266c64bff96e86a1a3907386531e16f0dcf38f5b1bcdba22f45e7965c6bf7",
+      "alternativeSignatures": [
+        "ad996650f8e2b17aeddcea222c0861f9cb257aee49f31e01a4de573d23e1b0fb"
+      ],
+      "target": "src/razor/eng/common/SetupNugetSources.ps1",
+      "line": 38,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "845ca607828540eafa4053b4f9368b97c23258b9b47ceecbcec8bd7e5aa59302": {
+      "signature": "845ca607828540eafa4053b4f9368b97c23258b9b47ceecbcec8bd7e5aa59302",
+      "alternativeSignatures": [
+        "c2cb1a24bf7f267ad949c325feaf69f29f60dd019f1b3879391f85f7d5316800"
+      ],
+      "target": "src/razor/eng/common/SetupNugetSources.ps1",
+      "line": 56,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "89bed4bb6776c3155318e4ff38e5062f655834cebcdf6f65b08cbd2312ac75f8": {
+      "signature": "89bed4bb6776c3155318e4ff38e5062f655834cebcdf6f65b08cbd2312ac75f8",
+      "alternativeSignatures": [
+        "c805484f8267753ac6867fe334b6ecfa42d2430b21488501a926b9d49a679bb1"
+      ],
+      "target": "src/razor/eng/common/SetupNugetSources.ps1",
+      "line": 88,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "c2496232c1468a250e567517e0a7a71632e3ed60330784450511cef2a1164af0": {
+      "signature": "c2496232c1468a250e567517e0a7a71632e3ed60330784450511cef2a1164af0",
+      "alternativeSignatures": [
+        "723a97522d855b779b011a0a6f84ea1ee7cf77d05f2b4808ffdbd521e655e6e3"
+      ],
+      "target": "src/roslyn/eng/common/SetupNugetSources.ps1",
+      "line": 38,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "e75c5f821dc59179ed407ca3da917756cd0cff7aac1755df7ef0ef6bf087f80c": {
+      "signature": "e75c5f821dc59179ed407ca3da917756cd0cff7aac1755df7ef0ef6bf087f80c",
+      "alternativeSignatures": [
+        "420deccac3e08a232a59caa2178b503d310d2645f847150b564dc8e02b28fbee"
+      ],
+      "target": "src/roslyn/eng/common/SetupNugetSources.ps1",
+      "line": 56,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "ad85fce8c033defdd63db5aa4ec2b2197bbf9310b506241e88bcd48b5a3b41da": {
+      "signature": "ad85fce8c033defdd63db5aa4ec2b2197bbf9310b506241e88bcd48b5a3b41da",
+      "alternativeSignatures": [
+        "784f946934a1f42d820c8a61ac865a094d735d0cfcca4c88fe10482306abf958"
+      ],
+      "target": "src/roslyn/eng/common/SetupNugetSources.ps1",
+      "line": 88,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "316329783213340b7da3052b8177bd48e10a05bf242da08dc6f9785361be2389": {
+      "signature": "316329783213340b7da3052b8177bd48e10a05bf242da08dc6f9785361be2389",
+      "alternativeSignatures": [
+        "2f83c91b8c20ef743240ee45997e2af37d73a0dd99d2ea345794960d775b567d"
+      ],
+      "target": "src/roslyn-analyzers/eng/common/SetupNugetSources.ps1",
+      "line": 38,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "2db32a47c814adc0ee80e257e1cb878a9054b92e6809cd9231690856066bcb33": {
+      "signature": "2db32a47c814adc0ee80e257e1cb878a9054b92e6809cd9231690856066bcb33",
+      "alternativeSignatures": [
+        "249d66492a4d48df01ea2c04aa25e302ad17daf74d130194bec5a90405111da4"
+      ],
+      "target": "src/roslyn-analyzers/eng/common/SetupNugetSources.ps1",
+      "line": 56,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "d2e9bf6a7e357eb1b1d594a06ed00bdf9fa193110f08e45f8e748427a370bfba": {
+      "signature": "d2e9bf6a7e357eb1b1d594a06ed00bdf9fa193110f08e45f8e748427a370bfba",
+      "alternativeSignatures": [
+        "41a0e4c2bbd23190b2ebaf6163c0a9471f126cd6c2144e8377d9cb1bf0a391ef"
+      ],
+      "target": "src/roslyn-analyzers/eng/common/SetupNugetSources.ps1",
+      "line": 88,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "c1e109d2139e82ef8545bb12a0431f4d25f2a805c9b5f71523515dbbb0be9fc3": {
+      "signature": "c1e109d2139e82ef8545bb12a0431f4d25f2a805c9b5f71523515dbbb0be9fc3",
+      "alternativeSignatures": [
+        "69b330936de5c13b57fd7f0f7590a7e66efa3dba98715b5f07d8953662df5025"
+      ],
+      "target": "src/runtime/eng/common/SetupNugetSources.ps1",
+      "line": 38,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "ec60cc4e84b44896c9f5a516e705340feebdaa61be024c82b07b546d3ad0c276": {
+      "signature": "ec60cc4e84b44896c9f5a516e705340feebdaa61be024c82b07b546d3ad0c276",
+      "alternativeSignatures": [
+        "f9c44b75edceaeaae9611fd772b6774ce086227bb3b758dd3844c57511fb2e7a"
+      ],
+      "target": "src/runtime/eng/common/SetupNugetSources.ps1",
+      "line": 56,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "5184980ee9ace427259fcaa3ee796a48efb25a7141fc16426c08dbc8903dbca9": {
+      "signature": "5184980ee9ace427259fcaa3ee796a48efb25a7141fc16426c08dbc8903dbca9",
+      "alternativeSignatures": [
+        "0610a76e8ba9f8fef499d2364bac7db02436cc8f89cee26eac4c6c2c6cab952c"
+      ],
+      "target": "src/runtime/eng/common/SetupNugetSources.ps1",
+      "line": 88,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "148a534bb099170811f8dcc0d51c1caa399488739a5ee98fb12bee51c7a9244d": {
+      "signature": "148a534bb099170811f8dcc0d51c1caa399488739a5ee98fb12bee51c7a9244d",
+      "alternativeSignatures": [],
+      "target": "src/source-build-externals/src/xunit/appveyor.yml",
+      "line": 7,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0130",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "1d9de8cd0e3cf1749dc40ad234b9d84e263f241dbcd8b35320808c8381840c3a": {
+      "signature": "1d9de8cd0e3cf1749dc40ad234b9d84e263f241dbcd8b35320808c8381840c3a",
+      "alternativeSignatures": [
+        "8af561a51ebf9394b93708f512784edbbaa8c13872c2f56da4c5b418f71ad34d"
+      ],
+      "target": "src/sourcelink/eng/common/SetupNugetSources.ps1",
+      "line": 38,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "d71d8881e3ad39939ff9894639cdc0012d968b48038b872ca7eba15ba93cbfe9": {
+      "signature": "d71d8881e3ad39939ff9894639cdc0012d968b48038b872ca7eba15ba93cbfe9",
+      "alternativeSignatures": [
+        "bea919b0d9a2e6c38a6de6300616becf31809eaa49616e63ab90118b5ec331eb"
+      ],
+      "target": "src/sourcelink/eng/common/SetupNugetSources.ps1",
+      "line": 56,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "4dbb69e7a5bbcaf97ee14aa268f0cc4b375111db79d91bc48b438f15e7f29859": {
+      "signature": "4dbb69e7a5bbcaf97ee14aa268f0cc4b375111db79d91bc48b438f15e7f29859",
+      "alternativeSignatures": [
+        "52e95c355d30e2e33b6ad0cf11af5c31db038107a89dd120854c94857aa2298b"
+      ],
+      "target": "src/sourcelink/eng/common/SetupNugetSources.ps1",
+      "line": 88,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "2960b8fc6b1f6665b5988544f1d44a05dfe83b9b39a14efef5e042d7a78e4e19": {
+      "signature": "2960b8fc6b1f6665b5988544f1d44a05dfe83b9b39a14efef5e042d7a78e4e19",
+      "alternativeSignatures": [
+        "b4177488d7a45f4a54472adf8bb97026f0799e61e10f580ea52fbbd74cf08f10"
+      ],
+      "target": "src/symreader/eng/common/SetupNugetSources.ps1",
+      "line": 38,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "c1c411bf7b80d684d2c444ed611f333f08f1073fbaaf4c6bd0238c16ffccbe4d": {
+      "signature": "c1c411bf7b80d684d2c444ed611f333f08f1073fbaaf4c6bd0238c16ffccbe4d",
+      "alternativeSignatures": [
+        "8ca9e6612eb3802d5c1fd93ce0f1de61c2559512966fc97dcbeb017d1942c0fe"
+      ],
+      "target": "src/symreader/eng/common/SetupNugetSources.ps1",
+      "line": 56,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "a0437af80b26a79fc6c7e101114a0a455bd0bc7a4e9ccea1fa3b355aaac07390": {
+      "signature": "a0437af80b26a79fc6c7e101114a0a455bd0bc7a4e9ccea1fa3b355aaac07390",
+      "alternativeSignatures": [
+        "495012003aa9faede4c4ad115a12784f6a8f549e1ebe976537b021d6e5296da9"
+      ],
+      "target": "src/symreader/eng/common/SetupNugetSources.ps1",
+      "line": 88,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "0df8574205ace03dd154be3c3a221b36feae675ac237c8fea3b994f48df75fb8": {
+      "signature": "0df8574205ace03dd154be3c3a221b36feae675ac237c8fea3b994f48df75fb8",
+      "alternativeSignatures": [
+        "15f5632806a855b11f25dc0c899f5f3982b9f92340841b85b35f9f5666c36921"
+      ],
+      "target": "src/test-templates/eng/common/SetupNugetSources.ps1",
+      "line": 38,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "851935ee9fe368011d0d65b595a839000849d57904224cd947664078ba46874d": {
+      "signature": "851935ee9fe368011d0d65b595a839000849d57904224cd947664078ba46874d",
+      "alternativeSignatures": [
+        "c8aefc4c57da1e828bfa02df6e1abc444cc98f2e9ba3f1b0bb4a4f0c04d1fab0"
+      ],
+      "target": "src/test-templates/eng/common/SetupNugetSources.ps1",
+      "line": 56,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "ba2a917a447947c7e8598dc49f18f6a918548051ed56fb0f38d801f52ebdaef0": {
+      "signature": "ba2a917a447947c7e8598dc49f18f6a918548051ed56fb0f38d801f52ebdaef0",
+      "alternativeSignatures": [
+        "0460e5c64d667a95521ca05da96915a79178a361764141acf4bf7c4a75c3e47e"
+      ],
+      "target": "src/test-templates/eng/common/SetupNugetSources.ps1",
+      "line": 88,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "91b70c20fca1cd70bc4d7a34ba446f9a79d78c3c73ed708750062fe49a55324e": {
+      "signature": "91b70c20fca1cd70bc4d7a34ba446f9a79d78c3c73ed708750062fe49a55324e",
+      "alternativeSignatures": [
+        "c884dc16288b0bfa8d5e7f06638c7c61a16bc42328f5a32c43f1d39c38da31f8"
+      ],
+      "target": "src/vstest/eng/common/SetupNugetSources.ps1",
+      "line": 38,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "519f950c7bea3463674233b674b3093990f25167389e2d1ea82cfdf5b0ad0abf": {
+      "signature": "519f950c7bea3463674233b674b3093990f25167389e2d1ea82cfdf5b0ad0abf",
+      "alternativeSignatures": [
+        "e3af28a3737f3eda0c96f52925a36770b7ccc6f3238b4ea855ce4b1d0e6e8f4b"
+      ],
+      "target": "src/vstest/eng/common/SetupNugetSources.ps1",
+      "line": 56,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "192073ddefc720c7b9af682598676a54d54492be32707bf4bef8b3233e8aa1bb": {
+      "signature": "192073ddefc720c7b9af682598676a54d54492be32707bf4bef8b3233e8aa1bb",
+      "alternativeSignatures": [
+        "795fa0e8fdbd60d899b1372eb853ec5b0b9b32c2f9117364c2f63856b7b17763"
+      ],
+      "target": "src/vstest/eng/common/SetupNugetSources.ps1",
+      "line": 88,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "85c9f67cf21f805e1e507792f3b78c20703a374e04a7a50a071250d75a3a34c5": {
+      "signature": "85c9f67cf21f805e1e507792f3b78c20703a374e04a7a50a071250d75a3a34c5",
+      "alternativeSignatures": [
+        "e387a1c8ec270a1be5c6048f2759118f30d2f43efceec3fae2aa37c892352391"
+      ],
+      "target": "src/xdt/eng/common/SetupNugetSources.ps1",
+      "line": 38,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "000bea6b6816c3cf71200ceeccd187ac5d43172eb225d70b53f27cf94e4e0091": {
+      "signature": "000bea6b6816c3cf71200ceeccd187ac5d43172eb225d70b53f27cf94e4e0091",
+      "alternativeSignatures": [
+        "977df07ec18dc533ce706b09124ec76a13719ca51a7e101762a0fb49c99b6985"
+      ],
+      "target": "src/xdt/eng/common/SetupNugetSources.ps1",
+      "line": 56,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "cc40ef86620baaad1faea5a6f3f6b19268b9e8f2fe7169c37dd9d1b1216225b5": {
+      "signature": "cc40ef86620baaad1faea5a6f3f6b19268b9e8f2fe7169c37dd9d1b1216225b5",
+      "alternativeSignatures": [
+        "154f374516f141697b001546e7871a8f6377f3da5d8a42565fc035fcacbc9d22"
+      ],
+      "target": "src/xdt/eng/common/SetupNugetSources.ps1",
+      "line": 88,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "f4c4a77a4a11940d05fa6484e202593866f3cc943f0679506a6dfbf3e2e3f254": {
+      "signature": "f4c4a77a4a11940d05fa6484e202593866f3cc943f0679506a6dfbf3e2e3f254",
+      "alternativeSignatures": [
+        "70e7d79088b1beda828977ecbbfd908e56848a3f7b0963dcbabb087c49ad650c"
+      ],
+      "target": "src/xliff-tasks/eng/common/SetupNugetSources.ps1",
+      "line": 38,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "7918a138214555e83a85a32519dd6fc31971b28aa956f66583194530de8b009c": {
+      "signature": "7918a138214555e83a85a32519dd6fc31971b28aa956f66583194530de8b009c",
+      "alternativeSignatures": [
+        "479b344b41e42fb75f1205d3643792af4211d89a7881dfac007fd6c7c5358e09"
+      ],
+      "target": "src/xliff-tasks/eng/common/SetupNugetSources.ps1",
+      "line": 56,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "fa7347c7f64562b9d7e0be884bcc9d60232f6995b2139a052bf4b8cfcc3d424a": {
+      "signature": "fa7347c7f64562b9d7e0be884bcc9d60232f6995b2139a052bf4b8cfcc3d424a",
+      "alternativeSignatures": [
+        "8926b16a96043571d926ccc99741a5844bb54b1215ccc929568d2dc528da9e40"
+      ],
+      "target": "src/xliff-tasks/eng/common/SetupNugetSources.ps1",
+      "line": 88,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingUsernameAndPasswordParams",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "3c494c3cdc3d2ab897a96f5b498fbf1731ba2c6dcc73e49399083635bc084e8a": {
+      "signature": "3c494c3cdc3d2ab897a96f5b498fbf1731ba2c6dcc73e49399083635bc084e8a",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/Shared/TestCertificates/aspnetdevcert.pfx",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "8bb20ad2a210dc906e39ceb48b0a6a39b240878688ad6854161240ae3a597c87": {
+      "signature": "8bb20ad2a210dc906e39ceb48b0a6a39b240878688ad6854161240ae3a597c87",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/Shared/TestCertificates/eku.client.pfx",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "486f45a6c6f00cc927a87f4b7b122829bee893d6f523fed279e7e2deda450aff": {
+      "signature": "486f45a6c6f00cc927a87f4b7b122829bee893d6f523fed279e7e2deda450aff",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/Shared/TestCertificates/eku.code_signing.pfx",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "643ded93447723ad1faad1de45b19108d986db08e488174a5422f3f1f7f0f7a3": {
+      "signature": "643ded93447723ad1faad1de45b19108d986db08e488174a5422f3f1f7f0f7a3",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/Shared/TestCertificates/eku.multiple_usages.pfx",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "51d877cdee6cab498e1a0fd4c4dd2702b3e5da9eb308e0a631d2104e2d3d2a8c": {
+      "signature": "51d877cdee6cab498e1a0fd4c4dd2702b3e5da9eb308e0a631d2104e2d3d2a8c",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/Shared/TestCertificates/eku.server.pfx",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "849b1bea0ba2f8d1c24a58896b9d230ca317e8cff7e9540f73d578dd1aba12cb": {
+      "signature": "849b1bea0ba2f8d1c24a58896b9d230ca317e8cff7e9540f73d578dd1aba12cb",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/Shared/TestCertificates/https-aspnet.key",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "c535332f090c89ae22a79aac4b9d344333c5479b891b79d72d252611c9364450": {
+      "signature": "c535332f090c89ae22a79aac4b9d344333c5479b891b79d72d252611c9364450",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/Shared/TestCertificates/https-dsa-protected.key",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "bc8ce9f1fd92dd123db1b6f8c33d15123bc8f3c4cb4fd42c54b4a2c5210bb158": {
+      "signature": "bc8ce9f1fd92dd123db1b6f8c33d15123bc8f3c4cb4fd42c54b4a2c5210bb158",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/Shared/TestCertificates/https-dsa.key",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "9507f913c4445bebb9bdd471960011afa198c1e42d19c45d44aea58af61a137d": {
+      "signature": "9507f913c4445bebb9bdd471960011afa198c1e42d19c45d44aea58af61a137d",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/Shared/TestCertificates/https-ecdsa-protected.key",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "9ac9e0a5efc7c0d1e6d89422ca8e70e913eaba647ef42650f0bbc50da080a556": {
+      "signature": "9ac9e0a5efc7c0d1e6d89422ca8e70e913eaba647ef42650f0bbc50da080a556",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/Shared/TestCertificates/https-ecdsa.key",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "5d49433b67f4a2f1b6b323c498722d16aeda2d8781dafe9fcb9faaf9db4ee3e1": {
+      "signature": "5d49433b67f4a2f1b6b323c498722d16aeda2d8781dafe9fcb9faaf9db4ee3e1",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/Shared/TestCertificates/https-ecdsa.key",
+      "line": 4,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "71ee57f56c77339e4a0cb3f5bdfd05d15191136fc8ad887cef26fe1488522529": {
+      "signature": "71ee57f56c77339e4a0cb3f5bdfd05d15191136fc8ad887cef26fe1488522529",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/Shared/TestCertificates/https-rsa-protected.key",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "74b8ab85959da39f4da6710c6375080c44c8929d6b68f59a06dede355aeffacc": {
+      "signature": "74b8ab85959da39f4da6710c6375080c44c8929d6b68f59a06dede355aeffacc",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/Shared/TestCertificates/https-rsa.key",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "ca37e6fb6eb26bdec92893b3f6b08f8f41e6241f573a1b8e14d4e4d4ff1d2c7a": {
+      "signature": "ca37e6fb6eb26bdec92893b3f6b08f8f41e6241f573a1b8e14d4e4d4ff1d2c7a",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/Shared/TestCertificates/intermediate2_ca.key",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "d7657bb2e0603e7b353f7b1e1d884306fe44f116c7665192fd6b33003333ef7a": {
+      "signature": "d7657bb2e0603e7b353f7b1e1d884306fe44f116c7665192fd6b33003333ef7a",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/Shared/TestCertificates/intermediate_ca.key",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "90b7e7a132c8df4864a9ee49670cbaec9cbc5f5c53bf009eba5a583e0934a24f": {
+      "signature": "90b7e7a132c8df4864a9ee49670cbaec9cbc5f5c53bf009eba5a583e0934a24f",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/Shared/TestCertificates/leaf.com.key",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "8a5003e2db05146eaba3a7fc7aba715f51a5506b741a6ac2662e47e39c6165aa": {
+      "signature": "8a5003e2db05146eaba3a7fc7aba715f51a5506b741a6ac2662e47e39c6165aa",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/Shared/TestCertificates/no_extensions.pfx",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "02590eb0efbb241f09bae58f60907c6dee5b33507519a4be87e168a458c2b9cb": {
+      "signature": "02590eb0efbb241f09bae58f60907c6dee5b33507519a4be87e168a458c2b9cb",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/Shared/TestCertificates/root_ca.key",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "df250772236d85876a9d789cca90b48e5eb79ad6cb13782465c8c88366c5d845": {
+      "signature": "df250772236d85876a9d789cca90b48e5eb79ad6cb13782465c8c88366c5d845",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/Shared/TestCertificates/testCert.pfx",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "3cd8e3eb9b94b01c93591c685406ea91d9d31b16aace0f109734e4bacb3838f2": {
+      "signature": "3cd8e3eb9b94b01c93591c685406ea91d9d31b16aace0f109734e4bacb3838f2",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/DefaultBuilder/test/Microsoft.AspNetCore.FunctionalTests/testCert.pfx",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "e91e45a96bf36327f551eadf27d9598b3d058fc051b0f9f0f1da9420410dc79a": {
+      "signature": "e91e45a96bf36327f551eadf27d9598b3d058fc051b0f9f0f1da9420410dc79a",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/Servers/IIS/tools/TestCert.pfx",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "1c8a3d52bb83c1fbd1208b94663769b6452e73988540113dff20bfb4df4ca010": {
+      "signature": "1c8a3d52bb83c1fbd1208b94663769b6452e73988540113dff20bfb4df4ca010",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/SignalR/common/Shared/testCert.pfx",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "8839c1c5ab6e962faf123ad7b79a584170d6491855f69555664986a425984a36": {
+      "signature": "8839c1c5ab6e962faf123ad7b79a584170d6491855f69555664986a425984a36",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/SignalR/common/Shared/testCertECC.pfx",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "d2df996be35f179b45a3bdc28fcd9d5254a924ab52d2ca14b068bfea35e65284": {
+      "signature": "d2df996be35f179b45a3bdc28fcd9d5254a924ab52d2ca14b068bfea35e65284",
+      "alternativeSignatures": [],
+      "target": "src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/test/Certs/SelfSigned1024_SHA1.pfx",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "7a20b01096651f581c51904be7cd1281150c40efc61352b70aabbca3c40ea177": {
+      "signature": "7a20b01096651f581c51904be7cd1281150c40efc61352b70aabbca3c40ea177",
+      "alternativeSignatures": [],
+      "target": "src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/test/Certs/SelfSigned1024_SHA256.pfx",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "ef394eaa05e6eb5af1f5e523fd01f4e970f36cb2c7eacb3d363b47c9f70b0fec": {
+      "signature": "ef394eaa05e6eb5af1f5e523fd01f4e970f36cb2c7eacb3d363b47c9f70b0fec",
+      "alternativeSignatures": [],
+      "target": "src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/test/Certs/SelfSigned2048_SHA256.pfx",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "cb83a69b59f2de3fa1d049750ddeb855030d5662c43a1c5fea6b95f01e21547f": {
+      "signature": "cb83a69b59f2de3fa1d049750ddeb855030d5662c43a1c5fea6b95f01e21547f",
+      "alternativeSignatures": [],
+      "target": "src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/test/Certs/SelfSigned2048_SHA256_2.pfx",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "d08376cdfec80b5c0884a8b85f18c8b34ffee19f1395d12aef1ffc2821120f03": {
+      "signature": "d08376cdfec80b5c0884a8b85f18c8b34ffee19f1395d12aef1ffc2821120f03",
+      "alternativeSignatures": [],
+      "target": "src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/test/Certs/SelfSigned2048_SHA384.pfx",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "ef471993ee9839701feba16b5b56a926545a165bf95224130d6c8a2bdafdd451": {
+      "signature": "ef471993ee9839701feba16b5b56a926545a165bf95224130d6c8a2bdafdd451",
+      "alternativeSignatures": [],
+      "target": "src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/test/Certs/SelfSigned2048_SHA512.pfx",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "d742600df5b4b6b71f65cf0079b09ec36a5d58bb4b8b07923b13ab8458f68a15": {
+      "signature": "d742600df5b4b6b71f65cf0079b09ec36a5d58bb4b8b07923b13ab8458f68a15",
+      "alternativeSignatures": [],
+      "target": "src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/test/Microsoft.IdentityModel.TestUtils/KeyingMaterial.cs",
+      "line": 31,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0060",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "fd9536ec348269dbb12b813270403b7410fc13575d1cbb7770604dcf54ee776b": {
+      "signature": "fd9536ec348269dbb12b813270403b7410fc13575d1cbb7770604dcf54ee776b",
+      "alternativeSignatures": [],
+      "target": "src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/test/Microsoft.IdentityModel.TestUtils/KeyingMaterial.cs",
+      "line": 40,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0060",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "1614f1f0821f8900c7c8d2cb3a784272518ef6b86fb82070bda88b4bac9dbda8": {
+      "signature": "1614f1f0821f8900c7c8d2cb3a784272518ef6b86fb82070bda88b4bac9dbda8",
+      "alternativeSignatures": [],
+      "target": "src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/test/Microsoft.IdentityModel.TestUtils/KeyingMaterial.cs",
+      "line": 50,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0060",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "3479973e9ab00c84264e70c5d7290a5bfda506aafdb08c3277cb1df5db688ab9": {
+      "signature": "3479973e9ab00c84264e70c5d7290a5bfda506aafdb08c3277cb1df5db688ab9",
+      "alternativeSignatures": [],
+      "target": "src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/test/Microsoft.IdentityModel.TestUtils/KeyingMaterial.cs",
+      "line": 56,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0060",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "e5bd231f55be121ed2579da9651c4ec0e661a386991ef8463facf3588c306a06": {
+      "signature": "e5bd231f55be121ed2579da9651c4ec0e661a386991ef8463facf3588c306a06",
+      "alternativeSignatures": [],
+      "target": "src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/test/Microsoft.IdentityModel.TestUtils/KeyingMaterial.cs",
+      "line": 65,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0060",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "19661fe89c5e1f59089cdec06cbdf6bdda2439b52731dfd630b50ff5885d6223": {
+      "signature": "19661fe89c5e1f59089cdec06cbdf6bdda2439b52731dfd630b50ff5885d6223",
+      "alternativeSignatures": [],
+      "target": "src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/test/Microsoft.IdentityModel.TestUtils/KeyingMaterial.cs",
+      "line": 75,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0060",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "3bf81d57b0872ef6c8ac7878513cb8f58044e07238883f71f24b09542a8d1a07": {
+      "signature": "3bf81d57b0872ef6c8ac7878513cb8f58044e07238883f71f24b09542a8d1a07",
+      "alternativeSignatures": [],
+      "target": "src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/test/Microsoft.IdentityModel.TestUtils/KeyingMaterial.cs",
+      "line": 80,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "2e07fdf491a04fc8a6cc50ae299f8345a81798499bda961a118e974970bb71a8": {
+      "signature": "2e07fdf491a04fc8a6cc50ae299f8345a81798499bda961a118e974970bb71a8",
+      "alternativeSignatures": [],
+      "target": "src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/test/Microsoft.IdentityModel.TestUtils/KeyingMaterial.cs",
+      "line": 86,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "560fdab2979120fa3cfd2d9865d1ce2c0ba164982cc086cdc871b7e16fd12466": {
+      "signature": "560fdab2979120fa3cfd2d9865d1ce2c0ba164982cc086cdc871b7e16fd12466",
+      "alternativeSignatures": [],
+      "target": "src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/test/Microsoft.IdentityModel.TestUtils/KeyingMaterial.cs",
+      "line": 92,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "489c5d92c47b3c961db0d5c32426a4d5fb48311e46ae49791be0f6ef03ddfc6e": {
+      "signature": "489c5d92c47b3c961db0d5c32426a4d5fb48311e46ae49791be0f6ef03ddfc6e",
+      "alternativeSignatures": [],
+      "target": "src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/test/Microsoft.IdentityModel.TestUtils/KeyingMaterial.cs",
+      "line": 101,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0060",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "5890ec8b0f533c8186a824f1b46b2d99c2d54e7ed09917e5fedcdaea19b34706": {
+      "signature": "5890ec8b0f533c8186a824f1b46b2d99c2d54e7ed09917e5fedcdaea19b34706",
+      "alternativeSignatures": [],
+      "target": "src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/test/Microsoft.IdentityModel.TestUtils/KeyingMaterial.cs",
+      "line": 230,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0140",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "70a8cd9f176fa02a78470ae78c285f56b617060ec339f0c8dfda095a5b0fc6c9": {
+      "signature": "70a8cd9f176fa02a78470ae78c285f56b617060ec339f0c8dfda095a5b0fc6c9",
+      "alternativeSignatures": [],
+      "target": "src/source-build-externals/src/humanizer/src/Humanizer.Tests.Uwp/Humanizer.Tests.Uwp_TemporaryKey.pfx",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "7afd296a74705d2e561497c0ab8c3750179c1eff425f496297d3b877ff718526": {
+      "signature": "7afd296a74705d2e561497c0ab8c3750179c1eff425f496297d3b877ff718526",
+      "alternativeSignatures": [],
+      "target": "src/source-build-externals/src/humanizer/src/Humanizer.Tests.Uwp.Runner/Humanizer.Tests.Uwp.Runner_TemporaryKey.pfx",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "6ffd69e0724ed3b57e926224932b0aeeed7a834ee5dc1ad24c3262deb49172d7": {
+      "signature": "6ffd69e0724ed3b57e926224932b0aeeed7a834ee5dc1ad24c3262deb49172d7",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/DataProtection/Extensions/test/TestFiles/TestCert.pfx",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "ca298b6b96ebfae8f14e29993264310b89fd738b365c2e7ca04e7af1a5cd67b7": {
+      "signature": "ca298b6b96ebfae8f14e29993264310b89fd738b365c2e7ca04e7af1a5cd67b7",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/DataProtection/Extensions/test/TestFiles/TestCert2.pfx",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "8764975fced41745e1a9c844144b2aacd30d3fcd77a8c4b1067adc5f2cd8b990": {
+      "signature": "8764975fced41745e1a9c844144b2aacd30d3fcd77a8c4b1067adc5f2cd8b990",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/DataProtection/Extensions/test/TestFiles/TestCert3.pfx",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "7cc3b3782554547d94e0f2e8817dbf823a84de8a95b6b358bdd29067bcff64c3": {
+      "signature": "7cc3b3782554547d94e0f2e8817dbf823a84de8a95b6b358bdd29067bcff64c3",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/DataProtection/Extensions/test/TestFiles/TestCert3WithoutPrivateKey.pfx",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "db15b8200219494e427c3943404a81e931bf17af175823bc51da9b85b63a6831": {
+      "signature": "db15b8200219494e427c3943404a81e931bf17af175823bc51da9b85b63a6831",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/DataProtection/Extensions/test/TestFiles/TestCertWithoutPrivateKey.pfx",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "979582e68b87ec6e4cd7d90df4e05f01a6f9150ed07a0abc205112a241f0c16f": {
+      "signature": "979582e68b87ec6e4cd7d90df4e05f01a6f9150ed07a0abc205112a241f0c16f",
+      "alternativeSignatures": [],
+      "target": "src/diagnostics/src/SOS/SOS.UnitTests/Debuggees/WebApp3/testCert.pfx",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "56b251ecea166720fac682142922d79e01699a8cc576683b6d8944dfd3158de2": {
+      "signature": "56b251ecea166720fac682142922d79e01699a8cc576683b6d8944dfd3158de2",
+      "alternativeSignatures": [],
+      "target": "src/nuget-client/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetCredentialsResponseTests.cs",
+      "line": 72,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0060",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "cbcd76cbd2a6b0a8028fd6c3d1d11ee2e211519af2420396399c3c111a4da667": {
+      "signature": "cbcd76cbd2a6b0a8028fd6c3d1d11ee2e211519af2420396399c3c111a4da667",
+      "alternativeSignatures": [],
+      "target": "src/nuget-client/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetCredentialsResponseTests.cs",
+      "line": 73,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0060",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "8060e90601237ded928ae57570ef982dd3a57e7bffbec010fcd37e0bda518f10": {
+      "signature": "8060e90601237ded928ae57570ef982dd3a57e7bffbec010fcd37e0bda518f10",
+      "alternativeSignatures": [],
+      "target": "src/nuget-client/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetCredentialsResponseTests.cs",
+      "line": 90,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0060",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "bc4b0a2231b13e5472e1548250ef4d7174d130daf559bca81f5d3c2c0c169690": {
+      "signature": "bc4b0a2231b13e5472e1548250ef4d7174d130daf559bca81f5d3c2c0c169690",
+      "alternativeSignatures": [],
+      "target": "src/nuget-client/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetCredentialsResponseTests.cs",
+      "line": 91,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0060",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "91f0752674a19d0db604c50e23950746ff4d231cc76e40a7fa0f53dd5e855f4d": {
+      "signature": "91f0752674a19d0db604c50e23950746ff4d231cc76e40a7fa0f53dd5e855f4d",
+      "alternativeSignatures": [],
+      "target": "src/nuget-client/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetCredentialsResponseTests.cs",
+      "line": 109,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0060",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "889e33f8e52ecb1d2b98d28772c572c2a10f0dc0c22fcc03b1da03df008d5f91": {
+      "signature": "889e33f8e52ecb1d2b98d28772c572c2a10f0dc0c22fcc03b1da03df008d5f91",
+      "alternativeSignatures": [],
+      "target": "src/nuget-client/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetCredentialsResponseTests.cs",
+      "line": 110,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0060",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "6969ae787ed7e1caef670545de569929814479666e60a227abcb36395c3d3f60": {
+      "signature": "6969ae787ed7e1caef670545de569929814479666e60a227abcb36395c3d3f60",
+      "alternativeSignatures": [],
+      "target": "src/nuget-client/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetCredentialsResponseTests.cs",
+      "line": 111,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0060",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "81adfccafd8eb134b75b59de6d4d0d8198c4639a3972d8072b61c67c9e1a104d": {
+      "signature": "81adfccafd8eb134b75b59de6d4d0d8198c4639a3972d8072b61c67c9e1a104d",
+      "alternativeSignatures": [],
+      "target": "src/nuget-client/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/GetCredentialsResponseTests.cs",
+      "line": 112,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0060",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "cf0223227addcd8b17bc89e4e5f0ee9174bca83c9ffc5b5493ef74940b33b58c": {
+      "signature": "cf0223227addcd8b17bc89e4e5f0ee9174bca83c9ffc5b5493ef74940b33b58c",
+      "alternativeSignatures": [],
+      "target": "src/nuget-client/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/SetCredentialsRequestTests.cs",
+      "line": 49,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0060",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "fc000248c70e613f381ee770fb96dfd28e26766fa9627d28e5b9eb5fb314a3c8": {
+      "signature": "fc000248c70e613f381ee770fb96dfd28e26766fa9627d28e5b9eb5fb314a3c8",
+      "alternativeSignatures": [],
+      "target": "src/nuget-client/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/Messages/SetCredentialsRequestTests.cs",
+      "line": 72,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0060",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "2987ea627ea4f2effb417244c4aac8f554bf42136d6ebe0fef1df440410be09c": {
+      "signature": "2987ea627ea4f2effb417244c4aac8f554bf42136d6ebe0fef1df440410be09c",
+      "alternativeSignatures": [],
+      "target": "src/runtime/src/libraries/System.Security.Cryptography/tests/X509Certificates/TestData.cs",
+      "line": 2743,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "4c2880cbace8da677942b80be039a982e356c18c827ebeddab265175c9640427": {
+      "signature": "4c2880cbace8da677942b80be039a982e356c18c827ebeddab265175c9640427",
+      "alternativeSignatures": [],
+      "target": "src/runtime/src/libraries/System.Security.Cryptography/tests/X509Certificates/TestData.cs",
+      "line": 2879,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "849ea2c1bdff1b36df8848a7f8898f11e981c3ba8f9b033abd9d1e8b1a03c8ca": {
+      "signature": "849ea2c1bdff1b36df8848a7f8898f11e981c3ba8f9b033abd9d1e8b1a03c8ca",
+      "alternativeSignatures": [],
+      "target": "src/runtime/src/libraries/System.Security.Cryptography/tests/X509Certificates/TestData.cs",
+      "line": 2962,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "1706aea6ec9bfbbe540cfab3713db9b1a9ebc7f475b49f2348860e3ee6d8e682": {
+      "signature": "1706aea6ec9bfbbe540cfab3713db9b1a9ebc7f475b49f2348860e3ee6d8e682",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/TestFiles/TestCert1.pfx",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "8369054f43a96d4f463976b23773b2d22f8081d95f715161f019ceb58296d64a": {
+      "signature": "8369054f43a96d4f463976b23773b2d22f8081d95f715161f019ceb58296d64a",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/TestFiles/TestCert2.pfx",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "4ab520e2ed77b36c88f9eeeb5473205fd7f8f0a761eacee4cbbff389368dad8f": {
+      "signature": "4ab520e2ed77b36c88f9eeeb5473205fd7f8f0a761eacee4cbbff389368dad8f",
+      "alternativeSignatures": [
+        "7ad51ffeb7d5438f15781162de5183c58d5db2d195f96e8c3527451adeb4e02c"
+      ],
+      "target": "src/aspnetcore/src/Hosting/Server.IntegrationTesting/src/Deployers/RemoteWindowsDeployer/RemotePSSessionHelper.ps1",
+      "line": 40,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingConvertToSecureStringWithPlainText",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "96ab8bbaf30065be77880d679174d028a151c0fc888fca38a79038d341710563": {
+      "signature": "96ab8bbaf30065be77880d679174d028a151c0fc888fca38a79038d341710563",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/Security/Authentication/Negotiate/samples/NegotiateAuthSample/Startup.cs",
+      "line": 30,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-MSFT0090",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "7bda7ae4037698bbdf188b4d3fb8a82e99063a8df2dcfe5f66ef747e3bd3f1a0": {
+      "signature": "7bda7ae4037698bbdf188b4d3fb8a82e99063a8df2dcfe5f66ef747e3bd3f1a0",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/Security/Authentication/Negotiate/test/Negotiate.FunctionalTest/negotiateAuthCert.pfx",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "a2dcb4a5d7e266049f9f865b27e69af19447e94f63ec9de8290763ddf901c756": {
+      "signature": "a2dcb4a5d7e266049f9f865b27e69af19447e94f63ec9de8290763ddf901c756",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/Security/Authentication/Negotiate/test/Negotiate.Test/LdapSettingsValidationTests.cs",
+      "line": 25,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-MSFT0090",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "3aaf66a9a1f5bfba3b78eb7964ce8bf4dcabf7132465a31e219c6961f53dec56": {
+      "signature": "3aaf66a9a1f5bfba3b78eb7964ce8bf4dcabf7132465a31e219c6961f53dec56",
+      "alternativeSignatures": [],
+      "target": "src/aspnetcore/src/Middleware/WebSockets/test/ConformanceTests/AutobahnTestApp/TestResources/testCert.pfx",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "c6ed8bf76382b72621892d895d0659eb8ed66ef400f5d38506a3b62129b0f60e": {
+      "signature": "c6ed8bf76382b72621892d895d0659eb8ed66ef400f5d38506a3b62129b0f60e",
+      "alternativeSignatures": [
+        "07873a6bbdd04caf121ed279cd4c24e55fb79ae3e86083c413b839d8d5e81cba"
+      ],
+      "target": "src/runtime/src/libraries/Common/tests/System/Net/Prerequisites/Deployment/setup_activedirectory_domaincontroller.ps1",
+      "line": 36,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingConvertToSecureStringWithPlainText",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "c511a0f0c15b79748a62ee0198689e7a0c8c2af102730c337823f6cd52b3ec66": {
+      "signature": "c511a0f0c15b79748a62ee0198689e7a0c8c2af102730c337823f6cd52b3ec66",
+      "alternativeSignatures": [
+        "7142b2e2126a0c0e5bf2ad08e9e56d405620fbb9f12dfcd3f90a9dfcc30f8bf5"
+      ],
+      "target": "src/runtime/src/libraries/Common/tests/System/Net/Prerequisites/Deployment/setup_iisserver.ps1",
+      "line": 82,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "psscriptanalyzer",
+      "ruleId": "PSAvoidUsingConvertToSecureStringWithPlainText",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "bfe258b52e19062b9009a68549bff3b2c99a6105f493cbf14332b3366691d446": {
+      "signature": "bfe258b52e19062b9009a68549bff3b2c99a6105f493cbf14332b3366691d446",
+      "alternativeSignatures": [],
+      "target": "src/runtime/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAKeyPemTests.cs",
+      "line": 54,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "52364f6839cf4bc824f1c82a31f3c7ee1cfb228383b3bee476ef7442526c0de8": {
+      "signature": "52364f6839cf4bc824f1c82a31f3c7ee1cfb228383b3bee476ef7442526c0de8",
+      "alternativeSignatures": [],
+      "target": "src/runtime/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAKeyPemTests.cs",
+      "line": 358,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "cef12040ed2c91d3bd7eba717e6c4bff8e547cb6d2b40363f1d859b02c873276": {
+      "signature": "cef12040ed2c91d3bd7eba717e6c4bff8e547cb6d2b40363f1d859b02c873276",
+      "alternativeSignatures": [],
+      "target": "src/runtime/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/ECKeyPemTests.cs",
+      "line": 61,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "ab290d190fa6582f2826c9b8524a4013ea67380f65328bc39c31dbcba59ec63c": {
+      "signature": "ab290d190fa6582f2826c9b8524a4013ea67380f65328bc39c31dbcba59ec63c",
+      "alternativeSignatures": [],
+      "target": "src/runtime/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/ECKeyPemTests.cs",
+      "line": 168,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "710963884a4d1e73d1ff4da0db7e1c8e1eeae25fe4a9e3c1de8b5019bb5d9d74": {
+      "signature": "710963884a4d1e73d1ff4da0db7e1c8e1eeae25fe4a9e3c1de8b5019bb5d9d74",
+      "alternativeSignatures": [],
+      "target": "src/runtime/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/ECKeyPemTests.cs",
+      "line": 412,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "db276fb1ea2a8e74e7ab80522362b8f402d361652ca823d7cab59465d038eb82": {
+      "signature": "db276fb1ea2a8e74e7ab80522362b8f402d361652ca823d7cab59465d038eb82",
+      "alternativeSignatures": [],
+      "target": "src/runtime/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAKeyPemTests.cs",
+      "line": 229,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "807277ed6647bcdc3eab2e24d8fbcaca0a6506d2ed455248b0497ceb42831e30": {
+      "signature": "807277ed6647bcdc3eab2e24d8fbcaca0a6506d2ed455248b0497ceb42831e30",
+      "alternativeSignatures": [],
+      "target": "src/runtime/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAKeyPemTests.cs",
+      "line": 328,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "685288ad132baddbcdf7a2201960f6d48805151f1aef2e094c4dbc16841b3e54": {
+      "signature": "685288ad132baddbcdf7a2201960f6d48805151f1aef2e094c4dbc16841b3e54",
+      "alternativeSignatures": [],
+      "target": "src/runtime/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAKeyPemTests.cs",
+      "line": 489,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "e972eb97ea7ea4a9524820036a42557f13a48240b6083c7baa0d465c00adfdee": {
+      "signature": "e972eb97ea7ea4a9524820036a42557f13a48240b6083c7baa0d465c00adfdee",
+      "alternativeSignatures": [],
+      "target": "src/runtime/src/tests/FunctionalTests/Android/Device_Emulator/gRPC/grpc-dotnet/testassets/Certs/InteropTests/server1.key",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    },
+    "1b2c907630acaff5b6e62eb4895043c82e93d885331f1f46296812634fd30abe": {
+      "signature": "1b2c907630acaff5b6e62eb4895043c82e93d885331f1f46296812634fd30abe",
+      "alternativeSignatures": [],
+      "target": "src/runtime/src/tests/FunctionalTests/Android/Device_Emulator/gRPC/grpc-dotnet/testassets/Certs/InteropTests/server1.pfx",
+      "line": 1,
+      "memberOf": [
+        "default"
+      ],
+      "tool": "credscan",
+      "ruleId": "CSCAN-GENERAL0020",
+      "createdDate": "2024-04-03 14:41:43Z"
+    }
+  }
+}

--- a/src/SourceBuild/content/eng/pipelines/ci.yml
+++ b/src/SourceBuild/content/eng/pipelines/ci.yml
@@ -30,6 +30,9 @@ extends:
         name: NetCore1ESPool-Internal
         image: 1es-windows-2022
         os: windows
+
+      baseline:
+        baselineFile: $(Build.SourcesDirectory)\.config\guardian\.gdnbaselines
     
     customBuildTags:
     - ES365AIMigrationTooling


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4294

This PR fixes the SDL errors by adding a baseline. This allows the "Guardian: Post Analysis" step to pass.

(Passing build with changes](https://dev.azure.com/dnceng/internal/_build/results?buildId=2423824&view=logs&j=bc38e8b8-e027-53cb-48e7-2adbd1070eca&t=d1aba2c3-5b21-511d-f336-affeabd629f9) (internal Microsoft link)
