### PR TITLE
Align riscv64 and loongarch64 checks

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,7 @@
     <Architecture Condition="'$(Architecture)' == '' AND '$(BuildArchitecture)' == 's390x'">$(BuildArchitecture)</Architecture>
     <Architecture Condition="'$(Architecture)' == '' AND '$(BuildArchitecture)' == 'ppc64le'">$(BuildArchitecture)</Architecture>
     <Architecture Condition="'$(Architecture)' == '' AND '$(BuildArchitecture)' == 'loongarch64'">$(BuildArchitecture)</Architecture>
+    <Architecture Condition="'$(Architecture)' == '' AND '$(BuildArchitecture)' == 'riscv64'">$(BuildArchitecture)</Architecture>
     <Architecture Condition="'$(Architecture)' == ''">x64</Architecture>
 
     <!--

--- a/src/redist/targets/Crossgen.targets
+++ b/src/redist/targets/Crossgen.targets
@@ -1,9 +1,8 @@
 <Project>
 
-  <!-- Crossgen is currently not supported on the s390x, ppc64le architecture as using mono instead of CoreCLR.
-       Neither crossgen2 nor mono is supported on the loongarch64 architecture at present. -->
+  <!-- Crossgen is currently not supported on the s390x, ppc64le architecture as using mono instead of CoreCLR. -->
   <Target Name="CrossgenLayout"
-          Condition="'$(DISABLE_CROSSGEN)' == '' AND '$(Architecture)' != 's390x' AND '$(Architecture)' != 'ppc64le' AND '$(Architecture)' != 'loongarch64' AND !('$(CROSSBUILD)' == 'true' AND '$(DotNetBuild)' == 'true')"
+          Condition="'$(DISABLE_CROSSGEN)' == '' AND '$(Architecture)' != 's390x' AND '$(Architecture)' != 'ppc64le' AND !('$(CROSSBUILD)' == 'true' AND '$(DotNetBuild)' == 'true')"
           DependsOnTargets="SetSdkBrandingInfo">
     <PropertyGroup>
       <RuntimeNETCoreAppPackageName>microsoft.netcore.app.runtime.$(SharedFrameworkRid)</RuntimeNETCoreAppPackageName>

--- a/src/redist/targets/GenerateBundledVersions.targets
+++ b/src/redist/targets/GenerateBundledVersions.targets
@@ -232,12 +232,14 @@
           @(Net80AppHostRids);
           linux-riscv64;
           linux-musl-riscv64;
+          linux-musl-loongarch64;
           " />
 
       <Net90RuntimePackRids Include="
           @(Net80RuntimePackRids);
           linux-riscv64;
           linux-musl-riscv64;
+          linux-musl-loongarch64
           " />
 
       <NetCoreAppHostRids Include="@(Net90AppHostRids)" />
@@ -306,6 +308,8 @@
         @(Net80MonoRuntimePackRids);
         linux-riscv64;
         linux-musl-riscv64;
+        linux-loongarch64;
+        linux-musl-loongarch64;
         " />
 
       <MonoRuntimePackRids Include="@(Net90MonoRuntimePackRids)" />
@@ -350,7 +354,9 @@
       <Net90Crossgen2SupportedRids Include="
         @(Net80Crossgen2SupportedRids);
         linux-riscv64;
-        linux-musl-riscv64
+        linux-musl-riscv64;
+        linux-loongarch64;
+        linux-musl-loongarch64;
         " />
 
       <Crossgen2SupportedRids Include="@(Net90Crossgen2SupportedRids);" />
@@ -426,7 +432,7 @@
       <AspNetCore70RuntimePackRids Include="@(AspNetCore60RuntimePackRids);linux-ppc64le" />
       <AspNetCore80RuntimePackRids Include="@(AspNetCore70RuntimePackRids);freebsd-x64;freebsd-arm64" />
       <AspNetCore80RuntimePackRids Remove="win-arm" />
-      <AspNetCore90RuntimePackRids Include="@(AspNetCore80RuntimePackRids);linux-riscv64;linux-musl-riscv64" />
+      <AspNetCore90RuntimePackRids Include="@(AspNetCore80RuntimePackRids);linux-riscv64;linux-musl-riscv64;linux-loongarch64;linux-musl-loongarch64;" />
       <AspNetCoreRuntimePackRids Include="@(AspNetCore90RuntimePackRids)" />
 
       <WindowsDesktop30RuntimePackRids Include="win-x64;win-x86" />


### PR DESCRIPTION
https://github.com/dotnet/installer/pull/18247 was picked up in runtime for R2R publishing of crossgen2 itself. With this, we can enable that for loongarch64 as well (once the next preview of sdk is picked up in runtime/global.json in a few weeks).

cc @akoeplinger, @shushanhf