### PR TITLE
Fix path for trx files

### DIFF
--- a/src/SourceBuild/content/eng/pipelines/templates/jobs/sdk-diff-tests.yml
+++ b/src/SourceBuild/content/eng/pipelines/templates/jobs/sdk-diff-tests.yml
@@ -159,9 +159,9 @@ jobs:
     condition: succeededOrFailed()
     continueOnError: true
     inputs:
-      testRunner: vSTest
-      testResultsFiles: '*.trx'
-      searchFolder: $(Build.SourcesDirectory)/test/Microsoft.DotNet.SourceBuild.SmokeTests/TestResults
+      testRunner: VSTest
+      testResultsFiles: '**/*.trx'
+      searchFolder: $(Build.SourcesDirectory)/artifacts/TestResults
       mergeTestResults: true
       publishRunAttachments: true
       testRunTitle: $(Agent.JobName)


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4319

The test artifacts were moved to the root artifacts directory, resulting in the sdk diff test pipeline not being able to find the .trx files produced by the tests. This was resolved by fixing the path for uploading the trx files and updating the file pattern.

[Test build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2433814&view=logs&j=c2a3fba4-babc-5882-e82a-8e0dc9edd6ec&t=a735ec37-26ed-5f6e-fd8e-051ca0d0456f) (internal Microsoft link)
