### PR TITLE
Fix empty RPM dependency versions

### DIFF
--- a/src/redist/targets/GenerateRPMs.targets
+++ b/src/redist/targets/GenerateRPMs.targets
@@ -88,13 +88,13 @@
     <!-- Replace config json variables -->
     <ItemGroup>
       <SDKTokenValue Include="%SHARED_FRAMEWORK_RPM_PACKAGE_VERSION%">
-        <ReplacementString>$(MicrosoftNETCoreAppRuntimeMajorMinorPatchVersion)</ReplacementString>
+        <ReplacementString>$(MicrosoftNETCoreAppMajorMinorPatchVersion)</ReplacementString>
       </SDKTokenValue>
       <SDKTokenValue Include="%NETCOREAPP_TARGETING_PACK_RPM_PACKAGE_VERSION%">
         <ReplacementString>$(MicrosoftNETCoreAppRefMajorMinorPatchVersion)</ReplacementString>
       </SDKTokenValue>
       <SDKTokenValue Include="%ASPNETCORE_SHAREDFX_RPM_PACKAGE_VERSION%">
-        <ReplacementString>$(AspNetCoreRuntimeMajorMinorPatchVersion)</ReplacementString>
+        <ReplacementString>$(AspNetCoreMajorMinorPatchVersion)</ReplacementString>
       </SDKTokenValue>
       <SDKTokenValue Include="%ASPNET_TARGETING_PACK_RPM_PACKAGE_VERSION%">
         <ReplacementString>$(AspNetCoreRefMajorMinorPatchVersion)</ReplacementString>

--- a/src/redist/targets/LinuxNativeInstallerDependencyVersions.targets
+++ b/src/redist/targets/LinuxNativeInstallerDependencyVersions.targets
@@ -9,16 +9,18 @@
 
     <GetLinuxNativeInstallerDependencyVersions PackageVersion="$(MicrosoftNETCoreAppRefPackageVersion)">
       <Output TaskParameter="VersionWithTilde" PropertyName="MicrosoftNETCoreAppRefPackageVersionWithTilde" />
+      <Output TaskParameter="MajorMinorPatchVersion" PropertyName="MicrosoftNETCoreAppRefMajorMinorPatchVersion" />
     </GetLinuxNativeInstallerDependencyVersions>
 
     <GetLinuxNativeInstallerDependencyVersions PackageVersion="$(MicrosoftAspNetCoreAppRuntimePackageVersion)">
       <Output TaskParameter="VersionWithTilde" PropertyName="AspNetCoreRuntimeVersionWithTilde" />
       <Output TaskParameter="MajorMinorVersion" PropertyName="AspNetCoreMajorMinorVersion" />
-      <Output TaskParameter="MajorMinorVersion" PropertyName="AspNetCoreMajorMinorPatchVersion" />
+      <Output TaskParameter="MajorMinorPatchVersion" PropertyName="AspNetCoreMajorMinorPatchVersion" />
     </GetLinuxNativeInstallerDependencyVersions>
 
     <GetLinuxNativeInstallerDependencyVersions  PackageVersion="$(MicrosoftAspNetCoreAppRefPackageVersion)">
       <Output TaskParameter="VersionWithTilde" PropertyName="AspNetCoreRefVersionWithTilde" />
+      <Output TaskParameter="MajorMinorPatchVersion" PropertyName="AspNetCoreRefMajorMinorPatchVersion" />
     </GetLinuxNativeInstallerDependencyVersions>
 
     <GetLinuxNativeInstallerDependencyVersions PackageVersion="$(HostFxrVersion)">


### PR DESCRIPTION
## Problem
The SDK RPM package was generated with **empty dependency versions**. In src/redist/targets/packaging/rpm/dotnet-config.json, each `rpm_dependencies` entry has a `package_version` token that `GenerateRPMs.targets` substitutes using four MSBuild properties:

- `MicrosoftNETCoreAppRuntimeMajorMinorPatchVersion`
- `MicrosoftNETCoreAppRefMajorMinorPatchVersion`
- `AspNetCoreRuntimeMajorMinorPatchVersion`
- `AspNetCoreRefMajorMinorPatchVersion`

None of these properties were ever defined (dangling since at least 2019), so the produced RPM had empty dependency versions, causing install failures on some machines.

The DEB path was unaffected because it consumes the `*WithTilde` outputs that **are** computed in the shared `LinuxNativeInstallerDependencyVersions.targets`.

## Fix
- Wire up the missing `MajorMinorPatchVersion` outputs in the shared `LinuxNativeInstallerDependencyVersions.targets` for the NETCore/ASP.NET targeting packs, and fix a copy/paste bug where `AspNetCoreMajorMinorPatchVersion` was assigned the 2-part `MajorMinorVersion` instead of the 3-part `MajorMinorPatchVersion`.
- Point the four token replacements in `GenerateRPMs.targets` at the correctly-named, now-defined properties.

Reuses the existing shared infrastructure rather than duplicating it; no impact on DEB/PKG paths.