### PR TITLE
Specify artifacts path

### DIFF
--- a/src/SourceBuild/content/eng/pipelines/templates/jobs/sdk-diff-tests.yml
+++ b/src/SourceBuild/content/eng/pipelines/templates/jobs/sdk-diff-tests.yml
@@ -64,14 +64,14 @@ jobs:
     parameters:
       buildName: ${{ parameters.buildName }}
       architecture: ${{ parameters.architecture }}
-      patterns: '**/dotnet-sdk-+([0-9]).+([0-9]).+([0-9])?(-@(alpha|preview|rc|rtm)*)-${{ parameters.targetRid }}.tar.gz' 
+      patterns: '**/assets/Release/dotnet-sdk-+([0-9]).+([0-9]).+([0-9])?(-@(alpha|preview|rc|rtm)*)-${{ parameters.targetRid }}.tar.gz' 
       displayName: Download Source Build SDK
 
   - template: ../steps/download-vmr-artifact.yml
     parameters:
       buildName: ${{ parameters.buildName }}
       architecture: ${{ parameters.architecture }}
-      patterns: '**/Private.SourceBuilt.Artifacts.+([0-9]).+([0-9]).+([0-9])?(-@(alpha|preview|rc|rtm)*).${{ parameters.targetRid }}.tar.gz' 
+      patterns: '**/assets/Release/Private.SourceBuilt.Artifacts.+([0-9]).+([0-9]).+([0-9])?(-@(alpha|preview|rc|rtm)*).${{ parameters.targetRid }}.tar.gz' 
       displayName: Download Source Built Artifacts
 
   - script: |


### PR DESCRIPTION
When I was working on the bootstrapping automation, I noticed that when pulling the sdk from the VMR build, two artifacts were being downloaded. I discovered that we publish two sdks: one in `assets/Release/` and another one in `assets/Release/Sdk/`. The sdk diff test pipeline was downloading both sdks.

This PR updates the sdk diff tests to only download the source-build Sdk that gets uploaded to `assets/Release`.

[Link the pipeline run with changes](https://dev.azure.com/dnceng/internal/_build/results?buildId=2446083&view=logs&j=c2a3fba4-babc-5882-e82a-8e0dc9edd6ec&t=28e0b171-8ef9-5c9e-b3e9-f7b41f70e0d0) (internal Microsoft link)
