### PR TITLE
Allow diagnostics test binaries

### DIFF
--- a/src/SourceBuild/content/eng/allowed-vmr-binaries.txt
+++ b/src/SourceBuild/content/eng/allowed-vmr-binaries.txt
@@ -38,13 +38,13 @@ src/cecil/symbols/**/Test/Resources/assemblies/*.pdb
 src/cecil/symbols/**/Test/Resources/assemblies/*.dll
 src/cecil/symbols/**/Test/Resources/assemblies/*.mdb
 
-# efcore
-src/efcore/test/EFCore.Sqlite.FunctionalTests/northwind.db # https://github.com/dotnet/source-build/issues/4326
-src/efcore/benchmark/EFCore.Sqlite.Benchmarks/AdventureWorks2014.db # https://github.com/dotnet/source-build/issues/4326
-
 # diagnostics
 src/diagnostics/src/tests/Microsoft.FileFormats.UnitTests/TestBinaries/**/*
 src/diagnostics/src/tests/Microsoft.SymbolStore.UnitTests/TestBinaries/**/*
+
+# efcore
+src/efcore/test/EFCore.Sqlite.FunctionalTests/northwind.db # https://github.com/dotnet/source-build/issues/4326
+src/efcore/benchmark/EFCore.Sqlite.Benchmarks/AdventureWorks2014.db # https://github.com/dotnet/source-build/issues/4326
 
 # fsharp
 src/fsharp/tests/**/*.resources

--- a/src/SourceBuild/content/eng/allowed-vmr-binaries.txt
+++ b/src/SourceBuild/content/eng/allowed-vmr-binaries.txt
@@ -42,6 +42,10 @@ src/cecil/symbols/**/Test/Resources/assemblies/*.mdb
 src/efcore/test/EFCore.Sqlite.FunctionalTests/northwind.db # https://github.com/dotnet/source-build/issues/4326
 src/efcore/benchmark/EFCore.Sqlite.Benchmarks/AdventureWorks2014.db # https://github.com/dotnet/source-build/issues/4326
 
+# diagnostics
+src/diagnostics/src/tests/Microsoft.FileFormats.UnitTests/TestBinaries/**/*
+src/diagnostics/src/tests/Microsoft.SymbolStore.UnitTests/TestBinaries/**/*
+
 # fsharp
 src/fsharp/tests/**/*.resources
 src/fsharp/tests/**/*.dll


### PR DESCRIPTION
Closes https://github.com/dotnet/source-build/issues/4375

Allows diagnostics test binaries into the VMR.
