### PR TITLE
Override azurelinux rid to ensure we find the right runtime package

### DIFF
--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -39,6 +39,7 @@
       <CoreSetupRid Condition="'$(CoreSetupRid)' == ''">$(HostRid)</CoreSetupRid>
       <CoreSetupRid Condition=" ('$(OSName)' == 'win' or '$(OSName)' == 'osx' or '$(OSName)' == 'freebsd') and '$(DotNetBuildFromSource)' != 'true' ">$(OSName)-$(Architecture)</CoreSetupRid>
       <CoreSetupRid Condition="$(HostRid.StartsWith('mariner.2.0'))">$(HostRid.Replace('mariner.2.0', 'cm.2'))</CoreSetupRid>
+      <CoreSetupRid Condition="$(HostRid.StartsWith('azurelinux.3.0'))">$(HostRid.Replace('azurelinux.3.0', 'cm.2'))</CoreSetupRid>
 
       <!-- only the runtime OSX .pkgs have a `-internal` suffix -->
       <InstallerStartSuffix Condition="$([MSBuild]::IsOSPlatform('OSX'))">-internal</InstallerStartSuffix>


### PR DESCRIPTION
We changed the container image that we build with but that changed the runtime package we were looking for as we use the rid. Runtime didn't change so this PR is reverting the runtime rid back to the cm.2 that they actually ship with.