### PR TITLE
Switch release/8.0.1xx builds to -Svc pools

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -78,7 +78,7 @@ extends:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
     sdl:
       sourceAnalysisPool:
-        name: $(DncEngInternalBuildPool)
+        name: NetCore1ESPool-Svc-Internal
         image: 1es-windows-2022
         os: windows
       ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
@@ -99,7 +99,7 @@ extends:
             image: 1es-windows-2022-open
             os: windows
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-            name: $(DncEngInternalBuildPool)
+            name: NetCore1ESPool-Svc-Internal
             image: 1es-windows-2022
             os: windows
         steps:
@@ -356,6 +356,6 @@ extends:
             publishUsingPipelines: true
             publishAssetsImmediately: true
             pool:
-              name: $(DncEngInternalBuildPool)
+              name: NetCore1ESPool-Svc-Internal
               image: 1es-windows-2022
               os: windows

--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -38,7 +38,7 @@ variables:
 
 - ${{ if eq(variables['System.TeamProject'], 'public') }}:
   - name: defaultPoolName
-    value: NetCore-Public-XL
+    value: NetCore-Public-Svc-XL
   - name: poolImage_Linux
     value: build.azurelinux.3.amd64.open
   - name: poolImage_LinuxArm64
@@ -48,7 +48,7 @@ variables:
 - ${{ else }}:
   - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
     - name: defaultPoolName
-      value: NetCore1ESPool-Internal-XL
+      value: NetCore1ESPool-Internal-Svc-XL
   - ${{ else }}:
     - name: defaultPoolName
       value: $(DncEngInternalBuildPool)

--- a/src/SourceBuild/content/eng/pipelines/sb-ci.yml
+++ b/src/SourceBuild/content/eng/pipelines/sb-ci.yml
@@ -24,7 +24,7 @@ extends:
   parameters:
     sdl:
       sourceAnalysisPool:
-        name: NetCore1ESPool-Internal
+        name: NetCore1ESPool-Svc-Internal
         image: 1es-windows-2022
         os: windows
 


### PR DESCRIPTION
Hardcode -Svc pool names for servicing branch builds to ensure they run on servicing infrastructure instead of R&D pools.

### Changes
- \\\ → \NetCore1ESPool-Svc-Internal\ (3 occurrences in .vsts-ci.yml)
- \NetCore-Public-XL\ → \NetCore-Public-Svc-XL\ (vmr-build.yml variables)
- \NetCore1ESPool-Internal-XL\ → \NetCore1ESPool-Internal-Svc-XL\ (vmr-build.yml variables)
- \NetCore1ESPool-Internal\ → \NetCore1ESPool-Svc-Internal\ (sb-ci.yml)

### Context
The \pool-providers.yml\ dynamic expression should auto-select -Svc pools for release branches but is not working in practice. This change hardcodes the correct -Svc pools to match the pattern used in dotnet/arcade PRs #16746, #16747, #16748.