### PR TITLE
Use correct image name for Arm pool

### DIFF
--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -48,7 +48,7 @@ parameters:
 - name: pool_LinuxArm64
   type: object
   default:
-    name: $(defaultPoolName)
+    name: $(poolName_LinuxArm64)
     image: $(poolImage_LinuxArm64)
     demands: ImageOverride -equals $(poolImage_LinuxArm64)
     hostArchitecture: Arm64

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -48,9 +48,9 @@ parameters:
 - name: pool_LinuxArm64
   type: object
   default:
-    name: $(poolName_LinuxArm64)
+    name: $(defaultPoolName)
     image: $(poolImage_LinuxArm64)
-    demands: ImageOverride -equals $(poolImage_Linux)
+    demands: ImageOverride -equals $(poolImage_LinuxArm64)
     hostArchitecture: Arm64
     os: linux
 

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -92,6 +92,23 @@ stages:
         useMonoRuntime: false              # 🚫
         withPreviousSDK: false             # 🚫
 
+    - template: ../jobs/vmr-build.yml
+      parameters:
+        # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
+        buildName: Ubuntu2204Arm64_Offline_MsftSdk
+        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+        vmrBranch: ${{ variables.VmrBranch }}
+        architecture: arm64
+        pool: ${{ parameters.pool_LinuxArm64 }}
+        container: ${{ variables.ubuntu2204ArmContainer }}
+        buildFromArchive: false            # 🚫
+        buildSourceOnly: true              # ✅
+        enablePoison: false                # 🚫
+        excludeOmniSharpTests: false       # 🚫
+        runOnline: false                   # 🚫
+        useMonoRuntime: false              # 🚫
+        withPreviousSDK: false             # 🚫
+
     ### Additional jobs for lite/full builds ###
     - ${{ if in(parameters.scope, 'lite', 'full') }}:
 

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -92,23 +92,6 @@ stages:
         useMonoRuntime: false              # 🚫
         withPreviousSDK: false             # 🚫
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-        buildName: Ubuntu2204Arm64_Offline_MsftSdk
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        vmrBranch: ${{ variables.VmrBranch }}
-        architecture: arm64
-        pool: ${{ parameters.pool_LinuxArm64 }}
-        container: ${{ variables.ubuntu2204ArmContainer }}
-        buildFromArchive: false            # 🚫
-        buildSourceOnly: true              # ✅
-        enablePoison: false                # 🚫
-        excludeOmniSharpTests: false       # 🚫
-        runOnline: false                   # 🚫
-        useMonoRuntime: false              # 🚫
-        withPreviousSDK: false             # 🚫
-
     ### Additional jobs for lite/full builds ###
     - ${{ if in(parameters.scope, 'lite', 'full') }}:
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4305

This PR allows the Public SB VMR builds to use the correct image name for the Arm pool.