### PR TITLE
[release/8.0.3xx] Do not run TestSdkRpm target

### DIFF
--- a/src/redist/targets/GenerateRPMs.targets
+++ b/src/redist/targets/GenerateRPMs.targets
@@ -12,8 +12,10 @@
           DependsOnTargets="GetCurrentRuntimeInformation;
                             GenerateRpmsInner" />
 
+  <!-- Removed TestSdkRpm. SDK RPMS should be tested in a separate container to avoid polluting or relying on the
+       build environment. https://github.com/dotnet/sdk/issues/41910 -->
   <Target Name="GenerateRpmsInner"
-          DependsOnTargets="TestFPMTool;BuildRpms;TestSdkRpm"
+          DependsOnTargets="TestFPMTool;BuildRpms"
           Condition=" '$(IsRPMBasedDistro)' == 'True' "
           Outputs="@(GeneratedInstallers)"/>
 


### PR DESCRIPTION
See https://github.com/dotnet/sdk/issues/41910
This target relies on a 'clean' (no dotnet) container state, which may not be available.