### PR TITLE
Make duplicate deb/rpm packages so we can sign them with the new PMC key

### DIFF
--- a/src/redist/targets/GenerateDebs.targets
+++ b/src/redist/targets/GenerateDebs.targets
@@ -93,6 +93,7 @@
     <PropertyGroup>
       <InstallerOutputDirectory>$(ArtifactsShippingPackagesDir)</InstallerOutputDirectory>
       <SdkDebInstallerFile>$(InstallerOutputDirectory)$(DistroSpecificArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk)$(InstallerExtension)</SdkDebInstallerFile>
+      <NewKeyDebInstallerFile>$(InstallerOutputDirectory)$(NewKeyArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk)$(InstallerExtension)</NewKeyDebInstallerFile>
       <SdkDebianIntermediateDirectory>$(IntermediateOutputPath)debian/sdk/</SdkDebianIntermediateDirectory>
       <DotNetDebToolOutputDirectory>$(SdkDebianIntermediateDirectory)deb-tool-output</DotNetDebToolOutputDirectory>
       <DebianTestResultsXmlFile>$(SdkDebianIntermediateDirectory)debian-testResults.xml</DebianTestResultsXmlFile>
@@ -316,6 +317,13 @@
         OverwriteReadOnlyFiles="True"
         SkipUnchangedFiles="False"
         UseHardlinksIfPossible="False" />
+
+      <Copy
+        DestinationFiles="$(NewKeyDebInstallerFile)"
+        SourceFiles="@(GeneratedDebFiles)"
+        OverwriteReadOnlyFiles="True"
+        SkipUnchangedFiles="False"
+        UseHardlinksIfPossible="False"/>
 
       <!-- Proactively remove all possible Shared Framework and Debian Packages -->
       <ItemGroup>

--- a/src/redist/targets/GenerateRPMs.targets
+++ b/src/redist/targets/GenerateRPMs.targets
@@ -213,6 +213,12 @@
       SkipUnchangedFiles="False"
       UseHardlinksIfPossible="False"/>
 
+    <Copy SourceFiles="@(GeneratedRpmFiles)"
+      DestinationFiles="$(NewKeyRpmFile)"
+      OverwriteReadOnlyFiles="True"
+      SkipUnchangedFiles="False"
+      UseHardlinksIfPossible="False"/>
+
   </Target>
 
   <Target Name="SetupRpmProps"
@@ -227,6 +233,7 @@
       <RpmFile>$(SdkRPMInstallerFile)</RpmFile>
       <MarinerRpmFile>$(ArtifactsShippingPackagesDir)$(MarinerArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk)$(InstallerExtension)</MarinerRpmFile>
       <Mariner2RpmFile>$(ArtifactsShippingPackagesDir)$(Mariner2ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk)$(InstallerExtension)</Mariner2RpmFile>
+      <NewKeyRpmFile>$(ArtifactsShippingPackagesDir)$(NewKeyArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk)$(InstallerExtension)</NewKeyRpmFile>
       <!-- Need to acquire manpage files from CLI repo: https://github.com/dotnet/cli/issues/10266 -->
       <ManPagesDir>$(RepoRoot)/Documentation/manpages</ManPagesDir>
       <EndToEndTestProject>$(RepoRoot)/test/EndToEnd/EndToEnd.csproj</EndToEndTestProject>

--- a/src/redist/targets/GetRuntimeInformation.targets
+++ b/src/redist/targets/GetRuntimeInformation.targets
@@ -52,6 +52,8 @@
       <!-- Mariner RPM names -->
       <MarinerArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk Condition=" '$(IsRPMBasedDistro)' == 'True' ">$(ArtifactNameCombinedHostHostFxrFrameworkSdk)-$(Version)-cm.1-$(InstallerTargetArchitecture)</MarinerArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>
       <Mariner2ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk Condition=" '$(IsRPMBasedDistro)' == 'True' ">$(ArtifactNameCombinedHostHostFxrFrameworkSdk)-$(Version)-cm.2-$(InstallerTargetArchitecture)</Mariner2ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>
+      <!-- NewKey RPM and Deb names-->
+      <NewKeyArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>$(ArtifactNameCombinedHostHostFxrFrameworkSdk)-$(Version)-newkey-$(InstallerTargetArchitecture)</NewKeyArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>
 
     </PropertyGroup>
   </Target>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/arcade/issues/16047

# Make duplicate deb/rpm packages so we can sign them with the new PMC key

## Description

PMC has added a new signing key for packages published to repositories for new Linux distributions they will add support for, such as Debian 13 and SLES vNext. Packages pushed to these feeds must be signed with the new key. Existing feeds will maintain the same keys. The .NET signing infrastructure requires us to have separate copies of the package files to have them signed with different keys. This PR introduces separate copies of the DEB and RPM installers to be signed with the new signing keys.

Contributes to https://github.com/dotnet/arcade/issues/16047

## Customer Impact

Without this change, we can't ship `.deb` installers for Debian 13. With this change, we can.

## Regression?

- [ ] Yes
- [X] No


## Risk

- [ ] High
- [ ] Medium
- [X] Low

[Justify the selection above]

## Verification

- [X] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [X] Yes
- [ ] No
- [ ] N/A
