### PR TITLE
Update Linux build host to Ubuntu 22.04

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -93,7 +93,7 @@ jobs:
       pool:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: $(DncEngPublicBuildPool)
-          image: 1es-ubuntu-2004-open
+          image: 1es-ubuntu-2204-open
           os: linux
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: $(DncEngInternalBuildPool)

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -97,7 +97,7 @@ jobs:
           os: linux
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: $(DncEngInternalBuildPool)
-          image: 1es-ubuntu-2004
+          image: 1es-ubuntu-2204
           os: linux
       container: ${{ parameters.container }}
     ${{ if eq(parameters.agentOs, 'Darwin') }}:


### PR DESCRIPTION
Fixes: https://github.com/dotnet/installer/issues/20636

Internal 8.0.1xx builds are failing as they are still using Ubuntu 20.04 host - [example](https://dev.azure.com/dnceng/internal/_build/results?buildId=2811544)

All other branches are using `Ubuntu 22.04` for those builds, i.e. 8.0.3xx: https://github.com/dotnet/installer/blob/5ccb2cf04c5dcb25c10370b3c49da8399872a10d/eng/build.yml#L98-L100

## Note

This will unblock internal 8.0.1xx builds.