### PR TITLE
Update VMR pipeline images to build.azurelinux.3.amd64

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-synchronization.yml
+++ b/eng/pipelines/templates/jobs/vmr-synchronization.yml
@@ -43,11 +43,11 @@ jobs:
   pool:
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
       name: $(DncEngPublicBuildPool)
-      image: 1es-ubuntu-2204-open
+      image: build.azurelinux.3.amd64.open
       os: linux
     ${{ else }}:
       name: $(DncEngInternalBuildPool)
-      demands: ImageOverride -equals 1es-ubuntu-2204
+      image: build.azurelinux.3.amd64
       os: linux
 
   steps:

--- a/src/SourceBuild/content/eng/pipelines/templates/stages/vmr-scan.yml
+++ b/src/SourceBuild/content/eng/pipelines/templates/stages/vmr-scan.yml
@@ -13,11 +13,11 @@ stages:
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
         name: $(DncEngPublicBuildPool)
-        image: 1es-ubuntu-2204-open
+        image: build.azurelinux.3.amd64.open
         os: linux
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         name: $(DncEngInternalBuildPool)
-        image: 1es-ubuntu-2204
+        image: build.azurelinux.3.amd64
         os: linux
 
     steps:


### PR DESCRIPTION
Update pool images in vmr-scan and vmr-synchronization templates from `1es-ubuntu-2204` to `build.azurelinux.3.amd64`.

Related to https://github.com/dotnet/source-build/issues/5542