### PR TITLE
Revert "[release/8.0.1xx] Stop building source-build in non-1xx branc…

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -330,6 +330,11 @@ extends:
             buildArchitecture: arm64
             runTests: false
 
+      # Source Build
+      - template: /eng/common/templates-official/jobs/source-build.yml@self
+        parameters:
+          enableInternalSources: true
+
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - stage: Publish
         dependsOn:

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -340,6 +340,10 @@ stages:
         linuxPortable: true
         runTests: false
 
+  - template: /eng/common/templates/jobs/source-build.yml
+    parameters:
+      enableInternalSources: true
+
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - stage: Publish
     dependsOn:


### PR DESCRIPTION
Reverts https://github.com/dotnet/installer/pull/20635

It was an accidental backport to 8.0.1xx.

We do want to build source-build in 8.0.1xx branch.

## Note

Infra change.