### PR TITLE
Add top-level controls to VMR for system libraries

### DIFF
--- a/src/SourceBuild/content/repo-projects/Directory.Build.props
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.props
@@ -79,6 +79,13 @@
     <!-- Only pass when enabled to reduce command line noise. -->
     <BuildArgs Condition="'$(DotNetBuildTests)' == 'true'">$(BuildArgs) /p:DotNetBuildTests=true</BuildArgs>
     <BuildArgs Condition="'$(NuGetConfigFile)' != ''">$(BuildArgs) /p:RestoreConfigFile=$(NuGetConfigFile)</BuildArgs>
+
+    <BuildArgs Condition="'$(UseSystemBrotli)' != ''">$(BuildArgs) /p:UseSystemBrotli=$(UseSystemBrotli)</BuildArgs>
+    <BuildArgs Condition="'$(UseSystemLibunwind)' != ''">$(BuildArgs) /p:UseSystemLibunwind=$(UseSystemLibunwind)</BuildArgs>
+    <BuildArgs Condition="'$(UseSystemLlvmLibunwind)' != ''">$(BuildArgs) /p:UseSystemLlvmLibunwind=$(UseSystemLlvmLibunwind)</BuildArgs>
+    <BuildArgs Condition="'$(UseSystemRapidjson)' != ''">$(BuildArgs) /p:UseSystemRapidjson=$(UseSystemRapidjson)</BuildArgs>
+    <BuildArgs Condition="'$(UseSystemZlib)' != ''">$(BuildArgs) /p:UseSystemZlib=$(UseSystemZlib)</BuildArgs>
+
     <!-- TODO rename this property https://github.com/dotnet/source-build/issues/4165 -->
     <BuildArgs Condition="'$(SourceBuildUseMonoRuntime)' == 'true'">$(BuildArgs) /p:SourceBuildUseMonoRuntime=$(SourceBuildUseMonoRuntime)</BuildArgs>
     <!-- Pass locations for assets -->


### PR DESCRIPTION
Often, when building .NET, we want to build with different configurations of external libraries. For example, runtime has a copy of brotli, and we may or may not want to use that.

This introduces top-level properties to the VMR to select whether to use the bundled copy of a library (eg in, runtime/src/native/external) vs the system copy of the library.

This will be used by https://github.com/dotnet/runtime/pull/101797