### PR TITLE
Fix rewriting testhost.deps.json

### DIFF
--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -496,7 +496,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <TestHostDepsJsonPath Include="$(OutputPath)/**/testhost.deps.json" />
+      <TestHostDepsJsonPath Include="$(RedistLayoutPath)/**/testhost.deps.json" />
     </ItemGroup>
     <ReplaceFileContents
       InputFiles="@(TestHostDepsJsonPath)"


### PR DESCRIPTION
Fix for previous PR that was working in project build, but not when building the actual redist packages.

https://github.com/dotnet/installer/pull/19320

Fix https://github.com/microsoft/vstest/issues/5265

![image](https://github.com/user-attachments/assets/49d1150a-1583-4943-80b7-deb7a6224ff1)
