### PR TITLE
Fix Alpine SB legs

### DIFF
--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -123,7 +123,6 @@ stages:
           artifactsRid: alpine.3.19-x64
           pool: ${{ parameters.pool_Linux }}
           container: ${{ variables.alpine319Container }}
-          targetOS: linux-musl
           buildFromArchive: false            # 🚫
           buildSourceOnly: true              # ✅
           enablePoison: true                 # ✅
@@ -144,7 +143,6 @@ stages:
             architecture: x64
             pool: ${{ parameters.pool_Linux }}
             container: ${{ variables.alpine319Container }}
-            targetOS: linux-musl
             buildFromArchive: false            # 🚫
             buildSourceOnly: true              # ✅
             enablePoison: false                # 🚫

--- a/src/SourceBuild/content/test/tests.proj
+++ b/src/SourceBuild/content/test/tests.proj
@@ -11,7 +11,7 @@
     <!-- Skip scenario tests if the portable OS (determined from the host machine) is different from the target OS
         since the tests require the ability to execute the built SDK. An example of where this would be disabled is
         cross-build of using Mariner to build for Alpine (linux vs linux-musl). -->
-    <_RunScenarioTests Condition="'$(BuildOS)' != 'windows' and '$(__PortableTargetOS.ToLowerInvariant())' != '$(TargetOS.ToLowerInvariant())'">false</_RunScenarioTests>
+    <_RunScenarioTests Condition="'$(BuildOS)' != 'windows' and '$(DotNetBuildSourceOnly)' == 'false' and '$(__PortableTargetOS.ToLowerInvariant())' != '$(TargetOS.ToLowerInvariant())'">false</_RunScenarioTests>
 
     <!-- The scenario tests are not supported when unofficial build versioning is used. -->
     <_RunScenarioTests Condition="'$(UseOfficialBuildVersioning)' == 'false'">false</_RunScenarioTests>


### PR DESCRIPTION
The changes from https://github.com/dotnet/installer/pull/19222 caused a regression for source build Alpine build legs, causing the following error:

```
/vmr/src/runtime/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj : error NU1100: Unable to resolve 'runtime.linux-musl-x64.Microsoft.DotNet.ILCompiler (>= 9.0.0-preview.4.24218.7)' for 'net9.0'. PackageSourceMapping is enabled, the following source(s) were not considered: prebuilt, previously-source-built, reference-packages, source-built-command-line-api, source-built-emsdk, source-built-source-build-externals, source-built-transport-arcade, source-built-transport-cecil, source-built-transport-emsdk. [/vmr/src/runtime/Build.proj]
/vmr/src/runtime/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj : error NU1100: Unable to resolve 'runtime.linux-musl-x64.Microsoft.DotNet.ILCompiler (>= 9.0.0-preview.4.24218.7)' for 'net9.0/linux-musl-x64'. PackageSourceMapping is enabled, the following source(s) were not considered: prebuilt, previously-source-built, reference-packages, source-built-command-line-api, source-built-emsdk, source-built-source-build-externals, source-built-transport-arcade, source-built-transport-cecil, source-built-transport-emsdk. [/vmr/src/runtime/Build.proj]
/vmr/src/runtime/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj : error NU1100: Unable to resolve 'Microsoft.NETCore.App.Runtime.linux-musl-x64 (= 9.0.0-preview.4.24218.7)' for 'net9.0'. PackageSourceMapping is enabled, the following source(s) were not considered: prebuilt, previously-source-built, reference-packages, source-built-command-line-api, source-built-emsdk, source-built-source-build-externals, source-built-transport-arcade, source-built-transport-cecil, source-built-transport-emsdk. [/vmr/src/runtime/Build.proj]
/vmr/src/runtime/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj : error NU1100: Unable to resolve 'Microsoft.NETCore.App.Host.linux-musl-x64 (= 9.0.0-preview.4.24218.7)' for 'net9.0'. PackageSourceMapping is enabled, the following source(s) were not considered: prebuilt, previously-source-built, reference-packages, source-built-command-line-api, source-built-emsdk, source-built-source-build-externals, source-built-transport-arcade, source-built-transport-cecil, source-built-transport-emsdk. [/vmr/src/runtime/Build.proj]
```

This is due to the change made in https://github.com/dotnet/dotnet/commit/546a6bbcddd23e2d13d6b794ae765b95f6917c8c#diff-e98dbe2aa8231e9d6264210a63f02e97b5e26de2cca16db7ee471a2257f32c8f to define `targetOS` for the Alpine build legs. That change was intended to make this check succeed: https://github.com/dotnet/dotnet/blob/00d6710677d75715dedef053b70a34b09af8bc47/test/tests.proj#L14.

The fix is to remove the setting of `targetOS` and update the test condition to not apply for source build since source build doesn't use portable RIDs.