### PR TITLE
[SDK Diff Tests] Update exclusion file before baseline assertion

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SdkContentTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SdkContentTests.cs
@@ -43,11 +43,11 @@ public class SdkContentTests : SdkTests
         WriteTarballFileList(Config.MsftSdkTarballPath, msftFileListingFileName, isPortable: true, MsftSdkType, exclusionsHelper);
         WriteTarballFileList(Config.SdkTarballPath, sbFileListingFileName, isPortable: false, SourceBuildSdkType, exclusionsHelper);
 
+        exclusionsHelper.GenerateNewBaselineFile("FileList");
+        
         string diff = BaselineHelper.DiffFiles(msftFileListingFileName, sbFileListingFileName, OutputHelper);
         diff = RemoveDiffMarkers(diff);
         BaselineHelper.CompareBaselineContents("MsftToSbSdkFiles.diff", diff, OutputHelper, Config.WarnOnSdkContentDiffs);
-
-        exclusionsHelper.GenerateNewBaselineFile("FileList");
     }
 
     [ConditionalFact(typeof(SdkContentTests), nameof(IncludeSdkContentTests))]


### PR DESCRIPTION
Closes https://github.com/dotnet/source-build/issues/4324#issuecomment-2052462180

This change allows the exclusions file to always be updated regardless of the baseline diff status.