### PR TITLE
Fix PR build for unofficial

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -71,7 +71,7 @@ extends:
       fedora41:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-41
       ubuntu2204:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-coredeps
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04
       azureLinux30CrossArm:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-cross-arm-alpine
       ubuntu2204DebPkg:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -41,6 +41,8 @@ variables:
 # Set the MicroBuild plugin installation directory to the agent temp directory to avoid SDL tool scanning.
 - name: MicroBuildOutputFolderOverride
   value: $(Agent.TempDirectory)
+# Sets: dn-bot-dnceng-artifact-feeds-rw
+- group: AzureDevOps-Artifact-Feeds-Pats
 
 resources:
   repositories:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -9,6 +9,12 @@ trigger:
     - release/*
     - internal/release/*
 
+parameters:
+- name: runPrBuild
+  displayName: Run PR Build
+  type: boolean
+  default: false
+
 variables:
 - name: _PublishUsingPipelines
   value: false
@@ -102,7 +108,7 @@ extends:
             artifactName: buildConfiguration
 
       # PR-only jobs
-      - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+      - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'), eq(parameters.runTestBuild, true)) }}:
         # Windows
         - template: eng/build.yml@self
           parameters:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -108,7 +108,7 @@ extends:
             artifactName: buildConfiguration
 
       # PR-only jobs
-      - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'), eq(parameters.runTestBuild, true)) }}:
+      - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'), eq(parameters.runPrBuild, true)) }}:
         # Windows
         - template: eng/build.yml@self
           parameters:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -71,7 +71,7 @@ extends:
       fedora41:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-41
       ubuntu2204:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-coredeps
       azureLinux30CrossArm:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-cross-arm-alpine
       ubuntu2204DebPkg:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -197,7 +197,7 @@ extends:
             runTests: true
 
       # Official/PGO instrumentation Builds
-      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - ${{ else }}:
         # Windows
         - template: eng/build.yml@self
           parameters:

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -181,6 +181,11 @@ jobs:
 
     ${{ if and(not(parameters.isBuiltFromVmr), ne(variables['System.TeamProject'], 'public')) }}:
       presteps:
+      # Install Azure CLI for enable-internal-runtimes.yml when the container is ubuntu2204 (the image is missing az).
+      - ${{ if and(eq(parameters.container, 'ubuntu2204'), eq(parameters.buildArchitecture, 'x64')) }}:
+        # Script from here: https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?view=azure-cli-latest&pivots=apt#install-azure-cli
+        - script: curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+          displayName: Install Azure CLI on Linux x64
       # # Install pwsh for enable-internal-runtimes.yml when the container is ubuntu2204 (the image is missing pwsh).
       # - ${{ if and(eq(parameters.container, 'ubuntu2204'), eq(parameters.buildArchitecture, 'x64')) }}:
       #   # Script from here: https://learn.microsoft.com/en-us/powershell/scripting/install/install-ubuntu?view=powershell-7.5#installation-via-package-repository-the-package-repository

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -183,44 +183,37 @@ jobs:
       presteps:
       # Install pwsh for enable-internal-runtimes.yml when the container is ubuntu2204 (the image is missing pwsh).
       - ${{ if and(eq(parameters.container, 'ubuntu2204'), eq(parameters.buildArchitecture, 'x64')) }}:
+        # Script from here: https://learn.microsoft.com/en-us/powershell/scripting/install/install-ubuntu?view=powershell-7.5#installation-via-package-repository-the-package-repository
         - script: |
-            #!/usr/bin/env bash
-            set -euo pipefail
+            ###################################
+            # Prerequisites
 
-            # Download and install the latest PowerShell release for Linux x64.
-            # Mirrors logic from PwshDownload.ps1.
-            # Requirements: curl, tar, sudo (for system-wide install), bash >= 4 (for reliability)
+            # Update the list of packages
+            sudo apt-get update
 
-            # Resolve the final redirected release URL to extract the tag (e.g. v7.5.3)
-            LATEST_URL="https://github.com/PowerShell/PowerShell/releases/latest"
-            FINAL_URL=$(curl -Ls -o /dev/null -w '%{url_effective}' "$LATEST_URL")
-            TAG="${FINAL_URL##*/}"          # e.g. v7.5.3
-            VERSION="${TAG#v}"              # strip leading v -> 7.5.3
-            ARCH="x64"                      # Could be enhanced to auto-detect; left static to match original
-            FILE_NAME="powershell-${VERSION}-linux-${ARCH}.tar.gz"
-            DOWNLOAD_URL="https://github.com/PowerShell/PowerShell/releases/download/${TAG}/${FILE_NAME}"
+            # Install pre-requisite packages.
+            sudo apt-get install -y wget apt-transport-https software-properties-common
 
-            printf 'Latest PowerShell tag: %s\n' "$TAG"
-            printf 'Resolved version: %s\n' "$VERSION"
-            printf 'Downloading: %s\n' "$DOWNLOAD_URL"
+            # Get the version of Ubuntu
+            source /etc/os-release
 
-            curl -L "$DOWNLOAD_URL" -o "$FILE_NAME"
+            # Download the Microsoft repository keys
+            wget -q https://packages.microsoft.com/config/ubuntu/$VERSION_ID/packages-microsoft-prod.deb
 
-            # Install to versioned directory under /opt and symlink pwsh into /usr/bin
-            INSTALL_ROOT="/opt/microsoft/powershell"
-            VERSION_DIR="${INSTALL_ROOT}/${VERSION}"
+            # Register the Microsoft repository keys
+            sudo dpkg -i packages-microsoft-prod.deb
 
-            echo "Installing to: ${VERSION_DIR}" 
+            # Delete the Microsoft repository keys file
+            rm packages-microsoft-prod.deb
 
-            sudo mkdir -p "$VERSION_DIR"
-            sudo tar -xzf "$FILE_NAME" -C "$VERSION_DIR"
+            # Update the list of packages after we added packages.microsoft.com
+            sudo apt-get update
 
-            # The extracted archive contains the 'pwsh' executable at the root of the expanded directory.
-            sudo ln -sf "${VERSION_DIR}/pwsh" /usr/bin/pwsh
+            ###################################
+            # Install PowerShell
+            sudo apt-get install -y powershell
 
-            echo "PowerShell ${VERSION} installed. Run: pwsh --version"
-
-            # Verify
+            # Show PowerShell version
             pwsh --version
           displayName: Install PowerShell on Linux x64
       - ${{ if eq(parameters.agentOs, 'Windows_NT') }}:

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -179,12 +179,9 @@ jobs:
 
     - template: /eng/common/templates-official/variables/pool-providers.yml
 
-    steps:
-    - checkout: self
-      clean: true
-    - template: /eng/common/templates/steps/enable-internal-runtimes.yml
-    - ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
-      - ${{ if and(not(parameters.isBuiltFromVmr), ne(variables['System.TeamProject'], 'public')) }}:
+    ${{ if and(not(parameters.isBuiltFromVmr), ne(variables['System.TeamProject'], 'public')) }}:
+      presteps:
+      - ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
         - task: PowerShell@2
           displayName: Setup Private Feeds Credentials
           inputs:
@@ -192,6 +189,20 @@ jobs:
             arguments: -ConfigFile $(installerRoot)/NuGet.config -Password $Env:Token
           env:
             Token: $(dn-bot-dnceng-artifact-feeds-rw)
+      - ${{ else }}:
+        - task: Bash@3
+          displayName: Setup Private Feeds Credentials
+          inputs:
+            filePath: $(installerRoot)/eng/common/SetupNugetSources.sh
+            arguments: $(installerRoot)/NuGet.config $Token
+          env:
+            Token: $(dn-bot-dnceng-artifact-feeds-rw)
+
+    steps:
+    - checkout: self
+      clean: true
+    - template: /eng/common/templates/steps/enable-internal-runtimes.yml
+    - ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
       - script: $(installerRoot)/build.cmd
                   $(_TestArg) $(_PackArg)
                   -publish -ci -sign
@@ -204,15 +215,6 @@ jobs:
         env:
           DOTNET_CLI_UI_LANGUAGE: ${{ parameters.dotnetCLIUILanguage }}
 
-    - ${{ if ne(parameters.agentOs, 'Windows_NT') }}:
-      - ${{ if and(not(parameters.isBuiltFromVmr), ne(variables['System.TeamProject'], 'public')) }}:
-        - task: Bash@3
-          displayName: Setup Private Feeds Credentials
-          inputs:
-            filePath: $(installerRoot)/eng/common/SetupNugetSources.sh
-            arguments: $(installerRoot)/NuGet.config $Token
-          env:
-            Token: $(dn-bot-dnceng-artifact-feeds-rw)
     - ${{ if eq(parameters.agentOs, 'Linux') }}:
       - script: $(installerRoot)/build.sh
                   $(_TestArg) $(_PackArg)

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -199,8 +199,6 @@ jobs:
             Token: $(dn-bot-dnceng-artifact-feeds-rw)
 
     steps:
-    - checkout: self
-      clean: true
     - template: /eng/common/templates/steps/enable-internal-runtimes.yml
     - ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
       - script: $(installerRoot)/build.cmd

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -181,41 +181,41 @@ jobs:
 
     ${{ if and(not(parameters.isBuiltFromVmr), ne(variables['System.TeamProject'], 'public')) }}:
       presteps:
-      # Install pwsh for enable-internal-runtimes.yml when the container is ubuntu2204 (the image is missing pwsh).
-      - ${{ if and(eq(parameters.container, 'ubuntu2204'), eq(parameters.buildArchitecture, 'x64')) }}:
-        # Script from here: https://learn.microsoft.com/en-us/powershell/scripting/install/install-ubuntu?view=powershell-7.5#installation-via-package-repository-the-package-repository
-        - script: |
-            ###################################
-            # Prerequisites
+      # # Install pwsh for enable-internal-runtimes.yml when the container is ubuntu2204 (the image is missing pwsh).
+      # - ${{ if and(eq(parameters.container, 'ubuntu2204'), eq(parameters.buildArchitecture, 'x64')) }}:
+      #   # Script from here: https://learn.microsoft.com/en-us/powershell/scripting/install/install-ubuntu?view=powershell-7.5#installation-via-package-repository-the-package-repository
+      #   - script: |
+      #       ###################################
+      #       # Prerequisites
 
-            # Update the list of packages
-            sudo apt-get update
+      #       # Update the list of packages
+      #       sudo apt-get update
 
-            # Install pre-requisite packages.
-            sudo apt-get install -y wget apt-transport-https software-properties-common
+      #       # Install pre-requisite packages.
+      #       sudo apt-get install -y wget apt-transport-https software-properties-common
 
-            # Get the version of Ubuntu
-            source /etc/os-release
+      #       # Get the version of Ubuntu
+      #       source /etc/os-release
 
-            # Download the Microsoft repository keys
-            wget -q https://packages.microsoft.com/config/ubuntu/$VERSION_ID/packages-microsoft-prod.deb
+      #       # Download the Microsoft repository keys
+      #       wget -q https://packages.microsoft.com/config/ubuntu/$VERSION_ID/packages-microsoft-prod.deb
 
-            # Register the Microsoft repository keys
-            sudo dpkg -i packages-microsoft-prod.deb
+      #       # Register the Microsoft repository keys
+      #       sudo dpkg -i packages-microsoft-prod.deb
 
-            # Delete the Microsoft repository keys file
-            rm packages-microsoft-prod.deb
+      #       # Delete the Microsoft repository keys file
+      #       rm packages-microsoft-prod.deb
 
-            # Update the list of packages after we added packages.microsoft.com
-            sudo apt-get update
+      #       # Update the list of packages after we added packages.microsoft.com
+      #       sudo apt-get update
 
-            ###################################
-            # Install PowerShell
-            sudo apt-get install -y powershell
+      #       ###################################
+      #       # Install PowerShell
+      #       sudo apt-get install -y powershell
 
-            # Show PowerShell version
-            pwsh --version
-          displayName: Install PowerShell on Linux x64
+      #       # Show PowerShell version
+      #       pwsh --version
+      #     displayName: Install PowerShell on Linux x64
       - ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
         - task: PowerShell@2
           displayName: Setup Private Feeds Credentials

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -181,46 +181,20 @@ jobs:
 
     ${{ if and(not(parameters.isBuiltFromVmr), ne(variables['System.TeamProject'], 'public')) }}:
       presteps:
-      # Install Azure CLI for enable-internal-runtimes.yml when the container is ubuntu2204 (the image is missing az).
+      # Install pwsh for enable-internal-runtimes.yml when the container is ubuntu2204 (the image is missing pwsh).
       - ${{ if and(eq(parameters.container, 'ubuntu2204'), eq(parameters.buildArchitecture, 'x64')) }}:
-        # Script from here: https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?view=azure-cli-latest&pivots=apt#install-azure-cli
-        - script: curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-          displayName: Install Azure CLI on Linux x64
-      # # Install pwsh for enable-internal-runtimes.yml when the container is ubuntu2204 (the image is missing pwsh).
-      # - ${{ if and(eq(parameters.container, 'ubuntu2204'), eq(parameters.buildArchitecture, 'x64')) }}:
-      #   # Script from here: https://learn.microsoft.com/en-us/powershell/scripting/install/install-ubuntu?view=powershell-7.5#installation-via-package-repository-the-package-repository
-      #   - script: |
-      #       ###################################
-      #       # Prerequisites
-
-      #       # Update the list of packages
-      #       sudo apt-get update
-
-      #       # Install pre-requisite packages.
-      #       sudo apt-get install -y wget apt-transport-https software-properties-common
-
-      #       # Get the version of Ubuntu
-      #       source /etc/os-release
-
-      #       # Download the Microsoft repository keys
-      #       wget -q https://packages.microsoft.com/config/ubuntu/$VERSION_ID/packages-microsoft-prod.deb
-
-      #       # Register the Microsoft repository keys
-      #       sudo dpkg -i packages-microsoft-prod.deb
-
-      #       # Delete the Microsoft repository keys file
-      #       rm packages-microsoft-prod.deb
-
-      #       # Update the list of packages after we added packages.microsoft.com
-      #       sudo apt-get update
-
-      #       ###################################
-      #       # Install PowerShell
-      #       sudo apt-get install -y powershell
-
-      #       # Show PowerShell version
-      #       pwsh --version
-      #     displayName: Install PowerShell on Linux x64
+        # Script from here: https://learn.microsoft.com/en-us/powershell/scripting/install/install-ubuntu?view=powershell-7.5#installation-via-package-repository-the-package-repository
+        - script: |
+            sudo apt-get update
+            sudo apt-get install -y wget apt-transport-https software-properties-common
+            source /etc/os-release
+            wget -q https://packages.microsoft.com/config/ubuntu/$VERSION_ID/packages-microsoft-prod.deb
+            sudo dpkg -i packages-microsoft-prod.deb
+            rm packages-microsoft-prod.deb
+            sudo apt-get update
+            sudo apt-get install -y powershell
+            pwsh --version
+          displayName: Install PowerShell on Ubuntu 22.04
       - ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
         - task: PowerShell@2
           displayName: Setup Private Feeds Credentials

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -181,6 +181,33 @@ jobs:
 
     ${{ if and(not(parameters.isBuiltFromVmr), ne(variables['System.TeamProject'], 'public')) }}:
       presteps:
+      # Install pwsh for enable-internal-runtimes.yml when the container is ubuntu2204 (the image is missing pwsh).
+      - ${{ if and(eq(parameters.container, 'ubuntu2204'), eq(parameters.buildArchitecture, 'x64')) }}:
+        - powershell: |
+            # Download the latest PowerShell tar.gz for Linux x64.
+            $pwshLatest = 'https://github.com/PowerShell/PowerShell/releases/latest'
+            $response = Invoke-WebRequest -Uri $pwshLatest -MaximumRedirection 15
+            # Get the final redirected URL and parse the version number out of the tag value.
+            # Example final URL: https://github.com/PowerShell/PowerShell/releases/tag/v7.5.3
+            # Example tag value: v7.5.3
+            $tag = ($response.BaseResponse.ResponseUri.AbsoluteUri -split '/')[-1]
+            # Parse the version number out of the tag value.
+            # Example tag value: v7.5.3
+            # Example version value: 7.5.3
+            $version = $tag -replace '^v', ''
+            # Example download URL: https://github.com/PowerShell/PowerShell/releases/download/v7.5.3/powershell-7.5.3-linux-x64.tar.gz
+            $fileName = "powershell-$version-linux-x64.tar.gz"
+            $downloadUrl = "https://github.com/PowerShell/PowerShell/releases/download/$tag/$fileName"
+            Invoke-WebRequest -Uri $downloadUrl -OutFile $fileName
+
+            # Silently install PowerShell tar.gz on Linux (requires root or sudo).
+            # 1. Create versioned install directory
+            sudo mkdir -p /opt/microsoft/powershell/$version
+            # 2. Extract archive contents into the versioned directory
+            sudo tar -xzf $fileName -C /opt/microsoft/powershell/$version
+            # 3. Create/update global symlink so 'pwsh' is on PATH
+            sudo ln -sf /opt/microsoft/powershell/$version/pwsh /usr/bin/pwsh
+          displayName: Install PowerShell on Linux x64
       - ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
         - task: PowerShell@2
           displayName: Setup Private Feeds Credentials

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -269,3 +269,11 @@ jobs:
         publishLocation: Container
       continueOnError: true
       condition: always()
+    - task: 1ES.PublishBuildArtifacts@1
+      displayName: Publish NuGet.config to VSTS
+      inputs:
+        PathtoPublish: '$(installerRoot)/NuGet.config'
+        ArtifactName: '$(_AgentOSName)_$(Agent.JobName)_$(Build.BuildNumber)_NuGetConfig'
+        publishLocation: Container
+      continueOnError: true
+      condition: always()

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -304,11 +304,3 @@ jobs:
         publishLocation: Container
       continueOnError: true
       condition: always()
-    - task: 1ES.PublishBuildArtifacts@1
-      displayName: Publish NuGet.config to VSTS
-      inputs:
-        PathtoPublish: '$(installerRoot)/NuGet.config'
-        ArtifactName: '$(_AgentOSName)_$(Agent.JobName)_$(Build.BuildNumber)_NuGetConfig'
-        publishLocation: Container
-      continueOnError: true
-      condition: always()

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -183,30 +183,45 @@ jobs:
       presteps:
       # Install pwsh for enable-internal-runtimes.yml when the container is ubuntu2204 (the image is missing pwsh).
       - ${{ if and(eq(parameters.container, 'ubuntu2204'), eq(parameters.buildArchitecture, 'x64')) }}:
-        - powershell: |
-            # Download the latest PowerShell tar.gz for Linux x64.
-            $pwshLatest = 'https://github.com/PowerShell/PowerShell/releases/latest'
-            $response = Invoke-WebRequest -Uri $pwshLatest -MaximumRedirection 15
-            # Get the final redirected URL and parse the version number out of the tag value.
-            # Example final URL: https://github.com/PowerShell/PowerShell/releases/tag/v7.5.3
-            # Example tag value: v7.5.3
-            $tag = ($response.BaseResponse.ResponseUri.AbsoluteUri -split '/')[-1]
-            # Parse the version number out of the tag value.
-            # Example tag value: v7.5.3
-            # Example version value: 7.5.3
-            $version = $tag -replace '^v', ''
-            # Example download URL: https://github.com/PowerShell/PowerShell/releases/download/v7.5.3/powershell-7.5.3-linux-x64.tar.gz
-            $fileName = "powershell-$version-linux-x64.tar.gz"
-            $downloadUrl = "https://github.com/PowerShell/PowerShell/releases/download/$tag/$fileName"
-            Invoke-WebRequest -Uri $downloadUrl -OutFile $fileName
+        - script: |
+            #!/usr/bin/env bash
+            set -euo pipefail
 
-            # Silently install PowerShell tar.gz on Linux (requires root or sudo).
-            # 1. Create versioned install directory
-            sudo mkdir -p /opt/microsoft/powershell/$version
-            # 2. Extract archive contents into the versioned directory
-            sudo tar -xzf $fileName -C /opt/microsoft/powershell/$version
-            # 3. Create/update global symlink so 'pwsh' is on PATH
-            sudo ln -sf /opt/microsoft/powershell/$version/pwsh /usr/bin/pwsh
+            # Download and install the latest PowerShell release for Linux x64.
+            # Mirrors logic from PwshDownload.ps1.
+            # Requirements: curl, tar, sudo (for system-wide install), bash >= 4 (for reliability)
+
+            # Resolve the final redirected release URL to extract the tag (e.g. v7.5.3)
+            LATEST_URL="https://github.com/PowerShell/PowerShell/releases/latest"
+            FINAL_URL=$(curl -Ls -o /dev/null -w '%{url_effective}' "$LATEST_URL")
+            TAG="${FINAL_URL##*/}"          # e.g. v7.5.3
+            VERSION="${TAG#v}"              # strip leading v -> 7.5.3
+            ARCH="x64"                      # Could be enhanced to auto-detect; left static to match original
+            FILE_NAME="powershell-${VERSION}-linux-${ARCH}.tar.gz"
+            DOWNLOAD_URL="https://github.com/PowerShell/PowerShell/releases/download/${TAG}/${FILE_NAME}"
+
+            printf 'Latest PowerShell tag: %s\n' "$TAG"
+            printf 'Resolved version: %s\n' "$VERSION"
+            printf 'Downloading: %s\n' "$DOWNLOAD_URL"
+
+            curl -L "$DOWNLOAD_URL" -o "$FILE_NAME"
+
+            # Install to versioned directory under /opt and symlink pwsh into /usr/bin
+            INSTALL_ROOT="/opt/microsoft/powershell"
+            VERSION_DIR="${INSTALL_ROOT}/${VERSION}"
+
+            echo "Installing to: ${VERSION_DIR}" 
+
+            sudo mkdir -p "$VERSION_DIR"
+            sudo tar -xzf "$FILE_NAME" -C "$VERSION_DIR"
+
+            # The extracted archive contains the 'pwsh' executable at the root of the expanded directory.
+            sudo ln -sf "${VERSION_DIR}/pwsh" /usr/bin/pwsh
+
+            echo "PowerShell ${VERSION} installed. Run: pwsh --version"
+
+            # Verify
+            pwsh --version
           displayName: Install PowerShell on Linux x64
       - ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
         - task: PowerShell@2


### PR DESCRIPTION
## Summary

After https://github.com/dotnet/installer/pull/20657, it came into question if the PR build would work as it previously also was not working. To investigate and subsequently fix, I did the following:

- Added a parameter, `runPrBuild`, to allow the unofficial pipeline manually run a PR build.
- Determined `SetupNugetSources.ps1/sh` needed to run prior to *NuGetAuthenticate*, which is at the start of the job template; thus, moved the `SetupNugetSources.ps1/sh` into a presteps parameter.
- Added access to the variable group *AzureDevOps-Artifact-Feeds-Pats* as it was required to access the variable `dn-bot-dnceng-artifact-feeds-rw`.
- Realized the `ubuntu2204` container was missing *pwsh*, which is required for some more recent Arcade templates; thus, added a step to install pwsh when that job is executed (as a prestep).
  - Documentation has a script to do this easily on Ubuntu: https://learn.microsoft.com/en-us/powershell/scripting/install/install-ubuntu?view=powershell-7.5#installation-via-package-repository-the-package-repository

## Build

- ~~https://dev.azure.com/dnceng/internal/_build/results?buildId=2818144&view=results~~
- https://dev.azure.com/dnceng/internal/_build/results?buildId=2822283&view=results