### PR TITLE
Work around license scan timeout by scanning source-build-assets serially

### DIFF
--- a/src/SourceBuild/content/eng/pipelines/vmr-license-scan.yml
+++ b/src/SourceBuild/content/eng/pipelines/vmr-license-scan.yml
@@ -37,7 +37,6 @@ extends:
     containers:
       licenseScanContainer:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-source-build-test-amd64
-        options: '--memory=12g'
     pool:
       name: NetCore1ESPool-Svc-Internal
       image: build.azurelinux.3.amd64
@@ -69,20 +68,37 @@ extends:
               local name="$1"
               local repoPath="$2"
               local scanIgnorePatterns="${3:-}"
+              local scanProcessCount="${4:-}"
               if [ ! -z "$matrix" ]; then
                 matrix="$matrix,"
               fi
-              matrix="$matrix \"$name\": { \"repoPath\": \"$repoPath\", \"scanIgnorePatterns\": \"$scanIgnorePatterns\" }"
+              matrix="$matrix \"$name\": { \"repoPath\": \"$repoPath\", \"scanIgnorePatterns\": \"$scanIgnorePatterns\", \"scanProcessCount\": \"$scanProcessCount\" }"
             }
 
             # Repos whose src/ subdirectories should be scanned as separate jobs.
             # The repo root is also scanned with --ignore to skip subdirectories covered by sub-scans.
             splitRepos="source-build-assets"
 
+            # Repos that should scan with a reduced number of scancode processes. This is
+            # independent of splitRepos. Their large, text-heavy content deadlocks scancode's
+            # multiprocessing pool at the end of a scan, so they are scanned serially (0 disables
+            # multiprocessing). Other repos use the test's default. Flows through the matrix.
+            serialScanRepos="source-build-assets"
+            serialScanProcessCount=0
+
+            # Returns the scancode --processes value for a repo, or empty to use the test's default.
+            getScanProcessCount() {
+              local repoName="$1"
+              if echo "$serialScanRepos" | grep -qw "$repoName"; then
+                echo "$serialScanProcessCount"
+              fi
+            }
+
             # If the repo name is provided, only scan that repo.
             if [ ! -z "$specificRepoName" ]; then
               repoName="$specificRepoName"
               dir="$vmrSrcDir/$specificRepoName"
+              scanProcessCount=$(getScanProcessCount "$repoName")
 
               if echo "$splitRepos" | grep -qw "$repoName"; then
                 ignorePatterns=""
@@ -94,17 +110,18 @@ extends:
                       ignorePatterns="$ignorePatterns "
                     fi
                     ignorePatterns="$ignorePatterns$subdirName"
-                    addMatrixEntry "${repoName}_${subdirName}" "$subdir"
+                    addMatrixEntry "${repoName}_${subdirName}" "$subdir" "" "$scanProcessCount"
                   fi
                 done
-                addMatrixEntry "$repoName" "$dir" "$ignorePatterns"
+                addMatrixEntry "$repoName" "$dir" "$ignorePatterns" "$scanProcessCount"
               else
-                addMatrixEntry "$repoName" "$dir"
+                addMatrixEntry "$repoName" "$dir" "" "$scanProcessCount"
               fi
             else
               for dir in "$vmrSrcDir"/*/
               do
                 repoName=$(basename "$dir")
+                scanProcessCount=$(getScanProcessCount "$repoName")
 
                 if echo "$splitRepos" | grep -qw "$repoName"; then
                   # Root scan: skip subdirectories that are covered by sub-scans
@@ -119,12 +136,12 @@ extends:
                         ignorePatterns="$ignorePatterns "
                       fi
                       ignorePatterns="$ignorePatterns$subdirName"
-                      addMatrixEntry "${repoName}_${subdirName}" "$subdir"
+                      addMatrixEntry "${repoName}_${subdirName}" "$subdir" "" "$scanProcessCount"
                     fi
                   done
-                  addMatrixEntry "$repoName" "$dir" "$ignorePatterns"
+                  addMatrixEntry "$repoName" "$dir" "$ignorePatterns" "$scanProcessCount"
                 else
-                  addMatrixEntry "$repoName" "$dir"
+                  addMatrixEntry "$repoName" "$dir" "" "$scanProcessCount"
                 fi
               done
             fi
@@ -166,6 +183,7 @@ extends:
             -clp:v=m
             -e SMOKE_TESTS_LICENSE_SCAN_PATH=$(repoPath)
             -e "SMOKE_TESTS_LICENSE_SCAN_IGNORE_PATTERNS=$(scanIgnorePatterns)"
+            -e SMOKE_TESTS_LICENSE_SCAN_PROCESS_COUNT=$(scanProcessCount)
             -e SMOKE_TESTS_RUNNING_IN_CI=true
             -e SMOKE_TESTS_WARN_LICENSE_SCAN_DIFFS=false
             -e SMOKE_TESTS_TARGET_RID=linux-x64

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/Config.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/Config.cs
@@ -24,6 +24,7 @@ internal static class Config
     public const string RunningInCIEnv = "SMOKE_TESTS_RUNNING_IN_CI";
     public const string LicenseScanPathEnv = "SMOKE_TESTS_LICENSE_SCAN_PATH";
     public const string LicenseScanIgnorePatternsEnv = "SMOKE_TESTS_LICENSE_SCAN_IGNORE_PATTERNS";
+    public const string LicenseScanProcessCountEnv = "SMOKE_TESTS_LICENSE_SCAN_PROCESS_COUNT";
 
     public static string DotNetDirectory { get; } =
         Environment.GetEnvironmentVariable(DotNetDirectoryEnv) ?? Path.Combine(Directory.GetCurrentDirectory(), ".dotnet");
@@ -49,4 +50,6 @@ internal static class Config
     
     public static string? LicenseScanPath { get; } = Environment.GetEnvironmentVariable(LicenseScanPathEnv);
     public static string? LicenseScanIgnorePatterns { get; } = Environment.GetEnvironmentVariable(LicenseScanIgnorePatternsEnv);
+    public static int? LicenseScanProcessCount { get; } =
+        int.TryParse(Environment.GetEnvironmentVariable(LicenseScanProcessCountEnv), out int processCount) ? processCount : null;
 }

--- a/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
+++ b/src/SourceBuild/content/test/Microsoft.DotNet.SourceBuild.SmokeTests/LicenseScanTests.cs
@@ -167,6 +167,12 @@ public class LicenseScanTests : TestBase
         // Indicates how long until a timeout occurs for scanning a given file
         const int FileScanTimeoutSeconds = 1800;
 
+        // Number of parallel processes scancode should use. Large, text-heavy repos can
+        // deadlock scancode's multiprocessing pool at the end of a scan, so the pipeline
+        // scans them serially by passing 0. Default to 4 when not specified by the pipeline.
+        const int DefaultProcessCount = 4;
+        int processCount = Config.LicenseScanProcessCount ?? DefaultProcessCount;
+
         string scancodeResultsPath = Path.Combine(LogsDirectory, "scancode-results.json");
 
         // Combine default and additional ignore patterns
@@ -182,7 +188,7 @@ public class LicenseScanTests : TestBase
         string ignoreOptions = string.Join(" ", allIgnorePatterns.Select(pattern => $"--ignore {pattern}"));
         ExecuteHelper.ExecuteProcessValidateExitCode(
             "scancode",
-            $"--license --processes 4 --timeout {FileScanTimeoutSeconds} --strip-root --only-findings {ignoreOptions} --json-pp {scancodeResultsPath} {Config.LicenseScanPath}",
+            $"--license --processes {processCount} --timeout {FileScanTimeoutSeconds} --strip-root --only-findings {ignoreOptions} --json-pp {scancodeResultsPath} {Config.LicenseScanPath}",
             OutputHelper);
 
         JsonDocument doc = JsonDocument.Parse(File.ReadAllText(scancodeResultsPath));


### PR DESCRIPTION
Backport of https://github.com/dotnet/dotnet/pull/7626