### PR TITLE
[release/6.0.1xx] Update 6.0 source-build CI distro matrix

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -63,8 +63,8 @@ extends:
     template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
   parameters:
     containers:
-      fedora38:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-38
+      fedora40:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-40
     sdl:
       sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -64,7 +64,7 @@ extends:
   parameters:
     containers:
       fedora40:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-40
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-39
     sdl:
       sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)

--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-create-tarball.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-create-tarball.yml
@@ -2,7 +2,7 @@
 
 jobs:
 - job: Source_Build_Create_Tarball
-  container: fedora40
+  container: fedora39
   displayName: Source-Build Create Tarball
   pool:
     ${{ if eq(variables['System.TeamProject'], 'public') }}:

--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-create-tarball.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-create-tarball.yml
@@ -2,7 +2,7 @@
 
 jobs:
 - job: Source_Build_Create_Tarball
-  container: fedora38
+  container: fedora40
   displayName: Source-Build Create Tarball
   pool:
     ${{ if eq(variables['System.TeamProject'], 'public') }}:

--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build-pr.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build-pr.yml
@@ -12,9 +12,8 @@ parameters:
   alpine317Container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.17
   centOS7Container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-source-build
   centOSStream9Container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9
-  debian11Arm64Container: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-arm64v8
-  fedora38Container: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-38
-  ubuntu1804Container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04
+  fedora40Container: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-40
+  ubuntu2004Arm64Container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-arm64
   poolInternalAmd64:
     name: NetCore1ESPool-Svc-Internal
     demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
@@ -64,17 +63,10 @@ jobs:
           _ExcludeOmniSharpTests: false
           _OverrideDistroDisablingSha1: true
           _RunOnline: false
-        Fedora38-Offline:
+        Fedora40-Offline:
           _BootstrapPrep: false
-          _Container: ${{ parameters.fedora38Container }}
+          _Container: ${{ parameters.fedora40Container }}
           _EnablePoison: true
-          _ExcludeOmniSharpTests: false
-          _OverrideDistroDisablingSha1: false
-          _RunOnline: false
-        Ubuntu1804-Offline:
-          _BootstrapPrep: false
-          _Container: ${{ parameters.ubuntu1804Container }}
-          _EnablePoison: false
           _ExcludeOmniSharpTests: false
           _OverrideDistroDisablingSha1: false
           _RunOnline: false
@@ -95,9 +87,9 @@ jobs:
       dependsOn: ${{ parameters.dependsOn }}
       installerBuildResourceId: ${{ parameters.installerBuildResourceId }}
       matrix:
-        Debian11-Offline:
+        Ubuntu2004-Offline:
           _BootstrapPrep: true
-          _Container: ${{ parameters.debian11Arm64Container }}
+          _Container: ${{ parameters.ubuntu2004Arm64Container }}
           _EnablePoison: false
           _ExcludeOmniSharpTests: false
           _OverrideDistroDisablingSha1: false
@@ -116,9 +108,9 @@ jobs:
       excludeSdkContentTests: true
       installerBuildResourceId: ${{ parameters.installerBuildResourceId }}
       matrix:
-        Fedora38-Offline:
-          _PreviousSourceBuildArtifact: Build_Tarball_x64 Fedora38-Offline_Artifacts
-          _Container: ${{ parameters.fedora38Container }}
+        Fedora40-Offline:
+          _PreviousSourceBuildArtifact: Build_Tarball_x64 Fedora40-Offline_Artifacts
+          _Container: ${{ parameters.fedora40Container }}
           _EnablePoison: false
           _ExcludeOmniSharpTests: false
           _OverrideDistroDisablingSha1: false

--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build-pr.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build-pr.yml
@@ -12,7 +12,7 @@ parameters:
   alpine317Container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.17
   centOS7Container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-source-build
   centOSStream9Container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9
-  fedora40Container: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-40
+  fedora39Container: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-39
   ubuntu2004Arm64Container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-arm64
   poolInternalAmd64:
     name: NetCore1ESPool-Svc-Internal
@@ -63,9 +63,9 @@ jobs:
           _ExcludeOmniSharpTests: false
           _OverrideDistroDisablingSha1: true
           _RunOnline: false
-        Fedora40-Offline:
+        Fedora39-Offline:
           _BootstrapPrep: false
-          _Container: ${{ parameters.fedora40Container }}
+          _Container: ${{ parameters.fedora39Container }}
           _EnablePoison: true
           _ExcludeOmniSharpTests: false
           _OverrideDistroDisablingSha1: false
@@ -108,9 +108,9 @@ jobs:
       excludeSdkContentTests: true
       installerBuildResourceId: ${{ parameters.installerBuildResourceId }}
       matrix:
-        Fedora40-Offline:
-          _PreviousSourceBuildArtifact: Build_Tarball_x64 Fedora40-Offline_Artifacts
-          _Container: ${{ parameters.fedora40Container }}
+        Fedora39-Offline:
+          _PreviousSourceBuildArtifact: Build_Tarball_x64 Fedora39-Offline_Artifacts
+          _Container: ${{ parameters.fedora39Container }}
           _EnablePoison: false
           _ExcludeOmniSharpTests: false
           _OverrideDistroDisablingSha1: false

--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build.yml
@@ -12,7 +12,7 @@ parameters:
   alpine317Container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.17
   centOS7Container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-source-build
   centOSStream9Container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9
-  fedora40Container: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-40
+  fedora39Container: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-39
   ubuntu2004Arm64Container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-arm64
   poolInternalAmd64:
     name: NetCore1ESPool-Svc-Internal
@@ -69,9 +69,9 @@ jobs:
           _ExcludeOmniSharpTests: false
           _OverrideDistroDisablingSha1: true
           _RunOnline: false
-        Fedora40-Offline:
+        Fedora39-Offline:
           _BootstrapPrep: false
-          _Container: ${{ parameters.fedora40Container }}
+          _Container: ${{ parameters.fedora39Container }}
           _EnablePoison: true
           _ExcludeOmniSharpTests: false
           _OverrideDistroDisablingSha1: false
@@ -114,9 +114,9 @@ jobs:
       excludeSdkContentTests: true
       installerBuildResourceId: ${{ parameters.installerBuildResourceId }}
       matrix:
-        Fedora40-Offline:
-          _PreviousSourceBuildArtifact: Build_Tarball_x64 Fedora40-Offline_Artifacts
-          _Container: ${{ parameters.fedora40Container }}
+        Fedora39-Offline:
+          _PreviousSourceBuildArtifact: Build_Tarball_x64 Fedora39-Offline_Artifacts
+          _Container: ${{ parameters.fedora39Container }}
           _EnablePoison: false
           _ExcludeOmniSharpTests: false
           _OverrideDistroDisablingSha1: false

--- a/src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build.yml
+++ b/src/SourceBuild/Arcade/eng/common/templates/job/source-build-run-tarball-build.yml
@@ -12,9 +12,8 @@ parameters:
   alpine317Container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.17
   centOS7Container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-source-build
   centOSStream9Container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9
-  debian11Arm64Container: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-arm64v8
-  fedora38Container: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-38
-  ubuntu1804Container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04
+  fedora40Container: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-40
+  ubuntu2004Arm64Container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-arm64
   poolInternalAmd64:
     name: NetCore1ESPool-Svc-Internal
     image: 1es-ubuntu-2004
@@ -70,17 +69,10 @@ jobs:
           _ExcludeOmniSharpTests: false
           _OverrideDistroDisablingSha1: true
           _RunOnline: false
-        Fedora38-Offline:
+        Fedora40-Offline:
           _BootstrapPrep: false
-          _Container: ${{ parameters.fedora38Container }}
+          _Container: ${{ parameters.fedora40Container }}
           _EnablePoison: true
-          _ExcludeOmniSharpTests: false
-          _OverrideDistroDisablingSha1: false
-          _RunOnline: false
-        Ubuntu1804-Offline:
-          _BootstrapPrep: false
-          _Container: ${{ parameters.ubuntu1804Container }}
-          _EnablePoison: false
           _ExcludeOmniSharpTests: false
           _OverrideDistroDisablingSha1: false
           _RunOnline: false
@@ -101,9 +93,9 @@ jobs:
       dependsOn: ${{ parameters.dependsOn }}
       installerBuildResourceId: ${{ parameters.installerBuildResourceId }}
       matrix:
-        Debian11-Offline:
+        Ubuntu2004-Offline:
           _BootstrapPrep: true
-          _Container: ${{ parameters.debian11Arm64Container }}
+          _Container: ${{ parameters.ubuntu2004Arm64Container }}
           _EnablePoison: false
           _ExcludeOmniSharpTests: false
           _OverrideDistroDisablingSha1: false
@@ -122,9 +114,9 @@ jobs:
       excludeSdkContentTests: true
       installerBuildResourceId: ${{ parameters.installerBuildResourceId }}
       matrix:
-        Fedora38-Offline:
-          _PreviousSourceBuildArtifact: Build_Tarball_x64 Fedora38-Offline_Artifacts
-          _Container: ${{ parameters.fedora38Container }}
+        Fedora40-Offline:
+          _PreviousSourceBuildArtifact: Build_Tarball_x64 Fedora40-Offline_Artifacts
+          _Container: ${{ parameters.fedora40Container }}
           _EnablePoison: false
           _ExcludeOmniSharpTests: false
           _OverrideDistroDisablingSha1: false

--- a/src/SourceBuild/tarball/content/eng/pipelines/security-partners-dotnet.yml
+++ b/src/SourceBuild/tarball/content/eng/pipelines/security-partners-dotnet.yml
@@ -37,9 +37,9 @@ extends:
           architecture: x64
           excludeSdkContentTests: true
           matrix:
-            Ubuntu1804-Offline:
+            Ubuntu2004-Offline:
               _BootstrapPrep: false
-              _Container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04
+              _Container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04
               _EnablePoison: false
               _ExcludeOmniSharpTests: false
               _RunOnline: false


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/4399

I did not invest in any improvements to maintainability like I did in 8.0 and main given the pipeline infra is so different in 6.0 and that EOL is in 6 months.
