### PR TITLE
Update to later version of nuget

### DIFF
--- a/src/SourceBuild/Arcade/src/SourceBuild.Tasks.csproj
+++ b/src/SourceBuild/Arcade/src/SourceBuild.Tasks.csproj
@@ -11,7 +11,7 @@
 
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" PrivateAssets="All" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" Publish="false" ExcludeAssets="runtime" />
-    <PackageReference Include="NuGet.Packaging" Version="5.8.0" />
+    <PackageReference Include="NuGet.Packaging" Version="5.11.6" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This is being flagged by a scanner. Not sure if 5.11.6 will work but it's the only available 5.* version that's compliant
