### PR TITLE
Use build.ubuntu.2204.amd64 pool image

### DIFF
--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -53,7 +53,7 @@ variables:
     - name: defaultPoolName
       value: $(DncEngInternalBuildPool)
   - name: poolImage_Linux
-    value: 1es-ubuntu-2204
+    value: build.ubuntu.2204.amd64
   - name: poolImage_LinuxArm64
     value: Azure-Linux-3-Arm64
   - name: poolName_LinuxArm64


### PR DESCRIPTION
The 1es-ubuntu-2204 image was re-provisioned with a 73GB root disk (down from 248GB), leaving only ~5.6GB free after ~67GB of pre-installed content. This causes VMR source-build failures due to disk exhaustion during Docker operations (exit code 134 / SIGABRT and job timeouts).

Switch to build.ubuntu.2204.amd64, which is the same image used successfully by 9.0.1xx builds.

Fixes: https://github.com/dotnet/source-build/issues/5525

[Pipeline run with fix](https://dev.azure.com/dnceng/internal/_build/results?buildId=2934820&view=results) (now passing previous timeout in prep)