### PR TITLE
Update Mariner-2-Docker-ARM64 internal build image to Azure-Linux-3-Arm64

### DIFF
--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -55,6 +55,6 @@ variables:
   - name: poolImage_Linux
     value: 1es-ubuntu-2204
   - name: poolImage_LinuxArm64
-    value: Mariner-2-Docker-ARM64
+    value: Azure-Linux-3-Arm64
   - name: poolName_LinuxArm64
     value: Docker-Linux-Arm-Internal


### PR DESCRIPTION
Related to: https://github.com/dotnet/source-build/issues/5388

See comments in issue about public images not being available yet.