### PR TITLE
Use `source-build-assets` repo

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -248,10 +248,10 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>81cabf2857a01351e5ab578947c7403a5b128ad1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.26203.3">
-      <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>9d83c59ff890ff2020aa38ebcf3bb514e38e9ffe</Sha>
-      <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-assets" Version="8.0.0-alpha.1.26208.3">
+      <Uri>https://github.com/dotnet/source-build-assets</Uri>
+      <Sha>e911a8db53ca72e45e66bb84376e68fe5c5999b9</Sha>
+      <SourceBuild RepoName="source-build-assets" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XliffTasks" Version="1.0.0-beta.23475.1" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
       <Uri>https://github.com/dotnet/xliff-tasks</Uri>

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -314,6 +314,7 @@
         <_NupkgDestinationPath>$(SourceBuiltPackagesPath)</_NupkgDestinationPath>
         <!-- SBRP packages unpack into the Reference packages directory instead of into blob-feed packages -->
         <_NupkgDestinationPath Condition="$([System.String]::Copy(%(_BuiltIntermediatePackages.Identity)).Contains('source-build-reference-packages'))">$(ReferencePackagesDir)</_NupkgDestinationPath>
+        <_NupkgDestinationPath Condition="$([System.String]::Copy(%(_BuiltIntermediatePackages.Identity)).Contains('source-build-assets'))">$(ReferencePackagesDir)</_NupkgDestinationPath>
     </PropertyGroup>
 
     <ZipFileExtractToDirectory Condition="'@(_BuiltIntermediatePackages)' != ''"

--- a/src/SourceBuild/content/repo-projects/Directory.Build.targets
+++ b/src/SourceBuild/content/repo-projects/Directory.Build.targets
@@ -313,7 +313,6 @@
     <PropertyGroup Condition="'@(_BuiltIntermediatePackages)' != ''">
         <_NupkgDestinationPath>$(SourceBuiltPackagesPath)</_NupkgDestinationPath>
         <!-- SBRP packages unpack into the Reference packages directory instead of into blob-feed packages -->
-        <_NupkgDestinationPath Condition="$([System.String]::Copy(%(_BuiltIntermediatePackages.Identity)).Contains('source-build-reference-packages'))">$(ReferencePackagesDir)</_NupkgDestinationPath>
         <_NupkgDestinationPath Condition="$([System.String]::Copy(%(_BuiltIntermediatePackages.Identity)).Contains('source-build-assets'))">$(ReferencePackagesDir)</_NupkgDestinationPath>
     </PropertyGroup>
 

--- a/src/SourceBuild/content/repo-projects/dotnet.proj
+++ b/src/SourceBuild/content/repo-projects/dotnet.proj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <!-- Toolsets -->
-    <RepositoryReference Include="source-build-reference-packages" />
+    <RepositoryReference Include="source-build-assets" />
     <RepositoryReference Include="arcade" />
 
     <!-- Product Repos -->

--- a/src/SourceBuild/content/repo-projects/package-source-build.proj
+++ b/src/SourceBuild/content/repo-projects/package-source-build.proj
@@ -34,15 +34,6 @@
       <SourceBuildReferencePackagesIntermediatePackage Include="$(SourceBuiltPackagesPath)$(SBRPIntermediateWildcard)"/>
     </ItemGroup>
 
-    <!-- Fallback to old SBRP intermediate package -->
-    <PropertyGroup Condition="'@(SourceBuildReferencePackagesIntermediatePackage)' != ''">
-      <SourceBuildReferencePackagesDestination>$(SourceBuiltPackagesPath)SourceBuildReferencePackages/</SourceBuildReferencePackagesDestination>
-      <SBRPIntermediateWildcard>Microsoft.SourceBuild.Intermediate.source-build-reference-packages*.nupkg</SBRPIntermediateWildcard>
-    </PropertyGroup>
-    <ItemGroup Condition="'@(SourceBuildReferencePackagesIntermediatePackage)' != ''">
-      <SourceBuildReferencePackagesIntermediatePackage Include="$(SourceBuiltPackagesPath)$(SBRPIntermediateWildcard)"/>
-    </ItemGroup>
-
     <MakeDir Directories="$(SourceBuildReferencePackagesDestination)" />
     <ZipFileExtractToDirectory Condition="'@(SourceBuildReferencePackagesIntermediatePackage)' != ''"
                             SourceArchive="%(SourceBuildReferencePackagesIntermediatePackage.Identity)"

--- a/src/SourceBuild/content/repo-projects/package-source-build.proj
+++ b/src/SourceBuild/content/repo-projects/package-source-build.proj
@@ -25,12 +25,21 @@
     <!-- Copy PVP to packages dir in order to package them together -->
     <Copy SourceFiles="$(IncludedPackageVersionPropsFile)" DestinationFiles="$(SourceBuiltPackagesPath)PackageVersions.props" />
 
-    <!-- Expand SBRP intermediate package into separate folder and remove intermediate package -->
+    <!-- Expand source-build-assets intermediate package into separate folder and remove intermediate package -->
     <PropertyGroup>
+      <SourceBuildReferencePackagesDestination>$(SourceBuiltPackagesPath)SourceBuildReferencePackages/</SourceBuildReferencePackagesDestination>
+      <SBRPIntermediateWildcard>Microsoft.SourceBuild.Intermediate.source-build-assets*.nupkg</SBRPIntermediateWildcard>
+    </PropertyGroup>
+    <ItemGroup>
+      <SourceBuildReferencePackagesIntermediatePackage Include="$(SourceBuiltPackagesPath)$(SBRPIntermediateWildcard)"/>
+    </ItemGroup>
+
+    <!-- Fallback to old SBRP intermediate package -->
+    <PropertyGroup Condition="'@(SourceBuildReferencePackagesIntermediatePackage)' != ''">
       <SourceBuildReferencePackagesDestination>$(SourceBuiltPackagesPath)SourceBuildReferencePackages/</SourceBuildReferencePackagesDestination>
       <SBRPIntermediateWildcard>Microsoft.SourceBuild.Intermediate.source-build-reference-packages*.nupkg</SBRPIntermediateWildcard>
     </PropertyGroup>
-    <ItemGroup>
+    <ItemGroup Condition="'@(SourceBuildReferencePackagesIntermediatePackage)' != ''">
       <SourceBuildReferencePackagesIntermediatePackage Include="$(SourceBuiltPackagesPath)$(SBRPIntermediateWildcard)"/>
     </ItemGroup>
 

--- a/src/SourceBuild/content/repo-projects/source-build-assets.proj
+++ b/src/SourceBuild/content/repo-projects/source-build-assets.proj
@@ -2,7 +2,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <LocalNuGetPackageCacheDirectory>$(BaseIntermediatePath)source-build-reference-package-cache</LocalNuGetPackageCacheDirectory>
+    <LocalNuGetPackageCacheDirectory>$(BaseIntermediatePath)source-build-assets-cache</LocalNuGetPackageCacheDirectory>
 
     <BuildCommandArgs>$(StandardSourceBuildArgs)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:MicrosoftNetCoreIlasmPackageRuntimeId=$(NETCoreSdkRuntimeIdentifier)</BuildCommandArgs>
@@ -20,7 +20,7 @@
 
     <AddSourceToNuGetConfig
       NuGetConfigFile="$(NuGetConfigFile)"
-      SourceName="source-build-reference-package-cache"
+      SourceName="source-build-assets-cache"
       SourcePath="$(LocalNuGetPackageCacheDirectory)" />
   </Target>
 

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseExclusions.txt
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/assets/LicenseExclusions.txt
@@ -232,21 +232,21 @@ src/source-build-externals/src/xunit/xunit.sln|json
 src/source-build-externals/patches/application-insights/0002-Remove-WebGrease-from-TPN-2816.patch
 
 #
-# source-build-reference-packages
+# source-build-assets
 #
 
 # False positive
-src/source-build-reference-packages/src/targetPacks/ILsrc/microsoft.netcore.app.ref/3.*/THIRD-PARTY-NOTICES.TXT|codesourcery-2004
-src/source-build-reference-packages/src/targetPacks/ILsrc/netstandard.library/1.6.1/ThirdPartyNotices.txt|unknown-license-reference
-src/source-build-reference-packages/src/targetPacks/ILsrc/netstandard.library/2.0.*/THIRD-PARTY-NOTICES.TXT|unknown-license-reference
-src/source-build-reference-packages/src/targetPacks/ILsrc/netstandard.library.ref/2.1.0/THIRD-PARTY-NOTICES.TXT|codesourcery-2004
-src/source-build-reference-packages/src/textOnlyPackages/src/microsoft.codeanalysis.collections/4.2.0-1.22102.8/ThirdPartyNotices.rtf|json
-src/source-build-reference-packages/src/textOnlyPackages/src/microsoft.netcore.*/1.*/ThirdPartyNotices.txt|unknown-license-reference
-src/source-build-reference-packages/src/textOnlyPackages/src/microsoft.private.intellisense/8.0.*/IntellisenseFiles/*/1033/System.Security.Permissions.xml|unknown-license-reference
+src/source-build-assets/src/targetPacks/ILsrc/microsoft.netcore.app.ref/3.*/THIRD-PARTY-NOTICES.TXT|codesourcery-2004
+src/source-build-assets/src/targetPacks/ILsrc/netstandard.library/1.6.1/ThirdPartyNotices.txt|unknown-license-reference
+src/source-build-assets/src/targetPacks/ILsrc/netstandard.library/2.0.*/THIRD-PARTY-NOTICES.TXT|unknown-license-reference
+src/source-build-assets/src/targetPacks/ILsrc/netstandard.library.ref/2.1.0/THIRD-PARTY-NOTICES.TXT|codesourcery-2004
+src/source-build-assets/src/textOnlyPackages/src/microsoft.codeanalysis.collections/4.2.0-1.22102.8/ThirdPartyNotices.rtf|json
+src/source-build-assets/src/textOnlyPackages/src/microsoft.netcore.*/1.*/ThirdPartyNotices.txt|unknown-license-reference
+src/source-build-assets/src/textOnlyPackages/src/microsoft.private.intellisense/8.0.*/IntellisenseFiles/*/1033/System.Security.Permissions.xml|unknown-license-reference
 
 # Contains references to licenses which are not applicable to the source
-src/source-build-reference-packages/src/packageSourceGenerator/PackageSourceGeneratorTask/RewriteNuspec.cs|unknown-license-reference,ms-net-library-2018-11
-src/source-build-reference-packages/src/textOnlyPackages/src/microsoft.private.intellisense/8.0.*/IntellisenseFiles/windowsdesktop/1033/PresentationCore.xml|proprietary-license
+src/source-build-assets/src/packageSourceGenerator/PackageSourceGeneratorTask/RewriteNuspec.cs|unknown-license-reference,ms-net-library-2018-11
+src/source-build-assets/src/textOnlyPackages/src/microsoft.private.intellisense/8.0.*/IntellisenseFiles/windowsdesktop/1033/PresentationCore.xml|proprietary-license
 
 #
 # sourcelink

--- a/src/VirtualMonoRepo/source-mappings.json
+++ b/src/VirtualMonoRepo/source-mappings.json
@@ -160,8 +160,8 @@
             ]
         },
         {
-            "name": "source-build-reference-packages",
-            "defaultRemote": "https://github.com/dotnet/source-build-reference-packages"
+            "name": "source-build-assets",
+            "defaultRemote": "https://github.com/dotnet/source-build-assets"
         },
         {
             "name": "sourcelink",

--- a/src/VirtualMonoRepo/source-mappings.json
+++ b/src/VirtualMonoRepo/source-mappings.json
@@ -164,8 +164,15 @@
             "defaultRemote": "https://github.com/dotnet/source-build-assets"
         },
         {
+            // TODO: Remove the source-build-reference-packages mapping once
+            // the synchronization flags it as unused.
+            // We no longer synchronize it but we can't remove it yet until
+            // it disappears from all of the Version.Details.xml files.
+            // https://github.com/dotnet/source-build/issues/5533
             "name": "source-build-reference-packages",
-            "defaultRemote": "https://github.com/dotnet/source-build-reference-packages"
+            "defaultRemote": "https://github.com/dotnet/source-build-reference-packages",
+            "ignoreDefaults": true,
+            "exclude": [ "**/*" ]
         },
         {
             "name": "sourcelink",

--- a/src/VirtualMonoRepo/source-mappings.json
+++ b/src/VirtualMonoRepo/source-mappings.json
@@ -164,6 +164,10 @@
             "defaultRemote": "https://github.com/dotnet/source-build-assets"
         },
         {
+            "name": "source-build-reference-packages",
+            "defaultRemote": "https://github.com/dotnet/source-build-reference-packages"
+        },
+        {
             "name": "sourcelink",
             "defaultRemote": "https://github.com/dotnet/sourcelink"
         },


### PR DESCRIPTION
After `source-build-reference-packages` repo was renamed to `source-build-assets`, some changes are needed in `installer` repo to allow proper consumption of the new repo artifacts.

This PR updates repo-related properties or values.

This PR does not update various SBRP-named property names as there is no need for that. While repo was renamed, in .NET 8.0 repo still contains just reference packages, so the infra is correct and isn't confusing.

After this PR is merged and VMR updated, it will likely be necessary to manually delete old repo clone in VMR and potentially old repo's project file in `repo-projects`. I will prepare a follow up with those changes.

## Validation

[Installer build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2947296&view=results)
[VMR build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2947411&view=results)