### PR TITLE
[VMR] Add aspire test certificates to allowed-vmr-binaries.txt

### DIFF
--- a/src/SourceBuild/content/eng/allowed-vmr-binaries.txt
+++ b/src/SourceBuild/content/eng/allowed-vmr-binaries.txt
@@ -13,6 +13,9 @@ src/arcade/src/Microsoft.DotNet.*.Tests/**/*
 src/arcade/src/Microsoft.DotNet.NuGetRepack/tests/Resources/*.nupkg
 src/arcade/src/Microsoft.DotNet.NuGetRepack/tests/Resources/.signature.p7s
 
+# aspire
+src/aspire/tests/Shared/TestCertificates/*.pfx
+
 # aspnetcore
 src/aspnetcore/src/submodules/MessagePack-CSharp/**/*.dll
 src/aspnetcore/src/SignalR/clients/java/signalr/gradle/wrapper/gradle-wrapper.jar


### PR DESCRIPTION
These are a copy of the ones from aspnetcore which are already in the list.

Fixes https://github.com/dotnet/source-build/issues/4306
