### PR TITLE
Switch release/8.0.4xx builds to -Svc pools

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -78,7 +78,7 @@ extends:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
     sdl:
       sourceAnalysisPool:
-        name: $(DncEngInternalBuildPool)
+        name: NetCore1ESPool-Svc-Internal
         image: 1es-windows-2022
         os: windows
     stages:
@@ -92,7 +92,7 @@ extends:
             image: 1es-windows-2022-open
             os: windows
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-            name: $(DncEngInternalBuildPool)
+            name: NetCore1ESPool-Svc-Internal
             image: 1es-windows-2022
             os: windows
         steps:
@@ -349,6 +349,6 @@ extends:
             publishUsingPipelines: true
             publishAssetsImmediately: true
             pool:
-              name: $(DncEngInternalBuildPool)
+              name: NetCore1ESPool-Svc-Internal
               image: 1es-windows-2022
               os: windows

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -16,14 +16,14 @@ parameters:
     name: NetCore1ESPool-Svc-Internal
     demands: ImageOverride -equals Build.Ubuntu.2204.Amd64
   poolInternalAmd64PR:
-    name: NetCore1ESPool-Internal-XL
+    name: NetCore1ESPool-Internal-Svc-XL
     demands: ImageOverride -equals Build.Ubuntu.2204.Amd64
   poolInternalArm64:
     name: Docker-Linux-Arm-Internal
 
   # Public builds / PRs
   poolPublicAmd64:
-    name: NetCore-Public-XL
+    name: NetCore-Public-Svc-XL
     demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
 
 stages:

--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -38,7 +38,7 @@ variables:
 
 - ${{ if eq(variables['System.TeamProject'], 'public') }}:
   - name: defaultPoolName
-    value: NetCore-Public-XL
+    value: NetCore-Public-Svc-XL
   - name: poolImage_Linux
     value: build.azurelinux.3.amd64.open
   - name: poolImage_LinuxArm64
@@ -48,10 +48,10 @@ variables:
 - ${{ else }}:
   - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
     - name: defaultPoolName
-      value: NetCore1ESPool-Internal-XL
+      value: NetCore1ESPool-Internal-Svc-XL
   - ${{ else }}:
     - name: defaultPoolName
-      value: $(DncEngInternalBuildPool)
+      value: NetCore1ESPool-Svc-Internal
   - name: poolImage_Linux
     value: build.azurelinux.3.amd64
   - name: poolImage_LinuxArm64


### PR DESCRIPTION
Hardcode -Svc pool names for servicing branch builds to ensure they run on servicing infrastructure instead of R&D pools.

### Changes
- DncEngInternalBuildPool variable references replaced with NetCore1ESPool-Svc-Internal (3 occurrences in .vsts-ci.yml)
- NetCore-Public-XL replaced with NetCore-Public-Svc-XL (vmr-build.yml variables and stages)
- NetCore1ESPool-Internal-XL replaced with NetCore1ESPool-Internal-Svc-XL (vmr-build.yml variables and stages)

### Context
The pool-providers.yml dynamic expression should auto-select -Svc pools for release branches but is not working in practice. This change hardcodes the correct -Svc pools to match the pattern used in dotnet/arcade PRs #16746, #16747, #16748.