### PR TITLE
[infra] Use newer Windows build images

### DIFF
--- a/eng/build-pr.yml
+++ b/eng/build-pr.yml
@@ -83,10 +83,10 @@ jobs:
       pool:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals windows.vs2019.amd64.open
+          demands: ImageOverride -equals windows.vs2022.amd64.open
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: $(DncEngInternalBuildPool)
-          demands: ImageOverride -equals windows.vs2019.amd64
+          demands: ImageOverride -equals windows.vs2022.amd64
     ${{ if eq(parameters.agentOs, 'Linux') }}:
       pool:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -83,11 +83,11 @@ jobs:
       pool:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: $(DncEngPublicBuildPool)
-          image: 1es-windows-2019-open
+          image: 1es-windows-2022-open
           os: windows
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: $(DncEngInternalBuildPool)
-          image: 1es-windows-2019
+          image: 1es-windows-2022
           os: windows
     ${{ if eq(parameters.agentOs, 'Linux') }}:
       pool:

--- a/src/finalizer/CMakeLists.txt
+++ b/src/finalizer/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.15.5)
 
+set(CMAKE_GENERATOR_TOOLSET "v143")
+
 # Create project named finalizer, this will
 # will generate Finalizer.vcxproj
 project(Finalizer)


### PR DESCRIPTION
Fixes: https://github.com/dotnet/installer/issues/20563

Fixes the Finalizer build with Windows 2022 base images. Also reverts the temporary workaround implemented with https://github.com/dotnet/installer/pull/20550

## Verification

Local build, all architectures.