### PR TITLE
Redo "NGEN Microsoft.DotNet.MSBuildSdkResolver.dll and its dependencies" for devenv only

### DIFF
--- a/src/core-sdk-tasks/GenerateMSBuildExtensionsSWR.cs
+++ b/src/core-sdk-tasks/GenerateMSBuildExtensionsSWR.cs
@@ -24,7 +24,8 @@ namespace Microsoft.DotNet.Cli.Build
 
             AddFolder(sb,
                       @"MSBuildSdkResolver",
-                      @"MSBuild\Current\Bin\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver");
+                      @"MSBuild\Current\Bin\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver",
+                      ngenAssemblies: true);
 
             AddFolder(sb,
                       @"msbuildExtensions",
@@ -39,7 +40,7 @@ namespace Microsoft.DotNet.Cli.Build
             return true;
         }
 
-        private void AddFolder(StringBuilder sb, string relativeSourcePath, string swrInstallDir)
+        private void AddFolder(StringBuilder sb, string relativeSourcePath, string swrInstallDir, bool ngenAssemblies = false)
         {
             string sourceFolder = Path.Combine(MSBuildExtensionsLayoutDirectory, relativeSourcePath);
             var files = Directory.GetFiles(sourceFolder)
@@ -55,7 +56,16 @@ namespace Microsoft.DotNet.Cli.Build
                 {
                     sb.Append(@"  file source=""$(PkgVS_Redist_Common_Net_Core_SDK_MSBuildExtensions)\");
                     sb.Append(Path.Combine(relativeSourcePath, Path.GetFileName(file)));
-                    sb.AppendLine("\"");
+                    sb.Append('"');
+
+                    if (ngenAssemblies && file.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                    {
+                        sb.Append(@" vs.file.ngenApplications=""[installDir]\Common7\IDE\vsn.exe""");
+                        sb.Append(@" vs.file.ngenApplications=""[installDir]\MSBuild\Current\Bin\MSBuild.exe""");
+                        sb.Append(" vs.file.ngenArchitecture=all");
+                    }
+
+                    sb.AppendLine();
                 }
 
                 sb.AppendLine();
@@ -67,6 +77,7 @@ namespace Microsoft.DotNet.Cli.Build
                 string newRelativeSourcePath = Path.Combine(relativeSourcePath, subfolderName);
                 string newSwrInstallDir = Path.Combine(swrInstallDir, subfolderName);
 
+                // Don't propagate ngenAssemblies to subdirectories.
                 AddFolder(sb, newRelativeSourcePath, newSwrInstallDir);
             }
         }

--- a/src/core-sdk-tasks/GenerateMSBuildExtensionsSWR.cs
+++ b/src/core-sdk-tasks/GenerateMSBuildExtensionsSWR.cs
@@ -61,8 +61,6 @@ namespace Microsoft.DotNet.Cli.Build
                     if (ngenAssemblies && file.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
                     {
                         sb.Append(@" vs.file.ngenApplications=""[installDir]\Common7\IDE\vsn.exe""");
-                        sb.Append(@" vs.file.ngenApplications=""[installDir]\MSBuild\Current\Bin\MSBuild.exe""");
-                        sb.Append(" vs.file.ngenArchitecture=all");
                     }
 
                     sb.AppendLine();


### PR DESCRIPTION
Fixes: [AB#2014670](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2014670)

### Description

A change was made in 8.0.2xx to register MSBuildSdkResolver for NGEN (#17732), against both devenv.exe and MSBuild.exe. Later a bug was found in the way MSBuild.exe loads the resolver so the change was reverted in 8.0.3xx (#19112). However, because the change had a measurable positive perf effect, the revert was effectively a regression for devenv.exe and got flagged so by PerfDDRITs.

This PR is a re-do of the original change, only this time with MSBuild.exe omitted, i.e. we're NGENing the resolver only for the default architecture of devenv.exe.

### Customer Impact

Startup perf regression, about 5% more methods JITted in scenarios measured by Visual Studio PerfDDRITs.

### Regression

Yes, perf regression in VS 17.10.

### Risk 

Low