### PR TITLE
Add a direct STJ reference to lift the verison used by the releases library

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -244,6 +244,10 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>af841c8b33cecc92d74222298f1e45bf7bf3d90a</Sha>
     </Dependency>
+    <Dependency Name="System.Text.Json" Version="8.0.5">
+      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
+      <Sha>81cabf2857a01351e5ab578947c7403a5b128ad1</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.24415.1">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
       <Sha>fe3794a68bd668d36d4d5014a9e6c9d22c0e6d86</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -103,6 +103,7 @@
     <NETStandardLibraryRefPackageVersion>2.1.0</NETStandardLibraryRefPackageVersion>
     <SystemFormatsAsn1PackageVersion>8.0.1</SystemFormatsAsn1PackageVersion>
     <MicrosoftIORedistPackageVersion>6.0.1</MicrosoftIORedistPackageVersion>
+    <SystemTextJsonPackageVersion>8.0.5</SystemTextJsonPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/windowsdesktop -->

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
      <PackageReference Include="Microsoft.DotNet.Build.Tasks.Installers" Version="$(MicrosoftDotNetBuildTasksInstallersPackageVersion)" />
+     <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonPackageVersion)"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
There is still an older STJ reference in msbuild but that team is working on getting the builds fixed which should flow it and resolve it here.

This one is for the releases library package that has already moved on to a net9 targeted version so fixing there would be challenging.