### PR TITLE
[VMR] Bump build timeout to account for slow Macs

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -100,7 +100,7 @@ jobs:
   ${{ if and(parameters.isBuiltFromVmr, startswith(parameters.buildName, 'Windows'), eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
     timeoutInMinutes: 720
   ${{ else }}:
-    timeoutInMinutes: 150
+    timeoutInMinutes: 240
 
   ${{ if ne(parameters.reuseBuildArtifactsFrom, '') }}:
     # Always attempt to run the bootstrap leg (e.g. even when stage 1 tests fail) in order to get a complete accessment of the build status.


### PR DESCRIPTION
The macOS runners available on public Azure Pipelines are quite slow and need more time to finish.
This mostly impacts `installer-unified-build-full` since we don't run macOS builds on the normal unified build PR pipeline.