### PR TITLE
[release/8.0.1xx-staging] Remove PGO builds

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -329,53 +329,6 @@ extends:
             buildArchitecture: arm64
             runTests: false
 
-        # Windows PGO Instrumentation builds
-        - template: eng/build.yml@self
-          parameters:
-            agentOs: Windows_NT
-            pgoInstrument: true
-            jobName: Build_Release_x64
-            buildConfiguration: Release
-            buildArchitecture: x64
-            additionalBuildParameters: '/p:PublishInternalAsset=true'
-            runTests: false
-        - template: eng/build.yml@self
-          parameters:
-            agentOs: Windows_NT
-            pgoInstrument: true
-            jobName: Build_Release_x86
-            buildConfiguration: Release
-            buildArchitecture: x86
-            runTests: false
-        - template: eng/build.yml@self
-          parameters:
-            agentOs: Windows_NT
-            pgoInstrument: true
-            jobName: Build_Release_arm64
-            buildConfiguration: Release
-            buildArchitecture: arm64
-            runTests: false
-
-        # Linux PGO Instrumentation builds
-        - template: eng/build.yml@self
-          parameters:
-            agentOs: Linux
-            pgoInstrument: true
-            jobName: Build_LinuxPortable_Release_x64
-            buildConfiguration: Release
-            buildArchitecture: x64
-            linuxPortable: true
-            runTests: false
-        - template: eng/build.yml@self
-          parameters:
-            agentOs: Linux
-            pgoInstrument: true
-            jobName: Build_Release_arm64
-            buildConfiguration: Release
-            buildArchitecture: arm64
-            linuxPortable: true
-            runTests: false
-
       # Source Build
       - template: /eng/common/templates-official/jobs/source-build.yml@self
 


### PR DESCRIPTION
Remove the PGO legs in dotnet/installer's official build. We aren't using these assets, and we accidentally regressed production of them in dotnet/runtime. We initially were going to fix this by [fixing the jobs in dotnet/runtime](https://github.com/dotnet/runtime/pull/102527), but respinning runtime is expensive at this time so we decided to modify the build here instead.

## Customer Impact

- [ ] Customer reported
- [X] Found internally

[Select one or both of the boxes. Describe how this issue impacts customers, citing the expected and actual behaviors and scope of the issue. If customer-reported, provide the issue number.]

## Regression

- [X] Yes
- [ ] No

[If yes, specify when the regression was introduced. Provide the PR or commit if known.]

Regressed with https://github.com/dotnet/runtime/pull/102097

## Testing

[How was the fix verified? How was the issue missed previously? What tests were added?]
This is just removing test lanes, so high confidence in the fix.

## Risk

[High/Medium/Low. Justify the indication by mentioning how risks were measured and addressed.]

Low risk. We're removing these jobs completely and the PGO assets are the only assets that were produced by these jobs.

