### PR TITLE
Run tests by default and again enable them in UB

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -361,18 +361,16 @@ jobs:
         set -ex
 
         dockerVolumeArgs="-v $(sourcesPath):/vmr"
-        poisonArg=''
         sourceOnlyArgs=''
 
-        if [[ '${{ parameters.enablePoison }}' == 'True' ]]; then
-          poisonArg='--poison'
-        fi
-
         if [[ '${{ parameters.buildSourceOnly }}' == 'True' ]]; then
-          sourceOnlyArgs='--source-only /p:SmokeTestsWarnOnSdkContentDiffs=true /p:SmokeTestsExcludeOmniSharpTests=${{ parameters.excludeOmniSharpTests }}'
+          if [[ '${{ parameters.enablePoison }}' == 'True' ]]; then
+            sourceOnlyArgs='--poison'
+          fi
+          sourceOnlyArgs='$sourceOnlyArgs --source-only /p:SmokeTestsWarnOnSdkContentDiffs=true /p:SmokeTestsExcludeOmniSharpTests=${{ parameters.excludeOmniSharpTests }}'
         fi
 
-        docker run --rm $dockerVolumeArgs -w /vmr ${{ parameters.container }} ./build.sh /bl:artifacts/log/Release/Test.binlog --test $poisonArg $sourceOnlyArgs $(additionalBuildArgs) 
+        docker run --rm $dockerVolumeArgs -w /vmr ${{ parameters.container }} ./build.sh /bl:artifacts/log/Release/Test.binlog --test $sourceOnlyArgs $(additionalBuildArgs) 
       displayName: Run Tests
 
   - ${{ if eq(parameters.targetOS, 'windows') }}:

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -383,6 +383,7 @@ jobs:
         if [[ -n "${{ parameters.container }}" ]]; then
           docker run --rm $dockerVolumeArgs -w /vmr ${{ parameters.container }} ./build.sh /bl:artifacts/log/Release/Test.binlog --test $sourceOnlyArgs $extraBuildProperties $(additionalBuildArgs) 
         else
+          cd $(sourcesPath)
           ./build.sh /bl:artifacts/log/Release/Test.binlog --test $sourceOnlyArgs $extraBuildProperties $(additionalBuildArgs)
         fi
 

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -363,6 +363,14 @@ jobs:
         dockerVolumeArgs="-v $(sourcesPath):/vmr"
         sourceOnlyArgs=''
 
+        if [[ ! -z '${{ parameters.targetOS }}' ]]; then
+          extraBuildProperties="$extraBuildProperties /p:TargetOS=${{ parameters.targetOS }}"
+        fi
+
+        if [[ ! -z '${{ parameters.targetArchitecture }}' ]]; then
+          extraBuildProperties="$extraBuildProperties /p:TargetArchitecture=${{ parameters.targetArchitecture }}"
+        fi
+
         if [[ '${{ parameters.buildSourceOnly }}' == 'True' ]]; then
           if [[ '${{ parameters.enablePoison }}' == 'True' ]]; then
             sourceOnlyArgs='--poison'
@@ -370,7 +378,7 @@ jobs:
           sourceOnlyArgs='$sourceOnlyArgs --source-only /p:SmokeTestsWarnOnSdkContentDiffs=true /p:SmokeTestsExcludeOmniSharpTests=${{ parameters.excludeOmniSharpTests }}'
         fi
 
-        docker run --rm $dockerVolumeArgs -w /vmr ${{ parameters.container }} ./build.sh /bl:artifacts/log/Release/Test.binlog --test $sourceOnlyArgs $(additionalBuildArgs) 
+        docker run --rm $dockerVolumeArgs -w /vmr ${{ parameters.container }} ./build.sh /bl:artifacts/log/Release/Test.binlog --test $sourceOnlyArgs $extraBuildProperties $(additionalBuildArgs) 
       displayName: Run Tests
 
   - ${{ if eq(parameters.targetOS, 'windows') }}:

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -355,39 +355,39 @@ jobs:
         fi
       displayName: Build
 
-  # Only run tests if enabled
-  - ${{ if eq(parameters.runTests, 'True') }}:
-    - script: |
-        set -ex
+    # Only run tests if enabled
+    - ${{ if eq(parameters.runTests, 'True') }}:
+      - script: |
+          set -ex
 
-        dockerVolumeArgs="-v $(sourcesPath):/vmr"
-        sourceOnlyArgs=''
-        extraBuildProperties=''
+          dockerVolumeArgs="-v $(sourcesPath):/vmr"
+          sourceOnlyArgs=''
+          extraBuildProperties=''
 
-        if [[ ! -z '${{ parameters.targetOS }}' ]]; then
-          extraBuildProperties="$extraBuildProperties /p:TargetOS=${{ parameters.targetOS }}"
-        fi
-
-        if [[ ! -z '${{ parameters.targetArchitecture }}' ]]; then
-          extraBuildProperties="$extraBuildProperties /p:TargetArchitecture=${{ parameters.targetArchitecture }}"
-        fi
-
-        if [[ '${{ parameters.buildSourceOnly }}' == 'True' ]]; then
-          if [[ '${{ parameters.enablePoison }}' == 'True' ]]; then
-            sourceOnlyArgs='--poison'
+          if [[ ! -z '${{ parameters.targetOS }}' ]]; then
+            extraBuildProperties="$extraBuildProperties /p:TargetOS=${{ parameters.targetOS }}"
           fi
-          sourceOnlyArgs="$sourceOnlyArgs --source-only /p:SmokeTestsWarnOnSdkContentDiffs=true /p:SmokeTestsExcludeOmniSharpTests=${{ parameters.excludeOmniSharpTests }}"
-        fi
 
-        # Only use Docker when a container is specified
-        if [[ -n "${{ parameters.container }}" ]]; then
-          docker run --rm $dockerVolumeArgs -w /vmr ${{ parameters.container }} ./build.sh /bl:artifacts/log/Release/Test.binlog --test $sourceOnlyArgs $extraBuildProperties $(additionalBuildArgs) 
-        else
-          cd $(sourcesPath)
-          ./build.sh /bl:artifacts/log/Release/Test.binlog --test $sourceOnlyArgs $extraBuildProperties $(additionalBuildArgs)
-        fi
+          if [[ ! -z '${{ parameters.targetArchitecture }}' ]]; then
+            extraBuildProperties="$extraBuildProperties /p:TargetArchitecture=${{ parameters.targetArchitecture }}"
+          fi
 
-      displayName: Run Tests
+          if [[ '${{ parameters.buildSourceOnly }}' == 'True' ]]; then
+            if [[ '${{ parameters.enablePoison }}' == 'True' ]]; then
+              sourceOnlyArgs='--poison'
+            fi
+            sourceOnlyArgs="$sourceOnlyArgs --source-only /p:SmokeTestsWarnOnSdkContentDiffs=true /p:SmokeTestsExcludeOmniSharpTests=${{ parameters.excludeOmniSharpTests }}"
+          fi
+
+          # Only use Docker when a container is specified
+          if [[ -n "${{ parameters.container }}" ]]; then
+            docker run --rm $dockerVolumeArgs -w /vmr ${{ parameters.container }} ./build.sh /bl:artifacts/log/Release/Test.binlog --test $sourceOnlyArgs $extraBuildProperties $(additionalBuildArgs) 
+          else
+            cd $(sourcesPath)
+            ./build.sh /bl:artifacts/log/Release/Test.binlog --test $sourceOnlyArgs $extraBuildProperties $(additionalBuildArgs)
+          fi
+
+        displayName: Run Tests
 
   - ${{ if eq(parameters.targetOS, 'windows') }}:
 

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -362,12 +362,17 @@ jobs:
 
         dockerVolumeArgs="-v $(sourcesPath):/vmr"
         poisonArg=''
+        sourceOnlyArgs=''
 
         if [[ '${{ parameters.enablePoison }}' == 'True' ]]; then
           poisonArg='--poison'
         fi
 
-        docker run --rm $dockerVolumeArgs -w /vmr ${{ parameters.container }} ./build.sh /bl:artifacts/log/Release/Test.binlog --source-only --test $poisonArg $(additionalBuildArgs) /p:SmokeTestsWarnOnSdkContentDiffs=true /p:SmokeTestsExcludeOmniSharpTests=${{ parameters.excludeOmniSharpTests }}
+        if [[ '${{ parameters.buildSourceOnly }}' == 'True' ]]; then
+          sourceOnlyArgs='--source-only /p:SmokeTestsWarnOnSdkContentDiffs=true /p:SmokeTestsExcludeOmniSharpTests=${{ parameters.excludeOmniSharpTests }}'
+        fi
+
+        docker run --rm $dockerVolumeArgs -w /vmr ${{ parameters.container }} ./build.sh /bl:artifacts/log/Release/Test.binlog --test $poisonArg $sourceOnlyArgs $(additionalBuildArgs) 
       displayName: Run Tests
 
   - ${{ if eq(parameters.targetOS, 'windows') }}:

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -69,7 +69,7 @@ parameters:
 
 - name: runTests
   type: boolean
-  default: false
+  default: true
 
 # Freeform field for extra values to pass to build.sh for special build modes
 - name: extraProperties

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -362,6 +362,7 @@ jobs:
 
         dockerVolumeArgs="-v $(sourcesPath):/vmr"
         sourceOnlyArgs=''
+        extraBuildProperties=''
 
         if [[ ! -z '${{ parameters.targetOS }}' ]]; then
           extraBuildProperties="$extraBuildProperties /p:TargetOS=${{ parameters.targetOS }}"

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -243,7 +243,7 @@ jobs:
 
     - ${{ if eq(parameters.runTests, 'True') }}:
       - script: |
-          call $(sourcesPath)\build.cmd -ci -prepareMachine -test ${{ parameters.extraProperties }}
+          call $(sourcesPath)\build.cmd -ci -prepareMachine -test /p:TargetOS=${{ parameters.targetOS }} /p:TargetArchitecture=${{ parameters.targetArchitecture }} ${{ parameters.extraProperties }}
         displayName: Run Tests
 
   - ${{ else }}:

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -379,7 +379,13 @@ jobs:
           sourceOnlyArgs="$sourceOnlyArgs --source-only /p:SmokeTestsWarnOnSdkContentDiffs=true /p:SmokeTestsExcludeOmniSharpTests=${{ parameters.excludeOmniSharpTests }}"
         fi
 
-        docker run --rm $dockerVolumeArgs -w /vmr ${{ parameters.container }} ./build.sh /bl:artifacts/log/Release/Test.binlog --test $sourceOnlyArgs $extraBuildProperties $(additionalBuildArgs) 
+        # Only use Docker when a container is specified
+        if [[ -n "${{ parameters.container }}" ]]; then
+          docker run --rm $dockerVolumeArgs -w /vmr ${{ parameters.container }} ./build.sh /bl:artifacts/log/Release/Test.binlog --test $sourceOnlyArgs $extraBuildProperties $(additionalBuildArgs) 
+        else
+          ./build.sh /bl:artifacts/log/Release/Test.binlog --test $sourceOnlyArgs $extraBuildProperties $(additionalBuildArgs)
+        fi
+
       displayName: Run Tests
 
   - ${{ if eq(parameters.targetOS, 'windows') }}:

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -375,7 +375,7 @@ jobs:
           if [[ '${{ parameters.enablePoison }}' == 'True' ]]; then
             sourceOnlyArgs='--poison'
           fi
-          sourceOnlyArgs='$sourceOnlyArgs --source-only /p:SmokeTestsWarnOnSdkContentDiffs=true /p:SmokeTestsExcludeOmniSharpTests=${{ parameters.excludeOmniSharpTests }}'
+          sourceOnlyArgs="$sourceOnlyArgs --source-only /p:SmokeTestsWarnOnSdkContentDiffs=true /p:SmokeTestsExcludeOmniSharpTests=${{ parameters.excludeOmniSharpTests }}"
         fi
 
         docker run --rm $dockerVolumeArgs -w /vmr ${{ parameters.container }} ./build.sh /bl:artifacts/log/Release/Test.binlog --test $sourceOnlyArgs $extraBuildProperties $(additionalBuildArgs) 

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -89,7 +89,6 @@ stages:
         enablePoison: false                # 🚫
         excludeOmniSharpTests: true        # ✅
         runOnline: true                    # ✅
-        runTests: true                     # ✅
         useMonoRuntime: false              # 🚫
         withPreviousSDK: false             # 🚫
 
@@ -110,7 +109,6 @@ stages:
           enablePoison: false                # 🚫
           excludeOmniSharpTests: true        # ✅
           runOnline: true                    # ✅
-          runTests: true                     # ✅
           useMonoRuntime: false              # 🚫
           withPreviousSDK: false             # 🚫
           reuseBuildArtifactsFrom: centOSStream9_Online_MsftSdk
@@ -130,7 +128,6 @@ stages:
           enablePoison: true                 # ✅
           excludeOmniSharpTests: true        # ✅
           runOnline: false                   # 🚫
-          runTests: true                     # ✅
           useMonoRuntime: false              # 🚫
           withPreviousSDK: true              # ✅
 
@@ -151,7 +148,6 @@ stages:
             enablePoison: false                # 🚫
             excludeOmniSharpTests: true        # ✅
             runOnline: true                    # ✅
-            runTests: true                     # ✅
             useMonoRuntime: false              # 🚫
             withPreviousSDK: false             # 🚫
 
@@ -169,7 +165,6 @@ stages:
             enablePoison: false                # 🚫
             excludeOmniSharpTests: false       # 🚫
             runOnline: false                   # 🚫
-            runTests: true                     # ✅
             useMonoRuntime: false              # 🚫
             withPreviousSDK: false             # 🚫
 
@@ -188,7 +183,6 @@ stages:
             enablePoison: false                # 🚫
             excludeOmniSharpTests: false       # 🚫
             runOnline: true                    # ✅
-            runTests: true                     # ✅
             useMonoRuntime: false              # 🚫
             withPreviousSDK: true              # ✅
 
@@ -207,7 +201,6 @@ stages:
             enablePoison: false                # 🚫
             excludeOmniSharpTests: true        # ✅
             runOnline: false                   # 🚫
-            runTests: true                     # ✅
             useMonoRuntime: false              # 🚫
             withPreviousSDK: true              # ✅
 
@@ -225,7 +218,6 @@ stages:
             enablePoison: false                # 🚫
             excludeOmniSharpTests: true        # ✅
             runOnline: false                   # 🚫
-            runTests: true                     # ✅
             useMonoRuntime: true               # ✅
             withPreviousSDK: false             # 🚫
 
@@ -243,7 +235,6 @@ stages:
             enablePoison: false                # 🚫
             excludeOmniSharpTests: false       # 🚫
             runOnline: false                   # 🚫
-            runTests: true                     # ✅
             useMonoRuntime: false              # 🚫
             withPreviousSDK: false             # 🚫
 
@@ -261,7 +252,6 @@ stages:
             enablePoison: false                # 🚫
             excludeOmniSharpTests: false       # 🚫
             runOnline: false                   # 🚫
-            runTests: true                     # ✅
             useMonoRuntime: false              # 🚫
             withPreviousSDK: false             # 🚫
 
@@ -279,7 +269,6 @@ stages:
             enablePoison: false                # 🚫
             excludeOmniSharpTests: false       # 🚫
             runOnline: false                   # 🚫
-            runTests: true                     # ✅
             useMonoRuntime: false              # 🚫
             withPreviousSDK: false             # 🚫
 
@@ -297,7 +286,6 @@ stages:
             enablePoison: false                # 🚫
             excludeOmniSharpTests: false       # 🚫
             runOnline: false                   # 🚫
-            runTests: true                     # ✅
             useMonoRuntime: false              # 🚫
             withPreviousSDK: false             # 🚫
             reuseBuildArtifactsFrom: Fedora39_Offline_MsftSdk

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -332,6 +332,7 @@ stages:
         container: ${{ variables.androidCrossContainer }}
         targetOS: android
         targetArchitecture: arm64
+        runTests: false
 
     - template: ../jobs/vmr-build.yml
       parameters:
@@ -344,6 +345,7 @@ stages:
         crossRootFs: '/crossrootfs/x64'
         targetOS: browser
         targetArchitecture: wasm
+        runTests: false
 
     - template: ../jobs/vmr-build.yml
       parameters:
@@ -354,6 +356,7 @@ stages:
         pool: ${{ parameters.pool_Mac }}
         targetOS: iossimulator
         targetArchitecture: arm64
+        runTests: false
 
     ### Additional jobs for full build ###
     - ${{ if in(parameters.scope, 'full') }}:
@@ -368,6 +371,7 @@ stages:
             container: ${{ variables.androidCrossContainer }}
             targetOS: android
             targetArchitecture: arm
+            runTests: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -379,6 +383,7 @@ stages:
             container: ${{ variables.androidCrossContainer }}
             targetOS: android
             targetArchitecture: x64
+            runTests: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -390,6 +395,7 @@ stages:
             container: ${{ variables.androidCrossContainer }}
             targetOS: android
             targetArchitecture: x86
+            runTests: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -403,6 +409,7 @@ stages:
             targetOS: browser
             targetArchitecture: wasm
             extraProperties: /p:DotNetBuildRuntimeWasmEnableThreads=true
+            runTests: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -415,6 +422,7 @@ stages:
             crossRootFs: '/crossrootfs/x64'
             targetOS: linux-bionic
             targetArchitecture: arm64
+            runTests: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -428,6 +436,7 @@ stages:
             targetOS: linux-bionic
             targetArchitecture: arm64
             extraProperties: /p:DotNetBuildRuntimeNativeAOTRuntimePack=true
+            runTests: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -440,6 +449,7 @@ stages:
             crossRootFs: '/crossrootfs/x64'
             targetOS: linux-bionic
             targetArchitecture: x64
+            runTests: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -453,6 +463,7 @@ stages:
             targetOS: linux-bionic
             targetArchitecture: x64
             extraProperties: /p:DotNetBuildRuntimeNativeAOTRuntimePack=true
+            runTests: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -463,6 +474,7 @@ stages:
             pool: ${{ parameters.pool_Mac }}
             targetOS: ios
             targetArchitecture: arm64
+            runTests: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -474,6 +486,7 @@ stages:
             targetOS: ios
             targetArchitecture: arm64
             extraProperties: /p:DotNetBuildRuntimeNativeAOTRuntimePack=true
+            runTests: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -485,6 +498,7 @@ stages:
             targetOS: iossimulator
             targetArchitecture: arm64
             extraProperties: /p:DotNetBuildRuntimeNativeAOTRuntimePack=true
+            runTests: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -495,6 +509,7 @@ stages:
             pool: ${{ parameters.pool_Mac }}
             targetOS: iossimulator
             targetArchitecture: x64
+            runTests: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -506,6 +521,7 @@ stages:
             targetOS: iossimulator
             targetArchitecture: x64
             extraProperties: /p:DotNetBuildRuntimeNativeAOTRuntimePack=true
+            runTests: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -516,6 +532,7 @@ stages:
             pool: ${{ parameters.pool_Mac }}
             targetOS: maccatalyst
             targetArchitecture: arm64
+            runTests: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -527,6 +544,7 @@ stages:
             targetOS: maccatalyst
             targetArchitecture: arm64
             extraProperties: /p:DotNetBuildRuntimeNativeAOTRuntimePack=true
+            runTests: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -537,6 +555,7 @@ stages:
             pool: ${{ parameters.pool_Mac }}
             targetOS: maccatalyst
             targetArchitecture: x64
+            runTests: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -548,6 +567,7 @@ stages:
             targetOS: maccatalyst
             targetArchitecture: x64
             extraProperties: /p:DotNetBuildRuntimeNativeAOTRuntimePack=true
+            runTests: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -558,6 +578,7 @@ stages:
             pool: ${{ parameters.pool_Mac }}
             targetOS: tvos
             targetArchitecture: arm64
+            runTests: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -569,6 +590,7 @@ stages:
             targetOS: tvos
             targetArchitecture: arm64
             extraProperties: /p:DotNetBuildRuntimeNativeAOTRuntimePack=true
+            runTests: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -579,6 +601,7 @@ stages:
             pool: ${{ parameters.pool_Mac }}
             targetOS: tvossimulator
             targetArchitecture: arm64
+            runTests: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -590,6 +613,7 @@ stages:
             targetOS: tvossimulator
             targetArchitecture: arm64
             extraProperties: /p:DotNetBuildRuntimeNativeAOTRuntimePack=true
+            runTests: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -600,6 +624,7 @@ stages:
             pool: ${{ parameters.pool_Mac }}
             targetOS: tvossimulator
             targetArchitecture: x64
+            runTests: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -611,6 +636,7 @@ stages:
             targetOS: tvossimulator
             targetArchitecture: x64
             extraProperties: /p:DotNetBuildRuntimeNativeAOTRuntimePack=true
+            runTests: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -623,6 +649,7 @@ stages:
             crossRootFs: '/crossrootfs/x64'
             targetOS: wasi
             targetArchitecture: wasm
+            runTests: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -751,6 +778,7 @@ stages:
             targetOS: osx
             targetArchitecture: x64
             extraProperties: /p:DotNetBuildRuntimeNativeAOTRuntimePack=true
+            runTests: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -762,6 +790,7 @@ stages:
             targetOS: osx
             targetArchitecture: arm64
             extraProperties: /p:DotNetBuildRuntimeNativeAOTRuntimePack=true
+            runTests: false
 
         - template: ../jobs/vmr-build.yml
           parameters:

--- a/src/SourceBuild/content/test/Microsoft.DotNet.UnifiedBuild.Tests/Microsoft.DotNet.UnifiedBuild.Tests.csproj
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.UnifiedBuild.Tests/Microsoft.DotNet.UnifiedBuild.Tests.csproj
@@ -5,6 +5,7 @@
     <DefaultExcludesInProjectFolder>$(DefaultExcludesInProjectFolder);assets/**/*</DefaultExcludesInProjectFolder>
     <UBTestsWarnOnSdkContentDiffs>true</UBTestsWarnOnSdkContentDiffs>
     <VSTestLogger>console%3bverbosity=diagnostic;trx%3bverbosity=diagnostic%3bLogFileName=$(MSBuildProjectName).trx</VSTestLogger>
+    <VSTestCLIRunSettings>$(VSTestCLIRunSettings);RunConfiguration.DotNetHostPath=$(DotnetTool)</VSTestCLIRunSettings>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
With https://github.com/dotnet/installer/commit/be917a934682e97a75f7094ae17f4048118fd443, the unified build tests were moved out of the
VMR build stage into the test stage. As none
of the vertical builds specified runTests: true,
the tests stopped running.

Change the runTests default to true as every single job should run tests.
