### PR TITLE
Add false positive wpf licenses to exclusions

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseExclusions.txt
@@ -284,5 +284,10 @@ src/wpf/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FontE
 src/wpf/eng/WpfArcadeSdk/tools/AvTrace/GenTraceSources.pl|proprietary-license
 src/wpf/eng/WpfArcadeSdk/tools/GenXmlStringTable.pl|proprietary-license
 
-# False positive
+# False positive - https://github.com/dotnet/source-build/issues/4373
 src/wpf/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/RMPublishingDialog.RightsTable.cs|unknown-license-reference
+src/wpf/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/WindowBackdropType.cs|bsd-2-clause-views
+src/wpf/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/*.xaml|bsd-2-clause-views
+src/wpf/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/*.xaml|bsd-2-clause-views
+src/wpf/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/*.xaml|bsd-2-clause-views
+src/wpf/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/*.xaml|mpl-2.0


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4373

Adds false positives to wpf exclusions list.

Tested locally:
```
.dotnet/dotnet test test/Microsoft.DotNet.SourceBuild.SmokeTests/Microsoft.DotNet.SourceBuild.SmokeTests.csproj --filter "FullyQualifiedName=Microsoft.DotNet.SourceBuild.SmokeTests.LicenseScanTests.ScanForLicenses" /p:SmokeTestsLicenseScanPath=/root/repos/dotnet/src/wpf/ /p:TargetRid=linux-x64 /p:PortableRid=linux-x64

  Determining projects to restore...
  All projects are up-to-date for restore.
  TestUtilities -> /root/repos/dotnet/artifacts/bin/TestUtilities/Release/TestUtilities.dll
  Microsoft.DotNet.SourceBuild.SmokeTests -> /root/repos/dotnet/artifacts/bin/Microsoft.DotNet.SourceBuild.SmokeTests/Release/Microsoft.DotNet.SourceBuild.SmokeTests.dll
  Passed Microsoft.DotNet.SourceBuild.SmokeTests.LicenseScanTests.ScanForLicenses [24m 46s]
  Outputs:
    Standard Output Messages:
   Executing: scancode --license --processes 4 --timeout 240 --strip-root --only-findings --ignore *.ildump --json-pp /root/repos/dotnet/artifacts/TestResults/Release/scancode-results.json /root/repos/dotnet/src/wpf/
  
  Passed! - Failed: 0, Passed: 1, Skipped: 0, Total: 1, Duration: [24m 47s]
```
