### PR TITLE
Upgrade latest Alpine to 3.21 for VMR builds

### DIFF
--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -2,7 +2,7 @@ variables:
 - name: almaLinuxContainer
   value: mcr.microsoft.com/dotnet-buildtools/prereqs:almalinux-8-source-build
 - name: alpineContainer
-  value: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.20-withnode
+  value: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.21-amd64
 - name: centOSStreamContainer
   value: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9
 - name: fedoraContainer
@@ -15,7 +15,7 @@ variables:
 - name: almaLinuxName
   value: AlmaLinux8
 - name: alpineName
-  value: Alpine320
+  value: Alpine321
 - name: centOSStreamName
   value: CentOSStream9
 - name: fedoraName
@@ -26,7 +26,7 @@ variables:
 - name: almaLinuxX64Rid
   value: almalinux.8-x64
 - name: alpineX64Rid
-  value: alpine.3.20-x64
+  value: alpine.3.21-x64
 - name: centOSStreamX64Rid
   value: centos.9-x64
 - name: fedoraX64Rid


### PR DESCRIPTION
Related to https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1284