### PR TITLE
Pass RepositoryName as a build argument in SourceBuild

### DIFF
--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -83,6 +83,7 @@
     <!-- Pass locations for assets -->
     <BuildArgs>$(BuildArgs) /p:SourceBuiltAssetsDir=$(ArtifactsAssetsDir)</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:SourceBuiltAssetManifestsDir=$(RepoAssetManifestsDir)</BuildArgs>
+    <BuildArgs>$(BuildArgs) /p:RepositoryName=$(RepositoryName)</BuildArgs>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">


### PR DESCRIPTION
Ref Issue: https://github.com/dotnet/source-build/issues/3898
Ref PRs: https://github.com/dotnet/arcade/pull/14718

We aim to trace the origin of the artifacts we produce as part of SourceBuild. The Ref PR introduces a RepoOrigin attribute to the AssetManifest.xml file that will serve as an indicator of the artifact's source. The current proposal passes RepositoryName as a build argument in SourceBuild.


Test: https://dev.azure.com/dnceng/internal/_build/results?buildId=2430776&view=artifacts&pathAsName=false&type=publishedArtifacts