### PR TITLE
Delete SourceBuiltArtifacts after bootstrap

### DIFF
--- a/src/SourceBuild/content/build.sh
+++ b/src/SourceBuild/content/build.sh
@@ -365,7 +365,7 @@ if [[ "$sourceOnly" == "true" ]]; then
     packageVersionsPath="$CUSTOM_PACKAGES_DIR/PackageVersions.props"
   elif [ -d "$packagesArchiveDir" ]; then
     sourceBuiltArchive=$(find "$packagesArchiveDir" -maxdepth 1 -name 'Private.SourceBuilt.Artifacts*.tar.gz')
-    if [ -f "${packagesPreviouslySourceBuiltDir}}PackageVersions.props" ]; then
+    if [ -f "${packagesPreviouslySourceBuiltDir}PackageVersions.props" ]; then
       packageVersionsPath=${packagesPreviouslySourceBuiltDir}PackageVersions.props
     elif [ -f "$sourceBuiltArchive" ]; then
       tar -xzf "$sourceBuiltArchive" -C /tmp PackageVersions.props
@@ -375,8 +375,9 @@ if [[ "$sourceOnly" == "true" ]]; then
 
   if [ ! -f "$packageVersionsPath" ]; then
     echo "Cannot find PackagesVersions.props.  Debugging info:"
-    echo "  Attempted archive path: $packagesArchiveDir"
     echo "  Attempted custom PVP path: $CUSTOM_PACKAGES_DIR/PackageVersions.props"
+    echo "  Attempted previously-source-built path: ${packagesPreviouslySourceBuiltDir}PackageVersions.props"
+    echo "  Attempted archive path: $packagesArchiveDir"
     exit 1
   fi
 

--- a/src/SourceBuild/content/eng/init-source-only.proj
+++ b/src/SourceBuild/content/eng/init-source-only.proj
@@ -24,12 +24,13 @@
           Outputs="$(BaseIntermediateOutputPath)UnpackTarballs.complete" >
     <PropertyGroup>
       <ExternalTarballsDir>$([MSBuild]::NormalizeDirectory('$(PrereqsPackagesDir)', 'archive'))</ExternalTarballsDir>
+      <SourceBuiltArtifactsTarballPath>$(ExternalTarballsDir)$(SourceBuiltArtifactsTarballName).*$(ArchiveExtension)</SourceBuiltArtifactsTarballPath>
     </PropertyGroup>
 
     <MakeDir Directories="$(PrebuiltSourceBuiltPackagesPath)" Condition="'$(CustomPrebuiltSourceBuiltPackagesPath)' == ''" />
-    <Exec Command="tar -xzf $(ExternalTarballsDir)$(SourceBuiltArtifactsTarballName).*$(ArchiveExtension)"
+    <Exec Command="tar -xzf $(SourceBuiltArtifactsTarballPath)"
           WorkingDirectory="$(PrebuiltSourceBuiltPackagesPath)"
-          Condition="'$(CustomPrebuiltSourceBuiltPackagesPath)' == ''" />
+          Condition="'$(CustomPrebuiltSourceBuiltPackagesPath)' == '' and Exists('$(SourceBuiltArtifactsTarballPath)')" />
 
     <!--
       Check for a prebuilt dependency tarball and extract if exists. If there isn't one, we expect

--- a/src/SourceBuild/content/prep-source-build.sh
+++ b/src/SourceBuild/content/prep-source-build.sh
@@ -247,4 +247,12 @@ if [ "$removeBinaries" == true ]; then
   --with-packages $packagesDir \
   --with-sdk $dotnetSdk \
 
+
+  # If --with-packages is not passed, delete original tarball after deleting binaries
+  if [[ "$packagesDir" == "$defaultPackagesDir" ]]; then
+    if [ -f "$sourceBuiltArchive" ]; then
+      rm -f "$sourceBuiltArchive"
+    fi
+  fi
+
 fi


### PR DESCRIPTION
When building the VMR in source-build bootstrap mode, we end up with duplicate copies of nuget packages - one set in the SourceBuiltArtifacts tarball, and another in the restored packages directory. We can safely delete the tarball since it's not longer relevant.

This comes up particularly when building .NET in scenarios where the actual build is done offline (eg, Fedora). For that scenario, we run the `./prep-source-build.sh --bootstrap` on a developer machine, then create a "source archive" with the results of that, and then upload/build that in the formal offline build systems. In that case, the extra SourceBuiltArtifacts increases the size of the "source archive" by more than a gigabyte.