### PR TITLE
Update 6.0 Test Baselines

### DIFF
--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdk.diff
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/MsftToSbSdk.diff
@@ -14,7 +14,20 @@ index ------------
  ./packs/Microsoft.AspNetCore.App.Ref/
  ./packs/Microsoft.AspNetCore.App.Ref/x.y.z/
 @@ ------------ @@
+ ./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/Microsoft.JSInterop.xml
+ ./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/Microsoft.Net.Http.Headers.dll
+ ./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/Microsoft.Net.Http.Headers.xml
++./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Diagnostics.DiagnosticSource.dll
++./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Diagnostics.DiagnosticSource.xml
+ ./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Diagnostics.EventLog.dll
+ ./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Diagnostics.EventLog.xml
++./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Formats.Asn1.dll
++./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Formats.Asn1.xml
+ ./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.IO.Pipelines.dll
  ./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.IO.Pipelines.xml
++./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Runtime.CompilerServices.Unsafe.dll
++./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Security.AccessControl.dll
++./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Security.AccessControl.xml
  ./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Security.Cryptography.Xml.dll
  ./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Security.Cryptography.Xml.xml
 -./packs/Microsoft.NETCore.App.Host.portable-rid/
@@ -29,6 +42,10 @@ index ------------
 -./packs/Microsoft.NETCore.App.Host.portable-rid/x.y.z/runtimes/portable-rid/native/libnethost.so
 -./packs/Microsoft.NETCore.App.Host.portable-rid/x.y.z/runtimes/portable-rid/native/nethost.h
 -./packs/Microsoft.NETCore.App.Host.portable-rid/x.y.z/runtimes/portable-rid/native/singlefilehost
++./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Text.Encodings.Web.dll
++./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Text.Encodings.Web.xml
++./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Text.Json.dll
++./packs/Microsoft.AspNetCore.App.Ref/x.y.z/ref/netx.y/System.Text.Json.xml
 +./packs/Microsoft.NETCore.App.Host.banana-rid/
 +./packs/Microsoft.NETCore.App.Host.banana-rid/x.y.z/
 +./packs/Microsoft.NETCore.App.Host.banana-rid/x.y.z/runtimes/

--- a/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/PoisonUsage.txt
+++ b/src/SourceBuild/tarball/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/baselines/PoisonUsage.txt
@@ -107,6 +107,12 @@
   <File Path="Microsoft.DotNet.Arcade.Sdk.x.y.z/tools/netx.y/NuGet.Versioning.dll">
     <Type>AssemblyAttribute</Type>
   </File>
+  <File Path="Microsoft.DotNet.Arcade.Sdk.x.y.z/tools/netx.y/runtimes/win/lib/netx.y/System.Security.AccessControl.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.Arcade.Sdk.x.y.z/tools/netx.y/runtimes/win/lib/netx.y/System.Security.AccessControl.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
   <File Path="Microsoft.DotNet.Arcade.Sdk.x.y.z/tools/netx.y/System.Reflection.Metadata.dll">
     <Type>AssemblyAttribute</Type>
   </File>
@@ -117,6 +123,12 @@
     <Type>AssemblyAttribute</Type>
   </File>
   <File Path="Microsoft.DotNet.Arcade.Sdk.x.y.z/tools/netx.y/System.Runtime.CompilerServices.Unsafe.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.Arcade.Sdk.x.y.z/tools/netx.y/System.Security.AccessControl.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.Arcade.Sdk.x.y.z/tools/netx.y/System.Security.AccessControl.dll">
     <Type>AssemblyAttribute</Type>
   </File>
   <File Path="Microsoft.DotNet.Build.Tasks.Installers.x.y.z/tools/netx.y/Newtonsoft.Json.dll">
@@ -251,10 +263,28 @@
   <File Path="Microsoft.DotNet.Build.Tasks.Packaging.x.y.z/tools/netx.y/runtimes/browser/lib/netx.y/System.Text.Encodings.Web.dll">
     <Type>AssemblyAttribute</Type>
   </File>
+  <File Path="Microsoft.DotNet.Build.Tasks.Packaging.x.y.z/tools/netx.y/runtimes/win/lib/netx.y/System.Security.AccessControl.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.Build.Tasks.Packaging.x.y.z/tools/netx.y/runtimes/win/lib/netx.y/System.Security.AccessControl.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.Build.Tasks.Packaging.x.y.z/tools/netx.y/runtimes/win/lib/netx.y/System.Security.Cryptography.Pkcs.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.Build.Tasks.Packaging.x.y.z/tools/netx.y/runtimes/win/lib/netx.y/System.Security.Cryptography.Pkcs.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
   <File Path="Microsoft.DotNet.Build.Tasks.Packaging.x.y.z/tools/netx.y/System.Collections.Immutable.dll">
     <Type>AssemblyAttribute</Type>
   </File>
   <File Path="Microsoft.DotNet.Build.Tasks.Packaging.x.y.z/tools/netx.y/System.Collections.Immutable.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.Build.Tasks.Packaging.x.y.z/tools/netx.y/System.Formats.Asn1.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.Build.Tasks.Packaging.x.y.z/tools/netx.y/System.Formats.Asn1.dll">
     <Type>AssemblyAttribute</Type>
   </File>
   <File Path="Microsoft.DotNet.Build.Tasks.Packaging.x.y.z/tools/netx.y/System.Reflection.Metadata.dll">
@@ -267,6 +297,18 @@
     <Type>AssemblyAttribute</Type>
   </File>
   <File Path="Microsoft.DotNet.Build.Tasks.Packaging.x.y.z/tools/netx.y/System.Runtime.CompilerServices.Unsafe.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.Build.Tasks.Packaging.x.y.z/tools/netx.y/System.Security.AccessControl.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.Build.Tasks.Packaging.x.y.z/tools/netx.y/System.Security.AccessControl.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.Build.Tasks.Packaging.x.y.z/tools/netx.y/System.Security.Cryptography.Pkcs.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.Build.Tasks.Packaging.x.y.z/tools/netx.y/System.Security.Cryptography.Pkcs.dll">
     <Type>AssemblyAttribute</Type>
   </File>
   <File Path="Microsoft.DotNet.Build.Tasks.Packaging.x.y.z/tools/netx.y/System.Text.Encodings.Web.dll">
@@ -315,6 +357,24 @@
     <Type>AssemblyAttribute</Type>
   </File>
   <File Path="Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.x.y.z/tools/netx.y/NuGet.Versioning.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.x.y.z/tools/netx.y/runtimes/win/lib/netx.y/System.Security.Cryptography.Pkcs.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.x.y.z/tools/netx.y/runtimes/win/lib/netx.y/System.Security.Cryptography.Pkcs.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.x.y.z/tools/netx.y/System.Formats.Asn1.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.x.y.z/tools/netx.y/System.Formats.Asn1.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.x.y.z/tools/netx.y/System.Security.Cryptography.Pkcs.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk.x.y.z/tools/netx.y/System.Security.Cryptography.Pkcs.dll">
     <Type>AssemblyAttribute</Type>
   </File>
   <File Path="Microsoft.DotNet.Build.Tasks.Workloads.x.y.z/tools/netx.y/cs/Microsoft.Deployment.DotNet.Releases.resources.dll">
@@ -491,10 +551,22 @@
   <File Path="Microsoft.DotNet.Build.Tasks.Workloads.x.y.z/tools/netx.y/runtimes/browser/lib/netx.y/System.Text.Encodings.Web.dll">
     <Type>AssemblyAttribute</Type>
   </File>
+  <File Path="Microsoft.DotNet.Build.Tasks.Workloads.x.y.z/tools/netx.y/runtimes/win/lib/netx.y/System.Security.Cryptography.Pkcs.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.Build.Tasks.Workloads.x.y.z/tools/netx.y/runtimes/win/lib/netx.y/System.Security.Cryptography.Pkcs.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
   <File Path="Microsoft.DotNet.Build.Tasks.Workloads.x.y.z/tools/netx.y/System.Collections.Immutable.dll">
     <Type>AssemblyAttribute</Type>
   </File>
   <File Path="Microsoft.DotNet.Build.Tasks.Workloads.x.y.z/tools/netx.y/System.Collections.Immutable.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.Build.Tasks.Workloads.x.y.z/tools/netx.y/System.Formats.Asn1.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.Build.Tasks.Workloads.x.y.z/tools/netx.y/System.Formats.Asn1.dll">
     <Type>AssemblyAttribute</Type>
   </File>
   <File Path="Microsoft.DotNet.Build.Tasks.Workloads.x.y.z/tools/netx.y/System.Reflection.Metadata.dll">
@@ -507,6 +579,12 @@
     <Type>AssemblyAttribute</Type>
   </File>
   <File Path="Microsoft.DotNet.Build.Tasks.Workloads.x.y.z/tools/netx.y/System.Runtime.CompilerServices.Unsafe.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.Build.Tasks.Workloads.x.y.z/tools/netx.y/System.Security.Cryptography.Pkcs.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.Build.Tasks.Workloads.x.y.z/tools/netx.y/System.Security.Cryptography.Pkcs.dll">
     <Type>AssemblyAttribute</Type>
   </File>
   <File Path="Microsoft.DotNet.Build.Tasks.Workloads.x.y.z/tools/netx.y/System.Text.Encodings.Web.dll">
@@ -911,6 +989,12 @@
   <File Path="Microsoft.DotNet.PackageTesting.x.y.z/tools/netx.y/ru/Microsoft.CodeAnalysis.resources.dll">
     <Type>AssemblyAttribute</Type>
   </File>
+  <File Path="Microsoft.DotNet.PackageTesting.x.y.z/tools/netx.y/runtimes/win/lib/netx.y/System.Security.Cryptography.Pkcs.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.PackageTesting.x.y.z/tools/netx.y/runtimes/win/lib/netx.y/System.Security.Cryptography.Pkcs.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
   <File Path="Microsoft.DotNet.PackageTesting.x.y.z/tools/netx.y/runtimes/win/lib/netx.y/System.Text.Encoding.CodePages.dll">
     <Type>AssemblyAttribute</Type>
   </File>
@@ -923,6 +1007,12 @@
   <File Path="Microsoft.DotNet.PackageTesting.x.y.z/tools/netx.y/System.Collections.Immutable.dll">
     <Type>AssemblyAttribute</Type>
   </File>
+  <File Path="Microsoft.DotNet.PackageTesting.x.y.z/tools/netx.y/System.Formats.Asn1.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.PackageTesting.x.y.z/tools/netx.y/System.Formats.Asn1.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
   <File Path="Microsoft.DotNet.PackageTesting.x.y.z/tools/netx.y/System.Reflection.Metadata.dll">
     <Type>AssemblyAttribute</Type>
   </File>
@@ -933,6 +1023,12 @@
     <Type>AssemblyAttribute</Type>
   </File>
   <File Path="Microsoft.DotNet.PackageTesting.x.y.z/tools/netx.y/System.Runtime.CompilerServices.Unsafe.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.PackageTesting.x.y.z/tools/netx.y/System.Security.Cryptography.Pkcs.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.PackageTesting.x.y.z/tools/netx.y/System.Security.Cryptography.Pkcs.dll">
     <Type>AssemblyAttribute</Type>
   </File>
   <File Path="Microsoft.DotNet.PackageTesting.x.y.z/tools/netx.y/System.Text.Encoding.CodePages.dll">
@@ -1257,6 +1353,24 @@
     <Type>AssemblyAttribute</Type>
   </File>
   <File Path="Microsoft.DotNet.SourceBuild.Tasks.x.y.z/tools/netx.y/NuGet.Versioning.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.SourceBuild.Tasks.x.y.z/tools/netx.y/runtimes/win/lib/netx.y/System.Security.Cryptography.Pkcs.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.SourceBuild.Tasks.x.y.z/tools/netx.y/runtimes/win/lib/netx.y/System.Security.Cryptography.Pkcs.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.SourceBuild.Tasks.x.y.z/tools/netx.y/System.Formats.Asn1.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.SourceBuild.Tasks.x.y.z/tools/netx.y/System.Formats.Asn1.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.SourceBuild.Tasks.x.y.z/tools/netx.y/System.Security.Cryptography.Pkcs.dll">
+    <Type>AssemblyAttribute</Type>
+  </File>
+  <File Path="Microsoft.DotNet.SourceBuild.Tasks.x.y.z/tools/netx.y/System.Security.Cryptography.Pkcs.dll">
     <Type>AssemblyAttribute</Type>
   </File>
   <File Path="Microsoft.Net.Compilers.Toolset.x.y.z/tasks/netcoreapp3.1/bincore/runtimes/win/lib/netcoreapp3.1/System.Text.Encoding.CodePages.dll">


### PR DESCRIPTION
Updates the SDK diff baseline and the poison usage report with results from [this test run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2452283&view=results) (internal Microsoft link)