### PR TITLE
Use official templates even for PRs when run internal

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -44,10 +44,7 @@ resources:
     ref: refs/tags/release
 
 extends:
-  ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
-    template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
-  ${{ else }}:
-    template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
     containers:
       alpine319WithNode:


### PR DESCRIPTION
New template guidance is that a production pipeline can only use the official templates. Rather than creating a completely separate PR  pipeline, we'll use the official templates.