### PR TITLE
Change pr.yml -> sb-pr.yml

### DIFF
--- a/src/SourceBuild/content/eng/pipelines/sb-pr.yml
+++ b/src/SourceBuild/content/eng/pipelines/sb-pr.yml
@@ -6,7 +6,6 @@ trigger:
   branches:
     include:
     - release/8.0.1xx
-    - internal/release/8.0.1xx
 
 pr:
   branches:

--- a/src/SourceBuild/content/eng/pipelines/sb-pr.yml
+++ b/src/SourceBuild/content/eng/pipelines/sb-pr.yml
@@ -5,9 +5,8 @@ trigger: none
 pr:
   branches:
     include:
-    - main
-    - release/*
-    - internal/release/*
+    - release/8.0.1xx
+    - internal/release/8.0.1xx
 
 stages:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/src/SourceBuild/content/eng/pipelines/sb-pr.yml
+++ b/src/SourceBuild/content/eng/pipelines/sb-pr.yml
@@ -1,7 +1,13 @@
 # This is the non-1ES PR pipeline for dotnet/dotnet
 # https://dev.azure.com/dnceng-public/public/_build?definitionId=240
 
-trigger: none
+trigger:
+  batch: true
+  branches:
+    include:
+    - release/8.0.1xx
+    - internal/release/8.0.1xx
+
 pr:
   branches:
     include:

--- a/src/SourceBuild/content/eng/pipelines/sb-pr.yml
+++ b/src/SourceBuild/content/eng/pipelines/sb-pr.yml
@@ -12,7 +12,6 @@ pr:
   branches:
     include:
     - release/8.0.1xx
-    - internal/release/8.0.1xx
 
 stages:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
This allows us to repoint the SB pipeline at this YAML file, meaning that we can manage triggers for UB, which uses pr.yml, via YAML files rather than the UI. Updated comments to reflect where this file will be used.