### PR TITLE
Fail the RPM build if FPM tool is not present

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -288,7 +288,7 @@ extends:
             buildArchitecture: x64
             # Do not publish zips and tarballs. The linux-x64 binaries are
             # already published by Build_LinuxPortable_Release_x64
-            additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:IsRPMBasedDistro=true'
+            additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:BuildSdkRpm=true'
             linuxPortable: true
             runTests: false
         - template: eng/build.yml@self
@@ -301,7 +301,7 @@ extends:
             runtimeIdentifier: 'linux-arm64'
             # Do not publish zips and tarballs. The linux-x64 binaries are
             # already published by Build_LinuxPortable_Release_x64
-            additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:CLIBUILD_SKIP_TESTS=true  /p:IsRPMBasedDistro=true'
+            additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:CLIBUILD_SKIP_TESTS=true  /p:BuildSdkRpm=true'
             linuxPortable: true
             runTests: false
         - template: eng/build.yml@self

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -247,7 +247,7 @@ stages:
         buildArchitecture: x64
         # Do not publish zips and tarballs. The linux-x64 binaries are
         # already published by Build_LinuxPortable_Release_x64
-        additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:IsRPMBasedDistro=true'
+        additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:BuildSdkRpm=true'
         linuxPortable: true
         runTests: false
     - template: eng/build-pr.yml
@@ -260,7 +260,7 @@ stages:
         runtimeIdentifier: 'linux-arm64'
         # Do not publish zips and tarballs. The linux-x64 binaries are
         # already published by Build_LinuxPortable_Release_x64
-        additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:CLIBUILD_SKIP_TESTS=true  /p:IsRPMBasedDistro=true'
+        additionalBuildParameters: '/p:PublishBinariesAndBadge=false /p:CLIBUILD_SKIP_TESTS=true  /p:BuildSdkRpm=true'
         linuxPortable: true
         runTests: false
     - template: eng/build-pr.yml

--- a/src/redist/targets/GenerateRPMs.targets
+++ b/src/redist/targets/GenerateRPMs.targets
@@ -317,10 +317,8 @@
       <FPMPresent Condition=" '$(FPMExitCode)' == '0' ">True</FPMPresent>
     </PropertyGroup>
 
-    <!-- Workaround for Jenkins machines that don't have the necessary packages https://github.com/dotnet/core-setup/issues/2260 -->
-    <Message Condition=" '$(FPMPresent)' != 'True' "
-             Text="FPM tool Not found, RPM packages will not be built."
-             Importance="High"/>
+    <Error Condition=" '$(FPMPresent)' != 'True' "
+           Text="FPM tool Not found, RPM packages will not be built." />
   </Target>
 
   <Target Name="TestSdkRpm"

--- a/src/redist/targets/GenerateRPMs.targets
+++ b/src/redist/targets/GenerateRPMs.targets
@@ -16,12 +16,12 @@
        build environment. https://github.com/dotnet/sdk/issues/41910 -->
   <Target Name="GenerateRpmsInner"
           DependsOnTargets="TestFPMTool;BuildRpms"
-          Condition=" '$(IsRPMBasedDistro)' == 'True' "
+          Condition=" '$(BuildSdkRpm)' == 'True' "
           Outputs="@(GeneratedInstallers)"/>
 
   <Target Name="BuildRpms"
           DependsOnTargets="GenerateSdkRpm"
-          Condition=" '$(IsRPMBasedDistro)' == 'True' and '$(FPMPresent)' == 'True' "/>
+          Condition=" '$(BuildSdkRpm)' == 'True' and '$(FPMPresent)' == 'True' "/>
 
   <Target Name="GenerateSdkRpm"
           DependsOnTargets="SetupRpmProps">
@@ -322,7 +322,7 @@
   </Target>
 
   <Target Name="TestSdkRpm"
-          Condition="  '$(CLIBUILD_SKIP_TESTS)' != 'true' and '$(IsRPMBasedDistro)' == 'True' and '$(FPMPresent)' == 'True' "
+          Condition="  '$(CLIBUILD_SKIP_TESTS)' != 'true' and '$(BuildSdkRpm)' == 'True' and '$(FPMPresent)' == 'True' "
           Inputs="$(DownloadedNetCoreAppTargetingPackInstallerFile);
                   $(DownloadedNetStandardTargetingPackInstallerFile);
                   $(DownloadedNetCoreAppHostPackInstallerFile);


### PR DESCRIPTION
Currently, if the build is supposed to produce RPM packages, but the tooling (i.e. `fpm`) is missing, a message will be logged and the build will skip the RPM package generation. This can result in successful builds that are missing the required artifacts.

Additional changes were needed, as RPM targets were being executed for any build that was running on RPM-based distro due to: https://github.com/dotnet/installer/blob/fa82557e82e7ec001df1acd1563b8e8478bd38b3/src/redist/targets/GenerateRPMs.targets#L19

The use of property `IsRPMBasedDistro` was overloaded to mean both that the distro is RPM-based **and** that we want to build installers.

Property was set here: https://github.com/dotnet/installer/blob/fa82557e82e7ec001df1acd1563b8e8478bd38b3/src/redist/targets/GetRuntimeInformation.targets#L27-L28

For installer build we were passing this same property, which was already being set on rpm-based distros, so this wasn't correct: https://github.com/dotnet/installer/blob/fa82557e82e7ec001df1acd1563b8e8478bd38b3/.vsts-pr.yml#L250

I am now setting a different property, `BuildSdkRpm`, in scenarios where RPM packaging is desired. This matches DEB build experience, where we have a similar pair of properties: `BuildSdkDeb` and `IsDebianBaseDistro`.

## Notes

Fix for 8.0.1xx - will be backported to other 8.0.x branches in support. Separate fix will be made for 9.0.

Contributes to https://github.com/dotnet/installer/issues/20561
