### PR TITLE
Copy artifacts to publishing directory

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -100,7 +100,7 @@ jobs:
     - output: pipelineArtifact
       displayName: 'Publish Artifacts'
       condition: succeededOrFailed()
-      targetPath: '${{ variables.sourcesPath }}/artifacts/${{ parameters.architecture }}/Release/'
+      targetPath: $(Build.ArtifactStagingDirectory)/publishing
       artifactName: $(Agent.JobName)_Artifacts
 
   steps:
@@ -267,6 +267,13 @@ jobs:
     continueOnError: true
     condition: succeededOrFailed()
 
+  - task: CopyFiles@2
+    inputs:
+      SourceFolder: ${{ variables.sourcesPath }}/artifacts/${{ parameters.architecture }}/Release/
+      TargetFolder: $(Build.ArtifactStagingDirectory)/publishing
+    displayName: Copy artifacts to Artifact Staging Directory
+    condition: succeededOrFailed()
+
   - ${{ if eq(variables['System.TeamProject'], 'public') }}:
     - publish: '$(Build.StagingDirectory)/BuildLogs'
       artifact: $(Agent.JobName)_BuildLogs_Attempt$(System.JobAttempt)
@@ -274,7 +281,7 @@ jobs:
       continueOnError: true
       condition: succeededOrFailed()
 
-    - publish: '${{ variables.sourcesPath }}/artifacts/${{ parameters.architecture }}/Release/'
+    - publish: $(Build.ArtifactStagingDirectory)/publishing
       artifact: $(Agent.JobName)_Artifacts
       displayName: Publish Artifacts
       condition: succeededOrFailed()


### PR DESCRIPTION
Contributes to dotnet/source-build#4318

This resolves the issue described in dotnet/source-build#4318 by copy the artifacts to a publishing staging directory and then publishing pipeline artifacts from that location. Don't know exactly what the issue is with the original location that causes the error but this resolves things. This puts the pipeline in closer alignment with the logic that exists in the main ranch.