### PR TITLE
Add a direct reference to STJ

### DIFF
--- a/src/core-sdk-tasks/core-sdk-tasks.csproj
+++ b/src/core-sdk-tasks/core-sdk-tasks.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1PackageVersion)"/>
     <PackageReference Include="Microsoft.IO.Redist" Version="$(MicrosoftIORedistPackageVersion)" Condition="'$(DotNetBuildFromSource)' != 'true'" />
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonPackageVersion)" Condition="'$(DotNetBuildFromSource)' != 'true'"/>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">


### PR DESCRIPTION
Add a direct reference to STJ to lift the version for the tasks lib as an old version is pulled in by msbuild. This project doesn't ship so it should be safe to just lift this version up 