### PR TITLE
[release/8.0.1xx] Update Fedora and CentOS Stream SB CI legs

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -164,8 +164,8 @@ jobs:
         notFoundMessage="No source-built SDK found to download..."
 
         echo "Looking for source-built SDK to download..."
-        archiveUrlLine=`grep -m 1 "<PrivateSourceBuiltSdkUrl_CentOS8Stream>" "$packageVersionsPath" || :`
-        urlPattern="<PrivateSourceBuiltSdkUrl_CentOS8Stream>(.*)</PrivateSourceBuiltSdkUrl_CentOS8Stream>"
+        archiveUrlLine=`grep -m 1 "<PrivateSourceBuiltSdkUrl>" "$packageVersionsPath" || :`
+        urlPattern="<PrivateSourceBuiltSdkUrl>(.*)</PrivateSourceBuiltSdkUrl>"
 
         if [[ $archiveUrlLine =~ $urlPattern ]]; then
           archiveUrl="${BASH_REMATCH[1]}"

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -19,27 +19,6 @@ parameters:
   type: boolean
   default: false
 
-  # The following parameters aren't expected to be passed in rather they are used for encapsulation
-  # -----------------------------------------------------------------------------------------------
-- name: alpine319Container
-  type: string
-  default: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19
-- name: centOSStream8Container
-  type: string
-  default: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8
-- name: centOSStream9Container
-  type: string
-  default: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9
-- name: fedora38Container
-  type: string
-  default: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-38
-- name: ubuntu2204Container
-  type: string
-  default: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04
-- name: ubuntu2204ArmContainer
-  type: string
-  default: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-arm64
-
 # These are not expected to be passed it but rather just object variables reused below
 - name: pool_Linux
   type: object
@@ -79,12 +58,12 @@ stages:
   - template: ../jobs/vmr-build.yml@self
     parameters:
       # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-      buildName: CentOSStream8_Online_MsftSdk
+      buildName: ${{ format('{0}_Online_MsftSdk', variables.centOSStreamName) }}
       isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
       vmrBranch: ${{ variables.VmrBranch }}
       architecture: x64
       pool: ${{ parameters.pool_Linux }}
-      container: ${{ parameters.centOSStream8Container }}
+      container: ${{ variables.centOSStreamContainer }}
       buildFromArchive: false            # 🚫
       enablePoison: false                # 🚫
       excludeOmniSharpTests: true        # ✅
@@ -95,12 +74,12 @@ stages:
   - template: ../jobs/vmr-build.yml@self
     parameters:
       # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-      buildName: CentOSStream8_Offline_MsftSdk
+      buildName: ${{ format('{0}_Offline_MsftSdk', variables.centOSStreamName) }}
       isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
       vmrBranch: ${{ variables.VmrBranch }}
       architecture: x64
       pool: ${{ parameters.pool_Linux }}
-      container: ${{ parameters.centOSStream8Container }}
+      container: ${{ variables.centOSStreamContainer }}
       buildFromArchive: true             # ✅
       enablePoison: false                # 🚫
       excludeOmniSharpTests: true        # ✅
@@ -115,12 +94,12 @@ stages:
     - template: ../jobs/vmr-build.yml@self
       parameters:
         # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-        buildName: Alpine319_Offline_MsftSdk
+        buildName: ${{ format('{0}_Offline_MsftSdk', variables.alpineName) }}
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
         vmrBranch: ${{ variables.VmrBranch }}
         architecture: x64
         pool: ${{ parameters.pool_Linux }}
-        container: ${{ parameters.alpine319Container }}
+        container: ${{ variables.alpineContainer }}
         buildFromArchive: false            # ✅
         enablePoison: false                # 🚫
         excludeOmniSharpTests: true        # ✅
@@ -131,12 +110,12 @@ stages:
     - template: ../jobs/vmr-build.yml@self
       parameters:
         # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-        buildName: CentOSStream8_Online_PreviousSourceBuiltSdk
+        buildName: ${{ format('{0}_Online_PreviousSourceBuiltSdk', variables.centOSStreamName) }}
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
         vmrBranch: ${{ variables.VmrBranch }}
         architecture: x64
         pool: ${{ parameters.pool_Linux }}
-        container: ${{ parameters.centOSStream8Container }}
+        container: ${{ variables.centOSStreamContainer }}
         buildFromArchive: false            # 🚫
         enablePoison: false                # 🚫
         excludeOmniSharpTests: true        # ✅
@@ -147,12 +126,12 @@ stages:
     - template: ../jobs/vmr-build.yml@self
       parameters:
         # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-        buildName: CentOSStream8_Offline_PreviousSourceBuiltSdk
+        buildName: ${{ format('{0}_Offline_PreviousSourceBuiltSdk', variables.centOSStreamName) }}
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
         vmrBranch: ${{ variables.VmrBranch }}
         architecture: x64
         pool: ${{ parameters.pool_Linux }}
-        container: ${{ parameters.centOSStream8Container }}
+        container: ${{ variables.centOSStreamContainer }}
         buildFromArchive: false            # 🚫
         enablePoison: false                # 🚫
         excludeOmniSharpTests: true        # ✅
@@ -163,12 +142,12 @@ stages:
     - template: ../jobs/vmr-build.yml@self
       parameters:
         # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-        buildName: CentOSStream8_Mono_Offline_MsftSdk
+        buildName: ${{ format('{0}_Mono_Offline_MsftSdk', variables.centOSStreamName) }}
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
         vmrBranch: ${{ variables.VmrBranch }}
         architecture: x64
         pool: ${{ parameters.pool_Linux }}
-        container: ${{ parameters.centOSStream8Container }}
+        container: ${{ variables.centOSStreamContainer }}
         buildFromArchive: true             # ✅
         enablePoison: false                # 🚫
         excludeOmniSharpTests: true        # ✅
@@ -179,28 +158,12 @@ stages:
     - template: ../jobs/vmr-build.yml@self
       parameters:
         # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-        buildName: CentOSStream9_Offline_MsftSdk
+        buildName: ${{ format('{0}_Offline_MsftSdk', variables.fedoraName) }}
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
         vmrBranch: ${{ variables.VmrBranch }}
         architecture: x64
         pool: ${{ parameters.pool_Linux }}
-        container: ${{ parameters.centOSStream9Container }}
-        buildFromArchive: true             # ✅
-        enablePoison: false                # 🚫
-        excludeOmniSharpTests: false       # 🚫
-        runOnline: false                   # 🚫
-        useMonoRuntime: false              # 🚫
-        withPreviousSDK: false             # 🚫
-
-    - template: ../jobs/vmr-build.yml@self
-      parameters:
-        # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-        buildName: Fedora38_Offline_MsftSdk
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        vmrBranch: ${{ variables.VmrBranch }}
-        architecture: x64
-        pool: ${{ parameters.pool_Linux }}
-        container: ${{ parameters.fedora38Container }}
+        container: ${{ variables.fedoraContainer }}
         buildFromArchive: true             # ✅
         enablePoison: true                 # ✅
         excludeOmniSharpTests: false       # 🚫
@@ -211,12 +174,12 @@ stages:
     - template: ../jobs/vmr-build.yml@self
       parameters:
         # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-        buildName: Ubuntu2204_Offline_MsftSdk
+        buildName: ${{ format('{0}_Offline_MsftSdk', variables.ubuntuName) }}
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
         vmrBranch: ${{ variables.VmrBranch }}
         architecture: x64
         pool: ${{ parameters.pool_Linux }}
-        container: ${{ parameters.ubuntu2204Container }}
+        container: ${{ variables.ubuntuContainer }}
         buildFromArchive: false            # 🚫
         enablePoison: false                # 🚫
         excludeOmniSharpTests: false       # 🚫
@@ -229,12 +192,12 @@ stages:
     - template: ../jobs/vmr-build.yml@self
       parameters:
         # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-        buildName: Ubuntu2204Arm64_Offline_MsftSdk
+        buildName: ${{ format('{0}Arm64_Offline_MsftSdk', variables.ubuntuName) }}
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
         vmrBranch: ${{ variables.VmrBranch }}
         architecture: arm64
         pool: ${{ parameters.pool_LinuxArm64 }}
-        container: ${{ parameters.ubuntu2204ArmContainer }}
+        container: ${{ variables.ubuntuArmContainer }}
         buildFromArchive: false            # 🚫
         enablePoison: false                # 🚫
         excludeOmniSharpTests: false       # 🚫
@@ -247,33 +210,33 @@ stages:
     - template: ../jobs/vmr-build.yml@self
       parameters:
         # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-        buildName: CentOSStream8_Online_CurrentSourceBuiltSdk
+        buildName: ${{ format('{0}_Online_CurrentSourceBuiltSdk', variables.centOSStreamName) }}
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
         vmrBranch: ${{ variables.VmrBranch }}
         architecture: x64
         pool: ${{ parameters.pool_Linux }}
-        container: ${{ parameters.centOSStream8Container }}
+        container: ${{ variables.centOSStreamContainer }}
         buildFromArchive: false            # 🚫
         enablePoison: false                # 🚫
         excludeOmniSharpTests: true        # ✅
         runOnline: false                   # 🚫
         useMonoRuntime: false              # 🚫
         withPreviousSDK: false             # 🚫
-        reuseBuildArtifactsFrom: CentOSStream8_Online_MsftSdk
+        reuseBuildArtifactsFrom: ${{ format('{0}_Online_MsftSdk', variables.centOSStreamName) }}
 
     - template: ../jobs/vmr-build.yml@self
       parameters:
         # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-        buildName: Fedora38_Offline_CurrentSourceBuiltSdk
+        buildName: ${{ format('{0}_Offline_CurrentSourceBuiltSdk', variables.fedoraName) }}
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
         vmrBranch: ${{ variables.VmrBranch }}
         architecture: x64
         pool: ${{ parameters.pool_Linux }}
-        container: ${{ parameters.fedora38Container }}
+        container: ${{ variables.fedoraContainer }}
         buildFromArchive: false            # 🚫
         enablePoison: false                # 🚫
         excludeOmniSharpTests: false       # 🚫
         runOnline: false                   # 🚫
         useMonoRuntime: false              # 🚫
         withPreviousSDK: false             # 🚫
-        reuseBuildArtifactsFrom: Fedora38_Offline_MsftSdk
+        reuseBuildArtifactsFrom: ${{ format('{0}_Offline_MsftSdk', variables.fedoraName) }}

--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -1,4 +1,34 @@
 variables:
+- name: alpineContainer
+  value: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
+- name: centOSStreamContainer
+  value: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9
+- name: fedoraContainer
+  value: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-40
+- name: ubuntuContainer
+  value: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04
+- name: ubuntuArmContainer
+  value: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-arm64
+
+- name: alpineName
+  value: Alpine319
+- name: centOSStreamName
+  value: CentOSStream9
+- name: fedoraName
+  value: Fedora40
+- name: ubuntuName
+  value: Ubuntu2204
+
+- name: alpineX64Rid
+  value: alpine.3.19-x64
+- name: centOSStreamX64Rid
+  value: centos.9-x64
+- name: fedoraX64Rid
+  value: fedora.40-x64
+- name: ubuntux64Rid
+  value: ubuntu.22.04-x64
+- name: ubuntuArm64Rid
+  value: ubuntu.22.04-arm64
 
 - ${{ if eq(variables['System.TeamProject'], 'public') }}:
   - name: defaultPoolName

--- a/src/SourceBuild/content/eng/Versions.props
+++ b/src/SourceBuild/content/eng/Versions.props
@@ -30,7 +30,7 @@
       These URLs can't be composed from their base URL and version as we read them from the
       prep.sh and pipeline scripts, outside of MSBuild.
     -->
-    <PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Artifacts.8.0.105-servicing.24224.1.centos.8-x64.tar.gz</PrivateSourceBuiltArtifactsUrl>
-    <PrivateSourceBuiltSdkUrl_CentOS8Stream>https://dotnetcli.azureedge.net/source-built-artifacts/sdks/dotnet-sdk-8.0.105-centos.8-x64.tar.gz</PrivateSourceBuiltSdkUrl_CentOS8Stream>
+    <PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Artifacts.8.0.105-servicing.24224.1.centos.9-x64.tar.gz</PrivateSourceBuiltArtifactsUrl>
+    <PrivateSourceBuiltSdkUrl>https://dotnetcli.azureedge.net/source-built-artifacts/sdks/dotnet-sdk-8.0.105-centos.9-x64.tar.gz</PrivateSourceBuiltSdkUrl>
   </PropertyGroup>
 </Project>

--- a/src/SourceBuild/content/eng/pipelines/source-build-sdk-diff-tests.yml
+++ b/src/SourceBuild/content/eng/pipelines/source-build-sdk-diff-tests.yml
@@ -43,7 +43,7 @@ jobs:
 
 - template: templates/jobs/sdk-diff-tests.yml
   parameters:
-    buildName: ${{ format('{0}_Online_MsftSdk', variables.alpineName) }}
+    buildName: ${{ format('{0}_Offline_MsftSdk', variables.alpineName) }}
     targetRid: ${{ variables.alpineX64Rid }}
     architecture: x64
     dotnetDotnetRunId: ${{ parameters.dotnetDotnetRunId }}

--- a/src/SourceBuild/content/eng/pipelines/source-build-sdk-diff-tests.yml
+++ b/src/SourceBuild/content/eng/pipelines/source-build-sdk-diff-tests.yml
@@ -30,45 +30,41 @@ parameters:
   type: string
   default: ' '
 
+variables:
+- template: /src/installer/eng/pipelines/templates/variables/vmr-build.yml@self
+
 jobs:
 - template: templates/jobs/sdk-diff-tests.yml
   parameters:
-    buildName: CentOSStream8_Offline_MsftSdk
-    targetRid: centos.8-x64
+    buildName: ${{ format('{0}_Offline_MsftSdk', variables.centOSStreamName) }}
+    targetRid: ${{ variables.centOSStreamX64Rid }}
     architecture: x64
     dotnetDotnetRunId: ${{ parameters.dotnetDotnetRunId }}
 
 - template: templates/jobs/sdk-diff-tests.yml
   parameters:
-    buildName: CentOSStream9_Offline_MsftSdk
-    targetRid: centos.9-x64
+    buildName: ${{ format('{0}_Online_MsftSdk', variables.alpineName) }}
+    targetRid: ${{ variables.alpineX64Rid }}
     architecture: x64
     dotnetDotnetRunId: ${{ parameters.dotnetDotnetRunId }}
 
 - template: templates/jobs/sdk-diff-tests.yml
   parameters:
-    buildName: Alpine319_Offline_MsftSdk
-    targetRid: alpine.3.19-x64
+    buildName: ${{ format('{0}_Offline_MsftSdk', variables.fedoraName) }}
+    targetRid: ${{ variables.fedoraX64Rid }}
     architecture: x64
     dotnetDotnetRunId: ${{ parameters.dotnetDotnetRunId }}
 
 - template: templates/jobs/sdk-diff-tests.yml
   parameters:
-    buildName: Fedora38_Offline_MsftSdk
-    targetRid: fedora.38-x64
+    buildName: ${{ format('{0}_Offline_MsftSdk', variables.ubuntuName) }}
+    targetRid: ${{ variables.ubuntuX64Rid }}
     architecture: x64
     dotnetDotnetRunId: ${{ parameters.dotnetDotnetRunId }}
 
 - template: templates/jobs/sdk-diff-tests.yml
   parameters:
-    buildName: Ubuntu2204_Offline_MsftSdk
-    targetRid: ubuntu.22.04-x64
-    architecture: x64
-    dotnetDotnetRunId: ${{ parameters.dotnetDotnetRunId }}
-
-- template: templates/jobs/sdk-diff-tests.yml
-  parameters:
-    buildName: Ubuntu2204Arm64_Offline_MsftSdk
-    targetRid: ubuntu.22.04-arm64
+    buildName: ${{ format('{0}Arm64_Offline_MsftSdk', variables.ubuntuName) }}
+    targetRid: ${{ variables.ubuntuArm64Rid }}
     architecture: arm64
     dotnetDotnetRunId: ${{ parameters.dotnetDotnetRunId }}


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/4399 and https://github.com/dotnet/source-build/issues/4301

- Updated Fedora 39 to 40
- Updated CentOS Stream 8 to 9
- Uploaded the appropriate CentOS Stream 9 artifacts
- Factored out distro versions into variables to make future upgrades easier

Test runs (internal Microsoft links)
[dotnet-source-build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2454341&view=results)
[source-build-sdk-diff-tests](https://dev.azure.com/dnceng/internal/_build/results?buildId=2454694&view=results)

