### PR TITLE
[release/8.0.4xx] Update branding to 8.0.421

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,7 +8,7 @@
     <VersionMajor>8</VersionMajor>
     <VersionMinor>0</VersionMinor>
     <VersionSDKMinor>4</VersionSDKMinor>
-    <VersionFeature>20</VersionFeature>
+    <VersionFeature>21</VersionFeature>
     <VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionSDKMinor)$(VersionFeature)</VersionPrefix>
     <MajorMinorVersion>$(VersionMajor).$(VersionMinor)</MajorMinorVersion>
     <CliProductBandVersion>$(MajorMinorVersion).$(VersionSDKMinor)</CliProductBandVersion>


### PR DESCRIPTION
This PR updates version branding on branch `release/8.0.4xx`.

**Changes:**
- Repository: installer
  - PatchVersion: `20` → `21`

**Files Modified:**
- eng/Versions.props (+1 -1)
