### PR TITLE
Rename publish.proj to merge-asset-manifests.proj

### DIFF
--- a/src/SourceBuild/content/build.proj
+++ b/src/SourceBuild/content/build.proj
@@ -22,8 +22,8 @@
     <ProjectReference Include="$(RepoProjectsDir)$(RootRepo).proj" />
 
     <!-- Post-build: Source-only validation, packaging and publishing -->
+    <ProjectReference Include="$(RepositoryEngineeringDir)merge-asset-manifests.proj" />
     <ProjectReference Include="$(RepositoryEngineeringDir)finish-source-only.proj" Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
-    <ProjectReference Include="$(RepositoryEngineeringDir)publish.proj" />
   </ItemGroup>
 
   <Target Name="PrintInfo">

--- a/src/SourceBuild/content/eng/finish-source-only.proj
+++ b/src/SourceBuild/content/eng/finish-source-only.proj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="$(TasksDir)Microsoft.DotNet.UnifiedBuild.Tasks\Microsoft.DotNet.UnifiedBuild.Tasks.csproj" />
     <ProjectReference Include="$(TasksDir)Microsoft.DotNet.SourceBuild.Tasks.LeakDetection\Microsoft.DotNet.SourceBuild.Tasks.LeakDetection.csproj" />
-    <ProjectReference Include="$(RepositoryEngineeringDir)publish.proj" />
+    <ProjectReference Include="$(RepositoryEngineeringDir)merge-asset-manifests.proj" />
   </ItemGroup>
 
   <!-- After building, generate a prebuilt usage report. -->

--- a/src/SourceBuild/content/eng/merge-asset-manifests.proj
+++ b/src/SourceBuild/content/eng/merge-asset-manifests.proj
@@ -16,6 +16,8 @@
       <RepoAssetManifest Include="$(AssetManifestsIntermediateDir)\**\*.xml" />
     </ItemGroup>
 
+    <Error Text="Couldn't find any repository asset manifest files." Condition="'@(RepoAssetManifest)' == ''" />
+
     <!-- It's OK for the VmrBuildNumber to be empty -->
     <Microsoft.DotNet.UnifiedBuild.Tasks.MergeAssetManifests 
       AssetManifest="@(RepoAssetManifest)" 

--- a/src/SourceBuild/content/eng/merge-asset-manifests.proj
+++ b/src/SourceBuild/content/eng/merge-asset-manifests.proj
@@ -11,12 +11,11 @@
   <!-- Create a merge manifest from the individual repository manifest files. -->
   <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.MergeAssetManifests" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
   <Target Name="MergeAssetManifests" AfterTargets="Build">
-
     <ItemGroup>
       <RepoAssetManifest Include="$(AssetManifestsIntermediateDir)\**\*.xml" />
     </ItemGroup>
 
-    <Error Text="Couldn't find any repository asset manifest files." Condition="'@(RepoAssetManifest)' == ''" />
+    <Error Text="Couldn't find any repository asset manifest file. Make sure to build the repositories before invoking this target." Condition="'@(RepoAssetManifest)' == ''" />
 
     <!-- It's OK for the VmrBuildNumber to be empty -->
     <Microsoft.DotNet.UnifiedBuild.Tasks.MergeAssetManifests 

--- a/src/SourceBuild/content/test/Microsoft.DotNet.UnifiedBuild.Tests/Microsoft.DotNet.UnifiedBuild.Tests.csproj
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.UnifiedBuild.Tests/Microsoft.DotNet.UnifiedBuild.Tests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
     <PackageReference Include="NuGet.Protocol" />
-    <ProjectReference Include="$(RepositoryEngineeringDir)publish.proj" ReferenceOutputAssembly="false" PrivateAssets="all" />
+    <ProjectReference Include="$(RepositoryEngineeringDir)merge-asset-manifests.proj" ReferenceOutputAssembly="false" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
... and add a conditional error task that throws
when the inner repositories haven't been built yet to provide a better build UX.