### PR TITLE
Switch to the 2019 images to unblock the arm64 build

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -83,11 +83,11 @@ jobs:
       pool:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: $(DncEngPublicBuildPool)
-          image: 1es-windows-2022-open
+          image: 1es-windows-2019-open
           os: windows
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: $(DncEngInternalBuildPool)
-          image: 1es-windows-2022
+          image: 1es-windows-2019
           os: windows
     ${{ if eq(parameters.agentOs, 'Linux') }}:
       pool:


### PR DESCRIPTION
This is temporary to unblock the arm64 build which was failing on the 2022 image