### PR TITLE
[VMR] Set "runTests: false" for Windows PGO jobs

### DIFF
--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -996,6 +996,7 @@ stages:
             targetOS: windows
             targetArchitecture: x64
             extraProperties: /p:PgoInstrument=true
+            runTests: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -1007,6 +1008,7 @@ stages:
             targetOS: windows
             targetArchitecture: x86
             extraProperties: /p:PgoInstrument=true
+            runTests: false
 
         - template: ../jobs/vmr-build.yml
           parameters:
@@ -1018,3 +1020,4 @@ stages:
             targetOS: windows
             targetArchitecture: arm64
             extraProperties: /p:PgoInstrument=true
+            runTests: false


### PR DESCRIPTION
They don't run tests and that causes a warning in AzDO since there are no test results: https://github.com/dotnet/installer/blob/6723ebcc082130711c92907b748f72d9f556a40b/src/SourceBuild/content/test/tests.proj#L6-L7
