### PR TITLE
Use Microsoft.Build.NoTargets in repo-projects

### DIFF
--- a/src/SourceBuild/content/repo-projects/arcade.proj
+++ b/src/SourceBuild/content/repo-projects/arcade.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <!-- Use a prebuilt Arcade to build Arcade -->

--- a/src/SourceBuild/content/repo-projects/aspire.proj
+++ b/src/SourceBuild/content/repo-projects/aspire.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <ItemGroup>
     <RepositoryReference Include="arcade" />

--- a/src/SourceBuild/content/repo-projects/aspnetcore.proj
+++ b/src/SourceBuild/content/repo-projects/aspnetcore.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <!-- AspNetCore doesn't have a root build script but one under the eng folder. -->

--- a/src/SourceBuild/content/repo-projects/cecil.proj
+++ b/src/SourceBuild/content/repo-projects/cecil.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <ItemGroup>
     <RepositoryReference Include="arcade" />

--- a/src/SourceBuild/content/repo-projects/command-line-api.proj
+++ b/src/SourceBuild/content/repo-projects/command-line-api.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <LogVerbosityOptOut>true</LogVerbosityOptOut>

--- a/src/SourceBuild/content/repo-projects/deployment-tools.proj
+++ b/src/SourceBuild/content/repo-projects/deployment-tools.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <ItemGroup>
     <RepositoryReference Include="arcade" />

--- a/src/SourceBuild/content/repo-projects/diagnostics.proj
+++ b/src/SourceBuild/content/repo-projects/diagnostics.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <ItemGroup>
     <RepositoryReference Include="arcade" />

--- a/src/SourceBuild/content/repo-projects/dotnet.proj
+++ b/src/SourceBuild/content/repo-projects/dotnet.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <!-- This is a wrapper project that doesn't build anything. -->

--- a/src/SourceBuild/content/repo-projects/emsdk.proj
+++ b/src/SourceBuild/content/repo-projects/emsdk.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <!-- Use the repo root build script -->

--- a/src/SourceBuild/content/repo-projects/fsharp.proj
+++ b/src/SourceBuild/content/repo-projects/fsharp.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <LogVerbosityOptOut>true</LogVerbosityOptOut>

--- a/src/SourceBuild/content/repo-projects/installer.proj
+++ b/src/SourceBuild/content/repo-projects/installer.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <!-- Need to set to false to calculate RepositoryCommit. -->

--- a/src/SourceBuild/content/repo-projects/msbuild.proj
+++ b/src/SourceBuild/content/repo-projects/msbuild.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <LogVerbosityOptOut>true</LogVerbosityOptOut>

--- a/src/SourceBuild/content/repo-projects/nuget-client.proj
+++ b/src/SourceBuild/content/repo-projects/nuget-client.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <NuGetKeyFilePath>$(KeysDir)NuGet.Client.snk</NuGetKeyFilePath>

--- a/src/SourceBuild/content/repo-projects/razor.proj
+++ b/src/SourceBuild/content/repo-projects/razor.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <!-- The toolset compiler doesn't get killed with 'build-server shutdown'.

--- a/src/SourceBuild/content/repo-projects/roslyn-analyzers.proj
+++ b/src/SourceBuild/content/repo-projects/roslyn-analyzers.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <LogVerbosityOptOut>true</LogVerbosityOptOut>

--- a/src/SourceBuild/content/repo-projects/roslyn.proj
+++ b/src/SourceBuild/content/repo-projects/roslyn.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <LogVerbosityOptOut>true</LogVerbosityOptOut>

--- a/src/SourceBuild/content/repo-projects/runtime.proj
+++ b/src/SourceBuild/content/repo-projects/runtime.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <LogVerbosityOptOut>true</LogVerbosityOptOut>

--- a/src/SourceBuild/content/repo-projects/scenario-tests.proj
+++ b/src/SourceBuild/content/repo-projects/scenario-tests.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <ItemGroup>
     <RepositoryReference Include="arcade" />

--- a/src/SourceBuild/content/repo-projects/sdk.proj
+++ b/src/SourceBuild/content/repo-projects/sdk.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <LogVerbosityOptOut>true</LogVerbosityOptOut>

--- a/src/SourceBuild/content/repo-projects/source-build-externals.proj
+++ b/src/SourceBuild/content/repo-projects/source-build-externals.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <!--

--- a/src/SourceBuild/content/repo-projects/source-build-reference-packages.proj
+++ b/src/SourceBuild/content/repo-projects/source-build-reference-packages.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <!-- All packages built in SBRP repo are copied to prereqs/package/reference.

--- a/src/SourceBuild/content/repo-projects/sourcelink.proj
+++ b/src/SourceBuild/content/repo-projects/sourcelink.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <LogVerbosityOptOut>true</LogVerbosityOptOut>

--- a/src/SourceBuild/content/repo-projects/symreader.proj
+++ b/src/SourceBuild/content/repo-projects/symreader.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <ItemGroup>
     <RepositoryReference Include="arcade" />

--- a/src/SourceBuild/content/repo-projects/templating.proj
+++ b/src/SourceBuild/content/repo-projects/templating.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <LogVerbosityOptOut>true</LogVerbosityOptOut>

--- a/src/SourceBuild/content/repo-projects/test-templates.proj
+++ b/src/SourceBuild/content/repo-projects/test-templates.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <LogVerbosityOptOut>true</LogVerbosityOptOut>

--- a/src/SourceBuild/content/repo-projects/vstest.proj
+++ b/src/SourceBuild/content/repo-projects/vstest.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <DeterministicBuildOptOut>true</DeterministicBuildOptOut>

--- a/src/SourceBuild/content/repo-projects/windowsdesktop.proj
+++ b/src/SourceBuild/content/repo-projects/windowsdesktop.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <LogVerbosityOptOut>true</LogVerbosityOptOut>

--- a/src/SourceBuild/content/repo-projects/winforms.proj
+++ b/src/SourceBuild/content/repo-projects/winforms.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <LogVerbosityOptOut>true</LogVerbosityOptOut>

--- a/src/SourceBuild/content/repo-projects/wpf.proj
+++ b/src/SourceBuild/content/repo-projects/wpf.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <LogVerbosityOptOut>true</LogVerbosityOptOut>

--- a/src/SourceBuild/content/repo-projects/xdt.proj
+++ b/src/SourceBuild/content/repo-projects/xdt.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <LogVerbosityOptOut>true</LogVerbosityOptOut>


### PR DESCRIPTION
The Microsoft.NET.Sdk should only be used when
invoking the compiler which these projects don't
do. Using the NoTargets msbuild sdk also means
less unnecesary work being done.

Note: This wasn't possible before https://github.com/dotnet/installer/commit/f7076a3de12a57723a5583f56ad62161c6033362