### PR TITLE
Allow test databases in the VMR build and add license suppressions for efcore

### DIFF
--- a/src/SourceBuild/content/eng/allowed-vmr-binaries.txt
+++ b/src/SourceBuild/content/eng/allowed-vmr-binaries.txt
@@ -38,6 +38,10 @@ src/cecil/symbols/**/Test/Resources/assemblies/*.pdb
 src/cecil/symbols/**/Test/Resources/assemblies/*.dll
 src/cecil/symbols/**/Test/Resources/assemblies/*.mdb
 
+# efcore
+src/efcore/test/EFCore.Sqlite.FunctionalTests/northwind.db # https://github.com/dotnet/source-build/issues/4326
+src/efcore/benchmark/EFCore.Sqlite.Benchmarks/AdventureWorks2014.db # https://github.com/dotnet/source-build/issues/4326
+
 # fsharp
 src/fsharp/tests/**/*.resources
 src/fsharp/tests/**/*.dll

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseExclusions.txt
@@ -69,8 +69,8 @@ src/diagnostics/THIRD-PARTY-NOTICES.TXT|codesourcery-2004
 #
 
 # False positive
-test/EfCore.Tests/ChangeTracking/ComplexPropertyEntryTest.cs|proprietary-license
-test/EfCore.Tests/ChangeTracking/MemberEntryTest.cs|proprietary-license
+src/efcore/test/EfCore.Tests/ChangeTracking/ComplexPropertyEntryTest.cs|proprietary-license
+src/efcore/test/EfCore.Tests/ChangeTracking/MemberEntryTest.cs|proprietary-license
 
 #
 # fsharp

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseExclusions.txt
@@ -65,6 +65,14 @@ src/deployment-tools/THIRD-PARTY-NOTICES.TXT|unknown-license-reference
 src/diagnostics/THIRD-PARTY-NOTICES.TXT|codesourcery-2004
 
 #
+# efcore
+#
+
+# False positive
+test/EfCore.Tests/ChangeTracking/ComplexPropertyEntryTest.cs|proprietary-license
+test/EfCore.Tests/ChangeTracking/MemberEntryTest.cs|proprietary-license
+
+#
 # fsharp
 #
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4326
Fixes https://github.com/dotnet/source-build/issues/4327