### PR TITLE
Rename out of date alpine CI leg

### DIFF
--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -115,7 +115,7 @@ stages:
     - template: ../jobs/vmr-build.yml@self
       parameters:
         # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-        buildName: Alpine317_Offline_MsftSdk
+        buildName: Alpine319_Offline_MsftSdk
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
         vmrBranch: ${{ variables.VmrBranch }}
         architecture: x64


### PR DESCRIPTION
This was pointed out in https://github.com/dotnet/source-build/issues/4339#issuecomment-2065384023, one leg name was missed in https://github.com/dotnet/installer/pull/19318
