### PR TITLE
Replace dn-bot PAT with WIF token for internal VMR push (9.0.1xx-preview4)

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-synchronization.yml
+++ b/eng/pipelines/templates/jobs/vmr-synchronization.yml
@@ -77,13 +77,31 @@ jobs:
   
     # Push internal/release branches to the internal VMR
     - ${{ if startsWith(parameters.vmrBranch, 'internal/release/') }}:
+      - task: AzureCLI@2
+        displayName: Mint AzDO token via WIF
+        inputs:
+          azureSubscription: 'dnceng-build-rw-code-rw-wif'
+          scriptType: 'pscore'
+          scriptLocation: 'inlineScript'
+          inlineScript: |
+            $token = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
+            if ($LASTEXITCODE -ne 0) {
+              Write-Error "Failed to acquire Azure DevOps access token via 'az account get-access-token'. Exit code: $LASTEXITCODE"
+              exit 1
+            }
+            $token = $token.Trim()
+            if ([string]::IsNullOrWhiteSpace($token)) {
+              Write-Error "Received an empty or whitespace Azure DevOps access token from 'az account get-access-token'."
+              exit 1
+            }
+            Write-Host "##vso[task.setvariable variable=WifAzdoToken;issecret=true]$token"
       - script: >
           ./.dotnet/dotnet darc vmr push
           --vmr '$(vmrPath)'
           --skip-commit-verification
           --branch '${{ parameters.vmrBranch }}'
           --remote-url '$(vmrInternalUrl)'
-          --azdev-pat '$(dn-bot-dnceng-build-rw-code-rw)'
+          --azdev-pat '$(WifAzdoToken)'
           --verbose
         displayName: Push changes to dotnet-dotnet (internal)
         workingDirectory: $(Agent.BuildDirectory)/installer


### PR DESCRIPTION
AB#10139

AB#10139  Migrate the darc vmr push command for internal/release branches from using the dn-bot-dnceng-build-rw-code-rw PAT (via DotNetBot-AzDO-PAT variable group) to a WIF-minted Entra token obtained through the dnceng-build-rw-code-rw-wif service connection.  ## Changes  - Added an AzureCLI@2 step that authenticates via the dnceng-build-rw-code-rw-wif service connection and mints an AzDO bearer token - Replaced --azdev-pat with WIF-minted token in the internal VMR push step  ## Context  Part of a set of PRs migrating this PAT across all active release branches: - #20821 (release/8.0.4xx) - #20822 (release/8.0.1xx) - #20823 (release/8.0.2xx) - #20824 (release/8.0.3xx) - #20825 (release/9.0.1xx-preview3) - This PR (release/9.0.1xx-preview4)  Part of PAT migration work item: https://dev.azure.com/dnceng/internal/_workitems/edit/10139  ## Prerequisites  Before merging, the dnceng-build-rw-code-rw-wif service principal needs: 1. Enrollment in the dnceng AzDO org 2. Contribute permission on the dotnet-dotnet repo 3. Bypass policies when pushing on the dotnet-dotnet repo