### PR TITLE
Retry all errors to handle curl (18)

### DIFF
--- a/src/SourceBuild/content/prep.sh
+++ b/src/SourceBuild/content/prep.sh
@@ -117,7 +117,23 @@ function DownloadArchive {
   if [[ $archiveVersionLine =~ $versionPattern ]]; then
       archiveUrl="${BASH_REMATCH[1]}"
       echo "  Downloading source-built $archiveType from $archiveUrl..."
-      (cd "$packagesArchiveDir" && curl --retry 5 -O "$archiveUrl")
+      (
+        cd "$packagesArchiveDir" &&
+        for i in {1..5}; do
+          if curl --retry 5 -O "$archiveUrl"; then
+            exit 0
+          else
+            case $? in
+              18)
+                sleep 3
+                ;;
+              *)
+                exit 1
+                ;;
+            esac
+          fi
+        done
+      )
   elif [ "$isRequired" == true ]; then
     echo "  ERROR: $notFoundMessage"
     exit 1


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/5282

curl 18 is CURLE_PARTIAL_FILE and doesn't count as a retry condition: https://curl.se/docs/manpage.html

8.0 build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2751145 (internal Microsoft link) (Passed)