### PR TITLE
Clean up contents from previously-sb tarball post binary-cleanup

### DIFF
--- a/src/SourceBuild/content/prep-source-build.sh
+++ b/src/SourceBuild/content/prep-source-build.sh
@@ -223,28 +223,34 @@ fi
 
 if [ "$removeBinaries" == true ]; then
 
+  originalPackagesDir=$packagesDir
+  # Create working directory for extracking packages
+  workingDir=$(mktemp -d)
+
   # If --with-packages is not passed, unpack PSB artifacts
   if [[ $packagesDir == $defaultPackagesDir ]]; then
+    echo "  Extracting previously source-built to $workingDir"
     sourceBuiltArchive=$(find "$packagesArchiveDir" -maxdepth 1 -name 'Private.SourceBuilt.Artifacts*.tar.gz')
 
-    if [ ! -d "$packagesDir" ] && [ -f "$sourceBuiltArchive" ]; then
-      echo "  Unpacking Private.SourceBuilt.Artifacts.*.tar.gz into $packagesDir"
-      mkdir -p "$packagesDir"
-      tar -xzf "$sourceBuiltArchive" -C "$packagesDir"
-    elif [ ! -f "$packagesDir/PackageVersions.props" ] && [ -f "$sourceBuiltArchive" ]; then
-      echo "  Creating $packagesDir/PackageVersions.props..."
-      tar -xzf "$sourceBuiltArchive" -C "$packagesDir" PackageVersions.props
-    elif [ ! -f "$sourceBuiltArchive" ]; then
+    if [ ! -f "$sourceBuiltArchive" ]; then
       echo "  ERROR: Private.SourceBuilt.Artifacts.*.tar.gz does not exist..."\
             "Cannot remove non-SB allowed binaries. Either pass --with-packages or download the artifacts."
       exit 1
     fi
+
+    echo "  Unpacking Private.SourceBuilt.Artifacts.*.tar.gz into $workingDir"
+    tar -xzf "$sourceBuiltArchive" -C "$workingDir"
+
+    packagesDir=$workingDir
   fi
 
- "$REPO_ROOT/eng/detect-binaries.sh" \
+  "$REPO_ROOT/eng/detect-binaries.sh" \
   --clean \
   --allowed-binaries-file "$REPO_ROOT/eng/allowed-sb-binaries.txt" \
   --with-packages $packagesDir \
   --with-sdk $dotnetSdk \
 
+  rm -rf "$workingDir"
+
+  packagesDir=$originalPackagesDir
 fi


### PR DESCRIPTION
If we extracted the previously-source-build tarball only for running the binary cleanup tool, clean up the extracted contents. This undo's the extraction operation that was only performed for running the binary-cleanup tool.

I am creating a tarball for building .NET offline post-prep. In that scenario, I run `./prep-source-build.sh --bootstrap`, and then package up the entire VMR directory into a tarball. Without this cleanup, there are a ton of duplicated binaries in the tarball, since the nuget packages are both in previously-source-built archive and in an extracted form. With this change, the archive size goes from just over 4GB to just over 2GB.