### PR TITLE
Update for publishing and package source mappings

### DIFF
--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/UpdateNuGetConfigPackageSourcesMappings.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/UpdateNuGetConfigPackageSourcesMappings.cs
@@ -245,11 +245,11 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks
                 }
                 else if (packageSource.Equals(PreviouslySourceBuiltSourceName))
                 {
-                    AddPackageSourceMappingIfPackageVersionNotInCurrentPackages(pkgSrc, packagePattern, previouslySourceBuiltPackages);
+                    AddPackageSourceMappingIfPackageVersionsNotInCurrentPackages(pkgSrc, packagePattern, previouslySourceBuiltPackages);
                 }
                 else if (packageSource.Equals(PrebuiltSourceName))
                 {
-                    AddPackageSourceMappingIfPackageVersionNotInCurrentPackages(pkgSrc, packagePattern, prebuiltPackages);
+                    AddPackageSourceMappingIfPackageVersionsNotInCurrentPackages(pkgSrc, packagePattern, prebuiltPackages);
                 }
                 else // unknown/unexpected source
                 {
@@ -260,16 +260,18 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks
             return pkgSrc;
         }
 
-        private void AddPackageSourceMappingIfPackageVersionNotInCurrentPackages(XElement pkgSrc, string packagePattern, Dictionary<string, List<string>> packages)
+        private void AddPackageSourceMappingIfPackageVersionsNotInCurrentPackages(XElement pkgSrc, string packagePattern, Dictionary<string, List<string>> packages)
         {
             foreach (string version in packages[packagePattern])
             {
-                if (!currentPackages[packagePattern].Contains(version))
+                // If any package version is in current packages, skip this package pattern
+                if (currentPackages[packagePattern].Contains(version))
                 {
-                    pkgSrc.Add(new XElement("package", new XAttribute("pattern", packagePattern)));
                     return;
                 }
             }
+
+            pkgSrc.Add(new XElement("package", new XAttribute("pattern", packagePattern)));
         }
 
         private void DiscoverPackagesFromAllSourceBuildSources(XElement pkgSourcesElement)

--- a/src/SourceBuild/content/repo-projects/roslyn.proj
+++ b/src/SourceBuild/content/repo-projects/roslyn.proj
@@ -34,9 +34,11 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
+    <RepositoryReference Include="roslyn-analyzers" />
     <RepositoryReference Include="runtime" />
     <RepositoryReference Include="source-build-externals" />
     <RepositoryReference Include="source-build-reference-packages" />
+    <RepositoryReference Include="symreader" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SourceBuild/patches/roslyn-analyzers/0001-Stop-publishing-of-additional-packages.patch
+++ b/src/SourceBuild/patches/roslyn-analyzers/0001-Stop-publishing-of-additional-packages.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nikola Milosavljevic <nikolam@microsoft.com>
+Date: Fri, 5 Apr 2024 22:44:35 +0000
+Subject: [PATCH] Stop publishing of additional packages
+
+Backport: https://github.com/dotnet/roslyn-analyzers/pull/7282
+---
+ eng/Publishing.props | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/eng/Publishing.props b/eng/Publishing.props
+index 355f94a01..2d3ce7dde 100644
+--- a/eng/Publishing.props
++++ b/eng/Publishing.props
+@@ -3,11 +3,4 @@
+     <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
+   </PropertyGroup>
+ 
+-  <ItemGroup>
+-    <ItemsToPushToBlobFeed Include="$(ArtifactsPackagesDir)Release\*.nupkg"
+-                           IsShipping="true"
+-                           UploadPathSegment="Roslyn-analyzers"
+-                           Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
+-  </ItemGroup>
+-
+ </Project>
+\ No newline at end of file

--- a/src/SourceBuild/patches/symreader/0001-Stop-publishing-of-additional-packages.patch
+++ b/src/SourceBuild/patches/symreader/0001-Stop-publishing-of-additional-packages.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nikola Milosavljevic <nikolam@microsoft.com>
+Date: Sun, 7 Apr 2024 15:22:46 +0000
+Subject: [PATCH] Stop publishing of additional packages
+
+Backport: https://github.com/dotnet/symreader/pull/318
+---
+ eng/Publishing.props | 13 -------------
+ 1 file changed, 13 deletions(-)
+ delete mode 100644 eng/Publishing.props
+
+diff --git a/eng/Publishing.props b/eng/Publishing.props
+deleted file mode 100644
+index 131a401..0000000
+--- a/eng/Publishing.props
++++ /dev/null
+@@ -1,13 +0,0 @@
+-<Project>
+-
+-  <ItemGroup>
+-    <!--
+-      Additional packages needed for source-only VMR build - https://github.com/dotnet/source-build/issues/4205
+-    -->
+-    <ItemsToPushToBlobFeed Include="$(ArtifactsPackagesDir)Release\**\*.nupkg"
+-                           IsShipping="true"
+-                           UploadPathSegment="Runtime"
+-                           Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
+-  </ItemGroup>
+-
+-</Project>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/4287
Fixes: https://github.com/dotnet/source-build/issues/4204
Fixes: https://github.com/dotnet/source-build/issues/4205

## Description of findings

Source-build has always had multiple versions of packages produced by `roslyn-analyzers` and `symreader` - stable and unstable package versions, i.e.
```
Microsoft.CodeAnalysis.NetAnalyzers.9.0.0.nupkg
Microsoft.CodeAnalysis.NetAnalyzers.9.0.0-preview.24203.1.nupkg
```

These packages would end up in PSB artifacts archive.

PVP flow would use the first encountered package version, so any consumers of `Microsoft.CodeAnalysis.NetAnalyzers` would get version `9.0.0`.

We wanted to fix NuGet non-determinism by carefully populating package source mappings for `previously-source-built` feed. However, we did allow package mapping for a package ID that has any version not present in current (live) package sources. Therefore, there would be a mapping in PSB feed for `Microsoft.CodeAnalysis.NetAnalyzers`. And there would be two identically-version packages (9.0.0), with different content - one in current sources, and one in PSB.

`roslyn` repo did not have a dependency on `roslyn-analyzers` repo, so it did not have access to those packages in current feeds. The only available package was in PSB, and this was causing a poison leak.

## Changes

- Add `roslyn-analyzers` and `symreader` dependencies to `roslyn` as there are packages consumed from both.
- Modify package-source mappings task to not add a mapping for a package in PSB, if any of PSB package versions are present in current (live) package sources.
- Stop publishing of additional packages in `roslyn-analyzers` - prevents publishing of stable-versioned packages
- Stop publishing of additional packages in `symreader` - prevents publishing of stable-versioned packages