### PR TITLE
Switch back to using the unofficial templates for PRs

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -44,7 +44,10 @@ resources:
     ref: refs/tags/release
 
 extends:
-  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+  ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+    template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+  ${{ else }}:
+    template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
   parameters:
     containers:
       alpine319WithNode:


### PR DESCRIPTION
They want us to split the PRs out into a separate pipeline that will have different capabilities (ie we can't sign from a PR pipeline). That needs to run on unofficial 1ES templates so the easiest way to do this is just add the conditional back.