### PR TITLE
Update SB artifact size baseline

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/ArtifactsSizes/centos.9-x64.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/ArtifactsSizes/centos.9-x64.txt
@@ -6,16 +6,11 @@ dotnet-dev-certs.x.y.z.nupkg: 65585
 dotnet-sourcelink.x.y.z.nupkg: 188477
 dotnet-user-jwts.x.y.z.nupkg: 360890
 dotnet-user-secrets.x.y.z.nupkg: 415188
-FSharp.Compiler.Service.x.y.z-1.nupkg: 8633447
-FSharp.Compiler.Service.x.y.z.nupkg: 8633479
-FSharp.Core.x.y.z-1.nupkg: 2578558
-FSharp.Core.x.y.z.nupkg: 2578536
 FSharp.NET.Sdk.x.y.z.nupkg: 3630
 host/fxr/x.y.z/libhostfxr.so: 4681016
 Humanizer.Core.x.y.z.nupkg: 945071
 LICENSE.txt: 1116
 metadata/workloads/x.y.z/userlocal: 0
-Microsoft.ApplicationInsights.x.y.z-1.nupkg: 148627
 Microsoft.ApplicationInsights.x.y.z.nupkg: 148568
 Microsoft.Arcade.Common.x.y.z.nupkg: 57342
 Microsoft.AspNetCore.Analyzers.x.y.z.nupkg: 17835
@@ -57,9 +52,7 @@ Microsoft.Build.Tasks.Core.x.y.z.nupkg: 1164405
 Microsoft.Build.Tasks.Git.x.y.z.nupkg: 81919
 Microsoft.Build.Utilities.Core.x.y.z.nupkg: 431843
 Microsoft.Build.x.y.z.nupkg: 2033343
-Microsoft.CodeAnalysis.Analyzers.x.y.z-1.nupkg: 1310350
 Microsoft.CodeAnalysis.Analyzers.x.y.z.nupkg: 1310366
-Microsoft.CodeAnalysis.AnalyzerUtilities.x.y.z-1.nupkg: 283229
 Microsoft.CodeAnalysis.AnalyzerUtilities.x.y.z.nupkg: 283223
 Microsoft.CodeAnalysis.Build.Tasks.x.y.z.nupkg: 173455
 Microsoft.CodeAnalysis.CodeStyle.Fixes.Symbols.x.y.z.nupkg: 394473
@@ -73,7 +66,6 @@ Microsoft.CodeAnalysis.CSharp.Workspaces.x.y.z.nupkg: 1076810
 Microsoft.CodeAnalysis.CSharp.x.y.z.nupkg: 10672401
 Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.x.y.z.nupkg: 55769
 Microsoft.CodeAnalysis.Features.x.y.z.nupkg: 6219098
-Microsoft.CodeAnalysis.NetAnalyzers.x.y.z-1.nupkg: 4600402
 Microsoft.CodeAnalysis.NetAnalyzers.x.y.z.nupkg: 4600374
 Microsoft.CodeAnalysis.Razor.Tooling.Internal.x.y.z.nupkg: 539710
 Microsoft.CodeAnalysis.Scripting.Common.x.y.z.nupkg: 293509
@@ -89,7 +81,6 @@ Microsoft.CodeAnalysis.x.y.z.nupkg: 5771
 Microsoft.Css.Parser.x.y.z.nupkg: 52964
 Microsoft.Deployment.DotNet.Releases.x.y.z.nupkg: 79562
 Microsoft.Diagnostics.NETCore.Client.x.y.z.nupkg: 63738
-Microsoft.DiaSymReader.x.y.z-1.nupkg: 57796
 Microsoft.DiaSymReader.x.y.z.nupkg: 57811
 Microsoft.DotNet.ApiCompat.Task.x.y.z.nupkg: 1280207
 Microsoft.DotNet.Arcade.Sdk.x.y.z.nupkg: 876107
@@ -121,7 +112,6 @@ Microsoft.DotNet.SignTool.x.y.z.nupkg: 212432
 Microsoft.DotNet.SourceBuild.Tasks.x.y.z.nupkg: 46762
 Microsoft.DotNet.Tar.x.y.z.nupkg: 15233
 microsoft.dotnet.templateLocator.x.y.z.nupkg: 105720
-Microsoft.DotNet.Test.ProjectTemplates.x.y.z-1.nupkg: 125860
 Microsoft.DotNet.Test.ProjectTemplates.x.y.z.nupkg: 125600
 Microsoft.DotNet.VersionTools.Cli.x.y.z.nupkg: 945017
 Microsoft.DotNet.VersionTools.Tasks.x.y.z.nupkg: 1060865
@@ -1402,7 +1392,6 @@ packs/NETStandard.Library.Ref/x.y.z/ref/netstandard2.1/System.Xml.XmlDocument.dl
 packs/NETStandard.Library.Ref/x.y.z/ref/netstandard2.1/System.Xml.XmlSerializer.dll: 3584
 packs/NETStandard.Library.Ref/x.y.z/ref/netstandard2.1/System.Xml.XPath.dll: 3584
 packs/NETStandard.Library.Ref/x.y.z/ref/netstandard2.1/System.Xml.XPath.XDocument.dll: 3072
-Roslyn.Diagnostics.Analyzers.x.y.z-1.nupkg: 787366
 Roslyn.Diagnostics.Analyzers.x.y.z.nupkg: 787364
 runtime.banana-rid.Microsoft.DotNet.ILCompiler.x.y.z.nupkg: 124999992
 runtime.banana-rid.Microsoft.NETCore.DotNetAppHost.x.y.z.nupkg: 92093343
@@ -2045,7 +2034,7 @@ sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/BuildHost-netcore/zh-H
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/BuildHost-netcore/zh-Hant/Microsoft.CodeAnalysis.resources.dll: 34304
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/BuildHost-netcore/zh-Hant/Microsoft.CodeAnalysis.Workspaces.resources.dll: 35840
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/BuildHost-netcore/zh-Hant/System.CommandLine.resources.dll: 8704
-sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/cs/dotnet-watch.resources.dll: 5632
+sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/cs/dotnet-watch.resources.dll: 7168
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/cs/Microsoft.CodeAnalysis.CSharp.Features.resources.dll: 36352
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/cs/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll: 7680
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/cs/Microsoft.CodeAnalysis.Features.resources.dll: 178688
@@ -2053,7 +2042,7 @@ sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/cs/Microsoft.CodeAnaly
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/cs/Microsoft.CodeAnalysis.Workspaces.MSBuild.resources.dll: 7168
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/cs/Microsoft.CodeAnalysis.Workspaces.resources.dll: 37888
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/cs/System.CommandLine.resources.dll: 8704
-sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/de/dotnet-watch.resources.dll: 5632
+sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/de/dotnet-watch.resources.dll: 7168
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/de/Microsoft.CodeAnalysis.CSharp.Features.resources.dll: 36864
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/de/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll: 7680
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/de/Microsoft.CodeAnalysis.Features.resources.dll: 188928
@@ -2067,7 +2056,7 @@ sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/dotnet-watch.dll.confi
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/dotnet-watch.runtimeconfig.json: 511
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/DotNetWatch.targets: 4381
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/DotNetWatchTasks.dll: 12288
-sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/es/dotnet-watch.resources.dll: 5632
+sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/es/dotnet-watch.resources.dll: 7168
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/es/Microsoft.CodeAnalysis.CSharp.Features.resources.dll: 36864
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/es/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll: 7680
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/es/Microsoft.CodeAnalysis.Features.resources.dll: 186368
@@ -2075,7 +2064,7 @@ sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/es/Microsoft.CodeAnaly
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/es/Microsoft.CodeAnalysis.Workspaces.MSBuild.resources.dll: 7168
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/es/Microsoft.CodeAnalysis.Workspaces.resources.dll: 39424
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/es/System.CommandLine.resources.dll: 8704
-sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/fr/dotnet-watch.resources.dll: 5632
+sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/fr/dotnet-watch.resources.dll: 7168
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/fr/Microsoft.CodeAnalysis.CSharp.Features.resources.dll: 37376
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/fr/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll: 7680
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/fr/Microsoft.CodeAnalysis.Features.resources.dll: 193024
@@ -2085,7 +2074,7 @@ sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/fr/Microsoft.CodeAnaly
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/fr/System.CommandLine.resources.dll: 8704
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/hotreload/Microsoft.Extensions.DotNetDeltaApplier.dll: 26624
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Humanizer.dll: 509952
-sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/it/dotnet-watch.resources.dll: 5632
+sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/it/dotnet-watch.resources.dll: 7168
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/it/Microsoft.CodeAnalysis.CSharp.Features.resources.dll: 36864
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/it/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll: 7680
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/it/Microsoft.CodeAnalysis.Features.resources.dll: 188416
@@ -2093,7 +2082,7 @@ sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/it/Microsoft.CodeAnaly
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/it/Microsoft.CodeAnalysis.Workspaces.MSBuild.resources.dll: 7168
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/it/Microsoft.CodeAnalysis.Workspaces.resources.dll: 39936
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/it/System.CommandLine.resources.dll: 8704
-sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/ja/dotnet-watch.resources.dll: 5632
+sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/ja/dotnet-watch.resources.dll: 7680
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/ja/Microsoft.CodeAnalysis.CSharp.Features.resources.dll: 38912
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/ja/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll: 7680
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/ja/Microsoft.CodeAnalysis.Features.resources.dll: 198656
@@ -2101,7 +2090,7 @@ sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/ja/Microsoft.CodeAnaly
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/ja/Microsoft.CodeAnalysis.Workspaces.MSBuild.resources.dll: 7680
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/ja/Microsoft.CodeAnalysis.Workspaces.resources.dll: 43008
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/ja/System.CommandLine.resources.dll: 8704
-sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/ko/dotnet-watch.resources.dll: 5632
+sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/ko/dotnet-watch.resources.dll: 7168
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/ko/Microsoft.CodeAnalysis.CSharp.Features.resources.dll: 35840
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/ko/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll: 7680
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/ko/Microsoft.CodeAnalysis.Features.resources.dll: 183808
@@ -2121,7 +2110,7 @@ sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Microsoft.CodeAnalysis
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Microsoft.DiaSymReader.dll: 76800
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/middleware/Microsoft.AspNetCore.Watch.BrowserRefresh.dll: 43008
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Newtonsoft.Json.dll: 692736
-sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/pl/dotnet-watch.resources.dll: 5632
+sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/pl/dotnet-watch.resources.dll: 7168
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/pl/Microsoft.CodeAnalysis.CSharp.Features.resources.dll: 36864
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/pl/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll: 7680
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/pl/Microsoft.CodeAnalysis.Features.resources.dll: 185344
@@ -2129,7 +2118,7 @@ sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/pl/Microsoft.CodeAnaly
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/pl/Microsoft.CodeAnalysis.Workspaces.MSBuild.resources.dll: 7168
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/pl/Microsoft.CodeAnalysis.Workspaces.resources.dll: 39424
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/pl/System.CommandLine.resources.dll: 8704
-sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/pt-BR/dotnet-watch.resources.dll: 5632
+sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/pt-BR/dotnet-watch.resources.dll: 7168
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/pt-BR/Microsoft.CodeAnalysis.CSharp.Features.resources.dll: 36352
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/pt-BR/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll: 7680
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/pt-BR/Microsoft.CodeAnalysis.Features.resources.dll: 184320
@@ -2137,7 +2126,7 @@ sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/pt-BR/Microsoft.CodeAn
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/pt-BR/Microsoft.CodeAnalysis.Workspaces.MSBuild.resources.dll: 7168
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/pt-BR/Microsoft.CodeAnalysis.Workspaces.resources.dll: 38912
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/pt-BR/System.CommandLine.resources.dll: 8704
-sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/ru/dotnet-watch.resources.dll: 6144
+sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/ru/dotnet-watch.resources.dll: 7680
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/ru/Microsoft.CodeAnalysis.CSharp.Features.resources.dll: 44544
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/ru/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll: 8192
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/ru/Microsoft.CodeAnalysis.Features.resources.dll: 248320
@@ -2160,7 +2149,7 @@ sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Resources.Exten
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Security.Cryptography.ProtectedData.dll: 26624
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Security.Permissions.dll: 103936
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/System.Windows.Extensions.dll: 16896
-sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/tr/dotnet-watch.resources.dll: 5632
+sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/tr/dotnet-watch.resources.dll: 7168
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/tr/Microsoft.CodeAnalysis.CSharp.Features.resources.dll: 35840
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/tr/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll: 7680
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/tr/Microsoft.CodeAnalysis.Features.resources.dll: 180224
@@ -2168,7 +2157,7 @@ sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/tr/Microsoft.CodeAnaly
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/tr/Microsoft.CodeAnalysis.Workspaces.MSBuild.resources.dll: 7168
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/tr/Microsoft.CodeAnalysis.Workspaces.resources.dll: 37888
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/tr/System.CommandLine.resources.dll: 8704
-sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/zh-Hans/dotnet-watch.resources.dll: 5632
+sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/zh-Hans/dotnet-watch.resources.dll: 7168
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/zh-Hans/Microsoft.CodeAnalysis.CSharp.Features.resources.dll: 33792
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/zh-Hans/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll: 7680
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/zh-Hans/Microsoft.CodeAnalysis.Features.resources.dll: 159744
@@ -2176,7 +2165,7 @@ sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/zh-Hans/Microsoft.Code
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/zh-Hans/Microsoft.CodeAnalysis.Workspaces.MSBuild.resources.dll: 7168
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/zh-Hans/Microsoft.CodeAnalysis.Workspaces.resources.dll: 35840
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/zh-Hans/System.CommandLine.resources.dll: 8704
-sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/zh-Hant/dotnet-watch.resources.dll: 5632
+sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/zh-Hant/dotnet-watch.resources.dll: 7168
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/zh-Hant/Microsoft.CodeAnalysis.CSharp.Features.resources.dll: 33792
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/zh-Hant/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll: 7680
 sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/zh-Hant/Microsoft.CodeAnalysis.Features.resources.dll: 161792


### PR DESCRIPTION
The FSharp removal is related to https://github.com/dotnet/installer/pull/19404.