### PR TITLE
Make unofficial pipeline functional

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -44,7 +44,7 @@ resources:
     ref: refs/tags/release
 
 extends:
-  ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+  ${{ if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'dotnet-installer-official-ci')) }}:
     template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   ${{ else }}:
     template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -335,7 +335,7 @@ extends:
         parameters:
           enableInternalSources: true
 
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'dotnet-installer-official-ci')) }}:
       - stage: Publish
         dependsOn:
         - Build

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -116,7 +116,7 @@ jobs:
     helixRepo: dotnet/installer
     workspace:
       clean: all
-    ${{ if ne(variables['Build.DefinitionName'], 'dotnet-installer-official-ci')) }}:
+    ${{ if ne(variables['Build.DefinitionName'], 'dotnet-installer-official-ci') }}:
       microbuildUseESRP: false
 
     variables:

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -79,8 +79,7 @@ jobs:
 
     # Set up the pool/machine info to be used based on the Agent OS
     ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
-      ${{ if eq(variables['Build.DefinitionName'], 'dotnet-installer-official-ci') }}:
-        enableMicrobuild: true
+      enableMicrobuild: true
       pool:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: $(DncEngPublicBuildPool)
@@ -117,9 +116,8 @@ jobs:
     helixRepo: dotnet/installer
     workspace:
       clean: all
-    # ${{ if ne(variables['Build.DefinitionName'], 'dotnet-installer-official-ci') }}:
-      # microbuildUseESRP: false
-      # enableMicrobuild: false
+    ${{ if ne(variables['Build.DefinitionName'], 'dotnet-installer-official-ci') }}:
+      microbuildUseESRP: false
 
     variables:
     # Test variables
@@ -171,7 +169,8 @@ jobs:
       - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         - group: DotNet-HelixApi-Access
         - _PushToVSFeed: true
-        - _SignType: real
+        - ${{ if eq(variables['Build.DefinitionName'], 'dotnet-installer-official-ci') }}:
+          - _SignType: real
         - _BuildArgs: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
                   /p:DotNetSignType=$(_SignType)
                   /p:TeamName=$(_TeamName)

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -117,7 +117,8 @@ jobs:
     workspace:
       clean: all
     ${{ if ne(variables['Build.DefinitionName'], 'dotnet-installer-official-ci') }}:
-      microbuildUseESRP: false
+      # microbuildUseESRP: false
+      enableMicrobuild: false
 
     variables:
     # Test variables

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -116,6 +116,8 @@ jobs:
     helixRepo: dotnet/installer
     workspace:
       clean: all
+    ${{ if ne(variables['Build.DefinitionName'], 'dotnet-installer-official-ci')) }}:
+      microbuildUseESRP: false
 
     variables:
     # Test variables

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -79,7 +79,8 @@ jobs:
 
     # Set up the pool/machine info to be used based on the Agent OS
     ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
-      enableMicrobuild: true
+      ${{ if eq(variables['Build.DefinitionName'], 'dotnet-installer-official-ci') }}:
+        enableMicrobuild: true
       pool:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: $(DncEngPublicBuildPool)
@@ -116,9 +117,9 @@ jobs:
     helixRepo: dotnet/installer
     workspace:
       clean: all
-    ${{ if ne(variables['Build.DefinitionName'], 'dotnet-installer-official-ci') }}:
+    # ${{ if ne(variables['Build.DefinitionName'], 'dotnet-installer-official-ci') }}:
       # microbuildUseESRP: false
-      enableMicrobuild: false
+      # enableMicrobuild: false
 
     variables:
     # Test variables


### PR DESCRIPTION
## Summary

This PR allows the [unofficial pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=1471&_a=summary) to run properly. Changes required:

- Use Official 1ES templates only for `dotnet-installer-official-ci`
- Disable *Publish* stage for non-`dotnet-installer-official-ci`
- Disable *microbuildUseESRP* for non-`dotnet-installer-official-ci`
- Use *_SignType* as **real** only for `dotnet-installer-official-ci`

## Test Run

- Success: https://dev.azure.com/dnceng/internal/_build/results?buildId=2817178&view=results