### PR TITLE
Publish Test Results in PR Validation

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -267,7 +267,7 @@ jobs:
     continueOnError: true
     condition: succeededOrFailed()
 
-  ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+  - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
     - publish: '$(Build.StagingDirectory)/BuildLogs'
       artifact: $(Agent.JobName)_BuildLogs_Attempt$(System.JobAttempt)
       displayName: Publish BuildLogs

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -266,6 +266,20 @@ jobs:
     displayName: Prepare BuildLogs staging directory
     continueOnError: true
     condition: succeededOrFailed()
+
+  ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+    - publish: '$(Build.StagingDirectory)/BuildLogs'
+      artifact: $(Agent.JobName)_BuildLogs_Attempt$(System.JobAttempt)
+      displayName: Publish BuildLogs
+      continueOnError: true
+      condition: succeededOrFailed()
+
+    - publish: '${{ variables.sourcesPath }}/artifacts/${{ parameters.architecture }}/Release/'
+      artifact: $(Agent.JobName)_Artifacts
+      displayName: Publish Artifacts
+      condition: succeededOrFailed()
+      continueOnError: true
+
   - task: PublishTestResults@2
     displayName: Publish Test Results
     condition: succeededOrFailed()

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -267,7 +267,7 @@ jobs:
     continueOnError: true
     condition: succeededOrFailed()
 
-  - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+  - ${{ if eq(variables['System.TeamProject'], 'public') }}:
     - publish: '$(Build.StagingDirectory)/BuildLogs'
       artifact: $(Agent.JobName)_BuildLogs_Attempt$(System.JobAttempt)
       displayName: Publish BuildLogs


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4315

After migrating to 1ES templates in 8.0, the pipeline artifacts are no longer being published in the public builds. The reason for this is that 1ES templates are not used in PR validation. To resolve this issue, this PR introduces changes so that the artifacts are conditionally uploaded in the "old" way when doing PR validation.