### PR TITLE
Trigger sdk diff tests on every VMR release build

### DIFF
--- a/src/SourceBuild/content/eng/pipelines/source-build-sdk-diff-tests.yml
+++ b/src/SourceBuild/content/eng/pipelines/source-build-sdk-diff-tests.yml
@@ -4,8 +4,18 @@ schedules:
   branches:
     include:
     - main
-    - release/*.0.1xx*
-    - internal/release/*.0.1xx*
+
+# Relies on dotnet-source-build being in the same repo as this pipeline
+# https://learn.microsoft.com/en-us/azure/devops/pipelines/process/pipeline-triggers?view=azure-devops#branch-considerations
+resources:
+  pipelines:
+  - pipeline: dotnet-source-build
+    source: dotnet-source-build
+    trigger:
+      branches:
+        include:
+          - release/*.0.1xx*
+          - internal/release/*.0.1xx*
 
 pr: none
 trigger: none


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/3297

Changes the SDK diff tests trigger for release branches from a schedule to being triggered for every build in a VMR release branch. 

The added pipeline resource trigger relies on the two pipelines being in the same repository. In this case, the SDK diff tests will be ran for the same branch as the triggering VMR build.

Example test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2424827&view=results 

![image](https://github.com/dotnet/installer/assets/106967057/3185598f-7d1d-4741-bcec-73487ebfb5cf)

### Additional steps once approved:
  - backport to 8.0: https://github.com/dotnet/installer/pull/19353
  - update source-build monitor docs if needed