### PR TITLE
Stop building source-build in non-1xx branches

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -323,11 +323,6 @@ extends:
             buildArchitecture: arm64
             runTests: false
 
-      # Source Build
-      - template: /eng/common/templates-official/jobs/source-build.yml@self
-        parameters:
-          enableInternalSources: true
-
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - stage: Publish
         dependsOn:

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -342,10 +342,6 @@ stages:
         linuxPortable: true
         runTests: false
 
-  - template: /eng/common/templates/jobs/source-build.yml
-    parameters:
-      enableInternalSources: true
-
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - stage: Publish
     dependsOn:


### PR DESCRIPTION
There is no need to build source-build legs in any feature band except 8.0.1xx. We often see issues related to this leg that require unnecessary work - i.e. https://github.com/dotnet/sdk/pull/50847#issuecomment-3303550283

This will need to be backported to 8.0.3xx.