### PR TITLE
.NET Source-Build 8.0.106 May 2024 Updates

### DIFF
--- a/src/SourceBuild/content/eng/Versions.props
+++ b/src/SourceBuild/content/eng/Versions.props
@@ -30,7 +30,7 @@
       These URLs can't be composed from their base URL and version as we read them from the
       prep.sh and pipeline scripts, outside of MSBuild.
     -->
-    <PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Artifacts.8.0.105-servicing.24224.1.centos.9-x64.tar.gz</PrivateSourceBuiltArtifactsUrl>
-    <PrivateSourceBuiltSdkUrl>https://dotnetcli.azureedge.net/source-built-artifacts/sdks/dotnet-sdk-8.0.105-centos.9-x64.tar.gz</PrivateSourceBuiltSdkUrl>
+    <PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Artifacts.8.0.106-servicing.24278.1.centos.8-x64.tar.gz</PrivateSourceBuiltArtifactsUrl>
+    <PrivateSourceBuiltSdkUrl>https://dotnetcli.azureedge.net/source-built-artifacts/sdks/dotnet-sdk-8.0.106-centos.8-x64.tar.gz</PrivateSourceBuiltSdkUrl>
   </PropertyGroup>
 </Project>

--- a/src/SourceBuild/content/eng/Versions.props
+++ b/src/SourceBuild/content/eng/Versions.props
@@ -30,7 +30,7 @@
       These URLs can't be composed from their base URL and version as we read them from the
       prep.sh and pipeline scripts, outside of MSBuild.
     -->
-    <PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Artifacts.8.0.106-servicing.24278.1.centos.8-x64.tar.gz</PrivateSourceBuiltArtifactsUrl>
-    <PrivateSourceBuiltSdkUrl>https://dotnetcli.azureedge.net/source-built-artifacts/sdks/dotnet-sdk-8.0.106-centos.8-x64.tar.gz</PrivateSourceBuiltSdkUrl>
+    <PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Artifacts.8.0.106-servicing.24278.1.centos.9-x64.tar.gz</PrivateSourceBuiltArtifactsUrl>
+    <PrivateSourceBuiltSdkUrl>https://dotnetcli.azureedge.net/source-built-artifacts/sdks/dotnet-sdk-8.0.106-centos.9-x64.tar.gz</PrivateSourceBuiltSdkUrl>
   </PropertyGroup>
 </Project>

--- a/src/SourceBuild/content/global.json
+++ b/src/SourceBuild/content/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "8.0.105"
+    "dotnet": "8.0.106"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.1",


### PR DESCRIPTION
Source-build updates for the .NET 8.0.6 / 8.0.106 May 2024 release.