### PR TITLE
Remove the 2.x pieces. Update for preview 6.

### DIFF
--- a/tools/sdk-readme-table-generator/TableGenerator/Program.fs
+++ b/tools/sdk-readme-table-generator/TableGenerator/Program.fs
@@ -9,37 +9,25 @@ let inputBranches =
         [ { GitBranchName = "main"
             DisplayName = "main<br>(9.0.x&nbsp;Runtime)"
             AkaMsChannel = Some("9.0.1xx/daily") }
-          { GitBranchName = "release/9.0.1XX-preview4"
-            DisplayName = "9.0.1XX-preview4<br>(9.0-preview4&nbsp;Runtime)"
-            AkaMsChannel = Some("9.0.1XX-preview4/daily") }
+          { GitBranchName = "release/9.0.1xx-preview6"
+            DisplayName = "9.0.1xx-preview6<br>(9.0-preview6&nbsp;Runtime)"
+            AkaMsChannel = Some("9.0.1xx-preview6/daily") }
           { GitBranchName = "release/8.0.4xx"
             DisplayName = "8.0.4xx<br>(8.0&nbsp;Runtime)"
-            AkaMsChannel = Some("8.0.4xx/daily") }
-          { GitBranchName = "release/8.0.3xx"
-            DisplayName = "8.0.3xx<br>(8.0&nbsp;Runtime)"
-            AkaMsChannel = Some("8.0.3xx/daily") }
-          { GitBranchName = "release/7.0.4xx"
-            DisplayName = "Release/7.0.4xx<br>(7.0.x&nbsp;Runtime)"
-            AkaMsChannel = Some("7.0.4xx/daily") }]
+            AkaMsChannel = Some("8.0.4xx/daily") }]
 
 
 let referentNotes = """Reference notes:
 > **1**: Our Debian packages are put together slightly differently than the other OS specific installers. Instead of combining everything, we have separate component packages that depend on each other. If you're installing the SDK from the .deb file (via dpkg or similar), then you'll need to install the corresponding dependencies first:
 > * [Host, Host FX Resolver, and Shared Framework](https://github.com/dotnet/runtime/blob/main/docs/project/dogfooding.md#nightly-builds-table)
-> * [ASP.NET Core Shared Framework](https://github.com/aspnet/AspNetCore/blob/main/docs/DailyBuilds.md)
-
-.NET Core SDK 2.x downloads can be found at [.NET Core SDK 2.x Installers and Binaries](Downloads2.x.md) but they are [out of support](https://dotnet.microsoft.com/platform/support/policy/dotnet-core)."""
-
-let sdksha2 =
-    "[sdk-shas-2.2.1XX]: https://github.com/dotnet/versions/tree/master/build-info/dotnet/product/cli/release/2.2#built-repositories"
+> * [ASP.NET Core Shared Framework](https://github.com/aspnet/AspNetCore/blob/main/docs/DailyBuilds.md)"""
 
 let wholeTable branches =
     String.Join
         (Environment.NewLine + Environment.NewLine,
          [ table branches
            referentNotes
-           referenceList branches
-           sdksha2 ])
+           referenceList branches ])
 
 [<EntryPoint>]
 let main argv =


### PR DESCRIPTION
The table tool didn't get ported over to the SDK repo. It's probably worth making sure it stays up to date in installer if we need it.