### PR TITLE
Update UsagePattern IdentityGlob with wildcard for versioning

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -12,8 +12,8 @@
     <UsagePattern IdentityGlob="NuGet.*/*" />
 
     <!-- These MSBuild packages are allowed for installer repo build. The live version will be flowed in for the VMR build. -->
-    <UsagePattern IdentityGlob="Microsoft.Build*/17.11.0-preview-24314-04" />
-    <UsagePattern IdentityGlob="Microsoft.NET.StringTools/17.11.0-preview-24314-04" />
+    <UsagePattern IdentityGlob="Microsoft.Build*/17.11.0-preview-*" />
+    <UsagePattern IdentityGlob="Microsoft.NET.StringTools/17.11.0-preview-*" />
 
     <!-- These are coming in via runtime but the source-build infra isn't able to automatically pick up the right intermediate. -->
     <UsagePattern IdentityGlob="Microsoft.NETCore.App.Crossgen2.linux-x64/*8.0.*" />


### PR DESCRIPTION
Every time the msbuild version is upgraded, it leads to the need for manual updates of `<UsagePattern IdentityGlob="Microsoft.Build/17.11.0-preview-24314-04" />` and `<UsagePattern IdentityGlob="Microsoft.NET.StringTools/17.11.0-preview-24314-04" />`. To avoid this, I have decided to use a wildcard. This change will help reduce the number of times we need to update manually. 