### PR TITLE
Add registry search for upgrade policy keys

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -166,10 +166,6 @@
     <SharedHostVersion>$(MicrosoftNETCoreAppRuntimePackageVersion)</SharedHostVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- This is the version of the zip archive for the WiX toolset and is different from the NuGet package version format. -->
-    <WixVersion>3.14.1.8722</WixVersion>
-  </PropertyGroup>
-  <PropertyGroup>
     <!-- 8.0 Template versions -->
     <MicrosoftDotnetWinFormsProjectTemplates80PackageVersion>$(MicrosoftDotnetWinFormsProjectTemplatesPackageVersion)</MicrosoftDotnetWinFormsProjectTemplates80PackageVersion>
     <MicrosoftDotNetWpfProjectTemplates80PackageVersion>$(MicrosoftDotNetWpfProjectTemplatesPackageVersion)</MicrosoftDotNetWpfProjectTemplates80PackageVersion>

--- a/src/redist/targets/GenerateMSIs.targets
+++ b/src/redist/targets/GenerateMSIs.targets
@@ -344,9 +344,11 @@
     </ItemGroup>
     <PropertyGroup>
       <LatestTemplateMsiInstallerFile>@(LatestTemplateInstallerComponent->'%(MSIInstallerFile)')</LatestTemplateMsiInstallerFile>
+      <UpgradePoliciesSrcPath>$(PkgMicrosoft_DotNet_Build_Tasks_Installers)\build\wix\bundle\upgradePolicies.wxs</UpgradePoliciesSrcPath>
     </PropertyGroup>
     
     <Exec Command="powershell -NoProfile -NoLogo $(SdkGenerateBundlePowershellScript) ^
+                      -UpgradePoliciesWxsFile '$(UpgradePoliciesSrcPath)' ^
                       -WorkloadManifestWxsFile '$(WorkloadManifestsWxsPath)' ^
                       -CLISDKMSIFile '$(SdkMSIInstallerFile)' ^
                       -ASPNETRuntimeWixLibFile '$(DownloadsFolder)$(DownloadedAspNetCoreSharedFxWixLibFileName)' ^
@@ -383,6 +385,7 @@
     <ItemGroup>
         <BundleMsiWixSrcFiles Include="$(WixRoot)\bundle.wixobj" />
         <BundleMsiWixSrcFiles Include="$(WixRoot)\WorkloadManifests.wixobj" />
+        <BundleMsiWixSrcFiles Include="$(WixRoot)\upgradePolicies.wixobj" />
         <BundleMsiWixSrcFiles Include="$(DownloadsFolder)$(DownloadedAspNetCoreSharedFxWixLibFileName)" />
     </ItemGroup>
     <CreateLightCommandPackageDrop
@@ -393,7 +396,7 @@
       InstallerFile="$(CombinedFrameworkSdkHostMSIInstallerFile)"
       WixExtensions="WixBalExtension;WixUtilExtension;WixTagExtension"
       WixSrcFiles="@(BundleMsiWixSrcFiles)"
-      AdditionalBasePaths="$(MSBuildThisFileDirectory)packaging/windows/clisdk">
+      AdditionalBasePaths="$(MSBuildThisFileDirectory)packaging/windows/clisdk;$(PkgMicrosoft_DotNet_Build_Tasks_Installers)\build\wix\bundle">
       <Output TaskParameter="OutputFile" PropertyName="_LightCommandPackageNameOutput" />
     </CreateLightCommandPackageDrop>
   </Target>

--- a/src/redist/targets/GenerateMSIs.targets
+++ b/src/redist/targets/GenerateMSIs.targets
@@ -3,10 +3,10 @@
   <Target Name="SetupWixProperties" DependsOnTargets="GetCurrentRuntimeInformation">
     <!-- AcquireWix Properties -->
     <PropertyGroup>
-      <WixDownloadUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/wix/Microsoft.Signed.Wix-$(WixVersion).zip</WixDownloadUrl>
-      <WixRoot>$(ArtifactsDir)Tools/WixTools/$(WixVersion)</WixRoot>
-      <WixDestinationPath>$(WixRoot)/WixTools.$(WixVersion).zip</WixDestinationPath>
-      <WixDownloadSentinel>$(WixRoot)/WixDownload.$(WixVersion).sentinel</WixDownloadSentinel>
+      <WixDownloadUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/wix/Microsoft.Signed.Wix-$(MicrosoftSignedWixVersion).zip</WixDownloadUrl>
+      <WixRoot>$(ArtifactsDir)Tools/WixTools/$(MicrosoftSignedWixVersion)</WixRoot>
+      <WixDestinationPath>$(WixRoot)/WixTools.$(MicrosoftSignedWixVersion).zip</WixDestinationPath>
+      <WixDownloadSentinel>$(WixRoot)/WixDownload.$(MicrosoftSignedWixVersion).sentinel</WixDownloadSentinel>
     </PropertyGroup>
 
     <!-- Generate MSI/Bundle Properties -->
@@ -126,7 +126,7 @@
     <MakeDir Directories="$(WixRoot)" />
     <WriteLinesToFile
         File="$(WixDownloadSentinel)"
-        Lines="$(WixVersion)"
+        Lines="$(MicrosoftSignedWixVersion)"
         Overwrite="true"
         Encoding="Unicode"/>
 

--- a/src/redist/targets/packaging/windows/clisdk/bundle.wxs
+++ b/src/redist/targets/packaging/windows/clisdk/bundle.wxs
@@ -35,6 +35,11 @@
 
     <swid:Tag Regid="microsoft.com" InstallPath="[$(var.Program_Files)]dotnet" />
 
+    <!-- Search references for upgrade policy keys -->
+    <util:RegistrySearchRef Id="RemovePreviousVersionRegistryKeySearch"/>
+    <util:RegistrySearchRef Id="RemoveSpecificPreviousVersionRegistryKeyExistsSearch"/>
+    <util:RegistrySearchRef Id="RemoveSpecificPreviousVersionRegistryKeySearch"/>
+
     <util:RegistrySearch Id="CheckDotnetInstallLocation_x86"
               Variable="DotnetInstallLocationExists_x86"
               Result="exists"

--- a/src/redist/targets/packaging/windows/clisdk/generatebundle.ps1
+++ b/src/redist/targets/packaging/windows/clisdk/generatebundle.ps1
@@ -2,6 +2,7 @@
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 param(
+    [Parameter(Mandatory=$true)][string]$UpgradePoliciesWxsFile,
     [Parameter(Mandatory=$true)][string]$WorkloadManifestWxsFile,
     [Parameter(Mandatory=$true)][string]$CLISDKMSIFile,
     [Parameter(Mandatory=$true)][string]$ASPNETRuntimeWixLibFile,
@@ -82,7 +83,7 @@ function RunCandleForBundle
         -ext WixBalExtension.dll `
         -ext WixUtilExtension.dll `
         -ext WixTagExtension.dll `
-        "$AuthWsxRoot\bundle.wxs" "$WorkloadManifestWxsFile"
+        "$AuthWsxRoot\bundle.wxs" "$WorkloadManifestWxsFile" "$UpgradePoliciesWxsFile"
 
     Write-Information "Candle output: $candleOutput"
 
@@ -102,6 +103,7 @@ function RunLightForBundle
     pushd "$WixRoot"
 
     $WorkloadManifestWixobjFile = [System.IO.Path]::GetFileNameWithoutExtension($WorkloadManifestWxsFile) + ".wixobj"
+    $UpgradePoliciesWixobjFile = [System.IO.Path]::GetFileNameWithoutExtension($UpgradePoliciesWxsFile) + ".wixobj"
 
     Write-Information "Running light for bundle.."
 
@@ -109,6 +111,7 @@ function RunLightForBundle
         -cultures:en-us `
         bundle.wixobj `
         $WorkloadManifestWixobjFile `
+        $UpgradePoliciesWixobjFile `
         $ASPNETRuntimeWixlibFile `
         -ext WixBalExtension.dll `
         -ext WixUtilExtension.dll `

--- a/src/redist/targets/packaging/windows/clisdk/generatebundle.ps1
+++ b/src/redist/targets/packaging/windows/clisdk/generatebundle.ps1
@@ -54,7 +54,9 @@ function RunCandleForBundle
         -dSDKProductBandVersion="$SDKProductBandVersion" `
         -dNugetVersion="$DotnetCLINugetVersion" `
         -dVersionMajor="$VersionMajor" `
+        -dMajorVersion="$VersionMajor" `
         -dVersionMinor="$VersionMinor" `
+        -dMinorVersion="$VersionMinor" `
         -dCLISDKMsiSourcePath="$CLISDKMSIFile" `
         -dDependencyKeyName="$DependencyKeyName" `
         -dUpgradeCode="$UpgradeCode" `


### PR DESCRIPTION
# Description
Add registry search operations to SDK installer bundles. The search operation will check for a global and version specific registry key. The version specific key takes precedence when present.

This is related to a customer request and part of a larger change. This PR only includes infrastructure changes to support changes in the Windows installer bundles. The change depends on changes in Arcade (https://github.com/dotnet/arcade/pull/15047). 

**NB: This PR will not build until the Arcade change is merged and flowed to the SDK.**

Unlike the runtime and desktop runtime, the SDK needs to explicitly pull in the additional source file.

# Risk
Low, this change only adds detection for the key, nothing will currently act on its value.

# Testing
Testing can be done once all the relevant Arcade/Wix changes are merged and have flowed through.