### PR TITLE
Fix assembly version diff test for missing file

### DIFF
--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SdkContentTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/SdkContentTests.cs
@@ -93,7 +93,11 @@ public class SdkContentTests : SdkTests
         {
             string assemblyPath = sbSdkFileArray[i];
             Version? sbVersion = sbSdkAssemblyVersions[assemblyPath];
-            Version? msftVersion = msftSdkAssemblyVersions[assemblyPath];
+            if (!msftSdkAssemblyVersions.TryGetValue(assemblyPath, out Version? msftVersion))
+            {
+                sbSdkAssemblyVersions.Remove(assemblyPath);
+                continue;
+            }
 
             if (sbVersion is not null &&
                 msftVersion is not null &&
@@ -163,7 +167,7 @@ public class SdkContentTests : SdkTests
             }
         }
 
-        Assert.Fail($"Unable to find matching file for '{representativeFile}' in '{rootDir}'.");
+        OutputHelper.WriteLine($"Unable to find matching file for '{representativeFile}' in '{rootDir}'.");
         return string.Empty;
     }
 


### PR DESCRIPTION
Backport of https://github.com/dotnet/sdk/pull/44156 and https://github.com/dotnet/sdk/pull/44192