### PR TITLE
Remove dash from sdk diff build tag

### DIFF
--- a/src/SourceBuild/content/eng/pipelines/templates/jobs/sdk-diff-tests.yml
+++ b/src/SourceBuild/content/eng/pipelines/templates/jobs/sdk-diff-tests.yml
@@ -47,7 +47,7 @@ jobs:
 
       echo "Installer build: https://dev.azure.com/dnceng/internal/_build/results?buildId=$installer_build&view=results"
 
-      echo "##vso[build.addbuildtag]installer-$installer_sha"
+      echo "##vso[build.addbuildtag]installer $installer_sha"
       echo "##vso[task.setvariable variable=InstallerBuildId]$installer_build"
       echo "##vso[task.setvariable variable=DotnetDotnetBuildId]$dotnet_dotnet_build"
     displayName: Find associated builds


### PR DESCRIPTION
The release pipeline looks for a corresponding sdk diff build tag in the format `<repo> <sha>`. This convention is currently effective for .NET 9 as the builds' tags align with this format: `sdk <sha>`. However, .NET 8 builds still follow the `installer-<sha>` format. To ensure consistency across different versions, the tag format should be uniform. Given that the release pipeline anticipates a tag without a dash, we should remove the dash from the 8.0 version tags.

[Example of the release pipeline looking for sdk diff build containing a tag without a dash](https://dev.azure.com/dnceng/internal/_build/results?buildId=2481357&view=logs&j=3a04dffd-22cf-5707-fa41-9bd4708cc1db&t=a2133bbe-9a51-5b40-3f86-f7807de1199c&l=13) (internal Microsoft link)
[Example of the associated sdk diff build containing a tag with a dash](https://dev.azure.com/dnceng/internal/_build/results?buildId=2476079&view=results) (internal Microsoft link)