### PR TITLE
Build the SourceBuilt tarball in the publish job and include the merged vertical manifest in it.

### DIFF
--- a/src/SourceBuild/content/Directory.Build.props
+++ b/src/SourceBuild/content/Directory.Build.props
@@ -189,4 +189,8 @@
     <PoisonUsageReportFile>$(PackageReportDir)poison-usage.xml</PoisonUsageReportFile>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <MergedAssetManifestOutputPath>$(ArtifactsDir)VerticalManifest.xml</MergedAssetManifestOutputPath>
+  </PropertyGroup>
+
 </Project>

--- a/src/SourceBuild/content/eng/finish-source-only.proj
+++ b/src/SourceBuild/content/eng/finish-source-only.proj
@@ -203,7 +203,7 @@
   <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.WritePackageVersionsProps" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
   <Target Name="CreatePrivateSourceBuiltArtifactsArchive"
           AfterTargets="Build"
-          DependsOnTargets="GetInputsOutputForCreatePrivateSourceBuiltArtifactsArchive;MergeAssetManifests"
+          DependsOnTargets="GetInputsOutputForCreatePrivateSourceBuiltArtifactsArchive"
           Inputs="@(ArtifactsPackageToBundle);@(ReferencePackageToBundle);$(MergedAssetManifestOutputPath)"
           Outputs="$(SourceBuiltTarballName);$(SourceBuiltVersionName);$(AllPackageVersionsPropsName);$(SourceBuiltMergedAssetManifestName)">
     <!-- Copy packages to layout directory. Since there are a large number of files,

--- a/src/SourceBuild/content/eng/finish-source-only.proj
+++ b/src/SourceBuild/content/eng/finish-source-only.proj
@@ -229,6 +229,14 @@
           DestinationFolder="$(SourceBuiltLayoutDir)"
           UseSymbolicLinksIfPossible="true" />
 
+    <!-- non-rid-specific versions of RID-specific version variables to use for bootstrapping -->
+    <ItemGroup>
+      <ExtraPackageVersionPropsPackageInfo Include="MicrosoftNETCoreAppRuntimeVersion" Version="%24(MicrosoftNETCoreAppRefPackageVersion)" />
+      <ExtraPackageVersionPropsPackageInfo Include="MicrosoftNETCoreAppHostPackageVersion" Version="%24(MicrosoftNETCoreAppRefPackageVersion)" />
+      <ExtraPackageVersionPropsPackageInfo Include="MicrosoftAspNetCoreAppRuntimeVersion" Version="%24(MicrosoftAspNetCoreAppRefPackageVersion)" />
+      <ExtraPackageVersionPropsPackageInfo Include="MicrosoftNETCoreAppCrossgen2Version" Version="%24(MicrosoftNETCoreAppRefPackageVersion)" />  
+    </ItemGroup>
+
     <!-- Create a PackageVersions.props file that includes entries for all packages. -->
     <WritePackageVersionsProps NuGetPackages="@(ArtifactsPackageToBundle)"
                                 ExtraProperties="@(ExtraPackageVersionPropsPackageInfo)"

--- a/src/SourceBuild/content/eng/finish-source-only.proj
+++ b/src/SourceBuild/content/eng/finish-source-only.proj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="$(TasksDir)Microsoft.DotNet.UnifiedBuild.Tasks\Microsoft.DotNet.UnifiedBuild.Tasks.csproj" />
     <ProjectReference Include="$(TasksDir)Microsoft.DotNet.SourceBuild.Tasks.LeakDetection\Microsoft.DotNet.SourceBuild.Tasks.LeakDetection.csproj" />
-    <ProjectReference Include="$(RepositoryEngineeringDir)publish.proj" Targets="Build;GetMergedManifestPath" OutputItemType="MergedAssetManifest" />
+    <ProjectReference Include="$(RepositoryEngineeringDir)publish.proj" />
   </ItemGroup>
 
   <!-- After building, generate a prebuilt usage report. -->
@@ -185,6 +185,7 @@
                                 Condition="!$([System.String]::Copy('%(Identity)').EndsWith('.symbols.nupkg'))" />
       <ReferencePackageToBundle Include="$(ReferencePackagesDir)**"
                                 Condition="!$([System.String]::Copy('%(Identity)').EndsWith('.symbols.nupkg'))" />
+      <MergedAssetManifest Include="$(MergedAssetManifestOutputPath)" />
     </ItemGroup>
 
     <PropertyGroup>
@@ -204,7 +205,7 @@
   <Target Name="CreatePrivateSourceBuiltArtifactsArchive"
           AfterTargets="Build"
           DependsOnTargets="GetInputsOutputForCreatePrivateSourceBuiltArtifactsArchive"
-          Inputs="@(ArtifactsPackageToBundle);@(ReferencePackageToBundle);$(MergedAssetManifestOutputPath)"
+          Inputs="@(ArtifactsPackageToBundle);@(ReferencePackageToBundle);@(MergedAssetManifest)"
           Outputs="$(SourceBuiltTarballName);$(SourceBuiltVersionName);$(AllPackageVersionsPropsName);$(SourceBuiltMergedAssetManifestName)">
     <!-- Copy packages to layout directory. Since there are a large number of files,
           this will use symlinks instead of copying files to make this execute quickly. -->
@@ -239,9 +240,9 @@
 
     <!-- Create a PackageVersions.props file that includes entries for all packages. -->
     <WritePackageVersionsProps NuGetPackages="@(ArtifactsPackageToBundle)"
-                                ExtraProperties="@(ExtraPackageVersionPropsPackageInfo)"
-                                VersionPropsFlowType="AllPackages"
-                                OutputPath="$(AllPackageVersionsPropsName)" />
+                               ExtraProperties="@(ExtraPackageVersionPropsPackageInfo)"
+                               VersionPropsFlowType="AllPackages"
+                               OutputPath="$(AllPackageVersionsPropsName)" />
 
     <Exec Command="tar --numeric-owner -czhf $(SourceBuiltTarballName) $([System.IO.Path]::GetFileName('$(SourceBuiltVersionName)')) *"
           WorkingDirectory="$(SourceBuiltLayoutDir)" />

--- a/src/SourceBuild/content/eng/finish-source-only.proj
+++ b/src/SourceBuild/content/eng/finish-source-only.proj
@@ -2,12 +2,15 @@
 <Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
+    <!-- Need to set to false to calculate RepositoryCommit. -->
+    <EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
     <TargetFramework>$(NetCurrent)</TargetFramework>
   </PropertyGroup>
   
   <ItemGroup>
     <ProjectReference Include="$(TasksDir)Microsoft.DotNet.UnifiedBuild.Tasks\Microsoft.DotNet.UnifiedBuild.Tasks.csproj" />
     <ProjectReference Include="$(TasksDir)Microsoft.DotNet.SourceBuild.Tasks.LeakDetection\Microsoft.DotNet.SourceBuild.Tasks.LeakDetection.csproj" />
+    <ProjectReference Include="$(RepositoryEngineeringDir)publish.proj" Targets="Build;GetMergedManifestPath" OutputItemType="MergedAssetManifest" />
   </ItemGroup>
 
   <!-- After building, generate a prebuilt usage report. -->
@@ -170,6 +173,73 @@
   <Target Name="ErrorOnPrebuilts"
           Condition="'@(PrebuiltFile)' != '' and '$(SkipErrorOnPrebuilts)' != 'true'">
     <Error Text="@(PrebuiltFile->Count()) Prebuilts Exist" />
+  </Target>
+
+  
+  <Target Name="GetInputsOutputForCreatePrivateSourceBuiltArtifactsArchive"
+          DependsOnTargets="DetermineSourceBuiltSdkVersion;ResolveProjectReferences">
+    <!-- Inputs: Packages to include in the tarball -->
+    <ItemGroup>
+      <ArtifactsPackageToBundle Include="$(ArtifactsShippingPackagesDir)**;
+                                          $(ArtifactsNonShippingPackagesDir)**"
+                                Condition="!$([System.String]::Copy('%(Identity)').EndsWith('.symbols.nupkg'))" />
+      <ReferencePackageToBundle Include="$(ReferencePackagesDir)**"
+                                Condition="!$([System.String]::Copy('%(Identity)').EndsWith('.symbols.nupkg'))" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <!-- Create a layout directory for the files that are to be included in the artifacts tarball. -->
+      <SourceBuiltLayoutDir>$([MSBuild]::NormalizeDirectory('$(BaseIntermediateOutputPath)', 'artifacts-layout'))</SourceBuiltLayoutDir>
+
+      <!-- Outputs -->
+      <SourceBuiltTarballName>$(ArtifactsAssetsDir)$(SourceBuiltArtifactsTarballName).$(SourceBuiltSdkVersion).$(TargetRid)$(ArchiveExtension)</SourceBuiltTarballName>
+      <SourceBuiltVersionName>$(SourceBuiltLayoutDir).version</SourceBuiltVersionName>
+      <AllPackageVersionsPropsName>$(SourceBuiltLayoutDir)PackageVersions.props</AllPackageVersionsPropsName>
+      <SourceBuiltMergedAssetManifestName>$(SourceBuiltLayoutDir)%(MergedAssetManifest.Filename)%(MergedAssetManifest.Extension)</SourceBuiltMergedAssetManifestName>
+    </PropertyGroup>
+  </Target>
+
+  <!-- Create the SourceBuilt.Private.Artifacts archive when building source-only. -->
+  <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.WritePackageVersionsProps" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
+  <Target Name="CreatePrivateSourceBuiltArtifactsArchive"
+          AfterTargets="Build"
+          DependsOnTargets="GetInputsOutputForCreatePrivateSourceBuiltArtifactsArchive;MergeAssetManifests"
+          Inputs="@(ArtifactsPackageToBundle);@(ReferencePackageToBundle);$(MergedAssetManifestOutputPath)"
+          Outputs="$(SourceBuiltTarballName);$(SourceBuiltVersionName);$(AllPackageVersionsPropsName);$(SourceBuiltMergedAssetManifestName)"
+          Condition="'$(DotNetBuildSourceOnly)' == 'true'">
+    <!-- Copy packages to layout directory. Since there are a large number of files,
+          this will use symlinks instead of copying files to make this execute quickly. -->
+    <Copy SourceFiles="@(ArtifactsPackageToBundle)"
+          DestinationFolder="$(SourceBuiltLayoutDir)"
+          UseSymbolicLinksIfPossible="true" />
+    <Copy SourceFiles="@(ReferencePackageToBundle)"
+          DestinationFolder="$(SourceBuiltLayoutDir)SourceBuildReferencePackages"
+          UseSymbolicLinksIfPossible="true" />
+
+    <!-- Content of the .version file to include in the tarball -->
+    <ItemGroup>
+      <VersionFileContent Include="$(RepositoryCommit);$(SourceBuiltSdkVersion)" />
+    </ItemGroup>
+
+    <WriteLinesToFile File="$(SourceBuiltVersionName)"
+                      Lines="@(VersionFileContent)"
+                      Overwrite="true" />
+
+    <!-- Copy the merged asset manifest into the tarball -->
+    <Copy SourceFiles="$(MergedAssetManifestOutputPath)"
+          DestinationFolder="$(SourceBuiltLayoutDir)"
+          UseSymbolicLinksIfPossible="true" />
+
+    <!-- Create a PackageVersions.props file that includes entries for all packages. -->
+    <WritePackageVersionsProps NuGetPackages="@(ArtifactsPackageToBundle)"
+                                ExtraProperties="@(ExtraPackageVersionPropsPackageInfo)"
+                                VersionPropsFlowType="AllPackages"
+                                OutputPath="$(AllPackageVersionsPropsName)" />
+
+    <Exec Command="tar --numeric-owner -czhf $(SourceBuiltTarballName) $([System.IO.Path]::GetFileName('$(SourceBuiltVersionName)')) *"
+          WorkingDirectory="$(SourceBuiltLayoutDir)" />
+
+    <Message Importance="High" Text="Packaged source-built artifacts to $(SourceBuiltTarballName)" />
   </Target>
 
 </Project>

--- a/src/SourceBuild/content/eng/finish-source-only.proj
+++ b/src/SourceBuild/content/eng/finish-source-only.proj
@@ -205,8 +205,7 @@
           AfterTargets="Build"
           DependsOnTargets="GetInputsOutputForCreatePrivateSourceBuiltArtifactsArchive;MergeAssetManifests"
           Inputs="@(ArtifactsPackageToBundle);@(ReferencePackageToBundle);$(MergedAssetManifestOutputPath)"
-          Outputs="$(SourceBuiltTarballName);$(SourceBuiltVersionName);$(AllPackageVersionsPropsName);$(SourceBuiltMergedAssetManifestName)"
-          Condition="'$(DotNetBuildSourceOnly)' == 'true'">
+          Outputs="$(SourceBuiltTarballName);$(SourceBuiltVersionName);$(AllPackageVersionsPropsName);$(SourceBuiltMergedAssetManifestName)">
     <!-- Copy packages to layout directory. Since there are a large number of files,
           this will use symlinks instead of copying files to make this execute quickly. -->
     <Copy SourceFiles="@(ArtifactsPackageToBundle)"

--- a/src/SourceBuild/content/eng/publish.proj
+++ b/src/SourceBuild/content/eng/publish.proj
@@ -1,10 +1,8 @@
 <Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
-    <!-- Need to set to false to calculate RepositoryCommit. -->
-    <EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
     <TargetFramework>$(NetCurrent)</TargetFramework>
-    <VerticalManifestFileName>VerticalManifest.xml</VerticalManifestFileName>
+    <MergedAssetManifestOutputPath>$(ArtifactsDir)VerticalManifest.xml</MergedAssetManifestOutputPath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,9 +12,6 @@
   <!-- Create a merge manifest from the individual repository manifest files. -->
   <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.MergeAssetManifests" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
   <Target Name="MergeAssetManifests" AfterTargets="Build">
-    <PropertyGroup>
-      <MergedAssetManifestOutputPath>$(ArtifactsDir)$(VerticalManifestFileName)</MergedAssetManifestOutputPath>
-    </PropertyGroup>
 
     <ItemGroup>
       <RepoAssetManifest Include="$(AssetManifestsIntermediateDir)\**\*.xml" />
@@ -29,70 +24,5 @@
       VmrBuildNumber="$(BUILD_BUILDNUMBER)" />
   </Target>
   
-  <Target Name="GetInputsOutputForCreatePrivateSourceBuiltArtifactsArchive"
-          DependsOnTargets="DetermineSourceBuiltSdkVersion">
-    <!-- Inputs: Packages to include in the tarball -->
-    <ItemGroup>
-      <ArtifactsPackageToBundle Include="$(ArtifactsShippingPackagesDir)**;
-                                         $(ArtifactsNonShippingPackagesDir)**"
-                                Condition="!$([System.String]::Copy('%(Identity)').EndsWith('.symbols.nupkg'))" />
-      <ReferencePackageToBundle Include="$(ReferencePackagesDir)**"
-                                Condition="!$([System.String]::Copy('%(Identity)').EndsWith('.symbols.nupkg'))" />
-    </ItemGroup>
-
-    <PropertyGroup>
-      <!-- Create a layout directory for the files that are to be included in the artifacts tarball. -->
-      <SourceBuiltLayoutDir>$([MSBuild]::NormalizeDirectory('$(BaseIntermediateOutputPath)', 'artifacts-layout'))</SourceBuiltLayoutDir>
-
-      <!-- Outputs -->
-      <SourceBuiltTarballName>$(ArtifactsAssetsDir)$(SourceBuiltArtifactsTarballName).$(SourceBuiltSdkVersion).$(TargetRid)$(ArchiveExtension)</SourceBuiltTarballName>
-      <SourceBuiltVersionName>$(SourceBuiltLayoutDir).version</SourceBuiltVersionName>
-      <AllPackageVersionsPropsName>$(SourceBuiltLayoutDir)PackageVersions.props</AllPackageVersionsPropsName>
-      <SourceBuiltMergedAssetManifestName>$(SourceBuiltLayoutDir)$(VerticalManifestFileName)</SourceBuiltMergedAssetManifestName>
-    </PropertyGroup>
-  </Target>
-
-  <!-- Create the SourceBuilt.Private.Artifacts archive when building source-only. -->
-  <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.WritePackageVersionsProps" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
-  <Target Name="CreatePrivateSourceBuiltArtifactsArchive"
-          AfterTargets="Build"
-          DependsOnTargets="GetInputsOutputForCreatePrivateSourceBuiltArtifactsArchive;MergeAssetManifests"
-          Inputs="@(ArtifactsPackageToBundle);@(ReferencePackageToBundle);$(MergedAssetManifestOutputPath)"
-          Outputs="$(SourceBuiltTarballName);$(SourceBuiltVersionName);$(AllPackageVersionsPropsName);$(SourceBuiltMergedAssetManifestName)"
-          Condition="'$(DotNetBuildSourceOnly)' == 'true'">
-    <!-- Copy packages to layout directory. Since there are a large number of files,
-         this will use symlinks instead of copying files to make this execute quickly. -->
-    <Copy SourceFiles="@(ArtifactsPackageToBundle)"
-          DestinationFolder="$(SourceBuiltLayoutDir)"
-          UseSymbolicLinksIfPossible="true" />
-    <Copy SourceFiles="@(ReferencePackageToBundle)"
-          DestinationFolder="$(SourceBuiltLayoutDir)SourceBuildReferencePackages"
-          UseSymbolicLinksIfPossible="true" />
-
-    <!-- Content of the .version file to include in the tarball -->
-    <ItemGroup>
-      <VersionFileContent Include="$(RepositoryCommit);$(SourceBuiltSdkVersion)" />
-    </ItemGroup>
-
-    <WriteLinesToFile File="$(SourceBuiltVersionName)"
-                      Lines="@(VersionFileContent)"
-                      Overwrite="true" />
-
-    <!-- Copy the merged asset manifest into the tarball -->
-    <Copy SourceFiles="$(MergedAssetManifestOutputPath)"
-          DestinationFolder="$(SourceBuiltLayoutDir)"
-          UseSymbolicLinksIfPossible="true" />
-
-    <!-- Create a PackageVersions.props file that includes entries for all packages. -->
-    <WritePackageVersionsProps NuGetPackages="@(ArtifactsPackageToBundle)"
-                               ExtraProperties="@(ExtraPackageVersionPropsPackageInfo)"
-                               VersionPropsFlowType="AllPackages"
-                               OutputPath="$(AllPackageVersionsPropsName)" />
-
-    <Exec Command="tar --numeric-owner -czhf $(SourceBuiltTarballName) $([System.IO.Path]::GetFileName('$(SourceBuiltVersionName)')) *"
-          WorkingDirectory="$(SourceBuiltLayoutDir)" />
-
-    <Message Importance="High" Text="Packaged source-built artifacts to $(SourceBuiltTarballName)" />
-  </Target>
-
+  <Target Name="GetMergedManifestPath" DependsOnTargets="MergeAssetManifests" Returns="$(MergedAssetManifestOutputPath)" />
 </Project>

--- a/src/SourceBuild/content/eng/publish.proj
+++ b/src/SourceBuild/content/eng/publish.proj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
-    <MergedAssetManifestOutputPath>$(ArtifactsDir)VerticalManifest.xml</MergedAssetManifestOutputPath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,6 +22,4 @@
       MergedAssetManifestOutputPath="$(MergedAssetManifestOutputPath)"
       VmrBuildNumber="$(BUILD_BUILDNUMBER)" />
   </Target>
-  
-  <Target Name="GetMergedManifestPath" DependsOnTargets="MergeAssetManifests" Returns="$(MergedAssetManifestOutputPath)" />
 </Project>

--- a/src/SourceBuild/content/eng/publish.proj
+++ b/src/SourceBuild/content/eng/publish.proj
@@ -22,4 +22,5 @@
       MergedAssetManifestOutputPath="$(MergedAssetManifestOutputPath)"
       VmrBuildNumber="$(BUILD_BUILDNUMBER)" />
   </Target>
+
 </Project>

--- a/src/SourceBuild/content/eng/publish.proj
+++ b/src/SourceBuild/content/eng/publish.proj
@@ -53,6 +53,7 @@
   </Target>
 
   <!-- Create the SourceBuilt.Private.Artifacts archive when building source-only. -->
+  <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.WritePackageVersionsProps" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
   <Target Name="CreatePrivateSourceBuiltArtifactsArchive"
           AfterTargets="Build"
           DependsOnTargets="GetInputsOutputForCreatePrivateSourceBuiltArtifactsArchive;MergeAssetManifests"

--- a/src/SourceBuild/content/eng/publish.proj
+++ b/src/SourceBuild/content/eng/publish.proj
@@ -1,7 +1,10 @@
 <Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
+    <!-- Need to set to false to calculate RepositoryCommit. -->
+    <EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
     <TargetFramework>$(NetCurrent)</TargetFramework>
+    <VerticalManifestFileName>VerticalManifest.xml</VerticalManifestFileName>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,7 +15,7 @@
   <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.MergeAssetManifests" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
   <Target Name="MergeAssetManifests" AfterTargets="Build">
     <PropertyGroup>
-      <MergedAssetManifestOutputPath>$(ArtifactsDir)VerticalManifest.xml</MergedAssetManifestOutputPath>
+      <MergedAssetManifestOutputPath>$(ArtifactsDir)$(VerticalManifestFileName)</MergedAssetManifestOutputPath>
     </PropertyGroup>
 
     <ItemGroup>
@@ -24,6 +27,71 @@
       AssetManifest="@(RepoAssetManifest)" 
       MergedAssetManifestOutputPath="$(MergedAssetManifestOutputPath)"
       VmrBuildNumber="$(BUILD_BUILDNUMBER)" />
+  </Target>
+  
+  <Target Name="GetInputsOutputForCreatePrivateSourceBuiltArtifactsArchive"
+          DependsOnTargets="DetermineSourceBuiltSdkVersion">
+    <!-- Inputs: Packages to include in the tarball -->
+    <ItemGroup>
+      <ArtifactsPackageToBundle Include="$(ArtifactsShippingPackagesDir)**;
+                                         $(ArtifactsNonShippingPackagesDir)**"
+                                Condition="!$([System.String]::Copy('%(Identity)').EndsWith('.symbols.nupkg'))" />
+      <ReferencePackageToBundle Include="$(ReferencePackagesDir)**"
+                                Condition="!$([System.String]::Copy('%(Identity)').EndsWith('.symbols.nupkg'))" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <!-- Create a layout directory for the files that are to be included in the artifacts tarball. -->
+      <SourceBuiltLayoutDir>$([MSBuild]::NormalizeDirectory('$(BaseIntermediateOutputPath)', 'artifacts-layout'))</SourceBuiltLayoutDir>
+
+      <!-- Outputs -->
+      <SourceBuiltTarballName>$(ArtifactsAssetsDir)$(SourceBuiltArtifactsTarballName).$(SourceBuiltSdkVersion).$(TargetRid)$(ArchiveExtension)</SourceBuiltTarballName>
+      <SourceBuiltVersionName>$(SourceBuiltLayoutDir).version</SourceBuiltVersionName>
+      <AllPackageVersionsPropsName>$(SourceBuiltLayoutDir)PackageVersions.props</AllPackageVersionsPropsName>
+      <SourceBuiltMergedAssetManifestName>$(SourceBuiltLayoutDir)$(VerticalManifestFileName)</SourceBuiltMergedAssetManifestName>
+    </PropertyGroup>
+  </Target>
+
+  <!-- Create the SourceBuilt.Private.Artifacts archive when building source-only. -->
+  <Target Name="CreatePrivateSourceBuiltArtifactsArchive"
+          AfterTargets="Build"
+          DependsOnTargets="GetInputsOutputForCreatePrivateSourceBuiltArtifactsArchive;MergeAssetManifests"
+          Inputs="@(ArtifactsPackageToBundle);@(ReferencePackageToBundle);$(MergedAssetManifestOutputPath)"
+          Outputs="$(SourceBuiltTarballName);$(SourceBuiltVersionName);$(AllPackageVersionsPropsName);$(SourceBuiltMergedAssetManifestName)"
+          Condition="'$(DotNetBuildSourceOnly)' == 'true'">
+    <!-- Copy packages to layout directory. Since there are a large number of files,
+         this will use symlinks instead of copying files to make this execute quickly. -->
+    <Copy SourceFiles="@(ArtifactsPackageToBundle)"
+          DestinationFolder="$(SourceBuiltLayoutDir)"
+          UseSymbolicLinksIfPossible="true" />
+    <Copy SourceFiles="@(ReferencePackageToBundle)"
+          DestinationFolder="$(SourceBuiltLayoutDir)SourceBuildReferencePackages"
+          UseSymbolicLinksIfPossible="true" />
+
+    <!-- Content of the .version file to include in the tarball -->
+    <ItemGroup>
+      <VersionFileContent Include="$(RepositoryCommit);$(SourceBuiltSdkVersion)" />
+    </ItemGroup>
+
+    <WriteLinesToFile File="$(SourceBuiltVersionName)"
+                      Lines="@(VersionFileContent)"
+                      Overwrite="true" />
+
+    <!-- Copy the merged asset manifest into the tarball -->
+    <Copy SourceFiles="$(MergedAssetManifestOutputPath)"
+          DestinationFolder="$(SourceBuiltLayoutDir)"
+          UseSymbolicLinksIfPossible="true" />
+
+    <!-- Create a PackageVersions.props file that includes entries for all packages. -->
+    <WritePackageVersionsProps NuGetPackages="@(ArtifactsPackageToBundle)"
+                               ExtraProperties="@(ExtraPackageVersionPropsPackageInfo)"
+                               VersionPropsFlowType="AllPackages"
+                               OutputPath="$(AllPackageVersionsPropsName)" />
+
+    <Exec Command="tar --numeric-owner -czhf $(SourceBuiltTarballName) $([System.IO.Path]::GetFileName('$(SourceBuiltVersionName)')) *"
+          WorkingDirectory="$(SourceBuiltLayoutDir)" />
+
+    <Message Importance="High" Text="Packaged source-built artifacts to $(SourceBuiltTarballName)" />
   </Target>
 
 </Project>

--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -246,10 +246,6 @@
 
     <!-- Used by sdk to determine msbuild version for fsharp -->
     <ExtraPackageVersionPropsPackageInfo Include="FSharpBuildVersion" Version="%24(MicrosoftBuildPackageVersion)" />
-
-    <!-- non-rid-specific versions of RID-specific version variables to use for bootstrapping -->
-    <ExtraPackageVersionPropsPackageInfo Include="MicrosoftAspNetCoreAppRuntimeVersion" Version="%24(MicrosoftAspNetCoreAppRefPackageVersion)" />
-    <ExtraPackageVersionPropsPackageInfo Include="MicrosoftNETCoreAppCrossgen2Version" Version="%24(MicrosoftNETCoreAppRefPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/SourceBuild/content/repo-projects/installer.proj
+++ b/src/SourceBuild/content/repo-projects/installer.proj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
-    <!-- Need to set to false to calculate RepositoryCommit. -->
-    <EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
-
     <!-- Use the repo root build script -->
     <BuildScript>$(ProjectDirectory)build$(ShellExtension)</BuildScript>
 
@@ -77,65 +74,6 @@
     <!-- https://github.com/dotnet/source-build/issues/4115. -->
     <EnvironmentVariables Include="PublishWindowsPdb=false" />
   </ItemGroup>
-
-  <Target Name="GetInputsOutputForCreatePrivateSourceBuiltArtifactsArchive"
-          DependsOnTargets="DetermineSourceBuiltSdkVersion">
-    <!-- Inputs: Packages to include in the tarball -->
-    <ItemGroup>
-      <ArtifactsPackageToBundle Include="$(ArtifactsShippingPackagesDir)**;
-                                         $(ArtifactsNonShippingPackagesDir)**"
-                                Condition="!$([System.String]::Copy('%(Identity)').EndsWith('.symbols.nupkg'))" />
-      <ReferencePackageToBundle Include="$(ReferencePackagesDir)**"
-                                Condition="!$([System.String]::Copy('%(Identity)').EndsWith('.symbols.nupkg'))" />
-    </ItemGroup>
-
-    <PropertyGroup>
-      <!-- Create a layout directory for the files that are to be included in the artifacts tarball. -->
-      <SourceBuiltLayoutDir>$([MSBuild]::NormalizeDirectory('$(BaseIntermediateOutputPath)', 'artifacts-layout'))</SourceBuiltLayoutDir>
-
-      <!-- Outputs -->
-      <SourceBuiltTarballName>$(ArtifactsAssetsDir)$(SourceBuiltArtifactsTarballName).$(SourceBuiltSdkVersion).$(TargetRid)$(ArchiveExtension)</SourceBuiltTarballName>
-      <SourceBuiltVersionName>$(SourceBuiltLayoutDir).version</SourceBuiltVersionName>
-      <AllPackageVersionsPropsName>$(SourceBuiltLayoutDir)PackageVersions.props</AllPackageVersionsPropsName>
-    </PropertyGroup>
-  </Target>
-
-  <!-- Create the SourceBuilt.Private.Artifacts archive when building source-only. -->
-  <Target Name="CreatePrivateSourceBuiltArtifactsArchive"
-          AfterTargets="Build"
-          DependsOnTargets="GetInputsOutputForCreatePrivateSourceBuiltArtifactsArchive"
-          Inputs="@(ArtifactsPackageToBundle);@(ReferencePackageToBundle)"
-          Outputs="$(SourceBuiltTarballName);$(SourceBuiltVersionName);$(AllPackageVersionsPropsName)"
-          Condition="'$(DotNetBuildSourceOnly)' == 'true'">
-    <!-- Copy packages to layout directory. Since there are a large number of files,
-         this will use symlinks instead of copying files to make this execute quickly. -->
-    <Copy SourceFiles="@(ArtifactsPackageToBundle)"
-          DestinationFolder="$(SourceBuiltLayoutDir)"
-          UseSymbolicLinksIfPossible="true" />
-    <Copy SourceFiles="@(ReferencePackageToBundle)"
-          DestinationFolder="$(SourceBuiltLayoutDir)SourceBuildReferencePackages"
-          UseSymbolicLinksIfPossible="true" />
-
-    <!-- Content of the .version file to include in the tarball -->
-    <ItemGroup>
-      <VersionFileContent Include="$(RepositoryCommit);$(SourceBuiltSdkVersion)" />
-    </ItemGroup>
-
-    <WriteLinesToFile File="$(SourceBuiltVersionName)"
-                      Lines="@(VersionFileContent)"
-                      Overwrite="true" />
-
-    <!-- Create a PackageVersions.props file that includes entries for all packages. -->
-    <WritePackageVersionsProps NuGetPackages="@(ArtifactsPackageToBundle)"
-                               ExtraProperties="@(ExtraPackageVersionPropsPackageInfo)"
-                               VersionPropsFlowType="AllPackages"
-                               OutputPath="$(AllPackageVersionsPropsName)" />
-
-    <Exec Command="tar --numeric-owner -czhf $(SourceBuiltTarballName) $([System.IO.Path]::GetFileName('$(SourceBuiltVersionName)')) *"
-          WorkingDirectory="$(SourceBuiltLayoutDir)" />
-
-    <Message Importance="High" Text="Packaged source-built artifacts to $(SourceBuiltTarballName)" />
-  </Target>
 
   <!-- Copy SDK archive to assets root. -->
   <Target Name="CopySdkArchive"


### PR DESCRIPTION
This (in combination with https://github.com/dotnet/installer/pull/19389) will allow us to rely exclusively on asset manifests for Versions.props inputs instead of grepping NuGet packages.