### PR TITLE
Update allowed binaries list

### DIFF
--- a/src/VirtualMonoRepo/allowed-binaries.txt
+++ b/src/VirtualMonoRepo/allowed-binaries.txt
@@ -32,10 +32,14 @@ src/aspnetcore/src/*.woff
 src/aspnetcore/src/*.woff2
 src/aspnetcore/src/Components/Web.JS/dist/Release/blazor.*.js # JavaScript files with a null bytes
 src/aspnetcore/src/ProjectTemplates/Web.ProjectTemplates/**/app.db
+src/aspnetcore/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/HtmlResponses.rc # UTF16-LE text file
 src/aspnetcore/src/submodules/spa-templates/**/app.db
 
 src/fsharp/**/signedtests/*
 src/fsharp/src/fsi/fsi.res # Icon
+src/fsharp/vsintegration/src/FSharp.LanguageService/VSPackage.resx # UTF16-LE text file
+
+src/installer/src/finalizer/native.rc # UTF16-LE text file
 
 src/msbuild/src/Tasks.UnitTests/*
 
@@ -51,7 +55,9 @@ src/runtime/src/mono/wasm/testassets/*
 src/runtime/src/native/external/brotli/common/dictionary.bin.br
 
 src/sdk/src/Assets/TestProjects/*
+src/sdk/src/GenAPI/genapi.slnf # UTF16-LE text file
 
+src/source-build-externals/src/application-insights/BASE/.PreReleaseVersion # UTF16-LE text file
 src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/build/strongNameBypass.reg # UTF16-LE text file
 src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/build/strongNameBypass2.reg # UTF16-LE text file
 src/source-build-externals/src/humanizer/src/Humanizer.Tests*


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/5391

All of these files are text files that are incorrectly flagged as binaries. The files are Unicode with a Unicode BOM. We already had exclusions for some other Unicode files. It is unclear why these files were suddenly flagged as binaries, but a likely suspect is the agent OS update to `ubuntu-22.04`.

This is not an issue in `main` or `release/9.0.1xx` as we use `BinaryToolKit` in those branches.