### PR TITLE
Use the repo asset manifests to discover dependency versions

### DIFF
--- a/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/WritePackageVersionsProps.cs
+++ b/src/SourceBuild/content/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/WritePackageVersionsProps.cs
@@ -176,12 +176,6 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks
                 return !Log.HasLoggedErrors;
             }
 
-            if (KnownPackages is null or [] && NuGetPackages is null or [])
-            {
-                Log.LogError("KnownPackages or NuGetPackages supplied with package information.");
-                return !Log.HasLoggedErrors;
-            }
-
             NuGetPackages ??= Array.Empty<ITaskItem>();
             KnownPackages ??= Array.Empty<ITaskItem>();
 

--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -192,19 +192,6 @@
   <ItemGroup>
     <!-- Make the WindowsDesktop SDK override opt-in for repos that need it. -->
     <WindowsDesktopSdkOverride Include="Microsoft.Net.Sdk.WindowsDesktop" Group="WINDOWS_DESKTOP" Location="$(ToolsDir)EmptySdk" Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
-
-    <!--
-      Add Microsoft.Build.NoTargets and Microsoft.Build.Traversal SDK overrides, for all repos,
-      except source-build-reference-packages repo, that builds these packages and utility projects.
-
-      We need to override all SDK packages that are used by repos, to prevent NuGet SDK Resolver from trying to
-      restore these packages from online feeds. In offline build we only want to use local source-build feeds.
-      Therefore, we create a copy of repo's NuGet.config file, modify it, and pass it into repo build using
-      RestoreConfigFile property. MSBuild uses NuGetSdkResolver to restore missing SDKs, which doesn't honor
-      RestoreConfigFile property and uses NuGet.config file from repo's root which has online feeds.
-    -->
-    <NoTargetsSdkOverride Include="Microsoft.Build.NoTargets" Group="NOTARGETS" Version="$(NOTARGETS_BOOTSTRAP_VERSION)" />
-    <SourceBuiltSdkOverride Include="@(NoTargetsSdkOverride)" Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(RepositoryName)' != 'source-build-reference-packages'" />
   </ItemGroup>
 
     <!-- CLI internal version is statically set by us to a version that will never show up in the wild.

--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -182,14 +182,12 @@
   </ItemGroup>
 
   <!-- If we're using the bootstrapped arcade, we can set the override here. -->
-  <ItemGroup Condition="'$(UseBootstrapArcade)' == 'true'">
-    <SourceBuiltSdkOverride Include="Microsoft.DotNet.Arcade.Sdk"
-                            Group="ARCADE"
-                            Version="$(ArcadeBootstrapVersion)"
-                            Location="$(BootstrapPackagesDir)microsoft.dotnet.arcade.sdk/$(ArcadeBootstrapVersion)" />
-  </ItemGroup>
-
   <ItemGroup>
+    <!-- Configure the bootstrapped Arcade version here. Repositories that build before arcade (and arcade itself) will use the bootstrapped SDK. -->
+    <BootstrapArcadeSdkOverride Include="Microsoft.DotNet.Arcade.Sdk"
+                                Group="ARCADE"
+                                Version="$(ArcadeBootstrapVersion)"
+                                Location="$(BootstrapPackagesDir)microsoft.dotnet.arcade.sdk/$(ArcadeBootstrapVersion)" />
     <!-- Make the WindowsDesktop SDK override opt-in for repos that need it. -->
     <WindowsDesktopSdkOverride Include="Microsoft.Net.Sdk.WindowsDesktop" Group="WINDOWS_DESKTOP" Location="$(ToolsDir)EmptySdk" Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
   </ItemGroup>

--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -204,9 +204,7 @@
       RestoreConfigFile property and uses NuGet.config file from repo's root which has online feeds.
     -->
     <NoTargetsSdkOverride Include="Microsoft.Build.NoTargets" Group="NOTARGETS" Version="$(NOTARGETS_BOOTSTRAP_VERSION)" />
-    <TraversalSdkOverride Include="Microsoft.Build.Traversal" Group="TRAVERSAL" Version="$(TRAVERSAL_BOOTSTRAP_VERSION)" />
     <SourceBuiltSdkOverride Include="@(NoTargetsSdkOverride)" Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(RepositoryName)' != 'source-build-reference-packages'" />
-    <SourceBuiltSdkOverride Include="@(TraversalSdkOverride)" Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(RepositoryName)' != 'source-build-reference-packages'" />
   </ItemGroup>
 
     <!-- CLI internal version is statically set by us to a version that will never show up in the wild.

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -289,7 +289,7 @@
                                OutputPath="$(PreviouslySourceBuiltPackageVersionPropsPath)"
                                Condition="@(_PreviouslyBuiltSourceBuiltPackages->Count()) != 0" />
 
-    <WriteLinesToFile File="$(CurrentSourceBuiltPackageVersionPropsPath)"
+    <WriteLinesToFile File="$(PreviouslySourceBuiltPackageVersionPropsPath)"
                       Lines="&lt;Project&gt;&lt;/Project&gt;" 
                       Condition="@(_PreviouslyBuiltSourceBuiltPackages->Count()) == 0" />
 

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -275,7 +275,12 @@
                                ExtraProperties="@(ExtraPackageVersionPropsPackageInfo)"
                                VersionPropsFlowType="$(PackageVersionPropsFlowType)"
                                VersionDetails="$(_VersionDetailsXml)"
-                               OutputPath="$(CurrentSourceBuiltPackageVersionPropsPath)" />
+                               OutputPath="$(CurrentSourceBuiltPackageVersionPropsPath)"
+                               Condition="'@(_DependencyProducedPackage->Count()) != 0" />
+    
+    <WriteLinesToFile File="$(CurrentSourceBuiltPackageVersionPropsPath)"
+                      Lines="&lt;Project&gt;&lt;/Project&gt;" 
+                      Condition="'@(_DependencyProducedPackage->Count()) == 0" />
 
     <!-- Create previously source-built inputs info -->
     <WritePackageVersionsProps NuGetPackages="@(_PreviouslyBuiltSourceBuiltPackages)"
@@ -294,7 +299,8 @@
          A key element of this algorith is that we must write the full package version props and not the filtered version. -->
     <WritePackageVersionsProps KnownPackages="@(_DependencyProducedPackage)"
                                VersionPropsFlowType="AllPackages"
-                               OutputPath="$(SnapshotPackageVersionPropsPath)" />
+                               OutputPath="$(SnapshotPackageVersionPropsPath)"
+                               Condition="'@(_DependencyProducedPackage->Count()) != 0" />
 
     <!-- Write a single file that contains imports for both the current and previously built packages -->
     <PropertyGroup>

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -564,7 +564,7 @@
     <Exec Command="df -h $(RepoRoot)" Condition="'$(BuildOS)' != 'windows'and '@(DirsToDeleteWithTrailingSeparator)' != ''" />
   </Target>
 
-  <Target Name="ExtractToolPackage"
+  <Target Name="ExtractToolPackageCore"
           DependsOnTargets="RepoBuild;$(ExtractToolPackageDependsOn)"
           Condition="'@(BuiltSdkPackageOverride)' != ''"
           Inputs="$(MSBuildProjectFullPath)"
@@ -601,6 +601,9 @@
       <Output TaskParameter="TouchedFiles" ItemName="FileWrites" />
     </Touch>
   </Target>
+
+  <Target Name="ExtractToolPackage"
+          DependsOnTargets="RepoBuild;$(ExtractToolPackageDependsOn);ExtractToolPackageCore" />
 
   <Target Name="Build"
           DependsOnTargets="

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -455,7 +455,7 @@
 
   <Target Name="GetRepoAssetManifests" Returns="@(RepoAssetManifest)">
     <ItemGroup>
-      <RepoAssetManifest Include="$(ArtifactsAssetsDir)*.xml" />
+      <RepoAssetManifest Include="$(RepoAssetManifestsDir)*.xml" />
     </ItemGroup>
   </Target>
 

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -396,7 +396,7 @@
                             UpdateGlobalJsonVersions;
                             UpdateEngCommonFiles;
                             CreateBuildInputProps;
-                            DiscoverArcadeSourceBuiltSdkOverrides;
+                            DiscoverBuiltSdkOverrides;
                             SetSourceBuiltSdkOverrides">
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Building $(RepositoryName)" />
     <Message Importance="High" Text="Running command:" />
@@ -449,7 +449,7 @@
     <Message Importance="High" Text="See '$(RepoConsoleLogFile)' for more information." Condition="Exists('$(RepoConsoleLogFile)') and '$(MinimalConsoleLogOutput)' == 'true'" />
   </Target>
 
-  <Target Name="GetRepoAssetManifests" Returns="@(RepoAssetManifest)">
+  <Target Name="GetRepoAssetManifests" DependsOnTargets="RepoBuild" Returns="@(RepoAssetManifest)">
     <ItemGroup>
       <RepoAssetManifest Include="$(RepoAssetManifestsDir)*.xml" />
     </ItemGroup>
@@ -457,7 +457,7 @@
 
   <!-- Log the new repo artifacts -->
   <Target Name="LogRepoArtifacts"
-          DependsOnTargets="RepoBuild;GetRepoAssetManifests"
+          DependsOnTargets="GetRepoAssetManifests"
           Condition="'$(IsUtilityProject)' != 'true'">
     <Error Text="Repo manifest files don't exist." Condition="'@(RepoAssetManifest)' == ''" />
 
@@ -572,7 +572,7 @@
     <Exec Command="df -h $(RepoRoot)" Condition="'$(BuildOS)' != 'windows'and '@(DirsToDeleteWithTrailingSeparator)' != ''" />
   </Target>
 
-  <Target Name="DiscoverToolPackageVersions" DependsOnTargets="RepoBuild;GetProducedPackages">
+  <Target Name="DiscoverToolPackageVersions" DependsOnTargets="GetProducedPackages">
     <JoinItems Left="@(ProducedPackage)"
                Right="@(BuiltSdkPackage)"
                LeftMetadata="*">
@@ -580,8 +580,8 @@
     </JoinItems>
   </Target>
 
-  <Target Name="ExtractToolPackageCore"
-          DependsOnTargets="RepoBuild;$(ExtractToolPackageDependsOn)"
+  <Target Name="ExtractToolPackage"
+          DependsOnTargets="RepoBuild;DiscoverToolPackageVersions"
           Condition="'@(BuiltSdkPackageOverride)' != ''"
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(BaseIntermediateOutputPath)ExtractToolPackage.complete">
@@ -619,7 +619,7 @@
   </Target>
 
   <Target Name="ExtractToolPackage"
-          DependsOnTargets="RepoBuild;$(ExtractToolPackageDependsOn);ExtractToolPackageCore" />
+          DependsOnTargets="DiscoverToolPackageVersions;ExtractToolPackageCore" />
 
   <Target Name="Build"
           DependsOnTargets="

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -80,8 +80,6 @@
     <ItemGroup Condition="'@(RepositoryReferenceInfo)' != ''">
       <DependentRepoSourceName Include="@(RepositoryReferenceInfo->'%(ShippingSourceName)')" />
       <DependentRepoSourceName Include="@(RepositoryReferenceInfo->'%(NonShippingSourceName)')" />
-      <DependentRepoPackageFile Include="%(RepositoryReferenceInfo.ShippingPackagesPath)**" />
-      <DependentRepoPackageFile Include="%(RepositoryReferenceInfo.NonShippingPackagesPath)**" />
     </ItemGroup>
   </Target>
 
@@ -258,13 +256,10 @@
        There are 3 files generated -->
   <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.WritePackageVersionsProps" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" />
   <Target Name="CreateBuildInputProps"
-          DependsOnTargets="GetRepositoryReferenceInfo"
+          DependsOnTargets="GetProducedPackagesFromTransitiveReferences"
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(BaseIntermediateOutputPath)CreateBuildInputProps.complete">
     <ItemGroup>
-      <!-- Collect all the NuGet packages from dependent repos except for the symbols -->
-      <_CurrentSourceBuiltPackages Include="@(DependentRepoPackageFile)"
-                                   Condition="!$([System.String]::Copy('%(Identity)').EndsWith('.symbols.nupkg'))" />
       <_PreviouslyBuiltSourceBuiltPackages Include="$(PrebuiltSourceBuiltPackagesPath)*.nupkg" />
     </ItemGroup>
 
@@ -276,7 +271,7 @@
     </PropertyGroup>
 
     <!-- Write the build input properties, then save off a copy that will be used for generating usage reports later -->
-    <WritePackageVersionsProps NuGetPackages="@(_CurrentSourceBuiltPackages)"
+    <WritePackageVersionsProps KnownPackages="@(_DependencyProducedPackage)"
                                ExtraProperties="@(ExtraPackageVersionPropsPackageInfo)"
                                VersionPropsFlowType="$(PackageVersionPropsFlowType)"
                                VersionDetails="$(_VersionDetailsXml)"
@@ -297,7 +292,7 @@
          A B and C.
 
          A key element of this algorith is that we must write the full package version props and not the filtered version. -->
-    <WritePackageVersionsProps NuGetPackages="@(_CurrentSourceBuiltPackages)"
+    <WritePackageVersionsProps KnownPackages="@(_DependencyProducedPackage)"
                                VersionPropsFlowType="AllPackages"
                                OutputPath="$(SnapshotPackageVersionPropsPath)" />
 
@@ -344,23 +339,14 @@
 
   <!-- Discover the Arcade SDKs built from the live Arcade source and set them as overrides here. -->
   <Target Name="DiscoverArcadeSourceBuiltSdkOverrides"
-          DependsOnTargets="BuildRepoReferences;GetRepositoryReferenceInfo"
+          DependsOnTargets="BuildRepoReferences;GetProducedPackagesFromTransitiveReferences"
           Condition="'$(UseBootstrapArcade)' != 'true'">
-    <PropertyGroup>
-      <_ArcadeSdkName>Microsoft.DotNet.Arcade.Sdk</_ArcadeSdkName>
-    </PropertyGroup>
-
-    <!--
-      Discover the version of the Arcade SDK NuGet package by matching the name of the nupkg file and extracting the version.
-      In the future, we should use the asset manifests to discover this information.
-    -->
     <ItemGroup>
-      <_BuiltArcadeSdkPackage Include="@(DependentRepoPackageFile)"
-                              Condition="!$([System.String]::new('%(Identity)').EndsWith('.symbols.nupkg')) and $([System.String]::new('%(Identity)').Contains($(_ArcadeSdkName)))" />
+      <_BuiltArcadeSdkPackage Include="@(_DependencyProducedPackage->WithMetadataValue('Identity', 'Microsoft.DotNet.Arcade.Sdk'))" />
     </ItemGroup>
 
     <PropertyGroup>
-      <_BuiltArcadeSdkPackageVersion>$([System.String]::new('%(_BuiltArcadeSdkPackage.FileName)').Substring($([MSBuild]::Add($(_ArcadeSdkName.Length), 1))))</_BuiltArcadeSdkPackageVersion>
+      <_BuiltArcadeSdkPackageVersion>@(_BuiltArcadeSdkPackage->MetadataValue('Version'))</_BuiltArcadeSdkPackageVersion>
     </PropertyGroup>
 
     <ItemGroup>
@@ -374,8 +360,26 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="DiscoverReferencePackageBuiltSdkOverrides"
+          DependsOnTargets="BuildRepoReferences;GetProducedPackagesFromTransitiveReferences"
+          Condition="'$(UseBootstrapSdks)' != 'true'">
+    <!--
+      Add Microsoft.Build.NoTargets and Microsoft.Build.Traversal SDK overrides, for all repos (except the one that builds this one, which opts out).
+
+      We need to override all SDK packages that are used by repos, to prevent NuGet SDK Resolver from trying to
+      restore these packages from online feeds. In offline build we only want to use local source-build feeds.
+      Therefore, we create a copy of repo's NuGet.config file, modify it, and pass it into repo build using
+      RestoreConfigFile property. MSBuild uses NuGetSdkResolver to restore missing SDKs, which doesn't honor
+      RestoreConfigFile property and uses NuGet.config file from repo's root which has online feeds.
+    -->
+    <ItemGroup>
+      <SourceBuiltSdkOverride Include="@(_DependencyProducedPackage->WithMetadataValue('Identity', 'Microsoft.Build.Traversal')" Group="TRAVERSAL" />
+      <SourceBuiltSdkOverride Include="@(_DependencyProducedPackage->WithMetadataValue('Identity', 'Microsoft.Build.NoTargets')" Group="NOTARGETS" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="SetSourceBuiltSdkOverrides"
-          DependsOnTargets="DiscoverArcadeSourceBuiltSdkOverrides"
+          DependsOnTargets="DiscoverArcadeSourceBuiltSdkOverrides;DiscoverReferencePackageBuiltSdkOverrides"
           Condition="'@(SourceBuiltSdkOverride)' != ''">
     <ItemGroup>
       <!-- Set the environment variables for MSBuild to look for our additional SDK Resolvers and or our resolver to find our source-built SDKs. -->
@@ -449,14 +453,16 @@
     <Message Importance="High" Text="See '$(RepoConsoleLogFile)' for more information." Condition="Exists('$(RepoConsoleLogFile)') and '$(MinimalConsoleLogOutput)' == 'true'" />
   </Target>
 
+  <Target Name="GetRepoAssetManifests" Returns="@(RepoAssetManifest)">
+    <ItemGroup>
+      <RepoAssetManifest Include="$(ArtifactsAssetsDir)*.xml" />
+    </ItemGroup>
+  </Target>
+
   <!-- Log the new repo artifacts -->
   <Target Name="LogRepoArtifacts"
-          DependsOnTargets="RepoBuild"
+          DependsOnTargets="RepoBuild;GetRepoAssetManifests"
           Condition="'$(IsUtilityProject)' != 'true'">
-    <ItemGroup>
-      <RepoAssetManifest Include="$(RepoAssetManifestsDir)*.xml" />
-    </ItemGroup>
-
     <Error Text="Repo manifest files don't exist." Condition="'@(RepoAssetManifest)' == ''" />
 
     <XmlPeek XmlInputPath="%(RepoAssetManifest.Identity)"
@@ -466,6 +472,36 @@
 
     <Message Importance="High" Text="New artifact(s) after building $(RepositoryName):" />
     <Message Importance="High" Text="  -> %(RepoManifestArtifact.Identity)" />
+  </Target>
+
+  <!-- Discover the produced packages from all repo asset manifests for this repository. -->
+  <Target Name="DiscoverProducedPackages" DependsOnTargets="GetRepoAssetManifests" Inputs="@(RepoAssetManifest)" Outputs="%(Identity).ForBatching">
+    <XmlPeek XmlInputPath="%(RepoAssetManifest.Identity)" Query="/Build/*[self::Package]">
+      <Output TaskParameter="Result" ItemName="ProducedPackageEntry" />
+    </XmlPeek>
+  </Target>
+  
+  <Target Name="ProcessPackageEntries" DependsOnTargets="DiscoverProducedPackages" Inputs="@(ProducedPackageEntry)" Outputs="%(Identity).ForBatching">
+    <XmlPeek XmlContent="%(ProducedPackageEntry.Identity)" Query="/Package/@Id">
+      <Output TaskParameter="Result" PropertyName="ProducedPackageId" />
+    </XmlPeek>
+    <XmlPeek XmlContent="%(ProducedPackageEntry.Identity)" Query="/Package/@Version">
+      <Output TaskParameter="Result" PropertyName="ProducedPackageVersion" />
+    </XmlPeek>
+
+    <ItemGroup>
+      <ProducedPackage Include="$(ProducedPackageId)" Version="$(ProducedPackageVersion)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="GetProducedPackages" DependsOnTargets="GetRepoAssetManifests;DiscoverProducedPackages;ProcessPackageEntries" Returns="@(ProducedPackage)" />
+
+  <Target Name="GetProducedPackagesFromTransitiveReferences" DependsOnTargets="GetTransitiveRepositoryReferences" Returns="@(_DependencyProducedPackage)">
+    <MSBuild Projects="@(RepositoryReference->'%(Identity).proj')"
+             Targets="GetProducedPackages"
+             BuildInParallel="true">
+      <Output TaskParameter="TargetOutputs" ItemName="_DependencyProducedPackage" />
+    </MSBuild>
   </Target>
 
   <!-- Copy restored packages from inner build to ensure they're included in the
@@ -541,7 +577,7 @@
   </Target>
 
   <Target Name="ExtractToolPackage"
-          DependsOnTargets="RepoBuild"
+          DependsOnTargets="RepoBuild;$(ExtractToolPackageDependsOn)"
           Condition="'@(BuiltSdkPackageOverride)' != ''"
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(BaseIntermediateOutputPath)ExtractToolPackage.complete">

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -485,7 +485,7 @@
   <Target Name="GetProducedPackages" DependsOnTargets="GetRepoAssetManifests;DiscoverProducedPackages;ProcessPackageEntries" Returns="@(ProducedPackage)" />
 
   <Target Name="GetProducedPackagesFromTransitiveReferences" DependsOnTargets="GetTransitiveRepositoryReferences" Returns="@(_DependencyProducedPackage)">
-    <MSBuild Projects="@(RepositoryReference->'%(Identity).proj')"
+    <MSBuild Projects="@(TransitiveRepositoryReference->'%(Identity).proj')"
              Targets="GetProducedPackages"
              BuildInParallel="true">
       <Output TaskParameter="TargetOutputs" ItemName="_DependencyProducedPackage" />

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -276,11 +276,11 @@
                                VersionPropsFlowType="$(PackageVersionPropsFlowType)"
                                VersionDetails="$(_VersionDetailsXml)"
                                OutputPath="$(CurrentSourceBuiltPackageVersionPropsPath)"
-                               Condition="'@(_DependencyProducedPackage->Count()) != 0" />
+                               Condition="@(_DependencyProducedPackage->Count()) != 0" />
     
     <WriteLinesToFile File="$(CurrentSourceBuiltPackageVersionPropsPath)"
                       Lines="&lt;Project&gt;&lt;/Project&gt;" 
-                      Condition="'@(_DependencyProducedPackage->Count()) == 0" />
+                      Condition="@(_DependencyProducedPackage->Count()) == 0" />
 
     <!-- Create previously source-built inputs info -->
     <WritePackageVersionsProps NuGetPackages="@(_PreviouslyBuiltSourceBuiltPackages)"
@@ -300,7 +300,7 @@
     <WritePackageVersionsProps KnownPackages="@(_DependencyProducedPackage)"
                                VersionPropsFlowType="AllPackages"
                                OutputPath="$(SnapshotPackageVersionPropsPath)"
-                               Condition="'@(_DependencyProducedPackage->Count()) != 0" />
+                               Condition="@(_DependencyProducedPackage->Count()) != 0" />
 
     <!-- Write a single file that contains imports for both the current and previously built packages -->
     <PropertyGroup>

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -564,6 +564,14 @@
     <Exec Command="df -h $(RepoRoot)" Condition="'$(BuildOS)' != 'windows'and '@(DirsToDeleteWithTrailingSeparator)' != ''" />
   </Target>
 
+  <Target Name="DiscoverToolPackageVersions" DependsOnTargets="RepoBuild;GetProducedPackages">
+    <JoinItems Left="@(ProducedPackage)"
+               Right="@(BuiltSdkPackage)"
+               LeftMetadata="*">
+      <Output TaskParameter="JoinResult" ItemName="BuiltSdkPackageOverride" />
+    </JoinItems>
+  </Target>
+
   <Target Name="ExtractToolPackageCore"
           DependsOnTargets="RepoBuild;$(ExtractToolPackageDependsOn)"
           Condition="'@(BuiltSdkPackageOverride)' != ''"

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -580,7 +580,7 @@
     </JoinItems>
   </Target>
 
-  <Target Name="ExtractToolPackage"
+  <Target Name="ExtractToolPackageCore"
           DependsOnTargets="RepoBuild;DiscoverToolPackageVersions"
           Condition="'@(BuiltSdkPackageOverride)' != ''"
           Inputs="$(MSBuildProjectFullPath)"

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -271,7 +271,7 @@
     </PropertyGroup>
 
     <!-- Write the build input properties, then save off a copy that will be used for generating usage reports later -->
-    <WritePackageVersionsProps KnownPackages="@(_DependencyProducedPackage)"
+    <WritePackageVersionsProps KnownPackages="@(_DependencyProducedPackage->WithMetadataValue('ReferenceOnly', 'false'))"
                                ExtraProperties="@(ExtraPackageVersionPropsPackageInfo)"
                                VersionPropsFlowType="$(PackageVersionPropsFlowType)"
                                VersionDetails="$(_VersionDetailsXml)"
@@ -292,7 +292,7 @@
          A B and C.
 
          A key element of this algorith is that we must write the full package version props and not the filtered version. -->
-    <WritePackageVersionsProps KnownPackages="@(_DependencyProducedPackage)"
+    <WritePackageVersionsProps KnownPackages="@(_DependencyProducedPackage->WithMetadataValue('ReferenceOnly', 'false'))"
                                VersionPropsFlowType="AllPackages"
                                OutputPath="$(SnapshotPackageVersionPropsPath)" />
 
@@ -478,7 +478,7 @@
     </XmlPeek>
 
     <ItemGroup>
-      <ProducedPackage Include="$(ProducedPackageId)" Version="$(ProducedPackageVersion)" />
+      <ProducedPackage Include="$(ProducedPackageId)" Version="$(ProducedPackageVersion)" ReferenceOnly="$([MSBuild]::ValueOrDefault('$(ReferenceOnlyRepoArtifacts)', 'false'))" />
     </ItemGroup>
   </Target>
 

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -286,7 +286,12 @@
     <WritePackageVersionsProps NuGetPackages="@(_PreviouslyBuiltSourceBuiltPackages)"
                                VersionPropsFlowType="$(PackageVersionPropsFlowType)"
                                VersionDetails="$(_VersionDetailsXml)"
-                               OutputPath="$(PreviouslySourceBuiltPackageVersionPropsPath)" />
+                               OutputPath="$(PreviouslySourceBuiltPackageVersionPropsPath)"
+                               Condition="@(_PreviouslyBuiltSourceBuiltPackages->Count()) != 0" />
+
+    <WriteLinesToFile File="$(CurrentSourceBuiltPackageVersionPropsPath)"
+                      Lines="&lt;Project&gt;&lt;/Project&gt;" 
+                      Condition="@(_PreviouslyBuiltSourceBuiltPackages->Count()) == 0" />
 
     <!-- Write a full package version props (unfiltered) that will be used to track which repo creates a package.
          Because not all repos implement the repo API (e.g. some are external), it's difficult to consistently gather

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -337,22 +337,30 @@
              RunEachTargetSeparately="$(RunEachTargetSeparately)" />
   </Target>
 
-  <!-- Discover the Arcade SDKs built from the live Arcade source and set them as overrides here. -->
-  <Target Name="DiscoverArcadeSourceBuiltSdkOverrides"
-          DependsOnTargets="BuildRepoReferences;GetProducedPackagesFromTransitiveReferences"
-          Condition="'$(UseBootstrapArcade)' != 'true'">
+  <Target Name="DiscoverBuiltSdkOverrides"
+          DependsOnTargets="BuildRepoReferences;GetProducedPackagesFromTransitiveReferences">
+
+    <!--
+      Discover the Arcade SDKs built from the live Arcade source and set them as overrides here.
+      This will automatically no-op for Arcade and SBRP, as these packages will not have been produced yet.
+    -->
     <ItemGroup>
-      <SourceBuiltSdkOverride Include="@(_DependencyProducedPackage->WithMetadataValue('Identity', 'Microsoft.DotNet.Arcade.Sdk'))" Group="ARCADE" />
+      <ArcadeBuiltArcadeSdk Include="@(_DependencyProducedPackage->WithMetadataValue('Identity', 'Microsoft.DotNet.Arcade.Sdk'))" />
+    </ItemGroup>
+
+    <Error Text="The source-built Arcade SDK should be available for any repository that does not explicitly set UseBootstrapArcade to true." Condition="'@(ArcadeBuiltArcadeSdk)' == '' and '$(UseBootstrapArcade)' != 'true'" />
+
+    <ItemGroup Condition="'@(ArcadeBuiltArcadeSdk)' == ''">
+      <SourceBuiltSdkOverride Include="@(BootstrapArcadeSdkOverride)" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <SourceBuiltSdkOverride Include="@(ArcadeBuiltArcadeSdk)" Group="ARCADE" />
       <SourceBuiltSdkOverride Include="@(_DependencyProducedPackage->WithMetadataValue('Identity', 'Microsoft.DotNet.SharedFramework.Sdk'))" Group="ARCADE_SHARED_FX_SDK" />
       <SourceBuiltSdkOverride Include="@(_DependencyProducedPackage->WithMetadataValue('Identity', 'Microsoft.DotNet.CMake.Sdk'))" Group="ARCADE_CMAKE_SDK" />
     </ItemGroup>
-  </Target>
-
-  <Target Name="DiscoverReferencePackageBuiltSdkOverrides"
-          DependsOnTargets="BuildRepoReferences;GetProducedPackagesFromTransitiveReferences"
-          Condition="'$(UseBootstrapSdks)' != 'true'">
     <!--
-      Add Microsoft.Build.NoTargets and Microsoft.Build.Traversal SDK overrides, for all repos (except the one that builds this one, which opts out).
+      Add Microsoft.Build.NoTargets and Microsoft.Build.Traversal SDK overrides, for all repos that have it built (ie. excluding SBRP as it builds the SDKs).
 
       We need to override all SDK packages that are used by repos, to prevent NuGet SDK Resolver from trying to
       restore these packages from online feeds. In offline build we only want to use local source-build feeds.
@@ -367,7 +375,7 @@
   </Target>
 
   <Target Name="SetSourceBuiltSdkOverrides"
-          DependsOnTargets="DiscoverArcadeSourceBuiltSdkOverrides;DiscoverReferencePackageBuiltSdkOverrides"
+          DependsOnTargets="DiscoverBuiltSdkOverrides"
           Condition="'@(SourceBuiltSdkOverride)' != ''">
     <ItemGroup>
       <!-- Set the environment variables for MSBuild to look for our additional SDK Resolvers and or our resolver to find our source-built SDKs. -->

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -384,8 +384,8 @@
       RestoreConfigFile property and uses NuGet.config file from repo's root which has online feeds.
     -->
     <ItemGroup>
-      <SourceBuiltSdkOverride Include="@(_DependencyProducedPackage->WithMetadataValue('Identity', 'Microsoft.Build.Traversal')" Group="TRAVERSAL" />
-      <SourceBuiltSdkOverride Include="@(_DependencyProducedPackage->WithMetadataValue('Identity', 'Microsoft.Build.NoTargets')" Group="NOTARGETS" />
+      <SourceBuiltSdkOverride Include="@(_DependencyProducedPackage->WithMetadataValue('Identity', 'Microsoft.Build.Traversal'))" Group="TRAVERSAL" />
+      <SourceBuiltSdkOverride Include="@(_DependencyProducedPackage->WithMetadataValue('Identity', 'Microsoft.Build.NoTargets'))" Group="NOTARGETS" />
     </ItemGroup>
   </Target>
 

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -342,21 +342,9 @@
           DependsOnTargets="BuildRepoReferences;GetProducedPackagesFromTransitiveReferences"
           Condition="'$(UseBootstrapArcade)' != 'true'">
     <ItemGroup>
-      <_BuiltArcadeSdkPackage Include="@(_DependencyProducedPackage->WithMetadataValue('Identity', 'Microsoft.DotNet.Arcade.Sdk'))" />
-    </ItemGroup>
-
-    <PropertyGroup>
-      <_BuiltArcadeSdkPackageVersion>@(_BuiltArcadeSdkPackage->MetadataValue('Version'))</_BuiltArcadeSdkPackageVersion>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <SourceBuiltSdkOverride Include="Microsoft.DotNet.Arcade.Sdk" Group="ARCADE" Version="$(_BuiltArcadeSdkPackageVersion)" />
-      <SourceBuiltSdkOverride Include="Microsoft.DotNet.SharedFramework.Sdk" Group="ARCADE_SHARED_FX_SDK" Version="$(_BuiltArcadeSdkPackageVersion)" />
-      <SourceBuiltSdkOverride Include="Microsoft.DotNet.CMake.Sdk" Group="ARCADE_CMAKE_SDK" Version="$(_BuiltArcadeSdkPackageVersion)" />
-  
-      <SourceBuiltSdkOverride Include="@(ArcadeSdkOverride)" />
-      <SourceBuiltSdkOverride Include="@(ArcadeCMakeSdkOverride)" />
-      <SourceBuiltSdkOverride Include="@(ArcadeSharedFrameworkSdkOverride)" />
+      <SourceBuiltSdkOverride Include="@(_DependencyProducedPackage->WithMetadataValue('Identity', 'Microsoft.DotNet.Arcade.Sdk'))" Group="ARCADE" />
+      <SourceBuiltSdkOverride Include="@(_DependencyProducedPackage->WithMetadataValue('Identity', 'Microsoft.DotNet.SharedFramework.Sdk'))" Group="ARCADE_SHARED_FX_SDK" />
+      <SourceBuiltSdkOverride Include="@(_DependencyProducedPackage->WithMetadataValue('Identity', 'Microsoft.DotNet.CMake.Sdk'))" Group="ARCADE_CMAKE_SDK" />
     </ItemGroup>
   </Target>
 

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -275,23 +275,13 @@
                                ExtraProperties="@(ExtraPackageVersionPropsPackageInfo)"
                                VersionPropsFlowType="$(PackageVersionPropsFlowType)"
                                VersionDetails="$(_VersionDetailsXml)"
-                               OutputPath="$(CurrentSourceBuiltPackageVersionPropsPath)"
-                               Condition="@(_DependencyProducedPackage->Count()) != 0" />
-    
-    <WriteLinesToFile File="$(CurrentSourceBuiltPackageVersionPropsPath)"
-                      Lines="&lt;Project&gt;&lt;/Project&gt;" 
-                      Condition="@(_DependencyProducedPackage->Count()) == 0" />
+                               OutputPath="$(CurrentSourceBuiltPackageVersionPropsPath)" />
 
     <!-- Create previously source-built inputs info -->
     <WritePackageVersionsProps NuGetPackages="@(_PreviouslyBuiltSourceBuiltPackages)"
                                VersionPropsFlowType="$(PackageVersionPropsFlowType)"
                                VersionDetails="$(_VersionDetailsXml)"
-                               OutputPath="$(PreviouslySourceBuiltPackageVersionPropsPath)"
-                               Condition="@(_PreviouslyBuiltSourceBuiltPackages->Count()) != 0" />
-
-    <WriteLinesToFile File="$(PreviouslySourceBuiltPackageVersionPropsPath)"
-                      Lines="&lt;Project&gt;&lt;/Project&gt;" 
-                      Condition="@(_PreviouslyBuiltSourceBuiltPackages->Count()) == 0" />
+                               OutputPath="$(PreviouslySourceBuiltPackageVersionPropsPath)" />
 
     <!-- Write a full package version props (unfiltered) that will be used to track which repo creates a package.
          Because not all repos implement the repo API (e.g. some are external), it's difficult to consistently gather
@@ -304,8 +294,7 @@
          A key element of this algorith is that we must write the full package version props and not the filtered version. -->
     <WritePackageVersionsProps KnownPackages="@(_DependencyProducedPackage)"
                                VersionPropsFlowType="AllPackages"
-                               OutputPath="$(SnapshotPackageVersionPropsPath)"
-                               Condition="@(_DependencyProducedPackage->Count()) != 0" />
+                               OutputPath="$(SnapshotPackageVersionPropsPath)" />
 
     <!-- Write a single file that contains imports for both the current and previously built packages -->
     <PropertyGroup>

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -36,7 +36,7 @@
   </PropertyGroup>
 
   <!-- Returns the repository references of this project and all the projects this project references, recursively -->
-  <Target Name="GetTransitiveRepositoryReferences" Outputs="@(TransitiveRepositoryReference)">
+  <Target Name="GetTransitiveRepositoryReferences" Returns="@(TransitiveRepositoryReference)">
     <ItemGroup>
       <_TransitiveRepositoryReference Include="@(RepositoryReference)" />
     </ItemGroup>
@@ -742,7 +742,7 @@
   <!-- Recursively walks the repo dependency graph gathering each repo's dependencies which are returned as a YAML string representation -->
   <Target Name="GetDependencyGraphString"
           DependsOnTargets="GetTransitiveRepositoryReferences"
-          Outputs="$(DependencyGraphString)">
+          Returns="$(DependencyGraphString)">
     <PropertyGroup>
       <!-- Each step deeper in the graph builds up the indentation used for the YAML representation.
            Use '_' as a placeholder for the space ' ' character since trailing spaces aren't handled well as property values. -->

--- a/src/SourceBuild/content/repo-projects/arcade.proj
+++ b/src/SourceBuild/content/repo-projects/arcade.proj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <!-- Use a prebuilt Arcade to build Arcade -->
     <UseBootstrapArcade>true</UseBootstrapArcade>
+    <ExtractToolPackageDependsOn>_DiscoverToolPackages</ExtractToolPackageDependsOn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,13 +11,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <BuiltSdkPackageOverride Include="Microsoft.DotNet.Arcade.Sdk" Version="$(OutputPackageVersion)" />
-    <BuiltSdkPackageOverride Include="Microsoft.DotNet.SharedFramework.Sdk" Version="$(OutputPackageVersion)" />
-    <BuiltSdkPackageOverride Include="Microsoft.DotNet.CMake.Sdk" Version="$(OutputPackageVersion)" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ExtraPackageVersionPropsPackageInfo Include="NuGetVersion" Version="%24(NuGetPackagingVersion)" />
   </ItemGroup>
 
+  <Target Name="_DiscoverToolPackages" 
+          DependsOnTargets="RepoBuild;GetProducedPackages">
+    <ItemGroup>
+      <BuiltSdkPackageOverride Include="@(ProducedPackage->WithMetadataValue('Identity', 'Microsoft.DotNet.Arcade.Sdk'))" />
+      <BuiltSdkPackageOverride Include="@(ProducedPackage->WithMetadataValue('Identity', 'Microsoft.DotNet.SharedFramework.Sdk'))" />
+      <BuiltSdkPackageOverride Include="@(ProducedPackage->WithMetadataValue('Identity', 'Microsoft.DotNet.CMake.Sdk'))" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/SourceBuild/content/repo-projects/arcade.proj
+++ b/src/SourceBuild/content/repo-projects/arcade.proj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <!-- Use a prebuilt Arcade to build Arcade -->
     <UseBootstrapArcade>true</UseBootstrapArcade>
-    <ExtractToolPackageDependsOn>_DiscoverToolPackages</ExtractToolPackageDependsOn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,12 +13,9 @@
     <ExtraPackageVersionPropsPackageInfo Include="NuGetVersion" Version="%24(NuGetPackagingVersion)" />
   </ItemGroup>
 
-  <Target Name="_DiscoverToolPackages" 
-          DependsOnTargets="RepoBuild;GetProducedPackages">
-    <ItemGroup>
-      <BuiltSdkPackageOverride Include="@(ProducedPackage->WithMetadataValue('Identity', 'Microsoft.DotNet.Arcade.Sdk'))" />
-      <BuiltSdkPackageOverride Include="@(ProducedPackage->WithMetadataValue('Identity', 'Microsoft.DotNet.SharedFramework.Sdk'))" />
-      <BuiltSdkPackageOverride Include="@(ProducedPackage->WithMetadataValue('Identity', 'Microsoft.DotNet.CMake.Sdk'))" />
-    </ItemGroup>
-  </Target>
+  <ItemGroup>
+    <BuiltSdkPackage Include="Microsoft.DotNet.Arcade.Sdk" />
+    <BuiltSdkPackage Include="Microsoft.DotNet.SharedFramework.Sdk" />
+    <BuiltSdkPackage Include="Microsoft.DotNet.CMake.Sdk" />
+  </ItemGroup>
 </Project>

--- a/src/SourceBuild/content/repo-projects/source-build-reference-packages.proj
+++ b/src/SourceBuild/content/repo-projects/source-build-reference-packages.proj
@@ -8,9 +8,6 @@
     <!-- SBRP builds before Arcade so it also needs the bootstrap Arcade version -->
     <UseBootstrapArcade>true</UseBootstrapArcade>
 
-    <!-- SBRP builds the reference SDKs so it needs the bootstrap SDK versions -->
-    <UseBootstrapSdks>true</UseBootstrapSdks>
-
     <LocalNuGetPackageCacheDirectory>$(ArtifactsObjDir)source-build-reference-package-cache</LocalNuGetPackageCacheDirectory>
 
     <BuildArgs>$(BuildArgs) /p:MicrosoftNetCoreIlasmPackageRuntimeId=$(NETCoreSdkRuntimeIdentifier)</BuildArgs>

--- a/src/SourceBuild/content/repo-projects/source-build-reference-packages.proj
+++ b/src/SourceBuild/content/repo-projects/source-build-reference-packages.proj
@@ -8,16 +8,24 @@
     <!-- SBRP builds before Arcade so it also needs the bootstrap Arcade version -->
     <UseBootstrapArcade>true</UseBootstrapArcade>
 
+    <!-- SBRP builds the reference SDKs so it needs the bootstrap SDK versions -->
+    <UseBootstrapSdks>true</UseBootstrapSdks>
+    
+    <ExtractToolPackageDependsOn>_DiscoverToolPackages</ExtractToolPackageDependsOn>
+
     <LocalNuGetPackageCacheDirectory>$(ArtifactsObjDir)source-build-reference-package-cache</LocalNuGetPackageCacheDirectory>
 
     <BuildArgs>$(BuildArgs) /p:MicrosoftNetCoreIlasmPackageRuntimeId=$(NETCoreSdkRuntimeIdentifier)</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:LocalNuGetPackageCacheDirectory=$(LocalNuGetPackageCacheDirectory)</BuildArgs>
   </PropertyGroup>
-
-  <ItemGroup>
-    <BuiltSdkPackageOverride Include="@(NoTargetsSdkOverride)" />
-    <BuiltSdkPackageOverride Include="@(TraversalSdkOverride)" />
-  </ItemGroup>
+  
+  <Target Name="_DiscoverToolPackages" 
+          DependsOnTargets="RepoBuild;GetProducedPackages">
+    <ItemGroup>
+      <BuiltSdkPackageOverride Include="@(ProducedPackage->WithMetadataValue('Identity', 'Microsoft.Build.NoTargets'))" />
+      <BuiltSdkPackageOverride Include="@(ProducedPackage->WithMetadataValue('Identity', 'Microsoft.Build.Traversal'))" />
+    </ItemGroup>
+  </Target>
 
   <Target Name="AddLocalNuGetPackageCacheDirectory"
           AfterTargets="CopyNuGetConfig"

--- a/src/SourceBuild/content/repo-projects/source-build-reference-packages.proj
+++ b/src/SourceBuild/content/repo-projects/source-build-reference-packages.proj
@@ -10,22 +10,17 @@
 
     <!-- SBRP builds the reference SDKs so it needs the bootstrap SDK versions -->
     <UseBootstrapSdks>true</UseBootstrapSdks>
-    
-    <ExtractToolPackageDependsOn>_DiscoverToolPackages</ExtractToolPackageDependsOn>
 
     <LocalNuGetPackageCacheDirectory>$(ArtifactsObjDir)source-build-reference-package-cache</LocalNuGetPackageCacheDirectory>
 
     <BuildArgs>$(BuildArgs) /p:MicrosoftNetCoreIlasmPackageRuntimeId=$(NETCoreSdkRuntimeIdentifier)</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:LocalNuGetPackageCacheDirectory=$(LocalNuGetPackageCacheDirectory)</BuildArgs>
   </PropertyGroup>
-  
-  <Target Name="_DiscoverToolPackages" 
-          DependsOnTargets="RepoBuild;GetProducedPackages">
-    <ItemGroup>
-      <BuiltSdkPackageOverride Include="@(ProducedPackage->WithMetadataValue('Identity', 'Microsoft.Build.NoTargets'))" />
-      <BuiltSdkPackageOverride Include="@(ProducedPackage->WithMetadataValue('Identity', 'Microsoft.Build.Traversal'))" />
-    </ItemGroup>
-  </Target>
+
+  <ItemGroup>
+    <BuiltSdkPackage Include="Microsoft.Build.NoTargets" />
+    <BuiltSdkPackage Include="Microsoft.Build.Traversal" />
+  </ItemGroup>
 
   <Target Name="AddLocalNuGetPackageCacheDirectory"
           AfterTargets="CopyNuGetConfig"


### PR DESCRIPTION
This ensures that we will always consume the live versions of dependencies from the current build no matter version number changes.

Fixes dotnet/source-build#4302
Fixes dotnet/source-build#4297
