### PR TITLE
Disable scenario tests

### DIFF
--- a/src/SourceBuild/content/test/tests.proj
+++ b/src/SourceBuild/content/test/tests.proj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.Build.Traversal">
 
   <PropertyGroup>
-    <_RunScenarioTests>true</_RunScenarioTests>
+    <!-- Temporarily disabled due to https://github.com/dotnet/source-build/issues/4371 -->
+    <_RunScenarioTests>false</_RunScenarioTests>
 
     <!-- Skip scenario tests if the host architecture is different from the target architecture since the tests
         require the ability to execute the built SDK. But the CLI is not capable of running on a host with a 


### PR DESCRIPTION
Disable scenario tests due to flakiness that is sometimes causing a hang: https://github.com/dotnet/source-build/issues/4371