### PR TITLE
[release/8.0.1xx] Publish prebuilt reports for each repo

### DIFF
--- a/src/SourceBuild/content/Directory.Build.props
+++ b/src/SourceBuild/content/Directory.Build.props
@@ -123,6 +123,7 @@
     <GitInfoRepoPropsFile>$(GitInfoDir)$(RepositoryName).props</GitInfoRepoPropsFile>
     <GitInfoAllRepoPropsFile>$(GitInfoDir)AllRepoVersions.props</GitInfoAllRepoPropsFile>
     <PackageReportDir>$(BaseOutputPath)prebuilt-report/</PackageReportDir>
+    <DotNetBuildPrebuiltReportDir>$(PackageReportDir)$(MSBuildProjectName)</DotNetBuildPrebuiltReportDir>
     <RepoProjectsDir>$(ProjectDir)/repo-projects/</RepoProjectsDir>
     <ResultingPrebuiltPackagesDir>$(PackageReportDir)prebuilt-packages/</ResultingPrebuiltPackagesDir>
     <PackageListsDir>$(PackageReportDir)packagelists/</PackageListsDir>

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -415,6 +415,21 @@
     <WriteLinesToFile File="$(RepoCompletedSemaphorePath)RemoveBuiltPackagesFromCache.complete" Overwrite="true" />
   </Target>
 
+  <Target Name="MoveDotNetBuildLogs"
+          AfterTargets="Build"
+          BeforeTargets="CleanupRepo"
+          Condition="'$(IsUtilityProject)' != 'true' and
+            Exists('$(ProjectDirectory)artifacts')">
+    <ItemGroup>
+      <PrebuiltReportsToMove Include="$(ProjectDirectory)artifacts/source-build/self/prebuilt-report/*" />
+    </ItemGroup>
+
+    <!-- Move the prebuilt reports -->
+    <Move SourceFiles="@(PrebuiltReportsToMove)"
+          DestinationFolder="$(DotNetBuildPrebuiltReportDir)"
+          Condition="'@(PrebuiltReportsToMove)' != ''" />
+  </Target>
+
   <Target Name="DisplayDirSizeBeforeBuild"
           BeforeTargets="Build"
           Condition=" '$(CleanWhileBuilding)' == 'true' ">


### PR DESCRIPTION
Backport https://github.com/dotnet/sdk/pull/43336 to release/8.0.1xx

<h1></h1>

Fixes https://github.com/dotnet/source-build/issues/4160

Store the prebuilt files for each repo as pipeline artifacts rather than the overall build's prebuilt report, which will make investigations of prebuilt go more quickly.

I introduced a new property `DotNetBuildPrebuiltReportDir` which point to `artifacts\prebuilt-report\<reponame>\`, all repo's prebuilt reports will respect this property and move to that folder.