### PR TITLE
Update artifact size basline

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/ArtifactsSizes/centos.9-x64.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/ArtifactsSizes/centos.9-x64.txt
@@ -4527,7 +4527,7 @@ Valleysoft.DockerCredsProvider.x.y.z-1.nupkg: 11628
 Valleysoft.DockerCredsProvider.x.y.z.nupkg: 11489
 vbc.Symbols.x.y.z.nupkg: 49555
 VBCSCompiler.Symbols.x.y.z.nupkg: 72561
-VerticalManifest.xml: 73620
+VerticalManifest.xml: 93949
 xunit.abstractions.x.y.z.nupkg: 7272
 xunit.core.x.y.z.nupkg: 6132
 xunit.extensibility.core.x.y.z.nupkg: 79927


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/4342

Update the artifact size baseline for `VerticalManifest.xml` in the main branch.

Related build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2437624&view=ms.vss-test-web.build-test-results-tab&runId=53521223&resultId=100002