### PR TITLE
Fix test results publishing on Windows

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -389,12 +389,15 @@ jobs:
 
         CopyWithRelativeFolders "artifacts/log/"             $targetFolder "*.binlog"
         CopyWithRelativeFolders "artifacts/log/"             $targetFolder "*.log"
-        CopyWithRelativeFolders "artifacts/TestResults/"     $targetFolder "*.binlog"
-        CopyWithRelativeFolders "artifacts/TestResults/"     $targetFolder "*.diff"
-        CopyWithRelativeFolders "artifacts/TestResults/"     $targetFolder "Updated*.txt"
-        CopyWithRelativeFolders "artifacts/TestResults/"     $targetFolder "*.trx"
         CopyWithRelativeFolders "src/"                       $targetFolder "*.binlog"
         CopyWithRelativeFolders "src/"                       $targetFolder "*.log"
+
+        if (Test-Path "artifacts/TestResults/*") {
+            CopyWithRelativeFolders "artifacts/TestResults/"     $targetFolder "*.binlog"
+            CopyWithRelativeFolders "artifacts/TestResults/"     $targetFolder "*.diff"
+            CopyWithRelativeFolders "artifacts/TestResults/"     $targetFolder "Updated*.txt"
+            CopyWithRelativeFolders "artifacts/TestResults/"     $targetFolder "*.trx"
+        }
 
         # check if we have assets to publish
         if (Test-Path "artifacts/assets/Release/*") {


### PR DESCRIPTION
Fixes:

> Get-ChildItem : Cannot find path 'D:\a\_work\1\vmr\artifacts\T' because it does not exist.
At D:\a\_work\_temp\b3c32b5e-af35-4301-a31e-9cae445b3735.ps1:5 char:3

https://dev.azure.com/dnceng-public/public/_build/results?buildId=635998&view=logs&j=9050e078-31bf-5111-d8ec-8b6fa95caf9c&t=ad0102f3-9833-50a7-1afc-6f296dfdd60c