### PR TITLE
Fixup tag for sdk diff test runs

### DIFF
--- a/src/SourceBuild/content/eng/pipelines/templates/jobs/sdk-diff-tests.yml
+++ b/src/SourceBuild/content/eng/pipelines/templates/jobs/sdk-diff-tests.yml
@@ -47,7 +47,7 @@ jobs:
 
       echo "Installer build: https://dev.azure.com/dnceng/internal/_build/results?buildId=$installer_build&view=results"
 
-      echo "##vso[build.addbuildtag]installer-$installer_sha"
+      echo "##vso[build.addbuildtag]installer $installer_sha"
       echo "##vso[task.setvariable variable=InstallerBuildId]$installer_build"
       echo "##vso[task.setvariable variable=DotnetDotnetBuildId]$dotnet_dotnet_build"
     displayName: Find associated builds


### PR DESCRIPTION
Resolves https://github.com/dotnet/source-build/issues/3297

Fixup build tag for SDK diff test pipeline runs to make them consistent with other pipelines using a similar pattern (such as `dotnet-source-build`)