### PR TITLE
Add registry search for upgrade policy keys

### DIFF
--- a/src/redist/targets/GenerateMSIs.targets
+++ b/src/redist/targets/GenerateMSIs.targets
@@ -324,9 +324,12 @@
     </ItemGroup>
     <PropertyGroup>
       <LatestTemplateMsiInstallerFile>@(LatestTemplateInstallerComponent->'%(MSIInstallerFile)')</LatestTemplateMsiInstallerFile>
+
+      <UpgradePoliciesSrcPath>$(PkgMicrosoft_DotNet_Build_Tasks_Installers)\build\wix\bundle\upgradePolicies.wxs</UpgradePoliciesSrcPath>
     </PropertyGroup>
     
     <Exec Command="powershell -NoProfile -NoLogo $(SdkGenerateBundlePowershellScript) ^
+                      '$(UpgradePoliciesSrcPath)' ^
                       '$(WorkloadManifestsWxsPath)' ^
                       '$(SdkMSIInstallerFile)' ^
                       '$(DownloadsFolder)$(DownloadedAspNetCoreSharedFxWixLibFileName)' ^
@@ -361,6 +364,7 @@
     <ItemGroup>
         <BundleMsiWixSrcFiles Include="$(WixRoot)\bundle.wixobj" />
         <BundleMsiWixSrcFiles Include="$(WixRoot)\WorkloadManifests.wixobj" />
+        <BundleMsiWixSrcFiles Include="$(WixRoot)\upgradePolicies.wixobj" />
         <BundleMsiWixSrcFiles Include="$(DownloadsFolder)$(DownloadedAspNetCoreSharedFxWixLibFileName)" />
     </ItemGroup>
     <CreateLightCommandPackageDrop
@@ -371,7 +375,7 @@
       InstallerFile="$(CombinedFrameworkSdkHostMSIInstallerFile)"
       WixExtensions="WixBalExtension;WixUtilExtension;WixTagExtension"
       WixSrcFiles="@(BundleMsiWixSrcFiles)"
-      AdditionalBasePaths="$(MSBuildThisFileDirectory)packaging/windows/clisdk">
+      AdditionalBasePaths="$(MSBuildThisFileDirectory)packaging/windows/clisdk;$(PkgMicrosoft_DotNet_Build_Tasks_Installers)\build\wix\bundle">
       <Output TaskParameter="OutputFile" PropertyName="_LightCommandPackageNameOutput" />
     </CreateLightCommandPackageDrop>
   </Target>

--- a/src/redist/targets/packaging/windows/clisdk/bundle.wxs
+++ b/src/redist/targets/packaging/windows/clisdk/bundle.wxs
@@ -34,6 +34,11 @@
 
     <swid:Tag Regid="microsoft.com" InstallPath="[$(var.Program_Files)]dotnet" />
 
+    <!-- Search references for upgrade policy keys -->
+    <util:RegistrySearchRef Id="RemovePreviousVersionRegistryKeySearch"/>
+    <util:RegistrySearchRef Id="RemoveSpecificPreviousVersionRegistryKeyExistsSearch"/>
+    <util:RegistrySearchRef Id="RemoveSpecificPreviousVersionRegistryKeySearch"/>
+
     <util:RegistrySearch Id="CheckDotnetInstallLocation_x86"
               Variable="DotnetInstallLocationExists_x86"
               Result="exists"

--- a/src/redist/targets/packaging/windows/clisdk/generatebundle.ps1
+++ b/src/redist/targets/packaging/windows/clisdk/generatebundle.ps1
@@ -2,6 +2,7 @@
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 param(
+    [Parameter(Mandatory=$true)][string]$UpgradePoliciesWxsFile,
     [Parameter(Mandatory=$true)][string]$WorkloadManifestWxsFile,
     [Parameter(Mandatory=$true)][string]$CLISDKMSIFile,
     [Parameter(Mandatory=$true)][string]$ASPNETRuntimeWixLibFile,
@@ -74,11 +75,13 @@ function RunCandleForBundle
         -dDotNetRuntimeVersion="$DotNetRuntimeVersion" `
         -dAspNetCoreVersion="$AspNetCoreVersion" `
         -dLocalizedContentDirs="$LocalizedContentDirs" `
+        -dMajorVersion="$($DotnetCLINugetVersion.Split(".")[0])" `
+        -dMinorVersion="$($DotnetCLINugetVersion.Split(".")[1])" `
         -arch "$Architecture" `
         -ext WixBalExtension.dll `
         -ext WixUtilExtension.dll `
         -ext WixTagExtension.dll `
-        "$AuthWsxRoot\bundle.wxs" "$WorkloadManifestWxsFile"
+        "$AuthWsxRoot\bundle.wxs" "$WorkloadManifestWxsFile" "$UpgradePoliciesWxsFile"
 
     Write-Information "Candle output: $candleOutput"
 
@@ -98,6 +101,7 @@ function RunLightForBundle
     pushd "$WixRoot"
 
     $WorkloadManifestWixobjFile = [System.IO.Path]::GetFileNameWithoutExtension($WorkloadManifestWxsFile) + ".wixobj"
+    $UpgradePoliciesWixobjFile = [System.IO.Path]::GetFileNameWithoutExtension($UpgradePoliciesWxsFile) + ".wixobj"
 
     Write-Information "Running light for bundle.."
 
@@ -105,6 +109,7 @@ function RunLightForBundle
         -cultures:en-us `
         bundle.wixobj `
         $WorkloadManifestWixobjFile `
+        $UpgradePoliciesWixobjFile `
         $ASPNETRuntimeWixlibFile `
         -ext WixBalExtension.dll `
         -ext WixUtilExtension.dll `


### PR DESCRIPTION
# Description
Add registry search operations to SDK installer bundles. The search operation will check for a global and version specific registry key. The version specific key takes precedence when present.

This is related to a customer request and part of a larger change. This PR only includes infrastructure changes to support changes in the Windows installer bundles. The change depends on changes in Arcade (https://github.com/dotnet/arcade/pull/14975). 

**NB: This PR will not build until the Arcade change is merged and flowed to the SDK.**

Unlike the runtime and desktop runtime, the SDK needs to explicitly pull in the additional source file.

# Risk
Low, this change only adds detection for the key, nothing will currently act on its value.

# Testing
Verified against a private build of SDK. Log excerpt below. The test machine contained only the global key, hence why the existence check returns 0 for the version specific key.

```
[0D28:1454][2024-07-26T08:43:38]i000: Setting string variable 'WixBundleName' to value 'Microsoft .NET SDK 6.0.425 (x64)'
[0D28:1454][2024-07-26T08:43:38]i000: Setting string variable 'RemoveUpgradeRelatedBundle' to value 'nextSession'
[0D28:1454][2024-07-26T08:43:38]i000: Registry key not found. Key = 'SOFTWARE\Microsoft\.NET\6.0'
[0D28:1454][2024-07-26T08:43:38]i000: Setting numeric variable 'RemoveSpecificPreviousVersionRegistryKeyExists' to value 0
```