### PR TITLE
Add explicit arcade reference

### DIFF
--- a/src/SourceBuild/content/repo-projects/nuget-client.proj
+++ b/src/SourceBuild/content/repo-projects/nuget-client.proj
@@ -8,6 +8,10 @@
     <BuildScript>$([MSBuild]::NormalizePath('$(ProjectDirectory)', 'eng', 'source-build', 'build$(ShellExtension)'))</BuildScript>
   </PropertyGroup>
 
+  <ItemGroup>
+    <RepositoryReference Include="arcade" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
     <RepositoryReference Include="msbuild" />
     <RepositoryReference Include="source-build-externals" />


### PR DESCRIPTION
In SB mode arcade was coming in via transitive reference. In reality, this repo directly depends on arcade for the wrapper infra, though it's not an arcadeified repo.